### PR TITLE
refactor(view/app): Issue #258 Phase3 loader/renderer 境界整理

### DIFF
--- a/view/app/src/app_asset_loader.rs
+++ b/view/app/src/app_asset_loader.rs
@@ -1,0 +1,24 @@
+//! app層向けアセット読み込みFacade。
+//!
+//! `debug_scene` などの呼び出し側が、個別loader実装詳細
+//! (`stl_loader` / `svg_loader`) に直接依存しないための薄い接続層。
+
+use render::vertex_3d::MeshVertex;
+use std::path::Path;
+
+pub type StlRenderLoadResult =
+    Result<(Vec<MeshVertex>, Vec<u32>, ([f32; 3], [f32; 3])), Box<dyn std::error::Error>>;
+
+pub type SvgRenderLoadResult = Result<Vec<MeshVertex>, Box<dyn std::error::Error>>;
+
+pub fn load_stl(path: &Path) -> StlRenderLoadResult {
+    crate::stl_loader::load_stl_for_rendering(path)
+}
+
+pub fn load_sample_stl_with_bounds(path: &Path) -> StlRenderLoadResult {
+    crate::stl_loader::create_sample_stl_with_bounds(path)
+}
+
+pub fn load_svg(path: &Path, tolerance: Option<f64>) -> SvgRenderLoadResult {
+    crate::svg_loader::load_svg_for_rendering(path, tolerance)
+}

