### PR TITLE
fix(#219): Camera view/projection matrix calculations

### DIFF
--- a/view/render/shaders/line.wgsl
+++ b/view/render/shaders/line.wgsl
@@ -22,13 +22,10 @@ var<uniform> uniforms: Uniforms;
 fn vs_main(input: VertexInput) -> VertexOutput {
     var out: VertexOutput;
 
-    // デバッグ: カメラ行列を無視して、ワールド座標を直接クリップ空間にマッピング
-    // ワークピース範囲 (0-100, 0-100, 0-50) を (-1,1) の範囲にマッピング
-    let x = (input.position.x / 50.0) - 1.0;  // 0-100 → -1 to 1
-    let y = (input.position.y / 50.0) - 1.0;  // 0-100 → -1 to 1
-    let z = 0.0;  // Z座標は固定（深度なし）
-    
-    out.clip_position = vec4<f32>(x, y, z, 1.0);
+    // カメラ行列を適用して正しい3D変換を実施
+    // model 行列でワールド座標に変換 → view_proj 行列でクリップ空間に変換
+    let world_position = uniforms.model * vec4<f32>(input.position, 1.0);
+    out.clip_position = uniforms.view_proj * world_position;
 
     return out;
 }

--- a/view/render/src/line.rs
+++ b/view/render/src/line.rs
@@ -180,7 +180,7 @@ impl LineResources {
         // proj × view の順序でview-projection行列を計算
         // camera.rs から to_column_major() で列優先形式の配列が渡されるため、
         // from_column_major() を使用して正しく行列を構築
-        // 
+        //
         // wgpu での行列乗算順序: view * proj（view先、projection後）
         // これは、ワールド座標をビュー空間に変換してから投影空間に変換するため
         let proj = Matrix4x4::from_column_major(proj_matrix);

--- a/view/render/src/line.rs
+++ b/view/render/src/line.rs
@@ -178,9 +178,14 @@ impl LineResources {
         );
 
         // proj × view の順序でview-projection行列を計算
-        let proj = Matrix4x4::from(proj_matrix);
-        let view = Matrix4x4::from(view_matrix);
-        let view_proj = (proj * view).to_column_major();
+        // camera.rs から to_column_major() で列優先形式の配列が渡されるため、
+        // from_column_major() を使用して正しく行列を構築
+        // 
+        // wgpu での行列乗算順序: view * proj（view先、projection後）
+        // これは、ワールド座標をビュー空間に変換してから投影空間に変換するため
+        let proj = Matrix4x4::from_column_major(proj_matrix);
+        let view = Matrix4x4::from_column_major(view_matrix);
+        let view_proj = (view * proj).to_column_major();
 
         tracing::warn!(
             "  view_proj[3]: [{:.3}, {:.3}, {:.3}, {:.3}]",

--- a/view/render/src/mesh.rs
+++ b/view/render/src/mesh.rs
@@ -193,9 +193,13 @@ impl MeshResources {
         proj_matrix: [[f32; 4]; 4],
     ) {
         // ビュー・プロジェクション行列を計算
-        let proj = Matrix4x4::from(proj_matrix);
-        let view = Matrix4x4::from(view_matrix);
-        let view_proj = (proj * view).to_column_major();
+        // camera.rs から to_column_major() で列優先形式の配列が渡されるため、
+        // from_column_major() を使用して正しく行列を構築
+        //
+        // wgpu での行列乗算順序: view * proj（view先、projection後）
+        let proj = Matrix4x4::from_column_major(proj_matrix);
+        let view = Matrix4x4::from_column_major(view_matrix);
+        let view_proj = (view * proj).to_column_major();
 
         let uniforms = MeshUniforms {
             view_proj,

--- a/viewmodel/graphics/src/camera.rs
+++ b/viewmodel/graphics/src/camera.rs
@@ -83,14 +83,18 @@ impl Camera {
 
     /// ビュー行列を計算
     pub fn view_matrix(&self) -> [[f32; 4]; 4] {
-        // カメラ位置を target, distance から計算（真上から見る視点）
-        let camera_pos = Vec3f::new(
-            self.target.x(),
-            self.target.y(),
-            self.target.z() + self.distance,
-        );
+        // カメラの基本方向ベクトル（Z軸の負方向を向く）
+        let forward_base = Vec3f::new(0.0, 0.0, -1.0);
 
-        let up = Vec3f::new(0.0, 1.0, 0.0); // Y軸をupとする
+        // クォータニオンで回転を適用
+        let forward = self.rotation.rotate_vector(&forward_base);
+
+        // カメラ位置 = target + (回転された方向 × 距離)
+        let camera_pos = self.target + forward * self.distance;
+
+        // Up ベクトルも回転を適用
+        let up_base = Vec3f::new(0.0, 1.0, 0.0);
+        let up = self.rotation.rotate_vector(&up_base);
 
         Matrix4x4::look_at(&camera_pos, &self.target, &up)
             .unwrap_or_else(|_| Matrix4x4::identity())
@@ -105,7 +109,9 @@ impl Camera {
                 let near = (self.distance * 0.01).max(0.001); // 距離の1%、最小0.001
                 let far = (self.distance * 100.0).min(1000.0); // 距離の100倍、最大1000
 
-                Matrix4x4::perspective(45.0 * PI / 180.0, aspect, near, far).to_column_major()
+                // wgpu は DirectX スタイル（Z範囲 [0, 1]）を使用
+                Matrix4x4::perspective_rh_01(45.0 * PI / 180.0, aspect, near, far)
+                    .to_column_major()
             }
             ProjectionMode::Orthographic => {
                 // 平行投影：距離とズームに基づいてサイズを決定
@@ -117,9 +123,42 @@ impl Camera {
                 let near = -1000.0; // 平行投影では大きな範囲を使用
                 let far = 1000.0;
 
-                Matrix4x4::orthographic(left, right, bottom, top, near, far).to_column_major()
+                // wgpu 用の平行投影行列（Z範囲 [0, 1]）を手動構築
+                self.orthographic_rh_01(left, right, bottom, top, near, far)
             }
         }
+    }
+
+    /// wgpu 用の平行投影行列（Z範囲 [0, 1]、右手座標系）
+    ///
+    /// analysis::Matrix4x4 は汎用ライブラリなので wgpu 固有の実装は持たない。
+    /// View 層の責務として、ここで wgpu に適した行列を構築する。
+    fn orthographic_rh_01(
+        &self,
+        left: f32,
+        right: f32,
+        bottom: f32,
+        top: f32,
+        near: f32,
+        far: f32,
+    ) -> [[f32; 4]; 4] {
+        let rl_inv = 1.0 / (right - left);
+        let tb_inv = 1.0 / (top - bottom);
+        let fn_inv = 1.0 / (far - near);
+
+        // wgpu (DirectX) スタイル: Z範囲 [0, 1]
+        // OpenGL と異なり、Z成分は -1/(far-near) を使用
+        [
+            [2.0 * rl_inv, 0.0, 0.0, 0.0],
+            [0.0, 2.0 * tb_inv, 0.0, 0.0],
+            [0.0, 0.0, -fn_inv, 0.0],
+            [
+                -(right + left) * rl_inv,
+                -(top + bottom) * tb_inv,
+                -near * fn_inv,
+                1.0,
+            ],
+        ]
     }
 
     /// 投影モードを切り替え

--- a/viewmodel/graphics/src/camera.rs
+++ b/viewmodel/graphics/src/camera.rs
@@ -110,8 +110,7 @@ impl Camera {
                 let far = (self.distance * 100.0).min(1000.0); // 距離の100倍、最大1000
 
                 // wgpu は DirectX スタイル（Z範囲 [0, 1]）を使用
-                Matrix4x4::perspective_rh_01(45.0 * PI / 180.0, aspect, near, far)
-                    .to_column_major()
+                Matrix4x4::perspective_rh_01(45.0 * PI / 180.0, aspect, near, far).to_column_major()
             }
             ProjectionMode::Orthographic => {
                 // 平行投影：距離とズームに基づいてサイズを決定


### PR DESCRIPTION
## Issue
Fixes #219

## 修正内容

### viewmodel/graphics/src/camera.rs
- **view_matrix() に Quaternion による回転を統合**
  - 修正前: 回転を無視した固定視点（真上から見る）
  - 修正後: クォータニオンで回転を正しく適用
  - `forward = rotation.rotate_vector(&forward_base)` で正しい視点を計算

- **projection_matrix() を wgpu (DirectX) 対応に修正**
  - 透視投影: `perspective()` → `perspective_rh_01()` に変更
    - OpenGL 形式: Z範囲 [-1, 1] → DirectX 形式: Z範囲 [0, 1]
  - 平行投影: `orthographic_rh_01()` メソッドを新規実装
    - View層の責務でwgpu固有の行列形式を構築
    - 責務分離の観点から、graphics層は汎用ライブラリに依存しない

### view/render/shaders/line.wgsl
- 暫定対応（カメラ行列を無視してワールド座標を直接変換）を削除
- 正しいカメラ行列を適用
  ```wgsl
  out.clip_position = uniforms.view_proj * world_position;
  ```

### view/render/src/line.rs, mesh.rs
- **行列フォーマット問題を修正**
  - `Matrix4x4::from()` → `from_column_major()` に変更
  - camera.rs が `to_column_major()` で列優先形式を返すため

- **行列乗算順序を修正**
  - `proj * view` → `view * proj` に変更
  - wgpu での正しい変換順序（ワールド座標 → ビュー空間 → クリップ空間）

## 動作確認
- ✅ `cargo test -p viewmodel-graphics`: 12/12 pass
- ✅ `cargo build`: エラーなし
- ✅ 実行時: Ctrl+マウスドラッグで視点回転が正常に機能
- ✅ Octree ワイヤーフレーム表示が正常に機能

## 関連ドキュメント
- Issue #207 (Octree可視化) で暫定対応されていた機能が正常化
- 今後の3D描画機能すべてに影響するカメラシステムの根本修正

## 注記
- カメラ操作性の向上（初期距離調整、パン操作など）は別Issue で対応予定
- 本PR は「カメラ行列計算の正確性」に焦点を当てたもの