### PR TITLE
fix(docs): add theme directory configuration for mdbook

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -15,6 +15,7 @@ preferred-dark-theme = "navy"
 smart-punctuation = true
 mathjax-support = true
 copy-fonts = true
+theme = "theme"
 additional-css = ["theme/custom.css"]
 additional-js = ["theme/custom.js"]
 git-repository-url = "https://github.com/RedRing2020/RedRing"


### PR DESCRIPTION
- Added theme = 'theme' to book.toml [output.html] section
- Resolves static files copy error during mdbook build
- mdbook build now works cleanly with custom styling