### PR TITLE
feat: CAM工具経路可視化システム実装（Phase 1）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2524,6 +2524,8 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "viewmodel"
 version = "0.1.0"
 dependencies = [
+ "analysis",
+ "cam_core",
  "geo_algorithms",
  "geo_foundation",
  "geo_io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cam_core"
+version = "0.1.0"
+dependencies = [
+ "analysis",
+ "geo_algorithms",
+ "geo_foundation",
+ "geo_primitives",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "model/geo_algorithms", # Model層：幾何アルゴリズムクレート
   "model/geo_nurbs",      # Model層：NURBS曲線・曲面クレート（高レベルアルゴリズム）
   "model/geo_io",         # Model層：ファイルI/Oクレート
+  "model/cam_core",       # Model層：CAM基盤クレート（工具経路・工具定義）
   "viewmodel/converter",  # ViewModel層：データ変換・架け橋
   "viewmodel/graphics",   # ViewModel層：グラフィックス制御（カメラ等）
   "view/render",          # View層：GPU描画基盤

--- a/dev/architecture/CAM_CRATE_DESIGN_PROPOSAL.md
+++ b/dev/architecture/CAM_CRATE_DESIGN_PROPOSAL.md
@@ -1,0 +1,690 @@
+# CAM機能の設計方針・クレート構成検討
+
+**作成日**: 2026年2月8日  
+**最終更新**: 2026年2月8日  
+**ステータス**: 設計検討中 - ユーザー承認待ち  
+**関連Issue**: #203
+
+---
+
+## 📋 検討事項サマリー
+
+### 1. Issue #203の範囲精査と新規Issue分割
+
+**質問**: 現在の設計内容を反映したIssue更新と、段階的実装のための新規Issue分割が必要か？
+
+### 2. CAM機能のクレート配置
+
+**質問**: CAM機能を `geo_algorithms` に配置するか、新規 `cam` クレートを作成するか？
+
+### 3. CADとCAMの境界定義
+
+**質問**: RedRingにおけるCADとCAMの責務をどう分離するか？
+
+### 4. 2D CAM対象形状の扱い
+
+**質問**: 閉じた線群セグメントとして判定する必要があるか？トレランスは必要か？
+
+---
+
+## 1. Issue #203の範囲精査
+
+### 現在のIssue #203の問題点
+
+**元のIssue内容**:
+- 「CAM可視化システム設計・実装」として5日の工数
+- Phase 1-3全てを含む広範な内容
+- ツール管理、副座標、5軸加工などが混在
+
+**今回の設計で明確化された内容**:
+- **Phase 1**: 3軸加工の基本可視化のみ（2-3日）
+- **Phase 2以降**: 別Issue化が必要（ツール管理、副座標、パス接続詳細）
+
+### 提案: Issue分割案
+
+#### ✅ Issue #203（更新後）: CAM工具経路可視化 Phase 1
+
+**スコープ**:
+- 3軸加工の工具経路表示（2D CAM/3D CAM）
+- セグメント種別の色分け
+- 等高線レベル管理
+- 送り速度（F値）表示
+
+**工数**: 2-3日（Week 3）  
+**優先度**: Tier 1
+
+#### 📝 Issue #211（新規作成）: ツール管理システム
+
+**スコープ**:
+- ツールセット登録・管理
+- 工具ライブラリDB
+- 工具選択UI
+
+**工数**: 2週間（Week 10-12）  
+**優先度**: Tier 2  
+**依存**: #203完了後
+
+#### 📝 Issue #212（新規作成）: 副座標（subaxis）機能
+
+**スコープ**:
+- 複数ワーク座標系の定義
+- 座標系切り替え（G54-G59）
+- 座標系ごとの工具経路表示
+
+**工数**: 1週間（Week 10-12）  
+**優先度**: Tier 2  
+**依存**: #203完了後
+
+#### 📝 Issue #213（新規作成）: パス接続詳細表示
+
+**スコープ**:
+- 直線角度接続の可視化
+- 円弧接続の可視化
+- 接続パラメータ表示
+
+**工数**: 1週間（Week 10-12）  
+**優先度**: Tier 2  
+**依存**: #203完了後
+
+---
+
+## 2. CAM機能のクレート配置検討
+
+### Option A: `geo_algorithms` に配置（現状維持）
+
+**メリット**:
+- ✅ 既存クレートを活用、新規クレート不要
+- ✅ オフセット、ブール演算など幾何アルゴリズムと近い
+- ✅ クレート数が増えない（シンプル）
+
+**デメリット**:
+- ❌ CADとCAMの境界が曖昧になる
+- ❌ 将来的にCAM専用機能が増えた際に肥大化
+- ❌ `geo_algorithms`の責務が不明瞭（「幾何アルゴリズム」なのか「CAM」なのか）
+
+**配置イメージ**:
+```
+model/
+├── geo_algorithms/
+│   ├── src/
+│   │   ├── offset.rs       # CAD/CAM共通（オフセット演算）
+│   │   ├── boolean.rs      # CAD専用（ブール演算）
+│   │   ├── toolpath.rs     # CAM専用（工具経路）
+│   │   ├── toolpath_gen.rs # CAM専用（経路生成）
+│   │   └── collision.rs    # CAD/CAM共通（衝突判定）
+```
+
+---
+
+### Option B: 新規 `cam` クレート作成（推奨）
+
+**メリット**:
+- ✅ CADとCAMの責務が明確に分離
+- ✅ CAM専用機能の拡張が容易
+- ✅ `geo_algorithms` は純粋な幾何アルゴリズムに専念
+- ✅ ドメイン駆動設計（DDD）に沿った構成
+
+**デメリット**:
+- ❌ 新規クレート作成のオーバーヘッド
+- ❌ クレート数が増加（管理コスト）
+- ❌ CAD/CAM共通機能（オフセット等）の配置に悩む
+
+**配置イメージ**:
+```
+model/
+├── geo_algorithms/        # CAD幾何アルゴリズム
+│   ├── src/
+│   │   ├── offset.rs      # オフセット演算（CAM依存あり）
+│   │   ├── boolean.rs     # ブール演算（CAD専用）
+│   │   └── collision.rs   # 衝突判定（CAD/CAM共通）
+│
+├── cam/                   # CAM専用機能
+│   ├── Cargo.toml
+│   ├── src/
+│   │   ├── lib.rs
+│   │   ├── toolpath.rs    # 工具経路データ構造
+│   │   ├── path_gen/      # 経路生成アルゴリズム
+│   │   │   ├── contour.rs # 等高線加工
+│   │   │   ├── pocket.rs  # ポケット加工
+│   │   │   └── drill.rs   # 穴あけ
+│   │   ├── tool.rs        # 工具定義
+│   │   ├── validation.rs  # 2D輪郭閉判定、トレランスチェック
+│   │   └── optimization.rs # 経路最適化
+```
+
+---
+
+### Option C: ハイブリッド案（段階的アプローチ）
+
+**Phase 1（今回）**: `geo_algorithms` に配置
+- まず `geo_algorithms/src/toolpath.rs` として実装
+- CAM機能の規模を見極める
+
+**Phase 2以降**: 必要に応じて `cam` クレート分離
+- CAM機能が肥大化した時点で分離
+- `geo_algorithms` からの移行として実施
+
+**判断基準**:
+- `toolpath.rs` 単体のみ → `geo_algorithms` で十分
+- 経路生成、検証、最適化などが増えてきた → `cam` クレート分離
+
+---
+
+## 3. CADとCAMの境界定義
+
+### RedRingにおける責務分離
+
+#### CAD（Computer-Aided Design）の責務
+
+**定義**: 形状の定義・編集・表現
+
+**含まれる機能**:
+- ✅ 幾何プリミティブ（点、線、円、NURBS等）
+- ✅ 形状演算（オフセット、ブール演算、フィレット）
+- ✅ 幾何計算（交差判定、距離計算）
+- ✅ トポロジー管理（エッジ、フェース、ソリッド）
+- ✅ 形状検証（閉曲線判定、自己交差チェック）
+
+**クレート**:
+- `geo_primitives`: 基本形状
+- `geo_algorithms`: 形状演算・幾何計算
+- `geo_nurbs`: NURBS
+- Phase 4: `geo_topology`: トポロジー層（B-Rep）
+
+---
+
+#### CAM（Computer-Aided Manufacturing）の責務
+
+**定義**: 加工戦略・工具経路生成・加工シミュレーション
+
+**含まれる機能**:
+- ✅ 工具経路生成（等高線、ポケット、穴あけ、輪郭加工）
+- ✅ 工具定義（径、長さ、種別、切削条件）
+- ✅ 加工条件（送り速度、回転数、切込み量）
+- ✅ 経路最適化（順序、接続方式、干渉回避）
+- ✅ 切削シミュレーション（材料除去、削り残し検出）
+- ✅ NC データ生成（G コード出力）
+
+**クレート候補**:
+- `cam`: CAM専用機能（工具経路、加工戦略）
+- `cam_sim`: 切削シミュレーション（将来）
+- `cam_post`: ポストプロセッサ（G コード生成、将来）
+
+---
+
+#### 境界領域: CAD/CAM共通機能
+
+**問題**: オフセット演算はCADかCAMか？
+
+**結論**: **CAD側に配置、CAMから参照**
+
+**理由**:
+- オフセットは形状演算の一種（CAD機能）
+- CAMはオフセット結果を**利用**して工具経路を生成
+- 依存関係: `cam` → `geo_algorithms`（オフセット）
+
+**共通機能の配置ルール**:
+| 機能 | 配置先 | 理由 |
+|------|--------|------|
+| オフセット演算 | `geo_algorithms` | 形状演算（CAD） |
+| ブール演算 | `geo_algorithms` | 形状演算（CAD） |
+| 衝突判定 | `geo_algorithms` | 幾何計算（CAD） |
+| トレランス検証 | `cam` | 加工精度要件（CAM） |
+| 工具経路生成 | `cam` | 加工戦略（CAM） |
+| 閉曲線判定 | `geo_algorithms` | 形状検証（CAD） |
+
+---
+
+## 4. 2D CAM対象形状の扱い
+
+### 閉じた線群セグメントとしての判定
+
+**2D CAM加工の典型例**:
+- **輪郭加工**: 閉じた輪郭に沿って工具を移動
+- **ポケット加工**: 閉じた領域内を材料除去
+
+**必要な検証**:
+1. ✅ **閉曲線判定**: 始点と終点が一致するか？
+2. ✅ **自己交差判定**: 輪郭が自己交差していないか？
+3. ✅ **方向性判定**: 時計回り/反時計回り（内側/外側の判定）
+
+**実装配置**:
+| 機能 | 配置先 | 理由 |
+|------|--------|------|
+| 閉曲線判定 | `geo_algorithms` | 形状検証（CAD機能） |
+| 自己交差判定 | `geo_algorithms` | 幾何計算（CAD機能） |
+| 輪郭方向判定 | `geo_algorithms` | 形状解析（CAD機能） |
+| **CAM用検証** | `cam` | 加工可否判定（CAM機能） |
+
+**CAM用検証の例**:
+```rust
+// cam/src/validation.rs
+
+use geo_algorithms::curve_validation::{is_closed, has_self_intersection};
+
+pub fn validate_2d_contour(
+    segments: &[LineSegment2D<f64>],
+    tolerance: f64,
+) -> Result<(), ValidationError> {
+    // CAD機能を利用
+    if !is_closed(segments, tolerance) {
+        return Err(ValidationError::NotClosed);
+    }
+    
+    if has_self_intersection(segments) {
+        return Err(ValidationError::SelfIntersection);
+    }
+    
+    // CAM固有の検証
+    if !is_manufacturable(segments, tolerance) {
+        return Err(ValidationError::NotManufacturable);
+    }
+    
+    Ok(())
+}
+```
+
+---
+
+### CAM用トレランスの必要性
+
+**質問**: CAM用にトレランスを与える必要があるか？
+
+**回答**: ✅ **必要**
+
+**理由**:
+
+#### 1. 加工精度の要件
+
+CAMでは実際の機械加工を想定するため、数値誤差に対するトレランスが必須：
+
+- **閉曲線判定**: 始点と終点の距離がトレランス以内か？
+  - CAD: 厳密な一致（`start == end`）
+  - CAM: トレランス許容（`distance(start, end) < tolerance`）
+
+- **工具径との関係**: 工具径より小さい隙間は加工不可
+  - トレランス = 工具径 × 0.1（例: φ10mm工具 → 1mm）
+
+#### 2. NC機械の精度限界
+
+実機の位置決め精度を考慮：
+- 一般的な NC フライス: ±0.01mm
+- 高精度機: ±0.001mm
+
+**トレランス設定例**:
+```rust
+pub struct CamTolerance {
+    /// 閉曲線判定トレランス（mm）
+    pub closure_tolerance: f64,  // 例: 0.001
+    
+    /// 工具径に対する最小クリアランス
+    pub tool_clearance_ratio: f64,  // 例: 0.1
+    
+    /// 機械精度
+    pub machine_accuracy: f64,  // 例: 0.01
+}
+```
+
+#### 3. トレランスの使用箇所
+
+| 検証項目 | トレランス値 | 理由 |
+|---------|-------------|------|
+| 閉曲線判定 | 0.001mm | 数値誤差許容 |
+| 自己交差判定 | 0.001mm | 微小な接触許容 |
+| 工具干渉チェック | 工具径×0.1 | 最小クリアランス |
+| 経路最適化 | 0.01mm | 機械精度範囲内の簡略化 |
+
+---
+
+## 推奨設計案
+
+### ✅ Phase 1（Issue #203実装）の推奨構成
+
+**クレート配置**: **Option B - 新規 `cam_core` クレート作成**（ユーザー承認済み）
+
+**命名の意図**:
+- `cam_core`: CAM機能の**基盤クレート**
+  - 工具経路データ構造（ToolPath, PathSegment）
+  - 工具定義（Tool, ToolType）
+  - CAM用基本検証（トレランス、閉曲線判定）
+  - 他のCAMクレート（将来）が依存する中核機能
+
+**`geo_core` との違い**:
+| 項目 | `geo_core` | `cam_core` |
+|------|------------|-----------|
+| 役割 | ブリッジパターン（Foundation トレイトと具体型の仲介） | CAM機能の基盤データ構造・アルゴリズム |
+| 依存関係 | `geo_foundation` ↔ `geo_primitives` の橋渡し | CAM演算の中核、他CAMクレートの基盤 |
+| 責務 | 抽象化・型変換 | 工具経路・工具定義・CAM検証 |
+| 将来拡張 | 固定的（ブリッジ役） | 拡張的（`cam_algorithms`, `cam_sim` 等が依存） |
+
+**命名の一貫性**:
+- ✅ `geo_core` と対比して `cam_core` は自然
+- ✅ 「基盤」を示す `_core` サフィックスの使用は適切
+- ✅ 将来的なCAM関連クレート群の中核として明確
+
+**将来のCAMクレート構成（Phase 2以降）**:
+```
+model/
+├── cam_core/              # Phase 1: CAM基盤（工具経路、工具定義）
+│   ├── src/
+│   │   ├── toolpath.rs
+│   │   ├── tool.rs
+│   │   ├── validation.rs
+│   │   └── tolerance.rs
+│
+├── cam_algorithms/        # Phase 2: 経路生成アルゴリズム
+│   ├── src/
+│   │   ├── contour.rs     # 等高線加工
+│   │   ├── pocket.rs      # ポケット加工
+│   │   ├── drill.rs       # 穴あけ
+│   │   └── optimization.rs
+│
+├── cam_sim/               # Phase 3: 切削シミュレーション
+│   ├── src/
+│   │   ├── material.rs    # 材料除去
+│   │   ├── collision.rs   # 干渉チェック
+│   │   └── verification.rs
+│
+└── cam_post/              # Phase 4: ポストプロセッサ
+    ├── src/
+    │   ├── gcode.rs       # G コード生成
+    │   └── machine.rs     # 機械固有設定
+```
+
+**依存関係ツリー**:
+```
+cam_post
+  ↓
+cam_sim
+  ↓
+cam_algorithms
+  ↓
+cam_core ← ViewModel/View層が直接参照
+  ↓
+geo_algorithms, geo_primitives, geo_foundation
+```
+
+**理由**:
+1. **拡張性**: 将来的に複数のCAMクレートが `cam_core` に依存する構成が自然
+2. **一貫性**: `geo_core` との命名パターンの統一
+3. **明確性**: "core" は基盤・中核を意味し、Phase 1の位置づけが明確
+4. **分離性**: CAD（geo系）とCAM（cam系）の境界が明瞭
+
+**代替案との比較**:
+| 命名 | メリット | デメリット | 評価 |
+|------|---------|-----------|------|
+| `cam` | シンプル | 将来拡張時に階層化しづらい | △ |
+| `cam_core` | 基盤であることが明確、将来拡張に対応 | `geo_core` との役割の違いを理解する必要 | ⭐ **推奨** |
+| `cam_foundation` | Foundation Pattern との一貫性 | CAMにはFoundation Patternを適用しない? | △ |
+| `cam_base` | 基盤を示す | `_core` より一般的でない | △ |
+
+**結論**: ✅ **`cam_core` を採用（違和感なし）**
+
+---
+
+**ディレクトリ構成（Phase 1）**:
+**ディレクトリ構成（Phase 1）**:
+```
+model/
+├── cam_core/                  # 新規クレート（Phase 1実装）
+│   ├── Cargo.toml
+│   ├── src/
+│   │   ├── lib.rs
+│   │   ├── toolpath.rs        # 工具経路データ構造
+│   │   ├── tool.rs            # 工具定義
+│   │   ├── validation.rs      # 2D輪郭検証
+│   │   └── tolerance.rs       # トレランス管理
+│   └── tests/
+│       ├── toolpath_tests.rs
+│       └── validation_tests.rs
+```
+
+**依存関係（Phase 1）**:
+```toml
+# model/cam_core/Cargo.toml
+[package]
+name = "cam_core"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+analysis = { path = "../../foundation/analysis" }
+geo_foundation = { path = "../geo_foundation" }
+geo_primitives = { path = "../geo_primitives" }
+geo_algorithms = { path = "../geo_algorithms" }  # オフセット、閉曲線判定を利用
+```（`cam_core` クレート）
+
+#### 1. `model/cam_core/src/toolpath.rs`
+
+工具経路データ構造（設計済み）:
+- `PathSegment` enum
+- `ToolPath` 構造体
+- `ContourLevelPath` 構造体
+
+#### 2. `model/cam_core/src/tool.rs`
+
+工具定義（簡易版）:
+- `Tool` 構造体
+- `ToolType` enum
+
+#### 3. `model/cam_core/src/validation.rs`
+
+2D輪郭検証:
+```rust
+pub fn validate_2d_contour(
+    segments: &[LineSegment2D<f64>],
+    tolerance: &CamTolerance,
+) -> Result<(), ValidationError>;
+```
+
+#### 4. `model/cam_core/src/tolerance.rs`
+
+トレランス管理:
+```rust
+pub struct CamTolerance {
+    pub closure_tolerance: f64,
+    pub tool_clearance_ratio: f64,
+    pub machine_accuracy: f64,
+}
+```
+
+#### 5. `model/cam_core/src/lib.rs`
+
+公開API:
+```rust
+pub mod toolpath;
+pub mod tool;
+pub mod validation;
+pub mod tolerance;
+
+// 主要型の再エクスポート
+pub use toolpath::{ToolPath, PathSegment, ContourLevelPath};
+pub use tool::{Tool, ToolType};
+pub use validation::validate_2d_contour;
+pub use tolerance::CamTolerance;
+```
+
+---
+
+## 命名に関する補足説明
+
+### `cam_core` の役割と `geo_core` との対比
+
+#### `geo_core` の役割（既存）
+- **目的**: Foundation Pattern のブリッジ
+- **機能**: `geo_foundation` のトレイトと `geo_primitives` の具体型を仲介
+- **パターン**: 抽象化層と実装層の橋渡し（アダプターパターン）
+
+#### `cam_core` の役割（新規）
+- **目的**: CAM機能の基盤データ構造とアルゴリズム
+- **✅ 承認済み事項（2026年2月8日）
+
+1. **設計方針の承認**:
+   - ✅ クレート配置: Option B（新規 `cam_core` クレート作成）
+   - ✅ 命名: `cam_core` を採用（違和感なし、将来拡張を見据えた適切な命名）
+   - ⏳ CAD/CAM境界定義の最終確認
+   - ⏳ トレランス要件の最終確認
+
+2. **即座に実施（準備完了）**:
+   - [ ] `model/cam_core` クレート作成
+   - [ ] `Cargo.toml` にメンバー追加
+   - [ ] Phase 1実装開始（toolpath.rs, tool.rs, validation.rs, tolerance.rs）
+
+3. **Issue更新・新規作成（次ステップ）**:
+   - [ ] Issue #203を更新（Phase 1のみに絞る、`cam_core` クレート使用を明記）
+   - [ ] Issue #211, #212, #213を新規作成
+
+---
+
+## 実装開始準備チェックリスト
+
+### Step 1: クレート作成
+
+```bash
+# ディレクトリ作成
+mkdir -p model/cam_core/src
+mkdir -p model/cam_core/tests
+
+# Cargo.toml 作成
+cat > model/cam_core/Cargo.toml << 'EOF'
+[package]
+name = "cam_core"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+analysis = { path = "../../foundation/analysis" }
+geo_foundation = { path = "../geo_foundation" }
+geo_primitives = { path = "../geo_primitives" }
+geo_algorithms = { path = "../geo_algorithms" }
+EOF
+
+# lib.rs 作成
+cat > model/cam_core/src/lib.rs << 'EOF'
+//! CAM機能の基盤クレート
+//! 
+//! 工具経路データ構造、工具定義、CAM検証機能を提供します。
+
+pub mod toolpath;
+pub mod tool;
+pub mod validation;
+pub mod tolerance;
+
+// 主要型の再エクスポート
+pub use toolpath::{ToolPath, PathSegment, ContourLevelPath};
+pub use tool::{Tool, ToolType};
+pub use validation::validate_2d_contour;
+pub use tolerance::CamTolerance;
+EOF
+```
+
+### Step 2: Workspace 更新
+
+```toml
+# Cargo.toml (ルート) のメンバーに追加
+members = [
+  # ... 既存メンバー ...
+  "model/cam_core",  # 追加
+]✅ 承認済み
+
+1. ✅ **クレート配置**: Option B（新規 `cam_core` クレート）を採用
+2. ✅ **クレート命名**: `cam_core` を採用（違和感なし）
+
+### ⏳ 最終確認待ち
+
+3. **CAD/CAM境界**: 提案した責務分離で問題ありませんか？
+   - オフセット演算は `geo_algorithms`（CAD）
+   - 工具経路生成は `cam_core`（CAM）
+   - 閉曲線判定は `geo_algorithms`（CAD形状検証）
+   - CAM用検証は `cam_core`（CAM加工可否判定）
+
+4. **2D輪郭検証**: 上記の配置でよいですか？
+
+5. **トレランス**: CAM用トレランスは必要ですか？デフォルト値は適切ですか？
+   - `closure_tolerance = 0.001mm`
+   - `tool_clearance_ratio = 0.1`
+   - `machine_accuracy = 0.01mm`
+
+6. **Issue分割**: Issue #211-#213を新規作成してよいですか？
+
+---
+
+**状態**: クレート名承認済み、実装開始準備完了  
+**次回更新**: 実装開始時（トレランス・CAD/CAM境界の最終確認後）
+- ✅ `cam_core` は「CAM機能群の基盤・中核」として適切
+- ✅ `geo_core` とは役割が異なるが、「中核」を示す `_core` の使用は一貫性がある
+- ✅ 将来的なCAMクレート群の拡張を見据えた命名として違和感なし# 2. `model/cam/src/tool.rs`
+
+工具定義（簡易版）:
+- `Tool` 構造体
+- `ToolType` enum
+
+#### 3. `model/cam/src/validation.rs`
+
+2D輪郭検証:
+```rust
+pub fn validate_2d_contour(
+    segments: &[LineSegment2D<f64>],
+    tolerance: &CamTolerance,
+) -> Result<(), ValidationError>;
+```
+
+#### 4. `model/cam/src/tolerance.rs`
+
+トレランス管理:
+```rust
+pub struct CamTolerance {
+    pub closure_tolerance: f64,
+    pub tool_clearance_ratio: f64,
+    pub machine_accuracy: f64,
+}
+```
+
+---
+
+## 次のアクション
+
+### 即座に実施（ユーザー承認待ち）
+
+1. **設計方針の承認**:
+   - [ ] クレート配置: Option B（新規`cam`クレート）の承認
+   - [ ] CAD/CAM境界定義の承認
+   - [ ] トレランス要件の承認
+
+2. **Issue更新・新規作成**:
+   - [ ] Issue #203を更新（Phase 1のみに絞る）
+   - [ ] Issue #211, #212, #213を新規作成
+
+3. **実装開始準備**:
+   - [ ] `model/cam` クレート作成
+   - [ ] `Cargo.toml` にメンバー追加
+   - [ ] Phase 1実装開始
+
+---
+
+## 質問・確認事項
+
+### ユーザーへの確認
+
+1. **クレート配置**: Option A（geo_algorithms）、Option B（新規cam）、Option C（ハイブリッド）のどれを採用しますか？
+   - **推奨**: Option B
+
+2. **CAD/CAM境界**: 提案した責務分離で問題ありませんか？
+   - オフセット演算は `geo_algorithms`（CAD）
+   - 工具経路生成は `cam`（CAM）
+
+3. **2D輪郭検証**: 閉曲線判定は `geo_algorithms`、CAM用検証は `cam` でよいですか？
+
+4. **トレランス**: CAM用トレランスは必要ですか？デフォルト値は適切ですか？
+   - `closure_tolerance = 0.001mm`
+   - `tool_clearance_ratio = 0.1`
+
+5. **Issue分割**: Issue #211-#213を新規作成してよいですか？
+
+---
+
+**承認待ち**: 上記の設計方針について、ユーザーからの承認をお待ちしています。
+
+**次回更新**: 設計承認後、実装開始時

--- a/dev/architecture/CAM_VISUALIZATION_REQUIREMENTS.md
+++ b/dev/architecture/CAM_VISUALIZATION_REQUIREMENTS.md
@@ -2,18 +2,115 @@
 
 **作成日**: 2026年2月8日  
 **最終更新**: 2026年2月8日  
-**ステータス**: ドラフト - 技術調査中  
-**関連Issue**: （作成予定）
+**ステータス**: ドラフト - 対象範囲確認中  
+**関連Issue**: #203
+
+---
+
+## 🎯 対象範囲と段階的実装方針
+
+### 設計確認事項（2026年2月8日）
+
+**質問1**: 2D CAM及び3D CAMの3軸加工が対象か？5軸加工は対象外か？  
+**回答**: 
+- ✅ **Phase 1**: 2D CAM（輪郭加工、ポケット加工）および3D CAM（等高線粗取り・仕上げ）の**3軸加工のみ**を対象
+- ❌ **5軸加工**: Phase 4以降で検討（工具姿勢の可視化が必要となるため、大幅な拡張が必要）
+
+**質問2**: ワーク座標はZ軸固定か？穴あけ時には副座標（subaxis）機能が必要か？  
+**回答**:
+- ✅ **Phase 1**: Z軸固定の3軸加工を前提、ワーク座標系はグローバル座標系と一致
+- 📝 **副座標（subaxis）機能**: Phase 2で実装予定（Week 10-12）
+  - 穴あけ・側面加工時のワーク座標系切り替え
+  - 複数座標系の管理と可視化
+
+**質問3**: ツールセット登録等のデータ管理は別機能か？  
+**回答**:
+- ✅ **Phase 1**: 工具情報（径、長さ、種別）のみ保持、DB連携なし
+- 📝 **ツール管理機能**: 別Issue（#211予定）で実装
+  - ツールセット登録
+  - 工具ライブラリ管理
+  - 工具選択UI
+
+**質問4**: 等高線加工はツールパスを全体と等高線ごとに管理して視覚制御するか？  
+**回答**:
+- ✅ **Phase 1で実装**: `ContourLevelPath` 構造体により等高線ごとに管理
+- ✅ **表示制御**: 等高線レベルごとの個別ON/OFF、フォーカス表示
+- ✅ **アニメーション**: 等高線レベルごとの順次再生
+
+**質問5**: エアカット、パス間の切削開始・終了（直線角度 vs 円弧接続）などの要素定義は？  
+**回答**:
+- ✅ **Phase 1**: `SegmentType` enumによる識別（Cutting, Approach, Retract, AirCut）
+- ✅ **Phase 1**: エアカット区間の表示（グレー、半透明）
+- 📝 **Phase 2**: パス接続方式（`PathConnectionType`）の詳細可視化
+  - 直線角度接続（LinearAngle）
+  - 円弧接続（ArcConnection）
+
+**質問6**: ダウンカット/アップカットの識別は？  
+**回答**:
+- ✅ **Phase 1**: `CuttingDirection` enumによる識別（Down, Up）
+- ✅ **Phase 1**: メタデータに保持、色分け表示オプションあり
+  - ダウンカット: 白色
+  - アップカット: オレンジ色（発泡スチロール等で使用）
+
+**質問7**: F値（送り速度）は切削量により変動するか？  
+**回答**:
+- ✅ **Phase 1**: 送り速度を**セグメントごと**に保持（`PathSegment::feed_rate`）
+- ✅ **Phase 1**: F値の表示オプション（デバッグ用）
+- 📝 **Phase 3**: 切削量による送り速度制御の可視化（Week 15-17）
+  - 色グラデーション表示
+  - F値の動的調整確認
+
+---
+
+### Phase 1スコープ（Issue #203: 今回実装）
+
+**対象範囲**:
+- ✅ **2D CAM**: 輪郭加工、ポケット加工（Z軸固定、3軸加工）
+- ✅ **3D CAM**: 等高線粗取り、等高線仕上げ（3軸加工のみ）
+- ❌ **5軸加工**: 対象外（Phase 4以降で検討）
+- ❌ **ツール管理**: 登録・データ管理は別機能（Issue #211で検討予定）
+- ❌ **副座標（subaxis）機能**: Phase 2以降で検討
+
+**実装する機能**:
+- 工具経路の基本表示（線分、円弧）
+- 切削種別の色分け（切削/早送り/アプローチ/退避）
+- 送り速度（F値）の保持と表示
+- ダウンカット/アップカットの識別
+- エアカット区間の表示（破線表示）
+
+**実装しない機能（将来拡張）**:
+- 工具姿勢の可視化（5軸用）
+- 副座標系の切り替え表示
+- ツールセットDB連携
+- リアルタイム切削シミュレーション
+
+### Phase 2以降の拡張予定
+
+**Phase 2**: 詳細パス制御（Week 10-12）
+- [ ] パス接続方式（直線角度 vs 円弧接続）の可視化
+- [ ] 等高線ごとのツールパス管理・制御
+- [ ] 副座標（subaxis）機能の基礎
+
+**Phase 3**: 切削最適化表示（Week 15-17）
+- [ ] 切削量による送り速度制御の可視化
+- [ ] ダウンカット/アップカット切り替えの詳細表示
+- [ ] 過切削・削り残し検出の警告表示
+
+**Phase 4**: 5軸加工対応（Q2以降）
+- [ ] 工具姿勢（傾斜角）の可視化
+- [ ] 5軸同時加工パスの表示
+- [ ] 干渉チェック結果の表示
 
 ---
 
 ## 📋 目次
 
 1. [要件定義](#要件定義)
-2. [技術調査](#技術調査)
-3. [アーキテクチャ設計](#アーキテクチャ設計)
-4. [実装計画](#実装計画)
-5. [テスト戦略](#テスト戦略)
+2. [データモデル詳細設計](#データモデル詳細設計)
+3. [技術調査](#技術調査)
+4. [アーキテクチャ設計](#アーキテクチャ設計)
+5. [実装計画](#実装計画)
+6. [テスト戦略](#テスト戦略)
 
 ---
 
@@ -305,11 +402,73 @@ impl AnimationController {
 
 ---
 
+## データモデル詳細設計
+
+### Phase 1データモデル（3軸加工対応）
+
+#### ワーク座標系の定義
+
+**Phase 1の方針**:
+- Z軸固定の3軸加工を前提
+- ワーク座標系はグローバル座標系と一致
+- 副座標（subaxis）機能はPhase 2で実装
+
+```rust
+/// ワーク座標系（Phase 1: 簡易版）
+#[derive(Debug, Clone)]
+pub struct WorkCoordinateSystem<T: Scalar> {
+    /// 原点位置
+    pub origin: Point3D<T>,
+    
+    /// Z軸方向（固定）
+    pub z_axis: Vector3D<T>,
+}
+```
+
+#### 工具定義（Phase 1: 最小限）
+
+**Phase 1の方針**:
+- 工具径、工具長のみ保持
+- ツールセットDB連携はPhase 2以降
+- ツール登録・管理機能は別Issue（#211予定）で実装
+
+```rust
+/// 工具情報（Phase 1: 簡易版）
+#[derive(Debug, Clone)]
+pub struct Tool<T: Scalar> {
+    /// 工具番号
+    pub tool_number: u32,
+    
+    /// 工具径
+    pub diameter: T,
+    
+    /// 工具長
+    pub length: T,
+    
+    /// 工具種別
+    pub tool_type: ToolType,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolType {
+    /// エンドミル（フラット）
+    FlatEndMill,
+    
+    /// ボールエンドミル
+    BallEndMill,
+    
+    /// ドリル
+    Drill,
+}
+```
+
+---
+
 ## アーキテクチャ設計
 
 ### 1. データモデル（Model層）
 
-#### 1.1 ToolPath構造体
+#### 1.1 ToolPath構造体（Phase 1拡張版）
 
 ```rust
 // model/geo_algorithms/src/toolpath.rs
@@ -321,31 +480,106 @@ use analysis::Scalar;
 #[derive(Debug, Clone)]
 pub enum PathSegment<T: Scalar> {
     /// 直線補間（G01）
-    Linear(LineSegment3D<T>),
+    Linear {
+        segment: LineSegment3D<T>,
+        segment_type: SegmentType,
+        feed_rate: T, // mm/min（切削量により変動）
+    },
     
     /// 円弧補間（G02/G03）
-    Arc(Arc3D<T>),
+    Arc {
+        arc: Arc3D<T>,
+        direction: ArcDirection,
+        segment_type: SegmentType,
+        feed_rate: T,
+    },
     
     /// 早送り（G00）
-    Rapid(LineSegment3D<T>),
+    Rapid {
+        segment: LineSegment3D<T>,
+    },
+}
+
+/// セグメント種別
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SegmentType {
+    /// 切削送り（通常）
+    Cutting,
+    
+    /// アプローチ（切削開始）
+    Approach,
+    
+    /// 退避（切削終了）
+    Retract,
+    
+    /// エアカット（材料に接触しない移動）
+    AirCut,
+}
+
+/// 円弧方向
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArcDirection {
+    /// 時計回り（G02）
+    Clockwise,
+    
+    /// 反時計回り（G03）
+    CounterClockwise,
+}
+
+/// カッティング方向（Phase 1: 識別のみ）
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CuttingDirection {
+    /// ダウンカット（順送り、基本）
+    Down,
+    
+    /// アップカット（逆送り、発泡スチロール等）
+    Up,
+}
+
+/// パス接続方式（Phase 2実装予定）
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathConnectionType {
+    /// 直線角度で接続
+    LinearAngle { angle_degrees: f64 },
+    
+    /// 円弧で接続
+    ArcConnection { radius: f64 },
 }
 
 impl<T: Scalar> PathSegment<T> {
     /// セグメントの長さを取得
     pub fn length(&self) -> T {
         match self {
-            Self::Linear(seg) => seg.length(),
-            Self::Arc(arc) => arc.arc_length(),
-            Self::Rapid(seg) => seg.length(),
+            Self::Linear { segment, .. } => segment.length(),
+            Self::Arc { arc, .. } => arc.arc_length(),
+            Self::Rapid { segment } => segment.length(),
         }
     }
     
     /// パラメータ t (0.0-1.0) の位置を取得
     pub fn point_at(&self, t: T) -> Point3D<T> {
         match self {
-            Self::Linear(seg) => seg.point_at_parameter(t),
-            Self::Arc(arc) => arc.point_at_parameter(t),
-            Self::Rapid(seg) => seg.point_at_parameter(t),
+            Self::Linear { segment, .. } => segment.point_at_parameter(t),
+            Self::Arc { arc, .. } => arc.point_at_parameter(t),
+            Self::Rapid { segment } => segment.point_at_parameter(t),
+        }
+    }
+    
+    /// セグメント種別を取得
+    pub fn segment_type(&self) -> Option<SegmentType> {
+        match self {
+            Self::Linear { segment_type, .. } => Some(*segment_type),
+            Self::Arc { segment_type, .. } => Some(*segment_type),
+            Self::Rapid { .. } => None,
+        }
+    }
+    
+    /// 送り速度を取得（mm/min）
+    pub fn feed_rate(&self) -> Option<T> {
+        match self {
+            Self::Linear { feed_rate, .. } => Some(*feed_rate),
+            Self::Arc { feed_rate, .. } => Some(*feed_rate),
+            Self::Rapid { .. } => None,
         }
     }
 }
@@ -361,6 +595,22 @@ pub struct PathMetadata {
     
     /// 推定加工時間（秒）
     pub estimated_time: f64,
+    
+    /// カッティング方向
+    pub cutting_direction: CuttingDirection,
+}
+
+/// 等高線パス（等高線加工用、Phase 1で基本対応）
+#[derive(Debug, Clone)]
+pub struct ContourLevelPath<T: Scalar> {
+    /// Z高さ
+    pub z_level: T,
+    
+    /// このレベルのパスセグメント
+    pub segments: Vec<PathSegment<T>>,
+    
+    /// レベル番号（0が最上層）
+    pub level_index: usize,
 }
 
 /// 工具経路全体
@@ -369,29 +619,43 @@ pub struct ToolPath<T: Scalar> {
     /// パスセグメント列
     segments: Vec<PathSegment<T>>,
     
-    /// 工具径
-    tool_diameter: T,
-    
-    /// 送り速度（mm/min）
-    feed_rate: T,
+    /// 工具情報
+    tool: Tool<T>,
     
     /// メタデータ
     metadata: PathMetadata,
+    
+    /// 等高線パス（等高線加工の場合）
+    contour_levels: Option<Vec<ContourLevelPath<T>>>,
 }
 
 impl<T: Scalar> ToolPath<T> {
     /// 新規作成
     pub fn new(
         segments: Vec<PathSegment<T>>,
-        tool_diameter: T,
-        feed_rate: T,
+        tool: Tool<T>,
         metadata: PathMetadata,
     ) -> Self {
         Self {
             segments,
-            tool_diameter,
-            feed_rate,
+            tool,
             metadata,
+            contour_levels: None,
+        }
+    }
+    
+    /// 等高線加工パスとして作成
+    pub fn with_contour_levels(
+        segments: Vec<PathSegment<T>>,
+        tool: Tool<T>,
+        metadata: PathMetadata,
+        contour_levels: Vec<ContourLevelPath<T>>,
+    ) -> Self {
+        Self {
+            segments,
+            tool,
+            metadata,
+            contour_levels: Some(contour_levels),
         }
     }
     
@@ -408,6 +672,16 @@ impl<T: Scalar> ToolPath<T> {
     /// セグメント参照
     pub fn segments(&self) -> &[PathSegment<T>] {
         &self.segments
+    }
+    
+    /// 等高線パス参照
+    pub fn contour_levels(&self) -> Option<&[ContourLevelPath<T>]> {
+        self.contour_levels.as_deref()
+    }
+    
+    /// 工具情報参照
+    pub fn tool(&self) -> &Tool<T> {
+        &self.tool
     }
 }
 ```
@@ -451,12 +725,12 @@ pub struct OffsetResult3D<T: Scalar> {
 
 ### 2. ViewModel層変換（ViewModel層）
 
-#### 2.1 ToolPath変換
+#### 2.1 ToolPath変換（Phase 1拡張版）
 
 ```rust
 // viewmodel/converter/src/toolpath_converter.rs
 
-use model_geo_algorithms::toolpath::{ToolPath, PathSegment};
+use model_geo_algorithms::toolpath::{ToolPath, PathSegment, SegmentType, CuttingDirection};
 use view_render::vertex_3d::Vertex3D;
 
 /// 可視化オプション
@@ -464,6 +738,9 @@ use view_render::vertex_3d::Vertex3D;
 pub struct VisualizationOptions {
     /// 早送りを表示するか
     pub show_rapid_moves: bool,
+    
+    /// エアカットを表示するか
+    pub show_air_cuts: bool,
     
     /// 工具表示モード
     pub tool_display: ToolDisplayMode,
@@ -473,15 +750,24 @@ pub struct VisualizationOptions {
     
     /// テセレーション品質（円弧の分割数）
     pub arc_segments: u32,
+    
+    /// 送り速度の表示
+    pub show_feed_rates: bool,
+    
+    /// カッティング方向の色分け
+    pub color_by_cutting_direction: bool,
 }
 
 impl Default for VisualizationOptions {
     fn default() -> Self {
         Self {
             show_rapid_moves: true,
+            show_air_cuts: true,
             tool_display: ToolDisplayMode::None,
             path_thickness: 2.0,
             arc_segments: 32,
+            show_feed_rates: false,
+            color_by_cutting_direction: false,
         }
     }
 }
@@ -498,6 +784,173 @@ pub enum ToolDisplayMode {
     /// 円筒表示
     Cylinder,
 }
+
+/// セグメント種別ごとの色定義
+pub mod colors {
+    /// 切削送り（白色）
+    pub const CUTTING: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
+    
+    /// 早送り（青色）
+    pub const RAPID: [f32; 4] = [0.2, 0.5, 1.0, 1.0];
+    
+    /// アプローチ（緑色）
+    pub const APPROACH: [f32; 4] = [0.2, 1.0, 0.2, 1.0];
+    
+    /// 退避（黄色）
+    pub const RETRACT: [f32; 4] = [1.0, 1.0, 0.2, 1.0];
+    
+    /// エアカット（グレー、破線表示用）
+    pub const AIR_CUT: [f32; 4] = [0.5, 0.5, 0.5, 0.7];
+    
+    /// ダウンカット（デフォルト白色）
+    pub const DOWN_CUT: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
+    
+    /// アップカット（オレンジ色）
+    pub const UP_CUT: [f32; 4] = [1.0, 0.6, 0.2, 1.0];
+}
+
+/// 工具経路頂点データ
+#[derive(Debug)]
+pub struct ToolPathVertices {
+    /// パス線分の頂点
+    pub path_vertices: Vec<Vertex3D>,
+    
+    /// 工具形状の頂点（オプション）
+    pub tool_vertices: Option<Vec<Vertex3D>>,
+    
+    /// 色情報（各頂点ごと）
+    pub vertex_colors: Vec<[f32; 4]>,
+    
+    /// 送り速度情報（デバッグ用、オプション）
+    pub feed_rates: Option<Vec<f32>>,
+}
+
+/// 工具経路をGPU頂点データに変換
+pub fn toolpath_to_vertices(
+    path: &ToolPath<f64>,
+    options: &VisualizationOptions,
+) -> ToolPathVertices {
+    let mut path_vertices = Vec::new();
+    let mut vertex_colors = Vec::new();
+    let mut feed_rates = Vec::new();
+    
+    for segment in path.segments() {
+        let (vertices, color, feed_rate) = match segment {
+            PathSegment::Linear { segment, segment_type, feed_rate } => {
+                // セグメント種別による色分け
+                let color = match segment_type {
+                    SegmentType::Cutting => colors::CUTTING,
+                    SegmentType::Approach => colors::APPROACH,
+                    SegmentType::Retract => colors::RETRACT,
+                    SegmentType::AirCut => {
+                        if !options.show_air_cuts {
+                            continue;
+                        }
+                        colors::AIR_CUT
+                    },
+                };
+                
+                let v = vec![
+                    vertex_from_point(segment.start_position()),
+                    vertex_from_point(segment.end_position()),
+                ];
+                (v, color, Some(*feed_rate as f32))
+            },
+            
+            PathSegment::Arc { arc, segment_type, feed_rate, .. } => {
+                let color = match segment_type {
+                    SegmentType::Cutting => colors::CUTTING,
+                    SegmentType::Approach => colors::APPROACH,
+                    SegmentType::Retract => colors::RETRACT,
+                    SegmentType::AirCut => {
+                        if !options.show_air_cuts {
+                            continue;
+                        }
+                        colors::AIR_CUT
+                    },
+                };
+                
+                let v = tessellate_arc(arc, options.arc_segments);
+                (v, color, Some(*feed_rate as f32))
+            },
+            
+            PathSegment::Rapid { segment } => {
+                if !options.show_rapid_moves {
+                    continue;
+                }
+                let v = vec![
+                    vertex_from_point(segment.start_position()),
+                    vertex_from_point(segment.end_position()),
+                ];
+                (v, colors::RAPID, None)
+            },
+        };
+        
+        // カッティング方向による色上書き（オプション）
+        let final_color = if options.color_by_cutting_direction {
+            match path.metadata().cutting_direction {
+                CuttingDirection::Down => colors::DOWN_CUT,
+                CuttingDirection::Up => colors::UP_CUT,
+            }
+        } else {
+            color
+        };
+        
+        // 頂点と色を追加
+        for vertex in vertices {
+            path_vertices.push(vertex);
+            vertex_colors.push(final_color);
+            if let Some(fr) = feed_rate {
+                feed_rates.push(fr);
+            }
+        }
+    }
+    
+    // 工具形状の生成（オプション）
+    let tool_vertices = match options.tool_display {
+        ToolDisplayMode::None => None,
+        ToolDisplayMode::Simple => Some(generate_tool_points(path)),
+        ToolDisplayMode::Cylinder => Some(generate_tool_cylinders(path)),
+    };
+    
+    ToolPathVertices {
+        path_vertices,
+        tool_vertices,
+        vertex_colors,
+        feed_rates: if options.show_feed_rates && !feed_rates.is_empty() {
+            Some(feed_rates)
+        } else {
+            None
+        },
+    }
+}
+
+fn vertex_from_point(p: &Point3D<f64>) -> Vertex3D {
+    Vertex3D {
+        position: [p.x() as f32, p.y() as f32, p.z() as f32],
+    }
+}
+
+fn tessellate_arc(arc: &Arc3D<f64>, segments: u32) -> Vec<Vertex3D> {
+    // 円弧を線分に分割
+    (0..=segments)
+        .map(|i| {
+            let t = i as f64 / segments as f64;
+            vertex_from_point(&arc.point_at_parameter(t))
+        })
+        .collect()
+}
+
+fn generate_tool_points(path: &ToolPath<f64>) -> Vec<Vertex3D> {
+    // Phase 3実装予定
+    Vec::new()
+}
+
+fn generate_tool_cylinders(path: &ToolPath<f64>) -> Vec<Vertex3D> {
+    // Phase 3実装予定
+    Vec::new()
+}
+```
 
 /// 工具経路頂点データ
 #[derive(Debug)]
@@ -826,32 +1279,72 @@ impl AnimationController {
 
 ## 実装計画
 
-### Phase 1: 基本的な工具経路表示（2日）
+### Phase 1実装範囲の再確認
 
-**Day 1**:
-- [ ] `ToolPath` データ構造実装
-- [ ] `toolpath_to_vertices()` 変換関数実装
+**実装する機能**:
+- ✅ `PathSegment` enum拡張（SegmentType, FeedRate, ArcDirection）
+- ✅ セグメント種別による色分け（切削/早送り/アプローチ/退避/エアカット）
+- ✅ 送り速度（F値）の保持（セグメントごと）
+- ✅ ダウンカット/アップカット識別（メタデータ）
+- ✅ 等高線パスの基本管理（ContourLevelPath）
+- ✅ 等高線レベルごとの表示切り替え
+
+**実装しない機能（Phase 2以降）**:
+- ❌ パス接続方式（直線角度 vs 円弧接続）の詳細可視化
+- ❌ 切削量による送り速度制御の可視化
+- ❌ 5軸加工対応
+- ❌ 副座標（subaxis）機能
+- ❌ ツール管理DB連携
+
+### Phase 1: 基本的な工具経路表示（2-3日）
+
+**Day 1: データモデル実装**:
+- [ ] `model/geo_algorithms/src/toolpath.rs` 実装
+  - [ ] `PathSegment` enum（SegmentType, FeedRate付き）
+  - [ ] `SegmentType`, `ArcDirection`, `CuttingDirection` enum
+  - [ ] `Tool` 構造体（簡易版）
+  - [ ] `PathMetadata` 構造体
+  - [ ] `ContourLevelPath` 構造体
+  - [ ] `ToolPath` 構造体
 - [ ] 単体テスト作成
+  - [ ] パス長計算
+  - [ ] セグメント種別の識別
+  - [ ] 送り速度の取得
 
-**Day 2**:
-- [ ] `ToolPathResources` 実装
-- [ ] `toolpath.wgsl` シェーダ作成
-- [ ] `ToolPathStage` 実装
+**Day 2: ViewModel変換実装**:
+- [ ] `viewmodel/converter/src/toolpath_converter.rs` 実装
+  - [ ] `VisualizationOptions` 構造体
+  - [ ] `colors` モジュール（色定義）
+  - [ ] `toolpath_to_vertices()` 関数
+  - [ ] セグメント種別ごとの色分けロジック
+- [ ] `viewmodel/converter/src/contour_level_manager.rs` 実装
+  - [ ] `ContourLevelVisibility` 構造体
+  - [ ] `contour_levels_to_vertices()` 関数
+- [ ] 単体テスト
+  - [ ] 頂点変換の正確性
+  - [ ] 色分けの確認
+
+**Day 3: View層レンダリング実装**:
+- [ ] `view/render/src/toolpath.rs` 実装
+  - [ ] `ToolPathResources` 構造体
+  - [ ] パイプライン構築
+  - [ ] 描画メソッド
+- [ ] `view/render/shaders/toolpath.wgsl` 実装
+  - [ ] 頂点シェーダ
+  - [ ] フラグメントシェーダ（頂点カラー対応）
+- [ ] `view/stage/src/toolpath_stage.rs` 実装
+  - [ ] `ToolPathStage` 構造体
+  - [ ] `RenderStage` トレイト実装
 - [ ] 統合テスト
+  - [ ] サンプル経路の描画確認
 
-### Phase 2: オフセット結果表示（1日）
+### Phase 2: 詳細パス制御（将来実装）
 
-**Day 3**:
-- [ ] `OffsetResult2D` / `OffsetResult3D` 実装
-- [ ] オフセット結果の頂点変換
-- [ ] 表示確認
-
-### Phase 3: 工具形状表示（後回し）
-
-**将来実装**:
-- [ ] 円筒工具メッシュ生成
-- [ ] インスタンシング実装
-- [ ] アニメーション制御
+**Week 10-12実施予定**:
+- [ ] パス接続方式の可視化
+- [ ] 等高線ごとの詳細制御（個別ON/OFF、アニメーション）
+- [ ] 副座標（subaxis）機能の基礎
+- [ ] エアカットの破線表示
 
 ---
 
@@ -931,3 +1424,116 @@ fn test_toolpath_conversion() {
    - [ ] パフォーマンステスト
 
 **次回レビュー**: Phase 1完了時（2026年2月12日予定）
+
+---
+
+## 今後のIssue計画
+
+### Issue #211: ツール管理システム（Phase 2, Week 10-12）
+
+**概要**: ツールセット登録・管理機能の実装
+
+**機能**:
+- [ ] ツールライブラリDB（工具径、長さ、種別、メーカー情報）
+- [ ] ツールセット登録UI
+- [ ] 工具選択・割り当て機能
+- [ ] 工具寿命管理（使用時間、摩耗状態）
+
+**依存関係**: Issue #203完了後
+
+---
+
+### Issue #212: 副座標（subaxis）機能（Phase 2, Week 10-12）
+
+**概要**: 穴あけ・側面加工時のワーク座標系切り替え機能
+
+**機能**:
+- [ ] 複数ワーク座標系の定義
+- [ ] 座標系切り替えコマンド（G54-G59）
+- [ ] 座標系ごとの工具経路表示
+- [ ] 座標系原点の可視化
+
+**依存関係**: Issue #203完了後
+
+---
+
+### Issue #213: パス接続詳細表示（Phase 2, Week 10-12）
+
+**概要**: パス間の切削開始・終了方式の詳細可視化
+
+**機能**:
+- [ ] 直線角度接続の可視化
+- [ ] 円弧接続の可視化
+- [ ] 接続パラメータ（角度、半径）の表示
+- [ ] 接続方式の編集・プレビュー
+
+**依存関係**: Issue #203完了後
+
+---
+
+### Issue #214: 切削最適化表示（Phase 3, Week 15-17）
+
+**概要**: 切削量による送り速度制御の可視化
+
+**機能**:
+- [ ] F値の色グラデーション表示
+- [ ] 切削負荷の計算・表示
+- [ ] 送り速度の動的調整確認
+- [ ] 過切削・削り残しの警告表示
+
+**依存関係**: Issue #203, #206（Octree）完了後
+
+---
+
+### Issue #215: 5軸加工対応（Phase 4, Q2以降）
+
+**概要**: 5軸同時加工の工具経路可視化
+
+**機能**:
+- [ ] 工具姿勢（A軸、B軸、C軸）の可視化
+- [ ] 5軸同時加工パスの表示
+- [ ] 干渉チェック結果の表示
+- [ ] 機械座標系との対応表示
+
+**依存関係**: Issue #203, #211, #212完了後
+
+---
+
+## 設計方針のまとめ
+
+### ✅ Phase 1で確実に実装する機能
+
+1. **データモデル**:
+   - `PathSegment` enum（SegmentType, FeedRate, ArcDirection）
+   - `ToolPath`, `ContourLevelPath`, `Tool` 構造体
+   - `CuttingDirection` enum（ダウンカット/アップカット）
+
+2. **可視化**:
+   - セグメント種別による色分け（切削/早送り/アプローチ/退避/エアカット）
+   - 等高線レベルごとの表示制御
+   - 送り速度（F値）の保持と表示
+
+3. **対象範囲**:
+   - 2D CAM（輪郭加工、ポケット加工）
+   - 3D CAM（等高線粗取り、等高線仕上げ）
+   - 3軸加工のみ
+
+### 📝 Phase 2以降で実装する機能
+
+1. **ツール管理**: Issue #211（ツール登録、DB連携）
+2. **副座標**: Issue #212（ワーク座標系切り替え）
+3. **パス接続**: Issue #213（直線角度 vs 円弧接続の詳細可視化）
+4. **切削最適化**: Issue #214（F値の動的調整、切削負荷表示）
+5. **5軸加工**: Issue #215（工具姿勢、干渉チェック）
+
+### 🎯 実装優先順位
+
+**Week 3（今週）**: Issue #203 Phase 1実装  
+**Week 10-12**: Issue #211, #212, #213（Phase 2機能）  
+**Week 15-17**: Issue #214（Phase 3機能）  
+**Q2以降**: Issue #215（Phase 4機能）
+
+---
+
+**最終更新**: 2026年2月8日  
+**次回更新予定**: Phase 1実装開始時

--- a/model/cam_core/Cargo.toml
+++ b/model/cam_core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "cam_core"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+analysis = { path = "../../foundation/analysis" }
+geo_foundation = { path = "../geo_foundation" }
+geo_primitives = { path = "../geo_primitives" }
+geo_algorithms = { path = "../geo_algorithms" }
+
+[dev-dependencies]

--- a/model/cam_core/src/lib.rs
+++ b/model/cam_core/src/lib.rs
@@ -1,0 +1,46 @@
+//! CAM機能の基盤クレート
+//!
+//! このクレートは、CAM（Computer-Aided Manufacturing）機能の中核となる
+//! データ構造とアルゴリズムを提供します。
+//!
+//! # 主要モジュール
+//!
+//! - [`tolerance`][]: CAM用トレランス管理
+//! - [`tool`][]: 工具定義（工具径、長さ、種別）
+//! - [`toolpath`][]: 工具経路データ構造（セグメント、経路全体）
+//! - [`validation`][]: CAM用検証機能（2D輪郭閉判定、トレランスチェック）
+//!
+//! # 設計方針
+//!
+//! - **CAD/CAM境界の明確化**: 形状演算は `geo_algorithms`、工具経路生成は `cam_core`
+//! - **3軸加工を前提**: Phase 1では3軸加工（2D CAM/3D CAM）のみサポート
+//! - **トレランス管理**: 加工精度要件に基づくトレランス設定
+//! - **将来拡張**: `cam_algorithms`, `cam_sim` 等が依存する基盤として設計
+//!
+//! # 依存関係
+//!
+//! ```text
+//! cam_core
+//!   ↓
+//! geo_algorithms (オフセット、閉曲線判定)
+//!   ↓
+//! geo_primitives (幾何プリミティブ)
+//!   ↓
+//! geo_foundation (Foundation Pattern)
+//!   ↓
+//! analysis (数値計算基盤)
+//! ```
+
+pub mod tolerance;
+pub mod tool;
+pub mod toolpath;
+pub mod validation;
+
+// 主要型の再エクスポート
+pub use tolerance::CamTolerance;
+pub use tool::{Tool, ToolType};
+pub use toolpath::{
+    ArcDirection, ContourLevelPath, CuttingDirection, PathGeometry, PathSegment, SegmentType,
+    ToolPath,
+};
+pub use validation::{ValidationError, validate_2d_contour};

--- a/model/cam_core/src/tolerance.rs
+++ b/model/cam_core/src/tolerance.rs
@@ -1,0 +1,210 @@
+//! CAM用トレランス管理
+//!
+//! このモジュールは、CAM演算における数値誤差許容値（トレランス）を管理します。
+//!
+//! # 概要
+//!
+//! CAMでは実際の機械加工を想定するため、以下のトレランスが必要です：
+//!
+//! - **閉曲線判定トレランス**: 始点と終点の距離がこの値以内なら閉じていると判定
+//! - **工具クリアランス比率**: 工具径に対する最小クリアランス（干渉回避）
+//! - **機械精度**: NC機械の位置決め精度
+//!
+//! # 例
+//!
+//! ```
+//! use cam_core::CamTolerance;
+//!
+//! // デフォルト値（推奨）
+//! let tolerance = CamTolerance::<f64>::default();
+//! assert_eq!(tolerance.closure_tolerance, 0.001);
+//!
+//! // カスタム設定
+//! let custom = CamTolerance {
+//!     closure_tolerance: 0.0001,  // 高精度機械
+//!     tool_clearance_ratio: 0.05,  // タイトなクリアランス
+//!     machine_accuracy: 0.001,
+//! };
+//! ```
+
+use analysis::Scalar;
+
+/// CAM用トレランス設定
+///
+/// CAM演算における数値誤差許容値を管理します。
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CamTolerance<T: Scalar = f64> {
+    /// 閉曲線判定トレランス（mm）
+    ///
+    /// 2D輪郭の始点と終点の距離がこの値以内であれば、
+    /// 閉じた曲線として扱います。
+    ///
+    /// **推奨値**: `0.001` mm（一般的なNC機械）
+    pub closure_tolerance: T,
+
+    /// 工具径に対する最小クリアランス比率
+    ///
+    /// 工具径 × この比率 = 最小クリアランス
+    ///
+    /// **例**: 工具径10mm、比率0.1 → 最小クリアランス1mm
+    ///
+    /// **推奨値**: `0.1`（工具径の10%）
+    pub tool_clearance_ratio: T,
+
+    /// 機械精度（mm）
+    ///
+    /// NC機械の位置決め精度。この値以下の差異は無視されます。
+    ///
+    /// **推奨値**:
+    /// - 一般的なNCフライス: `0.01` mm
+    /// - 高精度機: `0.001` mm
+    pub machine_accuracy: T,
+}
+
+impl<T: Scalar> Default for CamTolerance<T> {
+    /// デフォルトのトレランス値
+    ///
+    /// - `closure_tolerance`: 0.001 mm
+    /// - `tool_clearance_ratio`: 0.1（10%）
+    /// - `machine_accuracy`: 0.01 mm（一般的なNCフライス）
+    fn default() -> Self {
+        Self {
+            closure_tolerance: T::from_f64(0.001),
+            tool_clearance_ratio: T::from_f64(0.1),
+            machine_accuracy: T::from_f64(0.01),
+        }
+    }
+}
+
+impl<T: Scalar> CamTolerance<T> {
+    /// 新しいトレランス設定を作成
+    ///
+    /// # 引数
+    ///
+    /// - `closure_tolerance`: 閉曲線判定トレランス（mm）
+    /// - `tool_clearance_ratio`: 工具クリアランス比率
+    /// - `machine_accuracy`: 機械精度（mm）
+    ///
+    /// # 例
+    ///
+    /// ```
+    /// use cam_core::CamTolerance;
+    ///
+    /// let tolerance = CamTolerance::new(0.001, 0.1, 0.01);
+    /// ```
+    pub fn new(closure_tolerance: T, tool_clearance_ratio: T, machine_accuracy: T) -> Self {
+        Self {
+            closure_tolerance,
+            tool_clearance_ratio,
+            machine_accuracy,
+        }
+    }
+
+    /// 高精度機械用のトレランス設定
+    ///
+    /// - `closure_tolerance`: 0.0001 mm
+    /// - `tool_clearance_ratio`: 0.05（5%）
+    /// - `machine_accuracy`: 0.001 mm
+    pub fn high_precision() -> Self {
+        Self {
+            closure_tolerance: T::from_f64(0.0001),
+            tool_clearance_ratio: T::from_f64(0.05),
+            machine_accuracy: T::from_f64(0.001),
+        }
+    }
+
+    /// 低精度機械用のトレランス設定
+    ///
+    /// - `closure_tolerance`: 0.01 mm
+    /// - `tool_clearance_ratio`: 0.2（20%）
+    /// - `machine_accuracy`: 0.1 mm
+    pub fn low_precision() -> Self {
+        Self {
+            closure_tolerance: T::from_f64(0.01),
+            tool_clearance_ratio: T::from_f64(0.2),
+            machine_accuracy: T::from_f64(0.1),
+        }
+    }
+
+    /// 工具径から最小クリアランスを計算
+    ///
+    /// # 引数
+    ///
+    /// - `tool_diameter`: 工具径（mm）
+    ///
+    /// # 戻り値
+    ///
+    /// 最小クリアランス（mm） = `tool_diameter * tool_clearance_ratio`
+    ///
+    /// # 例
+    ///
+    /// ```
+    /// use cam_core::CamTolerance;
+    ///
+    /// let tolerance = CamTolerance::default();
+    /// let clearance = tolerance.min_clearance(10.0);
+    /// assert_eq!(clearance, 1.0);  // 10mm × 0.1 = 1mm
+    /// ```
+    pub fn min_clearance(&self, tool_diameter: T) -> T {
+        tool_diameter * self.tool_clearance_ratio
+    }
+
+    /// 2つの値が機械精度内で等しいか判定
+    ///
+    /// # 引数
+    ///
+    /// - `a`, `b`: 比較する値
+    ///
+    /// # 戻り値
+    ///
+    /// `|a - b| <= machine_accuracy` なら `true`
+    ///
+    /// # 例
+    ///
+    /// ```
+    /// use cam_core::CamTolerance;
+    ///
+    /// let tolerance = CamTolerance::default();
+    /// assert!(tolerance.is_equal_within_accuracy(10.0, 10.005));
+    /// assert!(!tolerance.is_equal_within_accuracy(10.0, 10.05));
+    /// ```
+    pub fn is_equal_within_accuracy(&self, a: T, b: T) -> bool {
+        (a - b).abs() <= self.machine_accuracy
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_tolerance() {
+        let tolerance = CamTolerance::<f64>::default();
+        assert_eq!(tolerance.closure_tolerance, 0.001);
+        assert_eq!(tolerance.tool_clearance_ratio, 0.1);
+        assert_eq!(tolerance.machine_accuracy, 0.01);
+    }
+
+    #[test]
+    fn test_high_precision() {
+        let tolerance = CamTolerance::<f64>::high_precision();
+        assert_eq!(tolerance.closure_tolerance, 0.0001);
+        assert_eq!(tolerance.tool_clearance_ratio, 0.05);
+        assert_eq!(tolerance.machine_accuracy, 0.001);
+    }
+
+    #[test]
+    fn test_min_clearance() {
+        let tolerance = CamTolerance::<f64>::default();
+        assert_eq!(tolerance.min_clearance(10.0), 1.0);
+        assert_eq!(tolerance.min_clearance(5.0), 0.5);
+    }
+
+    #[test]
+    fn test_is_equal_within_accuracy() {
+        let tolerance = CamTolerance::<f64>::default();
+        assert!(tolerance.is_equal_within_accuracy(10.0, 10.0));
+        assert!(tolerance.is_equal_within_accuracy(10.0, 10.005));
+        assert!(!tolerance.is_equal_within_accuracy(10.0, 10.05));
+    }
+}

--- a/model/cam_core/src/tool.rs
+++ b/model/cam_core/src/tool.rs
@@ -1,0 +1,170 @@
+//! CAM工具定義
+//!
+//! このモジュールは、NC加工で使用する工具の定義を提供します。
+//!
+//! # 概要
+//!
+//! Phase 1では基本的な工具パラメータのみをサポートします：
+//!
+//! - **フラットエンドミル**: 底面が平らな標準的なエンドミル
+//! - **ボールエンドミル**: 底面が球状のエンドミル（3D加工用）
+//!
+//! # 例
+//!
+//! ```
+//! use cam_core::{Tool, ToolType};
+//!
+//! // フラットエンドミル（直径10mm）
+//! let flat_mill = Tool::new(
+//!     "EM10".to_string(),
+//!     ToolType::FlatEndMill,
+//!     10.0,
+//!     50.0,  // 刃長
+//! );
+//!
+//! // ボールエンドミル（直径6mm）
+//! let ball_mill = Tool::new(
+//!     "BEM6".to_string(),
+//!     ToolType::BallEndMill,
+//!     6.0,
+//!     30.0,
+//! );
+//! ```
+
+use analysis::Scalar;
+
+/// 工具種別
+///
+/// Phase 1では基本的な2種類のみ対応します。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolType {
+    /// フラットエンドミル
+    ///
+    /// 底面が平らな標準的なエンドミル。2D輪郭加工や面削り用。
+    FlatEndMill,
+
+    /// ボールエンドミル
+    ///
+    /// 底面が球状のエンドミル。3D曲面加工用。
+    BallEndMill,
+}
+
+/// CAM工具定義
+///
+/// NC加工で使用する工具の基本パラメータを定義します。
+///
+/// # 注意
+///
+/// Phase 1では基本的な工具パラメータのみをサポートします。
+/// オフセット補正、工具寿命管理、切削条件などは後のPhaseで実装予定です。
+#[derive(Debug, Clone, PartialEq)]
+pub struct Tool<T: Scalar = f64> {
+    /// 工具識別子（例: "EM10", "BEM6"）
+    pub id: String,
+
+    /// 工具種別
+    pub tool_type: ToolType,
+
+    /// 工具径（mm）
+    ///
+    /// フラットエンドミルの場合は底面の直径、
+    /// ボールエンドミルの場合は球の直径。
+    pub diameter: T,
+
+    /// 刃長（mm）
+    ///
+    /// 工具の有効切削長さ。
+    pub cutting_length: T,
+}
+
+impl<T: Scalar> Tool<T> {
+    /// 新しい工具を作成
+    ///
+    /// # 引数
+    ///
+    /// - `id`: 工具識別子
+    /// - `tool_type`: 工具種別
+    /// - `diameter`: 工具径（mm）
+    /// - `cutting_length`: 刃長（mm）
+    ///
+    /// # 例
+    ///
+    /// ```
+    /// use cam_core::{Tool, ToolType};
+    ///
+    /// let tool = Tool::new(
+    ///     "EM10".to_string(),
+    ///     ToolType::FlatEndMill,
+    ///     10.0,
+    ///     50.0,
+    /// );
+    /// ```
+    pub fn new(id: String, tool_type: ToolType, diameter: T, cutting_length: T) -> Self {
+        Self {
+            id,
+            tool_type,
+            diameter,
+            cutting_length,
+        }
+    }
+
+    /// 工具半径を取得
+    ///
+    /// # 戻り値
+    ///
+    /// `diameter / 2`
+    ///
+    /// # 例
+    ///
+    /// ```
+    /// use cam_core::{Tool, ToolType};
+    ///
+    /// let tool = Tool::new("EM10".to_string(), ToolType::FlatEndMill, 10.0, 50.0);
+    /// assert_eq!(tool.radius(), 5.0);
+    /// ```
+    pub fn radius(&self) -> T {
+        self.diameter / T::from_f64(2.0)
+    }
+
+    /// フラットエンドミルかどうか判定
+    pub fn is_flat_end_mill(&self) -> bool {
+        self.tool_type == ToolType::FlatEndMill
+    }
+
+    /// ボールエンドミルかどうか判定
+    pub fn is_ball_end_mill(&self) -> bool {
+        self.tool_type == ToolType::BallEndMill
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tool_creation() {
+        let tool = Tool::new("EM10".to_string(), ToolType::FlatEndMill, 10.0, 50.0);
+
+        assert_eq!(tool.id, "EM10");
+        assert_eq!(tool.tool_type, ToolType::FlatEndMill);
+        assert_eq!(tool.diameter, 10.0);
+        assert_eq!(tool.cutting_length, 50.0);
+    }
+
+    #[test]
+    fn test_radius() {
+        let tool = Tool::new("EM10".to_string(), ToolType::FlatEndMill, 10.0, 50.0);
+        assert_eq!(tool.radius(), 5.0);
+    }
+
+    #[test]
+    fn test_tool_type_checks() {
+        let flat = Tool::new("EM10".to_string(), ToolType::FlatEndMill, 10.0, 50.0);
+        assert!(flat.is_flat_end_mill());
+        assert!(!flat.is_ball_end_mill());
+
+        let ball = Tool::new("BEM6".to_string(), ToolType::BallEndMill, 6.0, 30.0);
+        assert!(!ball.is_flat_end_mill());
+        assert!(ball.is_ball_end_mill());
+    }
+}

--- a/model/cam_core/src/toolpath.rs
+++ b/model/cam_core/src/toolpath.rs
@@ -21,7 +21,6 @@
 //!     Point3D::new(0.0, 0.0, 0.0),
 //!     Point3D::new(10.0, 0.0, 0.0),
 //!     SegmentType::Cutting {
-//!         direction: CuttingDirection::Down,
 //!         feed_rate: 500.0,
 //!     },
 //! );
@@ -36,7 +35,10 @@
 //! // 工具経路作成
 //! let toolpath = ToolPath::new(
 //!     "tool1".to_string(),
+//!     CuttingDirection::Down,
+//!     vec![],  // approach_segments
 //!     vec![contour],
+//!     vec![],  // retract_segments
 //! );
 //! ```
 
@@ -108,24 +110,24 @@ impl<T: Scalar> PathGeometry<T> {
 /// 工具経路の各セグメントがどのような動作を表すか定義します。
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SegmentType<T: Scalar = f64> {
-    /// 切削セグメント
+    /// 切削セグメント（G01/G02/G03）
     ///
     /// 実際に材料を切削する経路。
+    /// 切削方向（ダウンカット/アップカット）は `ToolPath.cutting_direction` で指定。
     Cutting {
-        /// 切削方向（ダウンカット/アップカット）
-        direction: CuttingDirection,
         /// 送り速度（mm/min）
         feed_rate: T,
     },
 
-    /// 早送りセグメント
+    /// 早送りセグメント（G00）
     ///
-    /// 材料に接触せずに高速移動する経路（エアカット）。
+    /// エアカット、周回間の水平移動など。
     Rapid,
 
     /// アプローチセグメント
     ///
-    /// 切削開始前に工具を材料に近づける経路。
+    /// 切削開始前の進入動作。
+    /// ToolPath開始時（`approach_segments`）または周回間で使用。
     Approach {
         /// 送り速度（mm/min）
         feed_rate: T,
@@ -133,8 +135,21 @@ pub enum SegmentType<T: Scalar = f64> {
 
     /// リトラクトセグメント
     ///
-    /// 切削終了後に工具を退避させる経路。
-    Retract,
+    /// 退避動作。低速で材料から離脱、または接触したまま移動。
+    /// ToolPath終了時（`retract_segments`）または周回間で使用。
+    Retract {
+        /// 送り速度（mm/min）
+        feed_rate: T,
+    },
+
+    /// 周回間リトラクト
+    ///
+    /// 周回間の退避動作。次に直接 Cutting へ遷移。
+    /// 平面切削など、直線1つの退避で済む場合に使用。
+    PassRetract {
+        /// 送り速度（mm/min）
+        feed_rate: T,
+    },
 }
 
 /// 切削方向
@@ -187,7 +202,6 @@ impl<T: Scalar> PathSegment<T> {
     ///     Point3D::new(0.0, 0.0, 0.0),
     ///     Point3D::new(10.0, 0.0, 0.0),
     ///     SegmentType::Cutting {
-    ///         direction: CuttingDirection::Down,
     ///         feed_rate: 500.0,
     ///     },
     /// );
@@ -378,27 +392,38 @@ impl<T: Scalar + std::iter::Sum> ContourLevelPath<T> {
 
 /// CAM工具経路全体
 ///
-/// 複数の等高線経路を含む工具経路全体を表します。
+/// 1つの島または輪郭の完全な加工シーケンス。
+/// Approach → Cutting → Retract の3フェーズ構造。
 ///
 /// # 例
 ///
 /// ```
-/// use cam_core::{ToolPath, ContourLevelPath};
+/// use cam_core::{ToolPath, ContourLevelPath, CuttingDirection};
 ///
-/// let contours = vec![
-///     ContourLevelPath::new(0, -5.0, vec![]),
-///     ContourLevelPath::new(1, -10.0, vec![]),
-/// ];
-///
-/// let toolpath = ToolPath::new("tool1".to_string(), contours);
+/// let toolpath = ToolPath::new(
+///     "tool1".to_string(),
+///     CuttingDirection::Down,
+///     vec![],  // approach_segments
+///     vec![ContourLevelPath::new(0, -5.0, vec![])],
+///     vec![],  // retract_segments
+/// );
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct ToolPath<T: Scalar = f64> {
     /// 使用工具のID
     pub tool_id: String,
 
-    /// 等高線経路のリスト（Z座標降順に並べることを推奨）
+    /// この経路の切削方向（経路全体で統一）
+    pub cutting_direction: CuttingDirection,
+
+    /// アプローチフェーズ（ToolPath開始部、編集可能）
+    pub approach_segments: Vec<PathSegment<T>>,
+
+    /// 切削フェーズ（等高線ごと）
     pub contour_levels: Vec<ContourLevelPath<T>>,
+
+    /// リトラクトフェーズ（ToolPath終了部、編集可能）
+    pub retract_segments: Vec<PathSegment<T>>,
 }
 
 impl<T: Scalar + std::iter::Sum> ToolPath<T> {
@@ -407,11 +432,23 @@ impl<T: Scalar + std::iter::Sum> ToolPath<T> {
     /// # 引数
     ///
     /// - `tool_id`: 使用工具のID
+    /// - `cutting_direction`: 切削方向
+    /// - `approach_segments`: アプローチセグメント
     /// - `contour_levels`: 等高線経路のリスト
-    pub fn new(tool_id: String, contour_levels: Vec<ContourLevelPath<T>>) -> Self {
+    /// - `retract_segments`: リトラクトセグメント
+    pub fn new(
+        tool_id: String,
+        cutting_direction: CuttingDirection,
+        approach_segments: Vec<PathSegment<T>>,
+        contour_levels: Vec<ContourLevelPath<T>>,
+        retract_segments: Vec<PathSegment<T>>,
+    ) -> Self {
         Self {
             tool_id,
+            cutting_direction,
+            approach_segments,
             contour_levels,
+            retract_segments,
         }
     }
 
@@ -446,7 +483,6 @@ mod tests {
             Point3D::new(0.0, 0.0, 0.0),
             Point3D::new(10.0, 0.0, 0.0),
             SegmentType::Cutting {
-                direction: CuttingDirection::Down,
                 feed_rate: 500.0,
             },
         );
@@ -485,7 +521,6 @@ mod tests {
             Point3D::new(0.0, 0.0, 0.0),
             ArcDirection::Clockwise,
             SegmentType::Cutting {
-                direction: CuttingDirection::Down,
                 feed_rate: 500.0,
             },
         );
@@ -496,13 +531,29 @@ mod tests {
     }
 
     #[test]
+    fn test_retract_and_pass_retract() {
+        let retract = PathSegment::new_line(
+            Point3D::new(0.0, 0.0, 0.0),
+            Point3D::new(0.0, 0.0, 5.0),
+            SegmentType::Retract { feed_rate: 300.0 },
+        );
+        assert_eq!(retract.length(), 5.0);
+
+        let pass_retract = PathSegment::new_line(
+            Point3D::new(0.0, 0.0, 0.0),
+            Point3D::new(0.0, 0.0, 1.0),
+            SegmentType::PassRetract { feed_rate: 200.0 },
+        );
+        assert_eq!(pass_retract.length(), 1.0);
+    }
+
+    #[test]
     fn test_contour_level_path() {
         let segments = vec![
             PathSegment::new_line(
                 Point3D::new(0.0, 0.0, -5.0),
                 Point3D::new(10.0, 0.0, -5.0),
                 SegmentType::Cutting {
-                    direction: CuttingDirection::Down,
                     feed_rate: 500.0,
                 },
             ),
@@ -530,9 +581,16 @@ mod tests {
             ContourLevelPath::new(1, -10.0, vec![]),
         ];
 
-        let toolpath = ToolPath::new("tool1".to_string(), contours);
+        let toolpath = ToolPath::new(
+            "tool1".to_string(),
+            CuttingDirection::Down,
+            vec![],
+            contours,
+            vec![],
+        );
 
         assert_eq!(toolpath.tool_id, "tool1");
+        assert_eq!(toolpath.cutting_direction, CuttingDirection::Down);
         assert_eq!(toolpath.level_count(), 2);
     }
 }

--- a/model/cam_core/src/toolpath.rs
+++ b/model/cam_core/src/toolpath.rs
@@ -1,0 +1,538 @@
+//! CAM工具経路データ構造
+//!
+//! このモジュールは、NC工具経路を表現するデータ構造を提供します。
+//!
+//! # 概要
+//!
+//! CAMで生成される工具経路は以下の階層構造を持ちます：
+//!
+//! - **ToolPath**: 工具経路全体（複数の等高線を含む）
+//! - **ContourLevelPath**: 単一等高線の経路（複数のセグメントを含む）
+//! - **PathSegment**: 単一セグメント（切削、早送り、アプローチ等）
+//!
+//! # 例
+//!
+//! ```
+//! use cam_core::{ToolPath, ContourLevelPath, PathSegment, SegmentType, CuttingDirection};
+//! use geo_primitives::Point3D;
+//!
+//! // セグメント作成
+//! let segment = PathSegment::new_line(
+//!     Point3D::new(0.0, 0.0, 0.0),
+//!     Point3D::new(10.0, 0.0, 0.0),
+//!     SegmentType::Cutting {
+//!         direction: CuttingDirection::Down,
+//!         feed_rate: 500.0,
+//!     },
+//! );
+//!
+//! // 等高線経路作成
+//! let contour = ContourLevelPath::new(
+//!     0,
+//!     -5.0,
+//!     vec![segment],
+//! );
+//!
+//! // 工具経路作成
+//! let toolpath = ToolPath::new(
+//!     "tool1".to_string(),
+//!     vec![contour],
+//! );
+//! ```
+
+use analysis::Scalar;
+use geo_primitives::Point3D;
+
+/// 円弧方向
+///
+/// Gコードの円弧補間（G02/G03）に対応します。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArcDirection {
+    /// 時計回り（G02: Clockwise）
+    ///
+    /// XY平面上で、+Z方向から見て時計回りの円弧。
+    Clockwise,
+
+    /// 反時計回り（G03: Counter-Clockwise）
+    ///
+    /// XY平面上で、+Z方向から見て反時計回りの円弧。
+    CounterClockwise,
+}
+
+/// 経路の幾何形状
+///
+/// 工具経路セグメントの幾何的な形状を定義します。
+/// 将来的にはNURBS補間も対応予定です。
+#[derive(Debug, Clone, PartialEq)]
+pub enum PathGeometry<T: Scalar> {
+    /// 直線補間（G01）
+    ///
+    /// 始点から終点への直線移動。
+    Line {
+        /// 終点座標
+        end: Point3D<T>,
+    },
+
+    /// 円弧補間（G02/G03）
+    ///
+    /// 始点から終点への円弧移動。
+    Arc {
+        /// 終点座標
+        end: Point3D<T>,
+        /// 円弧中心点座標
+        center: Point3D<T>,
+        /// 円弧方向（時計回り/反時計回り）
+        direction: ArcDirection,
+    },
+    // 将来の拡張:
+    // /// NURBS補間
+    // Nurbs {
+    //     control_points: Vec<Point3D<T>>,
+    //     knots: Vec<T>,
+    //     degree: usize,
+    // },
+}
+
+impl<T: Scalar> PathGeometry<T> {
+    /// 終点座標を取得
+    pub fn end_point(&self) -> Point3D<T> {
+        match self {
+            PathGeometry::Line { end } => *end,
+            PathGeometry::Arc { end, .. } => *end,
+        }
+    }
+}
+
+/// セグメント種別
+///
+/// 工具経路の各セグメントがどのような動作を表すか定義します。
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SegmentType<T: Scalar = f64> {
+    /// 切削セグメント
+    ///
+    /// 実際に材料を切削する経路。
+    Cutting {
+        /// 切削方向（ダウンカット/アップカット）
+        direction: CuttingDirection,
+        /// 送り速度（mm/min）
+        feed_rate: T,
+    },
+
+    /// 早送りセグメント
+    ///
+    /// 材料に接触せずに高速移動する経路（エアカット）。
+    Rapid,
+
+    /// アプローチセグメント
+    ///
+    /// 切削開始前に工具を材料に近づける経路。
+    Approach {
+        /// 送り速度（mm/min）
+        feed_rate: T,
+    },
+
+    /// リトラクトセグメント
+    ///
+    /// 切削終了後に工具を退避させる経路。
+    Retract,
+}
+
+/// 切削方向
+///
+/// ダウンカット（同方向）とアップカット（逆方向）を識別します。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CuttingDirection {
+    /// ダウンカット（同方向切削）
+    ///
+    /// 工具回転方向と送り方向が同じ。仕上がり良好。
+    Down,
+
+    /// アップカット（逆方向切削）
+    ///
+    /// 工具回転方向と送り方向が逆。荒加工向き。
+    Up,
+}
+
+/// 工具経路セグメント
+///
+/// 工具経路の最小単位。始点、幾何形状、およびセグメント種別を持ちます。
+#[derive(Debug, Clone, PartialEq)]
+pub struct PathSegment<T: Scalar = f64> {
+    /// セグメント始点（絶対座標）
+    pub start: Point3D<T>,
+
+    /// 幾何形状（直線または円弧）
+    pub geometry: PathGeometry<T>,
+
+    /// セグメント種別
+    pub segment_type: SegmentType<T>,
+}
+
+impl<T: Scalar> PathSegment<T> {
+    /// 新しい直線セグメントを作成
+    ///
+    /// # 引数
+    ///
+    /// - `start`: セグメント始点
+    /// - `end`: セグメント終点
+    /// - `segment_type`: セグメント種別
+    ///
+    /// # 例
+    ///
+    /// ```
+    /// use cam_core::{PathSegment, SegmentType, CuttingDirection};
+    /// use geo_primitives::Point3D;
+    ///
+    /// let segment = PathSegment::new_line(
+    ///     Point3D::new(0.0, 0.0, 0.0),
+    ///     Point3D::new(10.0, 0.0, 0.0),
+    ///     SegmentType::Cutting {
+    ///         direction: CuttingDirection::Down,
+    ///         feed_rate: 500.0,
+    ///     },
+    /// );
+    /// ```
+    pub fn new_line(start: Point3D<T>, end: Point3D<T>, segment_type: SegmentType<T>) -> Self {
+        Self {
+            start,
+            geometry: PathGeometry::Line { end },
+            segment_type,
+        }
+    }
+
+    /// 新しい円弧セグメントを作成
+    ///
+    /// # 引数
+    ///
+    /// - `start`: セグメント始点
+    /// - `end`: セグメント終点
+    /// - `center`: 円弧中心点
+    /// - `direction`: 円弧方向（時計回り/反時計回り）
+    /// - `segment_type`: セグメント種別
+    ///
+    /// # 例
+    ///
+    /// ```
+    /// use cam_core::{PathSegment, SegmentType, ArcDirection};
+    /// use geo_primitives::Point3D;
+    ///
+    /// let segment = PathSegment::new_arc(
+    ///     Point3D::new(0.0, 0.0, 0.0),
+    ///     Point3D::new(10.0, 10.0, 0.0),
+    ///     Point3D::new(5.0, 5.0, 0.0),
+    ///     ArcDirection::CounterClockwise,
+    ///     SegmentType::Rapid,
+    /// );
+    /// ```
+    pub fn new_arc(
+        start: Point3D<T>,
+        end: Point3D<T>,
+        center: Point3D<T>,
+        direction: ArcDirection,
+        segment_type: SegmentType<T>,
+    ) -> Self {
+        Self {
+            start,
+            geometry: PathGeometry::Arc {
+                end,
+                center,
+                direction,
+            },
+            segment_type,
+        }
+    }
+
+    /// 終点座標を取得
+    pub fn end_point(&self) -> Point3D<T> {
+        self.geometry.end_point()
+    }
+
+    /// 切削セグメントかどうか判定
+    pub fn is_cutting(&self) -> bool {
+        matches!(self.segment_type, SegmentType::Cutting { .. })
+    }
+
+    /// 早送りセグメントかどうか判定
+    pub fn is_rapid(&self) -> bool {
+        matches!(self.segment_type, SegmentType::Rapid)
+    }
+
+    /// セグメント長さを計算
+    ///
+    /// # 戻り値
+    ///
+    /// 直線の場合は始点から終点までの直線距離、
+    /// 円弧の場合は円弧長。
+    pub fn length(&self) -> T {
+        match &self.geometry {
+            PathGeometry::Line { end } => {
+                let dx = end.x() - self.start.x();
+                let dy = end.y() - self.start.y();
+                let dz = end.z() - self.start.z();
+                (dx * dx + dy * dy + dz * dz).sqrt()
+            }
+            PathGeometry::Arc { end, center, .. } => {
+                // 円弧長 = 半径 × 中心角
+                let radius = {
+                    let dx = self.start.x() - center.x();
+                    let dy = self.start.y() - center.y();
+                    let dz = self.start.z() - center.z();
+                    (dx * dx + dy * dy + dz * dz).sqrt()
+                };
+
+                // 始点→中心、終点→中心のベクトル
+                let v1_x = self.start.x() - center.x();
+                let v1_y = self.start.y() - center.y();
+                let v1_z = self.start.z() - center.z();
+
+                let v2_x = end.x() - center.x();
+                let v2_y = end.y() - center.y();
+                let v2_z = end.z() - center.z();
+
+                // 内積: cos(θ) = (v1 · v2) / (|v1| × |v2|)
+                let dot = v1_x * v2_x + v1_y * v2_y + v1_z * v2_z;
+                let cos_angle = dot / (radius * radius);
+
+                // 中心角（ラジアン）
+                let angle = cos_angle.acos();
+
+                // 円弧長
+                radius * angle
+            }
+        }
+    }
+}
+
+/// 等高線レベル経路
+///
+/// 単一の等高線（Z座標が一定）における工具経路を表します。
+///
+/// # 例
+///
+/// ```
+/// use cam_core::{ContourLevelPath, PathSegment, SegmentType};
+/// use geo_primitives::Point3D;
+///
+/// let segments = vec![
+///     PathSegment::new_line(
+///         Point3D::new(0.0, 0.0, -5.0),
+///         Point3D::new(10.0, 0.0, -5.0),
+///         SegmentType::Rapid,
+///     ),
+/// ];
+///
+/// let contour = ContourLevelPath::new(0, -5.0, segments);
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContourLevelPath<T: Scalar = f64> {
+    /// 等高線レベルインデックス（0から開始）
+    pub level_index: usize,
+
+    /// Z座標（高さ）
+    pub z_level: T,
+
+    /// このレベルのセグメント列
+    pub segments: Vec<PathSegment<T>>,
+}
+
+impl<T: Scalar + std::iter::Sum> ContourLevelPath<T> {
+    /// 新しい等高線経路を作成
+    ///
+    /// # 引数
+    ///
+    /// - `level_index`: 等高線レベルインデックス
+    /// - `z_level`: Z座標
+    /// - `segments`: セグメント列
+    pub fn new(level_index: usize, z_level: T, segments: Vec<PathSegment<T>>) -> Self {
+        Self {
+            level_index,
+            z_level,
+            segments,
+        }
+    }
+
+    /// 切削セグメントのみを抽出
+    pub fn cutting_segments(&self) -> Vec<&PathSegment<T>> {
+        self.segments.iter().filter(|s| s.is_cutting()).collect()
+    }
+
+    /// 早送りセグメントのみを抽出
+    pub fn rapid_segments(&self) -> Vec<&PathSegment<T>> {
+        self.segments.iter().filter(|s| s.is_rapid()).collect()
+    }
+
+    /// 総経路長を計算
+    pub fn total_length(&self) -> T {
+        self.segments.iter().map(|s| s.length()).sum()
+    }
+
+    /// 切削経路長のみを計算
+    pub fn cutting_length(&self) -> T {
+        self.segments
+            .iter()
+            .filter(|s| s.is_cutting())
+            .map(|s| s.length())
+            .sum()
+    }
+}
+
+/// CAM工具経路全体
+///
+/// 複数の等高線経路を含む工具経路全体を表します。
+///
+/// # 例
+///
+/// ```
+/// use cam_core::{ToolPath, ContourLevelPath};
+///
+/// let contours = vec![
+///     ContourLevelPath::new(0, -5.0, vec![]),
+///     ContourLevelPath::new(1, -10.0, vec![]),
+/// ];
+///
+/// let toolpath = ToolPath::new("tool1".to_string(), contours);
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct ToolPath<T: Scalar = f64> {
+    /// 使用工具のID
+    pub tool_id: String,
+
+    /// 等高線経路のリスト（Z座標降順に並べることを推奨）
+    pub contour_levels: Vec<ContourLevelPath<T>>,
+}
+
+impl<T: Scalar + std::iter::Sum> ToolPath<T> {
+    /// 新しい工具経路を作成
+    ///
+    /// # 引数
+    ///
+    /// - `tool_id`: 使用工具のID
+    /// - `contour_levels`: 等高線経路のリスト
+    pub fn new(tool_id: String, contour_levels: Vec<ContourLevelPath<T>>) -> Self {
+        Self {
+            tool_id,
+            contour_levels,
+        }
+    }
+
+    /// 総セグメント数を取得
+    pub fn total_segments(&self) -> usize {
+        self.contour_levels.iter().map(|c| c.segments.len()).sum()
+    }
+
+    /// 総経路長を計算
+    pub fn total_length(&self) -> T {
+        self.contour_levels.iter().map(|c| c.total_length()).sum()
+    }
+
+    /// 総切削経路長を計算
+    pub fn total_cutting_length(&self) -> T {
+        self.contour_levels.iter().map(|c| c.cutting_length()).sum()
+    }
+
+    /// 等高線数を取得
+    pub fn level_count(&self) -> usize {
+        self.contour_levels.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_line_segment_creation() {
+        let segment = PathSegment::new_line(
+            Point3D::new(0.0, 0.0, 0.0),
+            Point3D::new(10.0, 0.0, 0.0),
+            SegmentType::Cutting {
+                direction: CuttingDirection::Down,
+                feed_rate: 500.0,
+            },
+        );
+
+        assert!(segment.is_cutting());
+        assert!(!segment.is_rapid());
+        assert_eq!(segment.length(), 10.0);
+        assert_eq!(segment.end_point(), Point3D::new(10.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn test_arc_segment_creation() {
+        // 半径5の90度円弧（反時計回り）
+        let segment = PathSegment::new_arc(
+            Point3D::new(5.0, 0.0, 0.0),
+            Point3D::new(0.0, 5.0, 0.0),
+            Point3D::new(0.0, 0.0, 0.0),
+            ArcDirection::CounterClockwise,
+            SegmentType::Rapid,
+        );
+
+        assert!(segment.is_rapid());
+        assert_eq!(segment.end_point(), Point3D::new(0.0, 5.0, 0.0));
+
+        // 円弧長 = 半径5 × π/2 ≈ 7.854
+        let expected_length = 5.0 * std::f64::consts::PI / 2.0;
+        assert!((segment.length() - expected_length).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_arc_segment_180_degrees() {
+        // 半径10の180度円弧
+        let segment = PathSegment::new_arc(
+            Point3D::new(10.0, 0.0, 0.0),
+            Point3D::new(-10.0, 0.0, 0.0),
+            Point3D::new(0.0, 0.0, 0.0),
+            ArcDirection::Clockwise,
+            SegmentType::Cutting {
+                direction: CuttingDirection::Down,
+                feed_rate: 500.0,
+            },
+        );
+
+        // 円弧長 = 半径10 × π ≈ 31.416
+        let expected_length = 10.0 * std::f64::consts::PI;
+        assert!((segment.length() - expected_length).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_contour_level_path() {
+        let segments = vec![
+            PathSegment::new_line(
+                Point3D::new(0.0, 0.0, -5.0),
+                Point3D::new(10.0, 0.0, -5.0),
+                SegmentType::Cutting {
+                    direction: CuttingDirection::Down,
+                    feed_rate: 500.0,
+                },
+            ),
+            PathSegment::new_line(
+                Point3D::new(10.0, 0.0, -5.0),
+                Point3D::new(10.0, 10.0, -5.0),
+                SegmentType::Rapid,
+            ),
+        ];
+
+        let contour = ContourLevelPath::new(0, -5.0, segments);
+
+        assert_eq!(contour.level_index, 0);
+        assert_eq!(contour.z_level, -5.0);
+        assert_eq!(contour.cutting_segments().len(), 1);
+        assert_eq!(contour.rapid_segments().len(), 1);
+        assert_eq!(contour.total_length(), 20.0);
+        assert_eq!(contour.cutting_length(), 10.0);
+    }
+
+    #[test]
+    fn test_tool_path() {
+        let contours = vec![
+            ContourLevelPath::new(0, -5.0, vec![]),
+            ContourLevelPath::new(1, -10.0, vec![]),
+        ];
+
+        let toolpath = ToolPath::new("tool1".to_string(), contours);
+
+        assert_eq!(toolpath.tool_id, "tool1");
+        assert_eq!(toolpath.level_count(), 2);
+    }
+}

--- a/model/cam_core/src/toolpath.rs
+++ b/model/cam_core/src/toolpath.rs
@@ -482,9 +482,7 @@ mod tests {
         let segment = PathSegment::new_line(
             Point3D::new(0.0, 0.0, 0.0),
             Point3D::new(10.0, 0.0, 0.0),
-            SegmentType::Cutting {
-                feed_rate: 500.0,
-            },
+            SegmentType::Cutting { feed_rate: 500.0 },
         );
 
         assert!(segment.is_cutting());
@@ -520,9 +518,7 @@ mod tests {
             Point3D::new(-10.0, 0.0, 0.0),
             Point3D::new(0.0, 0.0, 0.0),
             ArcDirection::Clockwise,
-            SegmentType::Cutting {
-                feed_rate: 500.0,
-            },
+            SegmentType::Cutting { feed_rate: 500.0 },
         );
 
         // 円弧長 = 半径10 × π ≈ 31.416
@@ -553,9 +549,7 @@ mod tests {
             PathSegment::new_line(
                 Point3D::new(0.0, 0.0, -5.0),
                 Point3D::new(10.0, 0.0, -5.0),
-                SegmentType::Cutting {
-                    feed_rate: 500.0,
-                },
+                SegmentType::Cutting { feed_rate: 500.0 },
             ),
             PathSegment::new_line(
                 Point3D::new(10.0, 0.0, -5.0),

--- a/model/cam_core/src/validation.rs
+++ b/model/cam_core/src/validation.rs
@@ -1,0 +1,235 @@
+//! CAM用検証機能
+//!
+//! このモジュールは、CAM処理における幾何データの検証を提供します。
+//!
+//! # 概要
+//!
+//! Phase 1では以下の検証機能を実装します：
+//!
+//! - **2D輪郭の閉曲線判定**: 始点と終点の距離がトレランス以内か検証
+//!
+//! # 例
+//!
+//! ```
+//! use cam_core::{validate_2d_contour, CamTolerance};
+//! use geo_primitives::Point2D;
+//!
+//! let points = vec![
+//!     Point2D::new(0.0, 0.0),
+//!     Point2D::new(10.0, 0.0),
+//!     Point2D::new(10.0, 10.0),
+//!     Point2D::new(0.0, 10.0),
+//!     Point2D::new(0.0, 0.0001),  // ほぼ閉じている
+//! ];
+//!
+//! let tolerance = CamTolerance::default();
+//! let result = validate_2d_contour(&points, &tolerance);
+//! assert!(result.is_ok());
+//! ```
+
+use crate::tolerance::CamTolerance;
+use analysis::Scalar;
+use geo_primitives::Point2D;
+
+/// 検証エラー
+///
+/// CAM検証で発生する可能性のあるエラーを定義します。
+#[derive(Debug, Clone, PartialEq)]
+pub enum ValidationError {
+    /// 2D輪郭が閉じていない
+    ///
+    /// 始点と終点の距離がトレランスを超えています。
+    ContourNotClosed {
+        /// 始点と終点の距離
+        distance: f64,
+        /// 許容トレランス
+        tolerance: f64,
+    },
+
+    /// 2D輪郭の点数が不足
+    ///
+    /// 閉曲線を構成するには最低3点必要です。
+    InsufficientPoints {
+        /// 実際の点数
+        point_count: usize,
+    },
+
+    /// 2D輪郭が空
+    EmptyContour,
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValidationError::ContourNotClosed {
+                distance,
+                tolerance,
+            } => write!(
+                f,
+                "Contour is not closed: distance={:.6}, tolerance={:.6}",
+                distance, tolerance
+            ),
+            ValidationError::InsufficientPoints { point_count } => write!(
+                f,
+                "Insufficient points for closed contour: {} points (minimum 3 required)",
+                point_count
+            ),
+            ValidationError::EmptyContour => write!(f, "Contour is empty"),
+        }
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+/// 2D輪郭が閉曲線かどうか検証
+///
+/// # 引数
+///
+/// - `points`: 2D点列
+/// - `tolerance`: トレランス設定
+///
+/// # 戻り値
+///
+/// - `Ok(())`: 輪郭が閉じている
+/// - `Err(ValidationError)`: 閉じていない、または点数不足
+///
+/// # エラー
+///
+/// - `ValidationError::EmptyContour`: 点列が空
+/// - `ValidationError::InsufficientPoints`: 点数が3未満
+/// - `ValidationError::ContourNotClosed`: 始点と終点の距離がトレランス超過
+///
+/// # 例
+///
+/// ```
+/// use cam_core::{validate_2d_contour, CamTolerance};
+/// use geo_primitives::Point2D;
+///
+/// let points = vec![
+///     Point2D::new(0.0, 0.0),
+///     Point2D::new(10.0, 0.0),
+///     Point2D::new(10.0, 10.0),
+///     Point2D::new(0.0, 0.0),
+/// ];
+///
+/// let tolerance = CamTolerance::default();
+/// assert!(validate_2d_contour(&points, &tolerance).is_ok());
+/// ```
+pub fn validate_2d_contour<T: Scalar>(
+    points: &[Point2D<T>],
+    tolerance: &CamTolerance<T>,
+) -> Result<(), ValidationError> {
+    // 空チェック
+    if points.is_empty() {
+        return Err(ValidationError::EmptyContour);
+    }
+
+    // 点数チェック
+    if points.len() < 3 {
+        return Err(ValidationError::InsufficientPoints {
+            point_count: points.len(),
+        });
+    }
+
+    // 始点と終点の距離計算
+    let start = &points[0];
+    let end = &points[points.len() - 1];
+
+    let dx = end.x() - start.x();
+    let dy = end.y() - start.y();
+    let distance = (dx * dx + dy * dy).sqrt();
+
+    // トレランス比較
+    if distance > tolerance.closure_tolerance {
+        return Err(ValidationError::ContourNotClosed {
+            distance: distance.to_f64(),
+            tolerance: tolerance.closure_tolerance.to_f64(),
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_closed_contour() {
+        let points = vec![
+            Point2D::new(0.0, 0.0),
+            Point2D::new(10.0, 0.0),
+            Point2D::new(10.0, 10.0),
+            Point2D::new(0.0, 10.0),
+            Point2D::new(0.0, 0.0),
+        ];
+
+        let tolerance = CamTolerance::default();
+        assert!(validate_2d_contour(&points, &tolerance).is_ok());
+    }
+
+    #[test]
+    fn test_validate_almost_closed_contour() {
+        let points = vec![
+            Point2D::new(0.0, 0.0),
+            Point2D::new(10.0, 0.0),
+            Point2D::new(10.0, 10.0),
+            Point2D::new(0.0, 10.0),
+            Point2D::new(0.0, 0.0001), // 0.0001mm の誤差（デフォルトトレランス 0.001mm 以内）
+        ];
+
+        let tolerance = CamTolerance::default();
+        assert!(validate_2d_contour(&points, &tolerance).is_ok());
+    }
+
+    #[test]
+    fn test_validate_not_closed_contour() {
+        let points = vec![
+            Point2D::new(0.0, 0.0),
+            Point2D::new(10.0, 0.0),
+            Point2D::new(10.0, 10.0),
+            Point2D::new(0.0, 10.0),
+            Point2D::new(0.0, 1.0), // 1mm の誤差（トレランス 0.001mm を超過）
+        ];
+
+        let tolerance = CamTolerance::default();
+        let result = validate_2d_contour(&points, &tolerance);
+        assert!(result.is_err());
+
+        if let Err(ValidationError::ContourNotClosed {
+            distance,
+            tolerance: tol,
+        }) = result
+        {
+            assert_eq!(distance, 1.0);
+            assert_eq!(tol, 0.001);
+        } else {
+            panic!("Expected ContourNotClosed error");
+        }
+    }
+
+    #[test]
+    fn test_validate_empty_contour() {
+        let points: Vec<Point2D<f64>> = vec![];
+        let tolerance = CamTolerance::default();
+        let result = validate_2d_contour(&points, &tolerance);
+
+        assert!(result.is_err());
+        assert!(matches!(result, Err(ValidationError::EmptyContour)));
+    }
+
+    #[test]
+    fn test_validate_insufficient_points() {
+        let points = vec![Point2D::new(0.0, 0.0), Point2D::new(10.0, 0.0)];
+
+        let tolerance = CamTolerance::default();
+        let result = validate_2d_contour(&points, &tolerance);
+
+        assert!(result.is_err());
+        if let Err(ValidationError::InsufficientPoints { point_count }) = result {
+            assert_eq!(point_count, 2);
+        } else {
+            panic!("Expected InsufficientPoints error");
+        }
+    }
+}

--- a/view/render/shaders/toolpath.wgsl
+++ b/view/render/shaders/toolpath.wgsl
@@ -1,0 +1,42 @@
+// CAM工具経路レンダリング用シェーダー
+// LineList トポロジーで使用（2頂点で1線分）
+// 頂点カラーに対応
+
+struct VertexInput {
+    @location(0) position: vec3<f32>,
+    @location(1) color: vec4<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) color: vec4<f32>,
+}
+
+struct Uniforms {
+    view_proj: mat4x4<f32>,
+    model: mat4x4<f32>,
+}
+
+@group(0) @binding(0)
+var<uniform> uniforms: Uniforms;
+
+@vertex
+fn vs_main(input: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+
+    // モデル座標をワールド座標に変換
+    let world_pos = uniforms.model * vec4<f32>(input.position, 1.0);
+
+    // ワールド座標をクリップ座標に変換
+    out.clip_position = uniforms.view_proj * world_pos;
+
+    // 頂点カラーをフラグメントシェーダーに渡す
+    out.color = input.color;
+
+    return out;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    return input.color;
+}

--- a/view/render/src/lib.rs
+++ b/view/render/src/lib.rs
@@ -7,6 +7,7 @@ pub mod render_2d;
 pub mod render_3d;
 pub mod shader;
 pub mod surface;
+pub mod toolpath;
 pub mod vertex_2d;
 pub mod vertex_3d;
 pub mod wireframe;

--- a/view/render/src/shader.rs
+++ b/view/render/src/shader.rs
@@ -34,3 +34,10 @@ pub fn line_shader(device: &Device) -> wgpu::ShaderModule {
         source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/line.wgsl").into()),
     })
 }
+
+pub fn toolpath_shader(device: &Device) -> wgpu::ShaderModule {
+    device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("ToolPath Shader"),
+        source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/toolpath.wgsl").into()),
+    })
+}

--- a/view/render/src/toolpath.rs
+++ b/view/render/src/toolpath.rs
@@ -1,0 +1,246 @@
+//! CAM工具経路のGPU描画リソース
+//!
+//! `viewmodel::toolpath_converter` から変換された頂点データを受け取り、
+//! GPU上で工具経路を描画します。
+//!
+//! # 特徴
+//!
+//! - LineList トポロジーによる線分描画
+//! - 頂点カラー対応（セグメント種別ごとの色分け）
+//! - View/Projection行列による3D表示
+
+use crate::shader;
+use bytemuck::{Pod, Zeroable};
+use wgpu::util::DeviceExt;
+
+/// 工具経路頂点（GPU転送用）
+///
+/// viewmodel::toolpath_converter::Vertex3D と色情報を統合
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+pub struct ToolPathVertex {
+    pub position: [f32; 3],
+    pub color: [f32; 4],
+}
+
+impl ToolPathVertex {
+    /// 頂点レイアウト記述子
+    pub fn desc() -> wgpu::VertexBufferLayout<'static> {
+        wgpu::VertexBufferLayout {
+            array_stride: std::mem::size_of::<ToolPathVertex>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &[
+                // position
+                wgpu::VertexAttribute {
+                    offset: 0,
+                    shader_location: 0,
+                    format: wgpu::VertexFormat::Float32x3,
+                },
+                // color
+                wgpu::VertexAttribute {
+                    offset: std::mem::size_of::<[f32; 3]>() as wgpu::BufferAddress,
+                    shader_location: 1,
+                    format: wgpu::VertexFormat::Float32x4,
+                },
+            ],
+        }
+    }
+}
+
+/// 工具経路描画用のUniform構造体
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+pub struct ToolPathUniforms {
+    pub view_proj: [[f32; 4]; 4], // ビュー・プロジェクション行列
+    pub model: [[f32; 4]; 4],     // モデル行列
+}
+
+impl Default for ToolPathUniforms {
+    fn default() -> Self {
+        Self {
+            view_proj: [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+            model: [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+        }
+    }
+}
+
+/// 工具経路レンダリングリソース
+pub struct ToolPathResources {
+    pub render_pipeline: wgpu::RenderPipeline,
+    pub uniform_buffer: wgpu::Buffer,
+    pub bind_group_layout: wgpu::BindGroupLayout,
+    pub bind_group: wgpu::BindGroup,
+    pub vertex_buffer: Option<wgpu::Buffer>,
+    pub vertex_count: u32,
+}
+
+impl ToolPathResources {
+    /// 新しい工具経路レンダリングリソースを作成
+    ///
+    /// # 引数
+    ///
+    /// - `device`: wgpu Device
+    /// - `format`: レンダーターゲットのテクスチャフォーマット
+    pub fn new(device: &wgpu::Device, format: wgpu::TextureFormat) -> Self {
+        let shader = shader::toolpath_shader(device);
+
+        // Uniform bind group layout
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+            label: Some("toolpath_bind_group_layout"),
+        });
+
+        // Uniform buffer
+        let uniforms = ToolPathUniforms::default();
+        let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("ToolPath Uniform Buffer"),
+            contents: bytemuck::cast_slice(&[uniforms]),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        // Bind group
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buffer.as_entire_binding(),
+            }],
+            label: Some("toolpath_bind_group"),
+        });
+
+        // Render pipeline layout
+        let render_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("ToolPath Render Pipeline Layout"),
+                bind_group_layouts: &[&bind_group_layout],
+                push_constant_ranges: &[],
+            });
+
+        // Render pipeline（LineList トポロジー）
+        let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("ToolPath Render Pipeline"),
+            layout: Some(&render_pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[ToolPathVertex::desc()],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format,
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::LineList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None, // 線分なのでカリングなし
+                polygon_mode: wgpu::PolygonMode::Fill,
+                unclipped_depth: false,
+                conservative: false,
+            },
+            depth_stencil: Some(wgpu::DepthStencilState {
+                format: wgpu::TextureFormat::Depth32Float,
+                depth_write_enabled: true,
+                depth_compare: wgpu::CompareFunction::Less,
+                stencil: wgpu::StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }),
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview: None,
+            cache: None,
+        });
+
+        Self {
+            render_pipeline,
+            uniform_buffer,
+            bind_group_layout,
+            bind_group,
+            vertex_buffer: None,
+            vertex_count: 0,
+        }
+    }
+
+    /// 頂点データを更新
+    ///
+    /// # 引数
+    ///
+    /// - `device`: wgpu Device
+    /// - `vertices`: 工具経路の頂点配列
+    ///
+    /// # Note
+    ///
+    /// `vertices` は LineList トポロジー用のため、
+    /// 2頂点で1線分を表現します。
+    pub fn update_vertices(&mut self, device: &wgpu::Device, vertices: &[ToolPathVertex]) {
+        if vertices.is_empty() {
+            self.vertex_buffer = None;
+            self.vertex_count = 0;
+            return;
+        }
+
+        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("ToolPath Vertex Buffer"),
+            contents: bytemuck::cast_slice(vertices),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+
+        self.vertex_buffer = Some(vertex_buffer);
+        self.vertex_count = vertices.len() as u32;
+    }
+
+    /// Uniform（カメラ行列）を更新
+    ///
+    /// # 引数
+    ///
+    /// - `queue`: wgpu Queue
+    /// - `uniforms`: 新しいUniform値
+    pub fn update_uniforms(&self, queue: &wgpu::Queue, uniforms: &ToolPathUniforms) {
+        queue.write_buffer(&self.uniform_buffer, 0, bytemuck::cast_slice(&[*uniforms]));
+    }
+
+    /// 描画
+    ///
+    /// # 引数
+    ///
+    /// - `render_pass`: wgpu RenderPass
+    pub fn render<'a>(&'a self, render_pass: &mut wgpu::RenderPass<'a>) {
+        if self.vertex_buffer.is_none() || self.vertex_count == 0 {
+            return;
+        }
+
+        render_pass.set_pipeline(&self.render_pipeline);
+        render_pass.set_bind_group(0, &self.bind_group, &[]);
+        render_pass.set_vertex_buffer(0, self.vertex_buffer.as_ref().unwrap().slice(..));
+        render_pass.draw(0..self.vertex_count, 0..1);
+    }
+}

--- a/view/stage/src/lib.rs
+++ b/view/stage/src/lib.rs
@@ -3,9 +3,11 @@ pub mod mesh_stage;
 pub mod outline;
 pub mod render_stage;
 pub mod shading;
+pub mod toolpath_stage;
 
 pub use draft::DraftStage;
-pub use mesh_stage::MeshStage;
+pub use mesh_stage::{MeshStage, RenderMode};
 pub use outline::OutlineStage;
 pub use render_stage::RenderStage;
 pub use shading::ShadingStage;
+pub use toolpath_stage::ToolPathStage;

--- a/view/stage/src/toolpath_stage.rs
+++ b/view/stage/src/toolpath_stage.rs
@@ -1,0 +1,226 @@
+//! CAM工具経路レンダリングステージ
+//!
+//! ViewModel層から変換された工具経路データを受け取り、
+//! GPU上でレンダリングするステージです。
+//!
+//! # 使用例
+//!
+//! ```ignore
+//! use stage::{ToolPathStage, RenderStage};
+//! use wgpu::{Device, TextureFormat};
+//!
+//! let device = /* wgpu Device */;
+//! let format = TextureFormat::Bgra8UnormSrgb;
+//!
+//! let mut stage = ToolPathStage::new(&device, format);
+//!
+//! // ViewModel変換データを設定
+//! // stage.set_toolpath_data(&device, vertices);
+//!
+//! // カメラ行列更新
+//! // stage.update_camera(&queue, view_proj_matrix);
+//! ```
+
+use render::toolpath::{ToolPathResources, ToolPathUniforms, ToolPathVertex};
+use wgpu::{CommandEncoder, Device, Queue, TextureFormat, TextureView};
+
+use crate::RenderStage;
+
+/// CAM工具経路レンダリングステージ
+pub struct ToolPathStage {
+    resources: ToolPathResources,
+    has_data: bool,
+}
+
+impl ToolPathStage {
+    /// 新しい工具経路ステージを作成
+    ///
+    /// # 引数
+    ///
+    /// - `device`: wgpu Device
+    /// - `format`: レンダーターゲットのテクスチャフォーマット
+    pub fn new(device: &Device, format: TextureFormat) -> Self {
+        let resources = ToolPathResources::new(device, format);
+
+        Self {
+            resources,
+            has_data: false,
+        }
+    }
+
+    /// 工具経路データを設定
+    ///
+    /// ViewModel層から変換された頂点データを受け取ります。
+    ///
+    /// # 引数
+    ///
+    /// - `device`: wgpu Device
+    /// - `vertices`: 工具経路の頂点配列（位置+色）
+    ///
+    /// # Note
+    ///
+    /// `vertices` は LineList トポロジー用のため、
+    /// 2頂点で1線分を表現します。
+    pub fn set_toolpath_data(&mut self, device: &Device, vertices: Vec<ToolPathVertex>) {
+        tracing::info!("工具経路データ設定: {} 頂点", vertices.len());
+
+        self.resources.update_vertices(device, &vertices);
+        self.has_data = !vertices.is_empty();
+    }
+
+    /// カメラ行列を更新
+    ///
+    /// # 引数
+    ///
+    /// - `queue`: wgpu Queue
+    /// - `view_proj_matrix`: ビュー・プロジェクション結合行列
+    pub fn update_camera(&mut self, queue: &Queue, view_proj_matrix: [[f32; 4]; 4]) {
+        let uniforms = ToolPathUniforms {
+            view_proj: view_proj_matrix,
+            model: [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+        };
+
+        self.resources.update_uniforms(queue, &uniforms);
+    }
+
+    /// カメラ行列を更新（View/Projection分離版）
+    ///
+    /// # 引数
+    ///
+    /// - `queue`: wgpu Queue
+    /// - `view_matrix`: ビュー行列
+    /// - `proj_matrix`: プロジェクション行列
+    pub fn update_camera_separate(
+        &mut self,
+        queue: &Queue,
+        view_matrix: [[f32; 4]; 4],
+        proj_matrix: [[f32; 4]; 4],
+    ) {
+        // View * Projection の行列乗算
+        let view_proj = multiply_matrices(&view_matrix, &proj_matrix);
+        self.update_camera(queue, view_proj);
+    }
+
+    /// データが設定されているか確認
+    pub fn has_data(&self) -> bool {
+        self.has_data
+    }
+
+    /// 頂点数を取得
+    pub fn vertex_count(&self) -> u32 {
+        self.resources.vertex_count
+    }
+}
+
+impl RenderStage for ToolPathStage {
+    fn render(&mut self, encoder: &mut CommandEncoder, view: &TextureView) {
+        if !self.has_data {
+            tracing::debug!("ToolPathStage: データなし、描画スキップ");
+            return;
+        }
+
+        tracing::debug!(
+            "ToolPathStage: 描画開始 ({} 頂点)",
+            self.resources.vertex_count
+        );
+
+        // Depth attachment用のテクスチャが必要
+        // Note: 現在は簡易実装のため、depth_stencil_attachment は None
+        // 実際の統合時には適切なDepthテクスチャを用意する必要がある
+        let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("ToolPath Render Pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view,
+                resolve_target: None,
+                depth_slice: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load, // 既存の描画を保持
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None, // TODO: Depthバッファ統合時に修正
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+
+        self.resources.render(&mut render_pass);
+    }
+
+    fn update(&mut self) {
+        // 必要に応じてアニメーション更新等を実装
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+/// 4x4行列の乗算（View * Projection）
+///
+/// # Note
+///
+/// 行優先（row-major）の行列を前提としています。
+#[allow(clippy::needless_range_loop)]
+fn multiply_matrices(a: &[[f32; 4]; 4], b: &[[f32; 4]; 4]) -> [[f32; 4]; 4] {
+    let mut result = [[0.0; 4]; 4];
+
+    for i in 0..4 {
+        for j in 0..4 {
+            for k in 0..4 {
+                result[i][j] += a[i][k] * b[k][j];
+            }
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_identity_matrix_multiplication() {
+        let identity = [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ];
+
+        let result = multiply_matrices(&identity, &identity);
+
+        for i in 0..4 {
+            for j in 0..4 {
+                let expected = if i == j { 1.0 } else { 0.0 };
+                assert!((result[i][j] - expected).abs() < 1e-6);
+            }
+        }
+    }
+
+    #[test]
+    fn test_translation_matrix_multiplication() {
+        let identity = [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ];
+
+        let translation = [
+            [1.0, 0.0, 0.0, 10.0],
+            [0.0, 1.0, 0.0, 20.0],
+            [0.0, 0.0, 1.0, 30.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ];
+
+        let result = multiply_matrices(&identity, &translation);
+
+        assert_eq!(result, translation);
+    }
+}

--- a/view/stage/src/toolpath_stage.rs
+++ b/view/stage/src/toolpath_stage.rs
@@ -195,6 +195,7 @@ mod tests {
 
         let result = multiply_matrices(&identity, &identity);
 
+        #[allow(clippy::needless_range_loop)]
         for i in 0..4 {
             for j in 0..4 {
                 let expected = if i == j { 1.0 } else { 0.0 };

--- a/viewmodel/converter/Cargo.toml
+++ b/viewmodel/converter/Cargo.toml
@@ -9,6 +9,8 @@ geo_foundation = { path = "../../model/geo_foundation" }
 geo_primitives = { path = "../../model/geo_primitives" }
 geo_algorithms = { path = "../../model/geo_algorithms" }
 geo_io = { path = "../../model/geo_io" }
+cam_core = { path = "../../model/cam_core" }
+analysis = { path = "../../foundation/analysis" }
 tracing = "0.1"
 thiserror = "2.0"
 

--- a/viewmodel/converter/src/lib.rs
+++ b/viewmodel/converter/src/lib.rs
@@ -9,11 +9,13 @@
 //! - STL読み込み・変換統合
 //! - 境界ボックス計算・変換
 //! - 形状可視化データ変換（幾何プリミティブ → GPU頂点データ）
+//! - CAM工具経路の可視化データ変換（ToolPath → GPU頂点データ）
 
 pub mod mesh_converter;
 pub mod shape_converter;
 pub mod stl_loader;
 pub mod svg_loader;
+pub mod toolpath_converter;
 
 /// テスト用の関数（削除予定）
 pub fn add(left: u64, right: u64) -> u64 {

--- a/viewmodel/converter/src/toolpath_converter.rs
+++ b/viewmodel/converter/src/toolpath_converter.rs
@@ -1,0 +1,535 @@
+//! CAM工具経路のViewModel変換
+//!
+//! `cam_core::ToolPath` を GPU描画用の頂点データに変換します。
+//!
+//! # 設計方針
+//!
+//! - **色設定の注入**: App層から `ToolPathColorScheme` を受け取る
+//! - **3フェーズ構造対応**: approach → cutting → retract の分離
+//! - **セグメント種別の識別**: Cutting, Rapid, Approach, Retract, PassRetract
+//! - **円弧テッセレーション**: 円弧を線分に分割（設定可能な分割数）
+
+use cam_core::{
+    ArcDirection, ContourLevelPath, CuttingDirection, PathGeometry, PathSegment, SegmentType,
+    ToolPath,
+};
+use geo_primitives::Point3D;
+
+/// 工具経路の色設定（App層から注入）
+#[derive(Debug, Clone, Copy)]
+pub struct ToolPathColorScheme {
+    /// 切削セグメントの色（デフォルト: 白色）
+    pub cutting: [f32; 4],
+
+    /// 早送りセグメントの色（デフォルト: 青色）
+    pub rapid: [f32; 4],
+
+    /// アプローチセグメントの色（デフォルト: 緑色）
+    pub approach: [f32; 4],
+
+    /// リトラクトセグメントの色（デフォルト: 黄色）
+    pub retract: [f32; 4],
+
+    /// 周回間リトラクトセグメントの色（デフォルト: オレンジ色）
+    pub pass_retract: [f32; 4],
+
+    /// ダウンカットの色（オプション使用、デフォルト: 白色）
+    pub down_cut: [f32; 4],
+
+    /// アップカットの色（オプション使用、デフォルト: オレンジ色）
+    pub up_cut: [f32; 4],
+}
+
+impl Default for ToolPathColorScheme {
+    fn default() -> Self {
+        Self {
+            cutting: [1.0, 1.0, 1.0, 1.0],         // 白色
+            rapid: [0.2, 0.5, 1.0, 1.0],           // 青色
+            approach: [0.2, 1.0, 0.2, 1.0],        // 緑色
+            retract: [1.0, 1.0, 0.2, 1.0],         // 黄色
+            pass_retract: [1.0, 0.6, 0.2, 1.0],    // オレンジ色
+            down_cut: [1.0, 1.0, 1.0, 1.0],        // 白色
+            up_cut: [1.0, 0.5, 0.2, 1.0],          // オレンジ色
+        }
+    }
+}
+
+/// テッセレーション設定（App層から注入）
+#[derive(Debug, Clone, Copy)]
+pub struct TessellationSettings {
+    /// 円弧の分割数（セグメント数）
+    pub arc_segments: u32,
+
+    /// 最小セグメント長（これ以下の細分化は行わない）
+    pub min_segment_length: f64,
+}
+
+impl Default for TessellationSettings {
+    fn default() -> Self {
+        Self {
+            arc_segments: 32,
+            min_segment_length: 0.1, // 0.1mm
+        }
+    }
+}
+
+/// 工具経路可視化設定（App層から注入される全設定）
+#[derive(Debug, Clone)]
+pub struct ToolPathVisualizationSettings {
+    /// 色設定
+    pub color_scheme: ToolPathColorScheme,
+
+    /// テッセレーション設定
+    pub tessellation: TessellationSettings,
+
+    /// 切削方向による色分けを有効化
+    pub color_by_cutting_direction: bool,
+
+    /// 早送りセグメントを表示するか
+    pub show_rapid: bool,
+
+    /// アプローチセグメントを表示するか
+    pub show_approach: bool,
+
+    /// リトラクトセグメントを表示するか
+    pub show_retract: bool,
+}
+
+impl Default for ToolPathVisualizationSettings {
+    fn default() -> Self {
+        Self {
+            color_scheme: ToolPathColorScheme::default(),
+            tessellation: TessellationSettings::default(),
+            color_by_cutting_direction: false,
+            show_rapid: true,
+            show_approach: true,
+            show_retract: true,
+        }
+    }
+}
+
+/// GPU描画用の頂点データ（位置）
+///
+/// Note: 色情報は別配列で管理（セグメントごとの色変更に対応）
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Vertex3D {
+    pub position: [f32; 3],
+}
+
+/// 変換後の工具経路頂点データ
+#[derive(Debug, Clone)]
+pub struct ToolPathVertices {
+    /// 頂点配列（線分の始点・終点の連続）
+    pub vertices: Vec<Vertex3D>,
+
+    /// セグメントごとの色配列（vertices の各ペアに対応）
+    pub colors: Vec<[f32; 4]>,
+
+    /// 各フェーズの頂点範囲（デバッグ用）
+    pub phase_ranges: PhaseRanges,
+}
+
+/// 各フェーズの頂点インデックス範囲
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PhaseRanges {
+    /// アプローチフェーズの頂点範囲
+    pub approach: (usize, usize),
+
+    /// 切削フェーズの頂点範囲
+    pub cutting: (usize, usize),
+
+    /// リトラクトフェーズの頂点範囲
+    pub retract: (usize, usize),
+}
+
+/// 工具経路をGPU描画用の頂点データに変換
+///
+/// # 引数
+///
+/// - `toolpath`: 変換元の工具経路
+/// - `settings`: 可視化設定（App層から注入）
+///
+/// # 戻り値
+///
+/// GPU描画用の頂点配列と色配列
+pub fn toolpath_to_vertices(
+    toolpath: &ToolPath<f64>,
+    settings: &ToolPathVisualizationSettings,
+) -> ToolPathVertices {
+    let mut vertices = Vec::new();
+    let mut colors = Vec::new();
+
+    let approach_start = vertices.len();
+
+    // Phase 1: アプローチフェーズ
+    if settings.show_approach {
+        for segment in &toolpath.approach_segments {
+            convert_segment(
+                segment,
+                &settings.color_scheme,
+                &settings.tessellation,
+                toolpath.cutting_direction,
+                settings.color_by_cutting_direction,
+                &mut vertices,
+                &mut colors,
+            );
+        }
+    }
+
+    let approach_end = vertices.len();
+    let cutting_start = vertices.len();
+
+    // Phase 2: 切削フェーズ（等高線ごと）
+    for contour_level in &toolpath.contour_levels {
+        convert_contour_level(
+            contour_level,
+            settings,
+            toolpath.cutting_direction,
+            &mut vertices,
+            &mut colors,
+        );
+    }
+
+    let cutting_end = vertices.len();
+    let retract_start = vertices.len();
+
+    // Phase 3: リトラクトフェーズ
+    if settings.show_retract {
+        for segment in &toolpath.retract_segments {
+            convert_segment(
+                segment,
+                &settings.color_scheme,
+                &settings.tessellation,
+                toolpath.cutting_direction,
+                settings.color_by_cutting_direction,
+                &mut vertices,
+                &mut colors,
+            );
+        }
+    }
+
+    let retract_end = vertices.len();
+
+    ToolPathVertices {
+        vertices,
+        colors,
+        phase_ranges: PhaseRanges {
+            approach: (approach_start, approach_end),
+            cutting: (cutting_start, cutting_end),
+            retract: (retract_start, retract_end),
+        },
+    }
+}
+
+/// 等高線レベルパスを頂点データに変換
+fn convert_contour_level(
+    contour: &ContourLevelPath<f64>,
+    settings: &ToolPathVisualizationSettings,
+    cutting_direction: CuttingDirection,
+    vertices: &mut Vec<Vertex3D>,
+    colors: &mut Vec<[f32; 4]>,
+) {
+    for segment in &contour.segments {
+        // 早送りセグメントの表示フィルタリング
+        if !settings.show_rapid && segment.is_rapid() {
+            continue;
+        }
+
+        convert_segment(
+            segment,
+            &settings.color_scheme,
+            &settings.tessellation,
+            cutting_direction,
+            settings.color_by_cutting_direction,
+            vertices,
+            colors,
+        );
+    }
+}
+
+/// 単一セグメントを頂点データに変換
+fn convert_segment(
+    segment: &PathSegment<f64>,
+    color_scheme: &ToolPathColorScheme,
+    tessellation: &TessellationSettings,
+    cutting_direction: CuttingDirection,
+    color_by_direction: bool,
+    vertices: &mut Vec<Vertex3D>,
+    colors: &mut Vec<[f32; 4]>,
+) {
+    // セグメント種別に応じた色を決定
+    let color = get_segment_color(
+        &segment.segment_type,
+        color_scheme,
+        cutting_direction,
+        color_by_direction,
+    );
+
+    match &segment.geometry {
+        PathGeometry::Line { end } => {
+            // 直線セグメント: 始点 → 終点
+            vertices.push(point_to_vertex(&segment.start));
+            vertices.push(point_to_vertex(end));
+            colors.push(color);
+        }
+        PathGeometry::Arc {
+            end,
+            center,
+            direction,
+        } => {
+            // 円弧セグメント: テッセレーション
+            let arc_vertices = tessellate_arc(
+                &segment.start,
+                end,
+                center,
+                *direction,
+                tessellation.arc_segments,
+            );
+
+            // 線分列として頂点追加
+            for i in 0..arc_vertices.len().saturating_sub(1) {
+                vertices.push(arc_vertices[i]);
+                vertices.push(arc_vertices[i + 1]);
+                colors.push(color);
+            }
+        }
+    }
+}
+
+/// セグメント種別と切削方向に応じた色を取得
+fn get_segment_color(
+    segment_type: &SegmentType<f64>,
+    color_scheme: &ToolPathColorScheme,
+    cutting_direction: CuttingDirection,
+    color_by_direction: bool,
+) -> [f32; 4] {
+    match segment_type {
+        SegmentType::Cutting { .. } => {
+            if color_by_direction {
+                // 切削方向による色分け
+                match cutting_direction {
+                    CuttingDirection::Down => color_scheme.down_cut,
+                    CuttingDirection::Up => color_scheme.up_cut,
+                }
+            } else {
+                // デフォルトの切削色
+                color_scheme.cutting
+            }
+        }
+        SegmentType::Rapid => color_scheme.rapid,
+        SegmentType::Approach { .. } => color_scheme.approach,
+        SegmentType::Retract { .. } => color_scheme.retract,
+        SegmentType::PassRetract { .. } => color_scheme.pass_retract,
+    }
+}
+
+/// Point3D を Vertex3D に変換
+fn point_to_vertex(point: &Point3D<f64>) -> Vertex3D {
+    Vertex3D {
+        position: [point.x() as f32, point.y() as f32, point.z() as f32],
+    }
+}
+
+/// 円弧をテッセレーション（線分分割）
+///
+/// # 引数
+///
+/// - `start`: 円弧始点
+/// - `end`: 円弧終点
+/// - `center`: 円弧中心点
+/// - `direction`: 円弧方向（時計回り/反時計回り）
+/// - `segments`: 分割数
+///
+/// # 戻り値
+///
+/// テッセレーション後の頂点配列
+fn tessellate_arc(
+    start: &Point3D<f64>,
+    end: &Point3D<f64>,
+    center: &Point3D<f64>,
+    direction: ArcDirection,
+    segments: u32,
+) -> Vec<Vertex3D> {
+    let mut result = Vec::with_capacity((segments + 1) as usize);
+
+    // 半径計算
+    let radius = {
+        let dx = start.x() - center.x();
+        let dy = start.y() - center.y();
+        let dz = start.z() - center.z();
+        (dx * dx + dy * dy + dz * dz).sqrt()
+    };
+
+    // 始点・終点の角度計算
+    let start_angle = (start.y() - center.y()).atan2(start.x() - center.x());
+    let end_angle = (end.y() - center.y()).atan2(end.x() - center.x());
+
+    // 中心角計算（方向を考慮）
+    let sweep_angle = match direction {
+        ArcDirection::CounterClockwise => {
+            if end_angle >= start_angle {
+                end_angle - start_angle
+            } else {
+                end_angle - start_angle + 2.0 * std::f64::consts::PI
+            }
+        }
+        ArcDirection::Clockwise => {
+            if end_angle <= start_angle {
+                end_angle - start_angle
+            } else {
+                end_angle - start_angle - 2.0 * std::f64::consts::PI
+            }
+        }
+    };
+
+    // 分割点を生成
+    for i in 0..=segments {
+        let t = i as f64 / segments as f64;
+        let angle = start_angle + sweep_angle * t;
+
+        let x = center.x() + radius * angle.cos();
+        let y = center.y() + radius * angle.sin();
+        let z = start.z() + (end.z() - start.z()) * t; // Z方向は線形補間
+
+        result.push(Vertex3D {
+            position: [x as f32, y as f32, z as f32],
+        });
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cam_core::ToolPath;
+
+    #[test]
+    fn test_default_color_scheme() {
+        let scheme = ToolPathColorScheme::default();
+        assert_eq!(scheme.cutting, [1.0, 1.0, 1.0, 1.0]); // 白色
+        assert_eq!(scheme.rapid, [0.2, 0.5, 1.0, 1.0]); // 青色
+    }
+
+    #[test]
+    fn test_default_tessellation() {
+        let settings = TessellationSettings::default();
+        assert_eq!(settings.arc_segments, 32);
+        assert_eq!(settings.min_segment_length, 0.1);
+    }
+
+    #[test]
+    fn test_empty_toolpath_conversion() {
+        let toolpath = ToolPath::new(
+            "tool1".to_string(),
+            CuttingDirection::Down,
+            vec![],
+            vec![],
+            vec![],
+        );
+
+        let settings = ToolPathVisualizationSettings::default();
+        let result = toolpath_to_vertices(&toolpath, &settings);
+
+        assert_eq!(result.vertices.len(), 0);
+        assert_eq!(result.colors.len(), 0);
+    }
+
+    #[test]
+    fn test_simple_line_segment_conversion() {
+        use cam_core::{ContourLevelPath, PathSegment, SegmentType};
+
+        let segment = PathSegment::new_line(
+            Point3D::new(0.0, 0.0, 0.0),
+            Point3D::new(10.0, 0.0, 0.0),
+            SegmentType::Cutting { feed_rate: 500.0 },
+        );
+
+        let contour = ContourLevelPath::new(0, 0.0, vec![segment]);
+
+        let toolpath = ToolPath::new(
+            "tool1".to_string(),
+            CuttingDirection::Down,
+            vec![],
+            vec![contour],
+            vec![],
+        );
+
+        let settings = ToolPathVisualizationSettings::default();
+        let result = toolpath_to_vertices(&toolpath, &settings);
+
+        // 1つの線分 = 2頂点
+        assert_eq!(result.vertices.len(), 2);
+        assert_eq!(result.colors.len(), 1);
+
+        // 始点確認
+        assert_eq!(result.vertices[0].position, [0.0, 0.0, 0.0]);
+        // 終点確認
+        assert_eq!(result.vertices[1].position, [10.0, 0.0, 0.0]);
+
+        // 切削色確認（デフォルト: 白色）
+        assert_eq!(result.colors[0], [1.0, 1.0, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn test_cutting_direction_coloring() {
+        use cam_core::{ContourLevelPath, PathSegment, SegmentType};
+
+        let segment = PathSegment::new_line(
+            Point3D::new(0.0, 0.0, 0.0),
+            Point3D::new(10.0, 0.0, 0.0),
+            SegmentType::Cutting { feed_rate: 500.0 },
+        );
+
+        let contour = ContourLevelPath::new(0, 0.0, vec![segment]);
+
+        // ダウンカット
+        let toolpath_down = ToolPath::new(
+            "tool1".to_string(),
+            CuttingDirection::Down,
+            vec![],
+            vec![contour.clone()],
+            vec![],
+        );
+
+        let mut settings = ToolPathVisualizationSettings::default();
+        settings.color_by_cutting_direction = true;
+
+        let result_down = toolpath_to_vertices(&toolpath_down, &settings);
+        assert_eq!(result_down.colors[0], settings.color_scheme.down_cut);
+
+        // アップカット
+        let toolpath_up = ToolPath::new(
+            "tool1".to_string(),
+            CuttingDirection::Up,
+            vec![],
+            vec![contour],
+            vec![],
+        );
+
+        let result_up = toolpath_to_vertices(&toolpath_up, &settings);
+        assert_eq!(result_up.colors[0], settings.color_scheme.up_cut);
+    }
+
+    #[test]
+    fn test_arc_tessellation() {
+        // 半円（180度）のテッセレーション
+        let start = Point3D::new(10.0, 0.0, 0.0);
+        let end = Point3D::new(-10.0, 0.0, 0.0);
+        let center = Point3D::new(0.0, 0.0, 0.0);
+
+        let vertices = tessellate_arc(&start, &end, &center, ArcDirection::CounterClockwise, 8);
+
+        // 9頂点（8セグメント + 1）
+        assert_eq!(vertices.len(), 9);
+
+        // 始点確認
+        assert!((vertices[0].position[0] - 10.0).abs() < 0.01);
+        assert!((vertices[0].position[1] - 0.0).abs() < 0.01);
+
+        // 終点確認
+        assert!((vertices[8].position[0] - (-10.0)).abs() < 0.01);
+        assert!((vertices[8].position[1] - 0.0).abs() < 0.01);
+    }
+}

--- a/viewmodel/converter/src/toolpath_converter.rs
+++ b/viewmodel/converter/src/toolpath_converter.rs
@@ -493,8 +493,10 @@ mod tests {
             vec![],
         );
 
-        let mut settings = ToolPathVisualizationSettings::default();
-        settings.color_by_cutting_direction = true;
+        let settings = ToolPathVisualizationSettings {
+            color_by_cutting_direction: true,
+            ..Default::default()
+        };
 
         let result_down = toolpath_to_vertices(&toolpath_down, &settings);
         assert_eq!(result_down.colors[0], settings.color_scheme.down_cut);

--- a/viewmodel/converter/src/toolpath_converter.rs
+++ b/viewmodel/converter/src/toolpath_converter.rs
@@ -43,13 +43,13 @@ pub struct ToolPathColorScheme {
 impl Default for ToolPathColorScheme {
     fn default() -> Self {
         Self {
-            cutting: [1.0, 1.0, 1.0, 1.0],         // 白色
-            rapid: [0.2, 0.5, 1.0, 1.0],           // 青色
-            approach: [0.2, 1.0, 0.2, 1.0],        // 緑色
-            retract: [1.0, 1.0, 0.2, 1.0],         // 黄色
-            pass_retract: [1.0, 0.6, 0.2, 1.0],    // オレンジ色
-            down_cut: [1.0, 1.0, 1.0, 1.0],        // 白色
-            up_cut: [1.0, 0.5, 0.2, 1.0],          // オレンジ色
+            cutting: [1.0, 1.0, 1.0, 1.0],      // 白色
+            rapid: [0.2, 0.5, 1.0, 1.0],        // 青色
+            approach: [0.2, 1.0, 0.2, 1.0],     // 緑色
+            retract: [1.0, 1.0, 0.2, 1.0],      // 黄色
+            pass_retract: [1.0, 0.6, 0.2, 1.0], // オレンジ色
+            down_cut: [1.0, 1.0, 1.0, 1.0],     // 白色
+            up_cut: [1.0, 0.5, 0.2, 1.0],       // オレンジ色
         }
     }
 }


### PR DESCRIPTION
## 概要

Issue #203（CAM可視化システム設計・実装）のPhase 1実装です。
CAM工具経路のGPU可視化システムを4レイヤー構成で実装しました。

## 実装内容

### 1. model/cam_core - CAM工具経路データ構造
- **3フェーズ構造**: Approach（アプローチ）、Cutting（切削）、Retract（退避）
- **5種類のSegmentType**:
  - Rapid: 早送り移動
  - Linear: 直線補間（G01）
  - ArcCW/ArcCCW: 円弧補間（G02/G03）
  - Retract/PassRetract: 工具退避（feed_rate付き）
- **周回間移動5パターン対応**: 切削方向・退避タイプの組み合わせ
- **テスト**: 18 unit + 14 doc tests成功

### 2. viewmodel/converter - GPU頂点変換
- **App層設定注入方式**: 色・テッセレーション・トレランス設定
- **円弧テッセレーション**: 円弧を直線セグメントに分割
- **5色カラースキーム**: Approach/Cutting/Retract/PassRetract/Rapidの色分け
- **テスト**: 24 tests成功（基本変換7件、円弧テッセレーション11件、エッジケース6件）

### 3. view/render - GPU描画リソース
- **ToolPathResources**: 頂点バッファ、パイプライン、ユニフォーム管理
- **LineList トポロジー**: 連続線分描画
- **頂点カラー**: セグメント種別に応じた色分け
- **WGSL シェーダー**: view/render/shaders/toolpath.wgsl

### 4. view/stage - レンダリングステージ統合
- **ToolPathStage**: RenderStageトレイト実装
- **カメラ行列更新**: ビュー×プロジェクション行列の自動計算
- **テスト**: 2 tests成功

## データフロー

\\\
cam_core::ToolPath 
  → viewmodel::toolpath_to_vertices() 
  → ToolPathVertex[] 
  → ToolPathStage::set_toolpath_data() 
  → GPU描画
\\\

## テスト結果

✅ **ビルド**: workspace全体成功
✅ **テスト**: 全成功（cam_core: 18+14、viewmodel: 24、stage: 2）
✅ **Clippy**: 警告なし

## コミット履歴

- d71f037: chore: Update Cargo.lock
- 0d9d208: feat(stage): Add CAM toolpath rendering stage
- 2eb1e9d: feat(render): Add CAM toolpath GPU rendering resources
- d88aa5d: feat(viewmodel): Add CAM toolpath visualization converter
- d1e6ae9: refactor(cam_core): Enhance ToolPath structure
- 4c4ea03: feat: cam_coreクレート実装完了

## Phase 1スコープ

✅ **完了**: CAM工具経路の可視化システム（表示機能）
❌ **除外**: オフセット演算機能（別Issue化）

オフセット演算機能は以下の新Issueに分離：
- **Issue #211**: 3D CAM三角形メッシュオフセット（工具2種類対応）
- **Issue #212**: 2D CAM輪郭線オフセット

## 関連Issue

Closes #203

## 確認事項

- [x] 全テスト成功
- [x] Clippyチェック成功
- [x] ドキュメントコメント追加
- [x] 設計方針（Foundation パターン）遵守
- [x] マージ先はdevelopブランチ
