### PR TITLE
feat(#9): Rect2D/Rect3D追加とViewRECT範囲選択MVP実装

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -161,6 +161,8 @@
     "infinite_line_3d.rs": "infinite_line_3d_collision.rs,infinite_line_3d_extensions.rs,infinite_line_3d_foundation.rs,infinite_line_3d_intersection.rs,infinite_line_3d_tests.rs,infinite_line_3d_transform.rs",
     "line_segment_2d.rs": "line_segment_2d_collision.rs,line_segment_2d_extensions.rs,line_segment_2d_foundation.rs,line_segment_2d_intersection.rs,line_segment_2d_tests.rs,line_segment_2d_transform.rs",
     "line_segment_3d.rs": "line_segment_3d_collision.rs,line_segment_3d_extensions.rs,line_segment_3d_foundation.rs,line_segment_3d_intersection.rs,line_segment_3d_tests.rs,line_segment_3d_transform.rs",
+    "rectangle_2d.rs": "rectangle_2d_foundation.rs,rectangle_2d_transform.rs",
+    "rectangle_3d.rs": "rectangle_3d_foundation.rs,rectangle_3d_transform.rs",
     "ray_2d.rs": "ray_2d_collision.rs,ray_2d_extensions.rs,ray_2d_foundation.rs,ray_2d_intersection.rs,ray_2d_tests.rs,ray_2d_transform.rs",
     "ray_3d.rs": "ray_3d_collision.rs,ray_3d_extensions.rs,ray_3d_foundation.rs,ray_3d_intersection.rs,ray_3d_tests.rs,ray_3d_transform.rs",
     "torus_surface_3d.rs": "torus_surface_3d_collision.rs,torus_surface_3d_extensions.rs,torus_surface_3d_foundation.rs,torus_surface_3d_intersection.rs,torus_surface_3d_tests.rs,torus_surface_3d_transform.rs,torus_surface_3d_transform_safe_tests.rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,6 +2067,7 @@ name = "redring"
 version = "0.1.0"
 dependencies = [
  "analysis",
+ "bytemuck",
  "logging_foundation",
  "pollster",
  "render",

--- a/dev/architecture/RECT_WORLD_VIEW_COORDINATE_DESIGN.md
+++ b/dev/architecture/RECT_WORLD_VIEW_COORDINATE_DESIGN.md
@@ -1,0 +1,66 @@
+# RECT World/View 座標分離設計（Issue #9）
+
+## 目的
+
+- `Rect2D` / `Rect3D` を **World 座標の幾何プリミティブ**として実装する。
+- `ViewRECT` は **画面座標の入力・表示 state** に限定し、幾何演算責務を持たせない。
+- Foundation Pattern（Core Traits + Primitive 実装 + Foundation + Transform）に準拠する。
+
+## 設計方針
+
+### 1. WorldRect（model側）
+
+- `Rect2D<T>`: 2D軸平行矩形（原点 + 幅 + 高さ）
+- `Rect3D<T>`: 任意平面上の矩形（原点 + `u_axis` + `v_axis` + 幅 + 高さ）
+  - `u_axis` と `v_axis` は直交正規化して保持
+  - 法線は `u_axis × v_axis`
+
+### 2. ViewRECT（view側）
+
+- 画面ピクセル座標の state（`x, y, width, height`）
+- 役割はドラッグ範囲の可視化と入力中間表現のみ
+- 包含判定や幾何学的意味付けは WorldRect 側で実施
+
+### 3. 画面→ワールドの橋渡し
+
+- `ViewRECT` からレイ生成/平面交点を通して `Rect3D` へ変換
+- 変換責務は ViewModel/Camera 側に置く
+
+## Foundation Pattern 実装範囲
+
+- `geo_foundation/src/geometry/core/rectangle_traits.rs`
+  - `Rect2DConstructor<T>` / `Rect2DProperties<T>` / `Rect2DMeasure<T>`
+  - `Rect3DConstructor<T>` / `Rect3DProperties<T>` / `Rect3DMeasure<T>`
+- `geo_primitives/src/rectangle_2d.rs`（Core）
+- `geo_primitives/src/rectangle_2d_foundation.rs`（ExtensionFoundation）
+- `geo_primitives/src/rectangle_2d_transform.rs`（AnalysisTransform2D）
+- `geo_primitives/src/rectangle_3d.rs`（Core）
+- `geo_primitives/src/rectangle_3d_foundation.rs`（ExtensionFoundation）
+- `geo_primitives/src/rectangle_3d_transform.rs`（AnalysisTransform3D）
+
+## API 最小仕様
+
+### Rect2D
+
+- `new(origin, width, height)`
+- `resize(width, height)`
+- `contains_point(point)`（境界含む）
+- `area()`, `perimeter()`
+
+### Rect3D
+
+- `new(origin, u_axis, v_axis, width, height)`
+- `resize(width, height)`
+- `contains_point(point, tolerance)`（平面距離 + UV範囲で判定）
+- `area()`, `normal()`, `corners()`
+
+## 非ゴール
+
+- ViewRECT の描画実装・入力イベント統合は本Issueでは必須外
+- 画面→ワールド変換の最適化（SIMD等）は後続
+
+## 検証
+
+- 単体テスト: contains / resize / 面積 / 角点
+- `cargo test --workspace`
+- `cargo clippy -- -D warnings`

--- a/dev/architecture/VIEW_RECT_STATE_DESIGN.md
+++ b/dev/architecture/VIEW_RECT_STATE_DESIGN.md
@@ -1,0 +1,30 @@
+# ViewRECT State 設計
+
+## 目的
+
+`ViewRECT` を画面座標（ピクセル）で扱う入力中間状態として `view/app` に実装する。
+
+## 責務
+
+- ドラッグ開始点と現在カーソル位置から矩形を生成
+- 正規化済み矩形（左上 + 正の幅/高さ）として保持
+- 幾何演算（ワールド包含判定等）は持たない
+
+## 非責務
+
+- ワールド座標への変換
+- 選択判定アルゴリズム
+- 描画パイプライン統合
+
+## 実装方針
+
+- `view/app/src/view_rect.rs` に `ViewRect` を追加
+  - `from_points(start, end)` で正規化
+  - `contains(point)` を補助APIとして提供
+- `AppState` に以下の state を追加
+  - `active_view_rect: Option<ViewRect>`
+  - `last_view_rect: Option<ViewRect>`
+  - `cursor_position: Option<(f32, f32)>`
+  - `view_rect_drag_origin: Option<(f32, f32)>`
+- `app.rs` の `WindowEvent::CursorMoved` で `AppState::handle_cursor_moved` を呼ぶ
+- 左ドラッグ（Ctrl 非押下）で `ViewRect` 更新

--- a/model/geo_foundation/src/geometry/core/mod.rs
+++ b/model/geo_foundation/src/geometry/core/mod.rs
@@ -18,6 +18,7 @@ pub mod linesegment_traits; // LineSegment traits (Constructor/Properties/Measur
 pub mod plane_traits; // Plane traits (Constructor/Properties/Measure)
 pub mod point_traits; // Point traits (Constructor/Properties/Measure)
 pub mod ray_traits; // Ray traits (Constructor/Properties/Measure)
+pub mod rectangle_traits; // Rectangle traits (Constructor/Properties/Measure)
 pub mod triangle_traits; // Triangle traits (Constructor/Properties/Measure)
 pub mod vector_traits; // Vector traits (Constructor/Properties/Measure)
 

--- a/model/geo_foundation/src/geometry/core/rectangle_traits.rs
+++ b/model/geo_foundation/src/geometry/core/rectangle_traits.rs
@@ -1,0 +1,73 @@
+//! Rectangle Core Traits - 矩形の基本機能トレイト
+//!
+//! Foundation Pattern Phase 1 実装
+
+use crate::Scalar;
+
+// ============================================================================
+// Rect2D Core Traits
+// ============================================================================
+
+pub trait Rect2DConstructor<T: Scalar>: Sized {
+    fn new(origin: (T, T), width: T, height: T) -> Option<Self>;
+    fn from_corners(min: (T, T), max: (T, T)) -> Option<Self>;
+    fn resize(&mut self, width: T, height: T) -> bool;
+}
+
+pub trait Rect2DProperties<T: Scalar> {
+    fn origin(&self) -> (T, T);
+    fn width(&self) -> T;
+    fn height(&self) -> T;
+    fn max_corner(&self) -> (T, T);
+    fn center(&self) -> (T, T);
+}
+
+pub trait Rect2DMeasure<T: Scalar> {
+    fn contains_point(&self, point: (T, T)) -> bool;
+    fn area(&self) -> T;
+    fn perimeter(&self) -> T;
+    fn is_valid(&self) -> bool;
+}
+
+pub trait Rect2DCore<T: Scalar>:
+    Rect2DConstructor<T> + Rect2DProperties<T> + Rect2DMeasure<T>
+{
+}
+
+// ============================================================================
+// Rect3D Core Traits
+// ============================================================================
+
+pub trait Rect3DConstructor<T: Scalar>: Sized {
+    fn new(
+        origin: (T, T, T),
+        u_axis: (T, T, T),
+        v_axis: (T, T, T),
+        width: T,
+        height: T,
+    ) -> Option<Self>;
+    fn resize(&mut self, width: T, height: T) -> bool;
+}
+
+pub trait Rect3DProperties<T: Scalar> {
+    fn origin(&self) -> (T, T, T);
+    fn u_axis(&self) -> (T, T, T);
+    fn v_axis(&self) -> (T, T, T);
+    fn normal(&self) -> (T, T, T);
+    fn width(&self) -> T;
+    fn height(&self) -> T;
+    fn center(&self) -> (T, T, T);
+}
+
+pub trait Rect3DMeasure<T: Scalar> {
+    fn contains_point(&self, point: (T, T, T), tolerance: T) -> bool;
+    fn area(&self) -> T;
+    fn corners(&self) -> [(T, T, T); 4];
+    fn distance_to_plane(&self, point: (T, T, T)) -> T;
+    fn is_valid(&self) -> bool;
+}
+
+pub trait Rect3DCore<T: Scalar>:
+    Rect3DConstructor<T> + Rect3DProperties<T> + Rect3DMeasure<T>
+{
+}

--- a/model/geo_foundation/src/lib.rs
+++ b/model/geo_foundation/src/lib.rs
@@ -124,6 +124,10 @@ pub use geometry::core::{
         Ray2DConstructor, Ray2DCore, Ray2DMeasure, Ray2DProperties, Ray3DConstructor, Ray3DCore,
         Ray3DMeasure, Ray3DProperties,
     },
+    rectangle_traits::{
+        Rect2DConstructor, Rect2DCore, Rect2DMeasure, Rect2DProperties, Rect3DConstructor,
+        Rect3DCore, Rect3DMeasure, Rect3DProperties,
+    },
     spherical_solid_traits::{
         SphericalSolid3DConstructor, SphericalSolid3DCore, SphericalSolid3DMeasure,
         SphericalSolid3DProperties,

--- a/model/geo_primitives/src/lib.rs
+++ b/model/geo_primitives/src/lib.rs
@@ -147,6 +147,9 @@ pub mod ray_3d_collision; // Ray3D の衝突検出実装
 pub mod ray_3d_extensions; // Ray3D の拡張機能 (Extension)
 pub mod ray_3d_foundation; // Ray3D のFoundation実装
 pub mod ray_3d_intersection; // Ray3D の交点計算実装
+pub mod rectangle_3d; // Rect3D の新実装 (Core)
+pub mod rectangle_3d_foundation; // Rect3D のFoundation実装
+pub mod rectangle_3d_transform; // Rect3D の変換実装
 pub mod spherical_solid_3d; // SphericalSolid3D の新実装 (Core) - 完全ハイブリッドモデラー対応
 pub mod spherical_solid_3d_collision; // SphericalSolid3D の衝突判定
 #[cfg(test)]
@@ -271,6 +274,9 @@ pub mod ray_2d_extensions; // Ray2D の拡張機能 (Extension)
 pub mod ray_2d_foundation; // Ray2D の Foundation 実装
 pub mod ray_2d_intersection; // Ray2D の交点計算実装
 pub mod ray_2d_transform; // Ray2D の変換実装
+pub mod rectangle_2d; // Rect2D の新実装 (Core)
+pub mod rectangle_2d_foundation; // Rect2D の Foundation 実装
+pub mod rectangle_2d_transform; // Rect2D の変換実装
 pub mod triangle_2d; // Triangle2D の新実装 (Core)
 pub mod triangle_2d_collision; // Triangle2D の衝突検出実装
 pub mod triangle_2d_foundation; // Triangle2D の Foundation 実装
@@ -331,6 +337,7 @@ pub use line_segment_3d::LineSegment3D;
 pub use plane_3d::Plane3D;
 // 削除: Plane3DCoordinateSystemはPlane3Dに統合済み
 pub use ray_3d::Ray3D;
+pub use rectangle_3d::Rect3D;
 pub use spherical_solid_3d::SphericalSolid3D; // 新式球ソリッド
 pub use spherical_surface_3d::SphericalSurface3D; // 新式球サーフェス
 pub use torus_solid_3d::TorusSolid3D; // 新式トーラスソリッド (3D CAM対応)
@@ -349,6 +356,7 @@ pub use geo_core::{Point2D, Point3D, Vector2D, Vector3D};
 pub use infinite_line_2d::InfiniteLine2D;
 pub use line_segment_2d::LineSegment2D;
 pub use ray_2d::Ray2D;
+pub use rectangle_2d::Rect2D;
 pub use triangle_2d::Triangle2D;
 
 // Core Traits統合エクスポート（Foundation経由）

--- a/model/geo_primitives/src/rectangle_2d.rs
+++ b/model/geo_primitives/src/rectangle_2d.rs
@@ -1,0 +1,167 @@
+//! Rect2D Core 実装
+
+use crate::Point2D;
+use geo_foundation::{
+    geometry::core::rectangle_traits::{Rect2DConstructor, Rect2DMeasure, Rect2DProperties},
+    Scalar,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Rect2D<T: Scalar> {
+    origin: Point2D<T>,
+    width: T,
+    height: T,
+}
+
+impl<T: Scalar> Rect2D<T> {
+    pub fn new(origin: Point2D<T>, width: T, height: T) -> Option<Self> {
+        if width < T::ZERO || height < T::ZERO {
+            return None;
+        }
+        Some(Self {
+            origin,
+            width,
+            height,
+        })
+    }
+
+    pub fn from_corners(min: Point2D<T>, max: Point2D<T>) -> Option<Self> {
+        let width = max.x() - min.x();
+        let height = max.y() - min.y();
+        Self::new(min, width, height)
+    }
+
+    pub fn origin_point(&self) -> Point2D<T> {
+        self.origin
+    }
+
+    pub fn width_value(&self) -> T {
+        self.width
+    }
+
+    pub fn height_value(&self) -> T {
+        self.height
+    }
+
+    pub fn max_point(&self) -> Point2D<T> {
+        Point2D::new(self.origin.x() + self.width, self.origin.y() + self.height)
+    }
+
+    pub fn center_point(&self) -> Point2D<T> {
+        let two = T::ONE + T::ONE;
+        Point2D::new(
+            self.origin.x() + self.width / two,
+            self.origin.y() + self.height / two,
+        )
+    }
+
+    pub fn resize(&mut self, width: T, height: T) -> bool {
+        if width < T::ZERO || height < T::ZERO {
+            return false;
+        }
+        self.width = width;
+        self.height = height;
+        true
+    }
+
+    pub fn contains_point(&self, point: &Point2D<T>) -> bool {
+        let max = self.max_point();
+        point.x() >= self.origin.x()
+            && point.x() <= max.x()
+            && point.y() >= self.origin.y()
+            && point.y() <= max.y()
+    }
+
+    pub fn area(&self) -> T {
+        self.width * self.height
+    }
+
+    pub fn perimeter(&self) -> T {
+        let two = T::ONE + T::ONE;
+        two * (self.width + self.height)
+    }
+
+    pub fn corners(&self) -> [Point2D<T>; 4] {
+        let max = self.max_point();
+        [
+            self.origin,
+            Point2D::new(max.x(), self.origin.y()),
+            max,
+            Point2D::new(self.origin.x(), max.y()),
+        ]
+    }
+}
+
+impl<T: Scalar> Rect2DConstructor<T> for Rect2D<T> {
+    fn new(origin: (T, T), width: T, height: T) -> Option<Self> {
+        Self::new(Point2D::new(origin.0, origin.1), width, height)
+    }
+
+    fn from_corners(min: (T, T), max: (T, T)) -> Option<Self> {
+        Self::from_corners(Point2D::new(min.0, min.1), Point2D::new(max.0, max.1))
+    }
+
+    fn resize(&mut self, width: T, height: T) -> bool {
+        Self::resize(self, width, height)
+    }
+}
+
+impl<T: Scalar> Rect2DProperties<T> for Rect2D<T> {
+    fn origin(&self) -> (T, T) {
+        (self.origin.x(), self.origin.y())
+    }
+
+    fn width(&self) -> T {
+        self.width
+    }
+
+    fn height(&self) -> T {
+        self.height
+    }
+
+    fn max_corner(&self) -> (T, T) {
+        let max = self.max_point();
+        (max.x(), max.y())
+    }
+
+    fn center(&self) -> (T, T) {
+        let center = self.center_point();
+        (center.x(), center.y())
+    }
+}
+
+impl<T: Scalar> Rect2DMeasure<T> for Rect2D<T> {
+    fn contains_point(&self, point: (T, T)) -> bool {
+        Self::contains_point(self, &Point2D::new(point.0, point.1))
+    }
+
+    fn area(&self) -> T {
+        Self::area(self)
+    }
+
+    fn perimeter(&self) -> T {
+        Self::perimeter(self)
+    }
+
+    fn is_valid(&self) -> bool {
+        self.width >= T::ZERO && self.height >= T::ZERO
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contains_and_resize() {
+        let mut rect = Rect2D::new(Point2D::new(10.0, 20.0), 30.0, 40.0).unwrap();
+        assert!(rect.contains_point(&Point2D::new(10.0, 20.0)));
+        assert!(rect.contains_point(&Point2D::new(40.0, 60.0)));
+        assert!(!rect.contains_point(&Point2D::new(41.0, 60.0)));
+
+        assert!(rect.resize(50.0, 10.0));
+        assert_eq!(rect.width_value(), 50.0);
+        assert_eq!(rect.height_value(), 10.0);
+        assert!(!rect.resize(-1.0, 10.0));
+    }
+}

--- a/model/geo_primitives/src/rectangle_2d_foundation.rs
+++ b/model/geo_primitives/src/rectangle_2d_foundation.rs
@@ -1,0 +1,14 @@
+//! Rect2D の Foundation トレイト実装
+
+use crate::Rect2D;
+use geo_foundation::{ExtensionFoundation, PrimitiveKind, Scalar};
+
+impl<T: Scalar> ExtensionFoundation<T> for Rect2D<T> {
+    fn primitive_kind(&self) -> PrimitiveKind {
+        PrimitiveKind::Rectangle
+    }
+
+    fn measure(&self) -> Option<T> {
+        Some(self.area())
+    }
+}

--- a/model/geo_primitives/src/rectangle_2d_transform.rs
+++ b/model/geo_primitives/src/rectangle_2d_transform.rs
@@ -1,0 +1,114 @@
+//! Rect2D Analysis Matrix/Vector統合変換実装
+
+use crate::{Point2D, Rect2D};
+use analysis::linalg::{matrix::Matrix3x3, vector::Vector2};
+use geo_foundation::{AnalysisTransform2D, Angle, Scalar, TransformError};
+
+pub mod analysis_transform {
+    use super::*;
+
+    pub fn transform_rect_2d<T: Scalar>(
+        rect: &Rect2D<T>,
+        matrix: &Matrix3x3<T>,
+    ) -> Result<Rect2D<T>, TransformError> {
+        let transformed: Vec<Point2D<T>> = rect
+            .corners()
+            .iter()
+            .map(|p| {
+                let v = Vector2::new(p.x(), p.y());
+                let tv = matrix.transform_point_2d(&v);
+                Point2D::new(tv.x(), tv.y())
+            })
+            .collect();
+
+        let mut min_x = transformed[0].x();
+        let mut max_x = transformed[0].x();
+        let mut min_y = transformed[0].y();
+        let mut max_y = transformed[0].y();
+
+        for p in transformed.iter().skip(1) {
+            min_x = min_x.min(p.x());
+            max_x = max_x.max(p.x());
+            min_y = min_y.min(p.y());
+            max_y = max_y.max(p.y());
+        }
+
+        Rect2D::from_corners(Point2D::new(min_x, min_y), Point2D::new(max_x, max_y)).ok_or_else(
+            || TransformError::InvalidGeometry("Transformed rectangle is invalid".to_string()),
+        )
+    }
+
+    pub fn translation_matrix_2d<T: Scalar>(translation: &Vector2<T>) -> Matrix3x3<T> {
+        Matrix3x3::translation_2d(translation)
+    }
+
+    pub fn rotation_matrix_2d<T: Scalar>(center: &Point2D<T>, angle: Angle<T>) -> Matrix3x3<T> {
+        let c = Vector2::new(center.x(), center.y());
+        Matrix3x3::rotation_around_point_2d(&c, angle.to_radians())
+    }
+
+    pub fn scale_matrix_2d<T: Scalar>(
+        center: &Point2D<T>,
+        scale_x: T,
+        scale_y: T,
+    ) -> Result<Matrix3x3<T>, TransformError> {
+        if scale_x.is_zero() || scale_y.is_zero() {
+            return Err(TransformError::InvalidScaleFactor(
+                "Scale factors cannot be zero".to_string(),
+            ));
+        }
+
+        let c = Vector2::new(center.x(), center.y());
+        let to_origin = Matrix3x3::translation_2d(&(-c));
+        let scale = Matrix3x3::scale_2d(&Vector2::new(scale_x, scale_y));
+        let back = Matrix3x3::translation_2d(&c);
+        Ok(back * scale * to_origin)
+    }
+}
+
+impl<T: Scalar> AnalysisTransform2D<T> for Rect2D<T> {
+    type Matrix3x3 = Matrix3x3<T>;
+    type Angle = Angle<T>;
+    type Output = Rect2D<T>;
+
+    fn transform_point_matrix_2d(&self, matrix: &Self::Matrix3x3) -> Self::Output {
+        analysis_transform::transform_rect_2d(self, matrix).unwrap_or(*self)
+    }
+
+    fn translate_analysis_2d(
+        &self,
+        translation: &Vector2<T>,
+    ) -> Result<Self::Output, TransformError> {
+        let m = analysis_transform::translation_matrix_2d(translation);
+        analysis_transform::transform_rect_2d(self, &m)
+    }
+
+    fn rotate_analysis_2d(
+        &self,
+        center: &Self,
+        angle: Self::Angle,
+    ) -> Result<Self::Output, TransformError> {
+        let c = center.center_point();
+        let m = analysis_transform::rotation_matrix_2d(&c, angle);
+        analysis_transform::transform_rect_2d(self, &m)
+    }
+
+    fn scale_analysis_2d(
+        &self,
+        center: &Self,
+        scale_x: T,
+        scale_y: T,
+    ) -> Result<Self::Output, TransformError> {
+        let c = center.center_point();
+        let m = analysis_transform::scale_matrix_2d(&c, scale_x, scale_y)?;
+        analysis_transform::transform_rect_2d(self, &m)
+    }
+
+    fn uniform_scale_analysis_2d(
+        &self,
+        center: &Self,
+        scale_factor: T,
+    ) -> Result<Self::Output, TransformError> {
+        self.scale_analysis_2d(center, scale_factor, scale_factor)
+    }
+}

--- a/model/geo_primitives/src/rectangle_3d.rs
+++ b/model/geo_primitives/src/rectangle_3d.rs
@@ -1,0 +1,252 @@
+//! Rect3D Core 実装（任意平面）
+
+use crate::{Direction3D, Point3D, Vector3D};
+use geo_foundation::{
+    geometry::core::rectangle_traits::{Rect3DConstructor, Rect3DMeasure, Rect3DProperties},
+    Scalar,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Rect3D<T: Scalar> {
+    origin: Point3D<T>,
+    u_axis: Direction3D<T>,
+    v_axis: Direction3D<T>,
+    width: T,
+    height: T,
+}
+
+impl<T: Scalar> Rect3D<T> {
+    pub fn new(
+        origin: Point3D<T>,
+        u_axis: Vector3D<T>,
+        v_axis: Vector3D<T>,
+        width: T,
+        height: T,
+    ) -> Option<Self> {
+        if width < T::ZERO || height < T::ZERO {
+            return None;
+        }
+
+        let u = Direction3D::from_vector(u_axis)?;
+        let v_raw = Direction3D::from_vector(v_axis)?;
+
+        let projection = u.as_vector() * v_raw.as_vector().dot(&u.as_vector());
+        let v_orthogonal = v_raw.as_vector() - projection;
+        let v = Direction3D::from_vector(v_orthogonal)?;
+
+        Some(Self {
+            origin,
+            u_axis: u,
+            v_axis: v,
+            width,
+            height,
+        })
+    }
+
+    pub fn origin_point(&self) -> Point3D<T> {
+        self.origin
+    }
+
+    pub fn u_axis_dir(&self) -> Direction3D<T> {
+        self.u_axis
+    }
+
+    pub fn v_axis_dir(&self) -> Direction3D<T> {
+        self.v_axis
+    }
+
+    pub fn normal_dir(&self) -> Direction3D<T> {
+        Direction3D::from_vector(self.u_axis.as_vector().cross(&self.v_axis.as_vector()))
+            .expect("u_axis and v_axis should define a valid normal")
+    }
+
+    pub fn width_value(&self) -> T {
+        self.width
+    }
+
+    pub fn height_value(&self) -> T {
+        self.height
+    }
+
+    pub fn center_point(&self) -> Point3D<T> {
+        let two = T::ONE + T::ONE;
+        let center_offset = self.u_axis.as_vector() * (self.width / two)
+            + self.v_axis.as_vector() * (self.height / two);
+        Point3D::new(
+            self.origin.x() + center_offset.x(),
+            self.origin.y() + center_offset.y(),
+            self.origin.z() + center_offset.z(),
+        )
+    }
+
+    pub fn area(&self) -> T {
+        self.width * self.height
+    }
+
+    pub fn resize(&mut self, width: T, height: T) -> bool {
+        if width < T::ZERO || height < T::ZERO {
+            return false;
+        }
+        self.width = width;
+        self.height = height;
+        true
+    }
+
+    pub fn distance_to_plane(&self, point: Point3D<T>) -> T {
+        let relative = Vector3D::new(
+            point.x() - self.origin.x(),
+            point.y() - self.origin.y(),
+            point.z() - self.origin.z(),
+        );
+        relative.dot(&self.normal_dir().as_vector())
+    }
+
+    pub fn contains_point(&self, point: &Point3D<T>, tolerance: T) -> bool {
+        let relative = Vector3D::new(
+            point.x() - self.origin.x(),
+            point.y() - self.origin.y(),
+            point.z() - self.origin.z(),
+        );
+
+        let distance = relative.dot(&self.normal_dir().as_vector()).abs();
+        if distance > tolerance {
+            return false;
+        }
+
+        let u = relative.dot(&self.u_axis.as_vector());
+        let v = relative.dot(&self.v_axis.as_vector());
+
+        u >= -tolerance
+            && u <= self.width + tolerance
+            && v >= -tolerance
+            && v <= self.height + tolerance
+    }
+
+    pub fn corners(&self) -> [Point3D<T>; 4] {
+        let p0 = self.origin;
+        let p1 = Point3D::new(
+            self.origin.x() + self.u_axis.x() * self.width,
+            self.origin.y() + self.u_axis.y() * self.width,
+            self.origin.z() + self.u_axis.z() * self.width,
+        );
+        let p3 = Point3D::new(
+            self.origin.x() + self.v_axis.x() * self.height,
+            self.origin.y() + self.v_axis.y() * self.height,
+            self.origin.z() + self.v_axis.z() * self.height,
+        );
+        let p2 = Point3D::new(
+            p1.x() + self.v_axis.x() * self.height,
+            p1.y() + self.v_axis.y() * self.height,
+            p1.z() + self.v_axis.z() * self.height,
+        );
+        [p0, p1, p2, p3]
+    }
+}
+
+impl<T: Scalar> Rect3DConstructor<T> for Rect3D<T> {
+    fn new(
+        origin: (T, T, T),
+        u_axis: (T, T, T),
+        v_axis: (T, T, T),
+        width: T,
+        height: T,
+    ) -> Option<Self> {
+        Self::new(
+            Point3D::new(origin.0, origin.1, origin.2),
+            Vector3D::new(u_axis.0, u_axis.1, u_axis.2),
+            Vector3D::new(v_axis.0, v_axis.1, v_axis.2),
+            width,
+            height,
+        )
+    }
+
+    fn resize(&mut self, width: T, height: T) -> bool {
+        Self::resize(self, width, height)
+    }
+}
+
+impl<T: Scalar> Rect3DProperties<T> for Rect3D<T> {
+    fn origin(&self) -> (T, T, T) {
+        (self.origin.x(), self.origin.y(), self.origin.z())
+    }
+
+    fn u_axis(&self) -> (T, T, T) {
+        (self.u_axis.x(), self.u_axis.y(), self.u_axis.z())
+    }
+
+    fn v_axis(&self) -> (T, T, T) {
+        (self.v_axis.x(), self.v_axis.y(), self.v_axis.z())
+    }
+
+    fn normal(&self) -> (T, T, T) {
+        let n = self.normal_dir();
+        (n.x(), n.y(), n.z())
+    }
+
+    fn width(&self) -> T {
+        self.width
+    }
+
+    fn height(&self) -> T {
+        self.height
+    }
+
+    fn center(&self) -> (T, T, T) {
+        let c = self.center_point();
+        (c.x(), c.y(), c.z())
+    }
+}
+
+impl<T: Scalar> Rect3DMeasure<T> for Rect3D<T> {
+    fn contains_point(&self, point: (T, T, T), tolerance: T) -> bool {
+        Self::contains_point(self, &Point3D::new(point.0, point.1, point.2), tolerance)
+    }
+
+    fn area(&self) -> T {
+        Self::area(self)
+    }
+
+    fn corners(&self) -> [(T, T, T); 4] {
+        let c = Self::corners(self);
+        [
+            (c[0].x(), c[0].y(), c[0].z()),
+            (c[1].x(), c[1].y(), c[1].z()),
+            (c[2].x(), c[2].y(), c[2].z()),
+            (c[3].x(), c[3].y(), c[3].z()),
+        ]
+    }
+
+    fn distance_to_plane(&self, point: (T, T, T)) -> T {
+        Self::distance_to_plane(self, Point3D::new(point.0, point.1, point.2))
+    }
+
+    fn is_valid(&self) -> bool {
+        self.width >= T::ZERO && self.height >= T::ZERO
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contains_and_resize() {
+        let mut rect = Rect3D::new(
+            Point3D::new(0.0, 0.0, 0.0),
+            Vector3D::unit_x(),
+            Vector3D::unit_y(),
+            10.0,
+            5.0,
+        )
+        .unwrap();
+
+        assert!(rect.contains_point(&Point3D::new(5.0, 2.5, 0.0), 1e-9));
+        assert!(!rect.contains_point(&Point3D::new(11.0, 2.5, 0.0), 1e-9));
+        assert!(!rect.contains_point(&Point3D::new(5.0, 2.5, 0.1), 1e-3));
+
+        assert!(rect.resize(20.0, 10.0));
+        assert_eq!(rect.width_value(), 20.0);
+        assert_eq!(rect.height_value(), 10.0);
+        assert!(!rect.resize(-1.0, 10.0));
+    }
+}

--- a/model/geo_primitives/src/rectangle_3d_foundation.rs
+++ b/model/geo_primitives/src/rectangle_3d_foundation.rs
@@ -1,0 +1,14 @@
+//! Rect3D の Foundation トレイト実装
+
+use crate::Rect3D;
+use geo_foundation::{ExtensionFoundation, PrimitiveKind, Scalar};
+
+impl<T: Scalar> ExtensionFoundation<T> for Rect3D<T> {
+    fn primitive_kind(&self) -> PrimitiveKind {
+        PrimitiveKind::Rectangle
+    }
+
+    fn measure(&self) -> Option<T> {
+        Some(self.area())
+    }
+}

--- a/model/geo_primitives/src/rectangle_3d_transform.rs
+++ b/model/geo_primitives/src/rectangle_3d_transform.rs
@@ -1,0 +1,165 @@
+//! Rect3D Analysis Matrix/Vector統合変換実装
+
+use crate::{Point3D, Rect3D, Vector3D};
+use analysis::linalg::{matrix::Matrix4x4, vector::Vector3};
+use geo_foundation::{AnalysisTransform3D, Angle, Scalar, TransformError};
+
+pub mod analysis_transform {
+    use super::*;
+
+    pub fn transform_rect_3d<T: Scalar>(
+        rect: &Rect3D<T>,
+        matrix: &Matrix4x4<T>,
+    ) -> Result<Rect3D<T>, TransformError> {
+        let corners = rect.corners();
+        let p0v = Vector3::new(corners[0].x(), corners[0].y(), corners[0].z());
+        let p1v = Vector3::new(corners[1].x(), corners[1].y(), corners[1].z());
+        let p3v = Vector3::new(corners[3].x(), corners[3].y(), corners[3].z());
+
+        let tp0 = matrix.transform_point_3d(&p0v);
+        let tp1 = matrix.transform_point_3d(&p1v);
+        let tp3 = matrix.transform_point_3d(&p3v);
+
+        let new_origin = Point3D::new(tp0.x(), tp0.y(), tp0.z());
+        let u_vec = Vector3D::new(tp1.x() - tp0.x(), tp1.y() - tp0.y(), tp1.z() - tp0.z());
+        let v_vec = Vector3D::new(tp3.x() - tp0.x(), tp3.y() - tp0.y(), tp3.z() - tp0.z());
+
+        let width = u_vec.length();
+        let height = v_vec.length();
+
+        Rect3D::new(new_origin, u_vec, v_vec, width, height).ok_or_else(|| {
+            TransformError::InvalidGeometry("Transformed rectangle is invalid".to_string())
+        })
+    }
+
+    pub fn translation_matrix<T: Scalar>(translation: &Vector3<T>) -> Matrix4x4<T> {
+        Matrix4x4::translation(translation.x(), translation.y(), translation.z())
+    }
+
+    pub fn rotation_matrix<T: Scalar>(
+        center: &Point3D<T>,
+        axis: &Vector3<T>,
+        angle: Angle<T>,
+    ) -> Result<Matrix4x4<T>, TransformError> {
+        let axis_len = (axis.x() * axis.x() + axis.y() * axis.y() + axis.z() * axis.z()).sqrt();
+        if axis_len.is_zero() {
+            return Err(TransformError::InvalidRotation(
+                "Rotation axis cannot be zero vector".to_string(),
+            ));
+        }
+
+        let axis_n = Vector3::new(
+            axis.x() / axis_len,
+            axis.y() / axis_len,
+            axis.z() / axis_len,
+        );
+        let c = Vector3::new(center.x(), center.y(), center.z());
+        let to_origin = Matrix4x4::translation(-c.x(), -c.y(), -c.z());
+        let rot = Matrix4x4::rotation_axis_3d(axis_n, angle.to_radians());
+        let back = Matrix4x4::translation(c.x(), c.y(), c.z());
+        Ok(back * rot * to_origin)
+    }
+
+    pub fn scale_matrix<T: Scalar>(
+        center: &Point3D<T>,
+        scale_x: T,
+        scale_y: T,
+        scale_z: T,
+    ) -> Result<Matrix4x4<T>, TransformError> {
+        if scale_x.is_zero() || scale_y.is_zero() || scale_z.is_zero() {
+            return Err(TransformError::InvalidScaleFactor(
+                "Scale factors cannot be zero".to_string(),
+            ));
+        }
+
+        let c = Vector3::new(center.x(), center.y(), center.z());
+        let to_origin = Matrix4x4::translation(-c.x(), -c.y(), -c.z());
+        let scale = Matrix4x4::scale(scale_x, scale_y, scale_z);
+        let back = Matrix4x4::translation(c.x(), c.y(), c.z());
+        Ok(back * scale * to_origin)
+    }
+}
+
+impl<T: Scalar> AnalysisTransform3D<T> for Rect3D<T> {
+    type Matrix4x4 = Matrix4x4<T>;
+    type Angle = Angle<T>;
+    type Output = Rect3D<T>;
+
+    fn transform_point_matrix(&self, matrix: &Self::Matrix4x4) -> Self::Output {
+        analysis_transform::transform_rect_3d(self, matrix).unwrap_or(*self)
+    }
+
+    fn translate_analysis(&self, translation: &Vector3<T>) -> Result<Self::Output, TransformError> {
+        let m = analysis_transform::translation_matrix(translation);
+        analysis_transform::transform_rect_3d(self, &m)
+    }
+
+    fn rotate_analysis(
+        &self,
+        center: &Self,
+        axis: &Vector3<T>,
+        angle: Self::Angle,
+    ) -> Result<Self::Output, TransformError> {
+        let m = analysis_transform::rotation_matrix(&center.center_point(), axis, angle)?;
+        analysis_transform::transform_rect_3d(self, &m)
+    }
+
+    fn scale_analysis(
+        &self,
+        center: &Self,
+        scale_x: T,
+        scale_y: T,
+        scale_z: T,
+    ) -> Result<Self::Output, TransformError> {
+        let m =
+            analysis_transform::scale_matrix(&center.center_point(), scale_x, scale_y, scale_z)?;
+        analysis_transform::transform_rect_3d(self, &m)
+    }
+
+    fn uniform_scale_analysis(
+        &self,
+        center: &Self,
+        scale_factor: T,
+    ) -> Result<Self::Output, TransformError> {
+        self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
+    }
+
+    fn apply_composite_transform(
+        &self,
+        translation: Option<&Vector3<T>>,
+        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        scale: Option<(T, T, T)>,
+    ) -> Result<Self::Output, TransformError> {
+        let mut matrix = Matrix4x4::identity();
+
+        if let Some((sx, sy, sz)) = scale {
+            let scale_center = rotation.as_ref().map_or(self, |(center, _, _)| *center);
+            let scale_matrix =
+                analysis_transform::scale_matrix(&scale_center.center_point(), sx, sy, sz)?;
+            matrix = scale_matrix * matrix;
+        }
+
+        if let Some((center, axis, angle)) = rotation {
+            let rotation_matrix =
+                analysis_transform::rotation_matrix(&center.center_point(), axis, angle)?;
+            matrix = rotation_matrix * matrix;
+        }
+
+        if let Some(translation_vec) = translation {
+            let translation_matrix = analysis_transform::translation_matrix(translation_vec);
+            matrix = translation_matrix * matrix;
+        }
+
+        analysis_transform::transform_rect_3d(self, &matrix)
+    }
+
+    fn apply_composite_transform_uniform(
+        &self,
+        translation: Option<&Vector3<T>>,
+        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        scale: Option<T>,
+    ) -> Result<Self::Output, TransformError> {
+        let scale_tuple = scale.map(|s| (s, s, s));
+        self.apply_composite_transform(translation, rotation, scale_tuple)
+    }
+}

--- a/view/app/Cargo.toml
+++ b/view/app/Cargo.toml
@@ -22,3 +22,4 @@ render = { path = "../render" }
 stage = { path = "../stage" }
 analysis = { path = "../../foundation/analysis" }
 logging_foundation = { path = "../../foundation/logging_foundation" }
+bytemuck = { version = "1.24", features = ["derive"] }

--- a/view/app/src/app.rs
+++ b/view/app/src/app.rs
@@ -51,6 +51,9 @@ impl ApplicationHandler for App {
                 } => {
                     state.handle_mouse_button(button, button_state);
                 }
+                WindowEvent::CursorMoved { position, .. } => {
+                    state.handle_cursor_moved(position.x as f32, position.y as f32);
+                }
                 _ => {}
             }
         }

--- a/view/app/src/app_renderer.rs
+++ b/view/app/src/app_renderer.rs
@@ -1,27 +1,54 @@
 use stage::{DraftStage, OutlineStage, RenderStage, ShadingStage};
 use wgpu::{CommandEncoder, Device, SurfaceConfiguration, TextureView};
 
+use crate::view_rect::ViewRect;
+use crate::view_rect_renderer::ViewRectRenderer;
+
 pub struct AppRenderer {
     stage: Box<dyn RenderStage>,
+    view_rect_renderer: ViewRectRenderer,
 }
 
 impl AppRenderer {
     /// 初期化：Draftステージを生成
     pub fn new_draft(device: &Device, config: &SurfaceConfiguration) -> Self {
         let stage = Box::new(DraftStage::new(device, config.format));
-        Self { stage }
+        let view_rect_renderer = ViewRectRenderer::new(device, config.format);
+        Self {
+            stage,
+            view_rect_renderer,
+        }
     }
 
     /// 初期化：Outlineステージを生成
     pub fn new_outline(device: &Device, config: &SurfaceConfiguration) -> Self {
         let stage = Box::new(OutlineStage::new(device, config.format));
-        Self { stage }
+        let view_rect_renderer = ViewRectRenderer::new(device, config.format);
+        Self {
+            stage,
+            view_rect_renderer,
+        }
     }
 
     /// 初期化：Shadingステージを生成
     pub fn new_shading(device: &Device, config: &SurfaceConfiguration) -> Self {
         let stage = Box::new(ShadingStage::new(device, config.format));
-        Self { stage }
+        let view_rect_renderer = ViewRectRenderer::new(device, config.format);
+        Self {
+            stage,
+            view_rect_renderer,
+        }
+    }
+
+    pub fn update_view_rect_overlay(
+        &mut self,
+        queue: &wgpu::Queue,
+        rect: Option<ViewRect>,
+        viewport_width: u32,
+        viewport_height: u32,
+    ) {
+        self.view_rect_renderer
+            .update_rect(queue, rect, viewport_width, viewport_height);
     }
 
     /// ステージ切り替え（将来的なイベント駆動対応）
@@ -43,6 +70,7 @@ impl AppRenderer {
     ) {
         // 各ステージが depth を利用できるよう render_with_depth を呼ぶ
         self.stage.render_with_depth(encoder, view, depth_view);
+        self.view_rect_renderer.render(encoder, view);
     }
 
     pub fn update(&mut self) {

--- a/view/app/src/app_state.rs
+++ b/view/app/src/app_state.rs
@@ -3,6 +3,7 @@ use crate::entity_manager::EntityManager;
 use crate::graphic::{init_graphic, Graphic};
 use crate::mouse_input::MouseInput;
 use crate::stl_loader;
+use crate::view_rect::ViewRect;
 use analysis::linalg::{quaternion::Quaternionf, vector::Vec3f};
 use analysis::{LengthUnit, Tolerance};
 use stage::{
@@ -21,6 +22,8 @@ pub struct AppState {
     pub camera: Camera,
     pub mouse_input: MouseInput,
     pub entity_manager: EntityManager,
+    pub active_view_rect: Option<ViewRect>,
+    pub last_view_rect: Option<ViewRect>,
 
     /// アプリケーション単位系（CAD標準: ミリメートル）
     ///
@@ -33,6 +36,9 @@ pub struct AppState {
     /// 曲線のテッセレーション（分割）や近似計算で使用される許容誤差。
     /// この値により、曲線から生成される線分の精度が決まります。
     pub display_tolerance: Tolerance,
+
+    cursor_position: Option<(f32, f32)>,
+    view_rect_drag_origin: Option<(f32, f32)>,
 }
 
 impl AppState {
@@ -47,9 +53,13 @@ impl AppState {
             camera: Camera::new(),
             mouse_input: MouseInput::new(),
             entity_manager: EntityManager::new(),
+            active_view_rect: None,
+            last_view_rect: None,
             // CAD標準設定
             unit_system: LengthUnit::Millimeter,
             display_tolerance: Tolerance::default(), // 0.01mm
+            cursor_position: None,
+            view_rect_drag_origin: None,
         }
     }
 
@@ -121,6 +131,12 @@ impl AppState {
     }
 
     pub fn render(&mut self) {
+        self.renderer.update_view_rect_overlay(
+            &self.graphic.queue,
+            self.active_view_rect,
+            self.graphic.config.width,
+            self.graphic.config.height,
+        );
         self.graphic.render(&mut self.renderer);
     }
 
@@ -678,14 +694,19 @@ impl AppState {
                     tracing::info!("f: 正面視点");
                     tracing::info!("e: 緊急脱出");
                     tracing::info!("w: ワイヤーフレーム切替");
+                    tracing::info!("1: Draftステージ");
+                    tracing::info!("2: Outlineステージ");
+                    tracing::info!("3: Shadingステージ");
                     tracing::info!("=== デバッグ形状表示 ===");
                     tracing::info!("s: クリップ空間正方形（単位行列テスト）");
                     tracing::info!("l: LineSegment3D表示");
                     tracing::info!("c: Circle3D表示");
-                    tracing::info!("t: Triangle3D表示 (shift+t推奨)");
+                    tracing::info!("T: Triangle3D表示 (Shift+T)");
                     tracing::info!("a: Arc3D表示");
                     tracing::info!("n: NurbsCurve3D表示（GPU評価）");
                     tracing::info!("m: NurbsSurface3D表示（GPU評価）");
+                    tracing::info!("o: Octree表示");
+                    tracing::info!("p: ToolPath表示");
                     tracing::info!("=== その他 ===");
                     tracing::info!(
                         "マウス操作: 左ドラッグ=回転, 中ドラッグ=パン, 右ドラッグ=ズーム"
@@ -698,6 +719,24 @@ impl AppState {
                 "q" => {
                     // デバッグ: クリップ空間正方形（単位行列テスト）
                     self.load_debug_clip_square();
+                }
+                "1" => {
+                    // ステージ切替: Draft
+                    self.set_stage_draft();
+                    self.update_camera_uniforms();
+                    tracing::info!("ステージ切替: Draft");
+                }
+                "2" => {
+                    // ステージ切替: Outline
+                    self.set_stage_outline();
+                    self.update_camera_uniforms();
+                    tracing::info!("ステージ切替: Outline");
+                }
+                "3" => {
+                    // ステージ切替: Shading
+                    self.set_stage_shading();
+                    self.update_camera_uniforms();
+                    tracing::info!("ステージ切替: Shading");
                 }
                 "l" => {
                     // デバッグ: LineSegment3D表示
@@ -719,6 +758,18 @@ impl AppState {
                     // デバッグ: NurbsSurface3D表示（GPU評価）
                     self.load_debug_nurbs_surface();
                 }
+                "o" => {
+                    // デバッグ: Octree可視化表示
+                    self.load_debug_octree();
+                }
+                "p" => {
+                    // デバッグ: CAM工具経路可視化表示
+                    self.load_debug_toolpath();
+                }
+                "T" => {
+                    // デバッグ: Triangle3D表示（Shift+T）
+                    self.load_debug_triangle();
+                }
                 _ => {}
             }
         }
@@ -731,6 +782,40 @@ impl AppState {
         state: winit::event::ElementState,
     ) {
         self.mouse_input.update_mouse_button(button, state);
+
+        if button != winit::event::MouseButton::Left {
+            return;
+        }
+
+        match state {
+            winit::event::ElementState::Pressed => {
+                if self.mouse_input.ctrl_pressed {
+                    return;
+                }
+
+                if let Some(cursor) = self.cursor_position {
+                    self.view_rect_drag_origin = Some(cursor);
+                    self.active_view_rect = Some(ViewRect::from_points(cursor, cursor));
+                }
+            }
+            winit::event::ElementState::Released => {
+                if self.view_rect_drag_origin.take().is_some() {
+                    if let Some(rect) = self.active_view_rect.take() {
+                        if !rect.is_empty() {
+                            self.last_view_rect = Some(rect);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn handle_cursor_moved(&mut self, x: f32, y: f32) {
+        self.cursor_position = Some((x, y));
+
+        if let Some(origin) = self.view_rect_drag_origin {
+            self.active_view_rect = Some(ViewRect::from_points(origin, (x, y)));
+        }
     }
 
     /// マウス移動を処理

--- a/view/app/src/lib.rs
+++ b/view/app/src/lib.rs
@@ -7,3 +7,5 @@ pub mod logging;
 pub mod mouse_input;
 pub mod stl_loader;
 pub mod svg_loader;
+pub mod view_rect;
+pub mod view_rect_renderer;

--- a/view/app/src/view_rect.rs
+++ b/view/app/src/view_rect.rs
@@ -1,0 +1,56 @@
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ViewRect {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+impl ViewRect {
+    pub fn from_points(start: (f32, f32), end: (f32, f32)) -> Self {
+        let x = start.0.min(end.0);
+        let y = start.1.min(end.1);
+        let width = (end.0 - start.0).abs();
+        let height = (end.1 - start.1).abs();
+
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    pub fn contains(&self, point: (f32, f32)) -> bool {
+        point.0 >= self.x
+            && point.0 <= self.x + self.width
+            && point.1 >= self.y
+            && point.1 <= self.y + self.height
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.width <= 0.0 || self.height <= 0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_points() {
+        let rect = ViewRect::from_points((100.0, 200.0), (50.0, 120.0));
+        assert_eq!(rect.x, 50.0);
+        assert_eq!(rect.y, 120.0);
+        assert_eq!(rect.width, 50.0);
+        assert_eq!(rect.height, 80.0);
+    }
+
+    #[test]
+    fn contains_point() {
+        let rect = ViewRect::from_points((10.0, 10.0), (30.0, 20.0));
+        assert!(rect.contains((10.0, 10.0)));
+        assert!(rect.contains((30.0, 20.0)));
+        assert!(!rect.contains((31.0, 20.0)));
+    }
+}

--- a/view/app/src/view_rect_renderer.rs
+++ b/view/app/src/view_rect_renderer.rs
@@ -1,0 +1,180 @@
+use crate::view_rect::ViewRect;
+use bytemuck::{Pod, Zeroable};
+use wgpu::util::DeviceExt;
+
+const VIEW_RECT_SHADER: &str = r#"
+struct VsOut {
+    @builtin(position) position: vec4<f32>,
+    @location(0) color: vec4<f32>,
+};
+
+@vertex
+fn vs_main(@location(0) position: vec2<f32>) -> VsOut {
+    var out: VsOut;
+    out.position = vec4<f32>(position, 0.0, 1.0);
+    out.color = vec4<f32>(0.20, 0.80, 1.00, 1.0);
+    return out;
+}
+
+@fragment
+fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
+    return in.color;
+}
+"#;
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct OverlayVertex {
+    position: [f32; 2],
+}
+
+pub struct ViewRectRenderer {
+    pipeline: wgpu::RenderPipeline,
+    vertex_buffer: wgpu::Buffer,
+    vertex_count: u32,
+}
+
+impl ViewRectRenderer {
+    pub fn new(device: &wgpu::Device, format: wgpu::TextureFormat) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("ViewRect Overlay Shader"),
+            source: wgpu::ShaderSource::Wgsl(VIEW_RECT_SHADER.into()),
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("ViewRect Overlay Pipeline Layout"),
+            bind_group_layouts: &[],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("ViewRect Overlay Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<OverlayVertex>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[wgpu::VertexAttribute {
+                        format: wgpu::VertexFormat::Float32x2,
+                        offset: 0,
+                        shader_location: 0,
+                    }],
+                }],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format,
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::LineStrip,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                unclipped_depth: false,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("ViewRect Overlay Vertex Buffer"),
+            contents: &[0; std::mem::size_of::<OverlayVertex>() * 5],
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+        });
+
+        Self {
+            pipeline,
+            vertex_buffer,
+            vertex_count: 0,
+        }
+    }
+
+    pub fn update_rect(
+        &mut self,
+        queue: &wgpu::Queue,
+        rect: Option<ViewRect>,
+        viewport_width: u32,
+        viewport_height: u32,
+    ) {
+        let Some(rect) = rect else {
+            self.vertex_count = 0;
+            return;
+        };
+
+        if viewport_width == 0 || viewport_height == 0 || rect.is_empty() {
+            self.vertex_count = 0;
+            return;
+        }
+
+        let left = rect.x;
+        let top = rect.y;
+        let right = rect.x + rect.width;
+        let bottom = rect.y + rect.height;
+
+        let to_ndc = |x: f32, y: f32| -> [f32; 2] {
+            let ndc_x = (x / viewport_width as f32) * 2.0 - 1.0;
+            let ndc_y = 1.0 - (y / viewport_height as f32) * 2.0;
+            [ndc_x, ndc_y]
+        };
+
+        let vertices = [
+            OverlayVertex {
+                position: to_ndc(left, top),
+            },
+            OverlayVertex {
+                position: to_ndc(right, top),
+            },
+            OverlayVertex {
+                position: to_ndc(right, bottom),
+            },
+            OverlayVertex {
+                position: to_ndc(left, bottom),
+            },
+            OverlayVertex {
+                position: to_ndc(left, top),
+            },
+        ];
+
+        queue.write_buffer(&self.vertex_buffer, 0, bytemuck::cast_slice(&vertices));
+        self.vertex_count = vertices.len() as u32;
+    }
+
+    pub fn render(&self, encoder: &mut wgpu::CommandEncoder, view: &wgpu::TextureView) {
+        if self.vertex_count == 0 {
+            return;
+        }
+
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("ViewRect Overlay Pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+                depth_slice: None,
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+
+        pass.set_pipeline(&self.pipeline);
+        pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+        pass.draw(0..self.vertex_count, 0..1);
+    }
+}

--- a/viewmodel/graphics/src/camera.rs
+++ b/viewmodel/graphics/src/camera.rs
@@ -423,6 +423,7 @@ impl Camera {
         self.target = Vec3f::new(0.0, 0.0, 0.0);
         self.distance = 10.0;
         self.zoom = 1.0;
+        self.orthographic_bounds = None;
 
         // 初期表示は回転なし（Z軸正方向から真正面に見る）
         self.rotation = Quaternionf::identity();


### PR DESCRIPTION
## 概要
Issue #9 に対して、Rectの基盤実装（World）と範囲選択MVP（ViewRECT）を追加しました。

## 変更内容
- Foundation Pattern
  - `rectangle_traits` を追加（Rect2D/Rect3D Constructor/Properties/Measure）
- Primitives
  - `Rect2D` 実装 + Foundation + Transform
  - `Rect3D`（任意平面）実装 + Foundation + Transform
- View側（MVP）
  - `ViewRect`（画面座標state）を追加
  - 左ドラッグで `active_view_rect` を更新
  - オーバーレイ矩形レンダラーを追加し描画に接続
- 操作系整合
  - `o`（Octree）, `p`（ToolPath）復旧
  - `1/2/3` ステージ切替、`Shift+T` Triangle 表示を整合
- ドキュメント
  - `RECT_WORLD_VIEW_COORDINATE_DESIGN.md`
  - `VIEW_RECT_STATE_DESIGN.md`

## 検証
- `cargo test -p geo_primitives --quiet` ✅
- `cargo test -p redring --quiet` ✅

## 補足
- Octree表示の不具合（`o`時の表示問題）は別Issueで対応予定（本PRスコープ外）。

Closes #9