--- a/view/app/src/app_renderer.rs
+++ b/view/app/src/app_renderer.rs
@@ -12,9 +12,11 @@ pub struct AppRenderer {
 }
 
 impl AppRenderer {
-    /// 初期化：Draftステージを生成
-    pub fn new_draft(device: &Device, config: &SurfaceConfiguration) -> Self {
-        let stage = Box::new(DraftStage::new(device, config.format));
+    fn new_with_stage(
+        device: &Device,
+        config: &SurfaceConfiguration,
+        stage: Box<dyn RenderStage>,
+    ) -> Self {
         let view_rect_renderer = ViewRectRenderer::new(device, config.format);
         let snapshot_overlay_renderer = SnapshotOverlayRenderer::new(device, config.format);
         Self {
@@ -22,30 +24,24 @@ impl AppRenderer {
             view_rect_renderer,
             snapshot_overlay_renderer,
         }
+    }
+
+    /// 初期化：Draftステージを生成
+    pub fn new_draft(device: &Device, config: &SurfaceConfiguration) -> Self {
+        let stage = Box::new(DraftStage::new(device, config.format));
+        Self::new_with_stage(device, config, stage)
     }
 
     /// 初期化：Outlineステージを生成
     pub fn new_outline(device: &Device, config: &SurfaceConfiguration) -> Self {
         let stage = Box::new(OutlineStage::new(device, config.format));
-        let view_rect_renderer = ViewRectRenderer::new(device, config.format);
-        let snapshot_overlay_renderer = SnapshotOverlayRenderer::new(device, config.format);
-        Self {
-            stage,
-            view_rect_renderer,
-            snapshot_overlay_renderer,
-        }
+        Self::new_with_stage(device, config, stage)
     }
 
     /// 初期化：Shadingステージを生成
     pub fn new_shading(device: &Device, config: &SurfaceConfiguration) -> Self {
         let stage = Box::new(ShadingStage::new(device, config.format));
-        let view_rect_renderer = ViewRectRenderer::new(device, config.format);
-        let snapshot_overlay_renderer = SnapshotOverlayRenderer::new(device, config.format);
-        Self {
-            stage,
-            view_rect_renderer,
-            snapshot_overlay_renderer,
-        }
+        Self::new_with_stage(device, config, stage)
     }
 
     pub fn update_view_rect_overlay(

--- a/view/app/src/app_state/debug_scene.rs
+++ b/view/app/src/app_state/debug_scene.rs
@@ -388,7 +388,7 @@ impl AppState {
     pub fn load_stl_file(&mut self, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
         tracing::info!("STLファイル読み込み開始: {:?}", path);
 
-        let (vertices, indices, _bounds) = crate::stl_loader::load_stl_for_rendering(path)?;
+        let (vertices, indices, _bounds) = crate::app_asset_loader::load_stl(path)?;
 
         self.camera.reset_to_standard_cad_view();
 
@@ -412,7 +412,7 @@ impl AppState {
         let sample_path = std::env::temp_dir().join("redring_sample.stl");
 
         let (vertices, indices, _bounds) =
-            crate::stl_loader::create_sample_stl_with_bounds(&sample_path)?;
+            crate::app_asset_loader::load_sample_stl_with_bounds(&sample_path)?;
 
         self.camera.reset_to_standard_cad_view();
 
@@ -433,7 +433,7 @@ impl AppState {
         tracing::info!("デバッグ形状: LineSegment3D表示（EntityManager経由）");
 
         let svg_path = Path::new("tests/fixtures/shapes/line.svg");
-        match crate::svg_loader::load_svg_for_rendering(svg_path, None) {
+        match crate::app_asset_loader::load_svg(svg_path, None) {
             Ok(vertices) => {
                 tracing::info!("SVG読み込み成功: {} 頂点", vertices.len());
 
@@ -454,7 +454,7 @@ impl AppState {
         tracing::info!("デバッグ形状: Circle3D表示（SVGから）");
 
         let svg_path = Path::new("tests/fixtures/shapes/circle.svg");
-        match crate::svg_loader::load_svg_for_rendering(svg_path, None) {
+        match crate::app_asset_loader::load_svg(svg_path, None) {
             Ok(vertices) => {
                 tracing::info!("SVG読み込み成功: {} 頂点", vertices.len());
 
@@ -480,7 +480,7 @@ impl AppState {
         tracing::warn!("DEBUG: クリップ空間正方形を表示（SVGから）");
 
         let svg_path = Path::new("tests/fixtures/shapes/clip_square.svg");
-        match crate::svg_loader::load_svg_for_rendering(svg_path, None) {
+        match crate::app_asset_loader::load_svg(svg_path, None) {
             Ok(vertices) => {
                 tracing::warn!("SVG読み込み成功: {} 頂点", vertices.len());
 
@@ -505,7 +505,7 @@ impl AppState {
         tracing::info!("デバッグ形状: Triangle3D表示（SVGから）");
 
         let svg_path = Path::new("tests/fixtures/shapes/triangle.svg");
-        match crate::svg_loader::load_svg_for_rendering(svg_path, None) {
+        match crate::app_asset_loader::load_svg(svg_path, None) {
             Ok(vertices) => {
                 tracing::info!("SVG読み込み成功: {} 頂点", vertices.len());
 
@@ -533,7 +533,7 @@ impl AppState {
         tracing::info!("デバッグ形状: Arc3D表示（SVGから）");
 
         let svg_path = Path::new("tests/fixtures/shapes/arc.svg");
-        match crate::svg_loader::load_svg_for_rendering(svg_path, None) {
+        match crate::app_asset_loader::load_svg(svg_path, None) {
             Ok(vertices) => {
                 tracing::info!("SVG読み込み成功: {} 頂点", vertices.len());
 

--- a/view/app/src/lib.rs
+++ b/view/app/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod app;
+pub mod app_asset_loader;
 pub mod app_renderer;
 pub mod app_state;
 pub mod entity_manager;
 pub mod graphic;
 pub mod logging;
 pub mod mouse_input;
+pub mod overlay_coords;
 pub mod snapshot_overlay_renderer;
 pub mod stage_factory;
 pub mod stl_loader;

--- a/view/app/src/overlay_coords.rs
+++ b/view/app/src/overlay_coords.rs
@@ -1,0 +1,7 @@
+//! Overlay描画向けの座標変換ユーティリティ。
+
+pub fn screen_to_ndc(x: f32, y: f32, viewport_width: u32, viewport_height: u32) -> [f32; 2] {
+    let ndc_x = (x / viewport_width as f32) * 2.0 - 1.0;
+    let ndc_y = 1.0 - (y / viewport_height as f32) * 2.0;
+    [ndc_x, ndc_y]
+}

--- a/view/app/src/snapshot_overlay_renderer.rs
+++ b/view/app/src/snapshot_overlay_renderer.rs
@@ -1,3 +1,6 @@
+//! Snapshot進捗オーバーレイを描画するレンダラー。
+
+use crate::overlay_coords::screen_to_ndc;
 use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
 
@@ -162,11 +165,8 @@ impl SnapshotOverlayRenderer {
         let gap = 1.0f32;
         let block_width = (width - gap * (block_count as f32 - 1.0)) / block_count as f32;
 
-        let to_ndc = |x: f32, y: f32| -> [f32; 2] {
-            let ndc_x = (x / viewport_width as f32) * 2.0 - 1.0;
-            let ndc_y = 1.0 - (y / viewport_height as f32) * 2.0;
-            [ndc_x, ndc_y]
-        };
+        let to_ndc =
+            |x: f32, y: f32| -> [f32; 2] { screen_to_ndc(x, y, viewport_width, viewport_height) };
 
         let c_track = style.track_color;
         let c_done = style.done_color;

--- a/view/app/src/view_rect_renderer.rs
+++ b/view/app/src/view_rect_renderer.rs
@@ -1,3 +1,6 @@
+//! ViewRect（選択矩形）オーバーレイを描画するレンダラー。
+
+use crate::overlay_coords::screen_to_ndc;
 use crate::view_rect::ViewRect;
 use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
@@ -124,11 +127,8 @@ impl ViewRectRenderer {
         let right = rect.x + rect.width;
         let bottom = rect.y + rect.height;
 
-        let to_ndc = |x: f32, y: f32| -> [f32; 2] {
-            let ndc_x = (x / viewport_width as f32) * 2.0 - 1.0;
-            let ndc_y = 1.0 - (y / viewport_height as f32) * 2.0;
-            [ndc_x, ndc_y]
-        };
+        let to_ndc =
+            |x: f32, y: f32| -> [f32; 2] { screen_to_ndc(x, y, viewport_width, viewport_height) };
 
         let vertices = [
             OverlayVertex {


### PR DESCRIPTION
## 概要
Issue #258 Phase3（`*_loader.rs` / `*renderer.rs` の責務整理）の途中成果です。挙動は維持したまま、View層の境界を明確化しました。

## 変更内容
- `app_renderer` の生成重複を `new_with_stage(...)` に集約
- `app_asset_loader` を新規追加し、`debug_scene` からの STL/SVG 読み込み入口を app 層 Facade 経由へ統一
- `overlay_coords::screen_to_ndc(...)` を新規追加し、overlay系 renderer の座標変換重複を共通化
- `view_rect_renderer` / `snapshot_overlay_renderer` に責務要約コメントを追加
- `lib.rs` に新規モジュール公開を追加

## チェック
- [x] `cargo fmt`
- [x] `cargo build -p redring`
- [x] `cargo clippy -p redring -- -D warnings`

## 関連
- Refs #258