### PR TITLE
refactor(view/app): Issue #258 Phase4 app loader/renderer Facade+Factory

### DIFF
--- a/dev/architecture/ISSUE_258_PHASE4_APP_FACTORY_FACADE_DESIGN.md
+++ b/dev/architecture/ISSUE_258_PHASE4_APP_FACTORY_FACADE_DESIGN.md
@@ -1,0 +1,40 @@
+# Issue #258 Phase4: app loader/renderer 接続の Facade + Factory 化
+
+- 日付: 2026-02-26
+- 対象Issue: #258 (Phase4)
+- スコープ: `view/app/src/app_asset_loader.rs`, `view/app/src/app_renderer.rs`, `view/app/src/app_state.rs`, `view/app/src/app_state/debug_scene.rs`
+
+## 背景
+
+Phase3 で loader/renderer 側の重複は一部共通化済みだが、
+`app_state` から見た接続責務が「関数群ベース」のため、責務境界の意図が型として読み取りづらい。
+
+## 目的
+
+- loader 接続を `AppAssetLoaderFacade` へ集約し、呼び出し側依存を一本化
+- renderer 生成責務を `AppRendererFactory` として明示し、初期化経路を読み取りやすくする
+- 既存挙動・既存 API 互換を維持する
+
+## 方針
+
+1. `app_asset_loader.rs`
+   - `AppAssetLoaderFacade`（ユニット struct）を追加
+   - 既存関数 (`load_stl` / `load_sample_stl_with_bounds` / `load_svg`) は互換維持の薄い委譲として残す
+2. `app_renderer.rs`
+   - `AppRendererFactory` を追加し、stage + overlay 初期化を factory に集約
+   - `AppRenderer::new_draft/new_outline/new_shading` は factory 呼び出しへ委譲
+3. `app_state.rs` / `debug_scene.rs`
+   - 呼び出し側を Facade/Factory 型経由へ切り替え
+
+## 受け入れ条件
+
+- `cargo fmt` 成功
+- `cargo build -p redring` 成功
+- `cargo clippy -p redring -- -D warnings` 成功
+- 挙動変更なし（デバッグロード/ステージ切替/overlay 描画）
+
+## 非対象
+
+- 新機能追加
+- renderer/stage の責務再定義
+- model 層への変更

--- a/view/app/src/app_asset_loader.rs
+++ b/view/app/src/app_asset_loader.rs
@@ -11,14 +11,30 @@ pub type StlRenderLoadResult =
 
 pub type SvgRenderLoadResult = Result<Vec<MeshVertex>, Box<dyn std::error::Error>>;
 
+pub struct AppAssetLoaderFacade;
+
+impl AppAssetLoaderFacade {
+    pub fn load_stl(path: &Path) -> StlRenderLoadResult {
+        crate::stl_loader::load_stl_for_rendering(path)
+    }
+
+    pub fn load_sample_stl_with_bounds(path: &Path) -> StlRenderLoadResult {
+        crate::stl_loader::create_sample_stl_with_bounds(path)
+    }
+
+    pub fn load_svg(path: &Path, tolerance: Option<f64>) -> SvgRenderLoadResult {
+        crate::svg_loader::load_svg_for_rendering(path, tolerance)
+    }
+}
+
 pub fn load_stl(path: &Path) -> StlRenderLoadResult {
-    crate::stl_loader::load_stl_for_rendering(path)
+    AppAssetLoaderFacade::load_stl(path)
 }
 
 pub fn load_sample_stl_with_bounds(path: &Path) -> StlRenderLoadResult {
-    crate::stl_loader::create_sample_stl_with_bounds(path)
+    AppAssetLoaderFacade::load_sample_stl_with_bounds(path)
 }
 
 pub fn load_svg(path: &Path, tolerance: Option<f64>) -> SvgRenderLoadResult {
-    crate::svg_loader::load_svg_for_rendering(path, tolerance)
+    AppAssetLoaderFacade::load_svg(path, tolerance)
 }

--- a/view/app/src/app_renderer.rs
+++ b/view/app/src/app_renderer.rs
@@ -11,37 +11,53 @@ pub struct AppRenderer {
     snapshot_overlay_renderer: SnapshotOverlayRenderer,
 }
 
-impl AppRenderer {
-    fn new_with_stage(
+pub struct AppRendererFactory;
+
+impl AppRendererFactory {
+    fn create_with_stage(
         device: &Device,
         config: &SurfaceConfiguration,
         stage: Box<dyn RenderStage>,
-    ) -> Self {
+    ) -> AppRenderer {
         let view_rect_renderer = ViewRectRenderer::new(device, config.format);
         let snapshot_overlay_renderer = SnapshotOverlayRenderer::new(device, config.format);
-        Self {
+        AppRenderer {
             stage,
             view_rect_renderer,
             snapshot_overlay_renderer,
         }
     }
 
+    pub fn create_draft(device: &Device, config: &SurfaceConfiguration) -> AppRenderer {
+        let stage = Box::new(DraftStage::new(device, config.format));
+        Self::create_with_stage(device, config, stage)
+    }
+
+    pub fn create_outline(device: &Device, config: &SurfaceConfiguration) -> AppRenderer {
+        let stage = Box::new(OutlineStage::new(device, config.format));
+        Self::create_with_stage(device, config, stage)
+    }
+
+    pub fn create_shading(device: &Device, config: &SurfaceConfiguration) -> AppRenderer {
+        let stage = Box::new(ShadingStage::new(device, config.format));
+        Self::create_with_stage(device, config, stage)
+    }
+}
+
+impl AppRenderer {
     /// 初期化：Draftステージを生成
     pub fn new_draft(device: &Device, config: &SurfaceConfiguration) -> Self {
-        let stage = Box::new(DraftStage::new(device, config.format));
-        Self::new_with_stage(device, config, stage)
+        AppRendererFactory::create_draft(device, config)
     }
 
     /// 初期化：Outlineステージを生成
     pub fn new_outline(device: &Device, config: &SurfaceConfiguration) -> Self {
-        let stage = Box::new(OutlineStage::new(device, config.format));
-        Self::new_with_stage(device, config, stage)
+        AppRendererFactory::create_outline(device, config)
     }
 
     /// 初期化：Shadingステージを生成
     pub fn new_shading(device: &Device, config: &SurfaceConfiguration) -> Self {
-        let stage = Box::new(ShadingStage::new(device, config.format));
-        Self::new_with_stage(device, config, stage)
+        AppRendererFactory::create_shading(device, config)
     }
 
     pub fn update_view_rect_overlay(

--- a/view/app/src/app_state.rs
+++ b/view/app/src/app_state.rs
@@ -1,4 +1,4 @@
-use crate::app_renderer::AppRenderer;
+use crate::app_renderer::{AppRenderer, AppRendererFactory};
 use crate::entity_manager::EntityManager;
 use crate::graphic::{init_graphic, Graphic};
 use crate::mouse_input::MouseInput;
@@ -112,7 +112,7 @@ impl AppState {
 
     pub fn new(window: Arc<Window>) -> Self {
         let graphic = init_graphic(window.clone());
-        let renderer = AppRenderer::new_draft(&graphic.device, &graphic.config);
+        let renderer = AppRendererFactory::create_draft(&graphic.device, &graphic.config);
         let viewing_operation_settings = ViewingOperationSettings::default();
 
         let mut app_state = Self {

--- a/view/app/src/app_state/debug_scene.rs
+++ b/view/app/src/app_state/debug_scene.rs
@@ -8,6 +8,8 @@ use std::path::Path;
 use viewmodel::octree_converter::WireframeVertex;
 use viewmodel::snapshot_converter::{CamSimulationSnapshotInput, DomainSnapshotSeries};
 
+use crate::app_asset_loader::AppAssetLoaderFacade;
+
 #[derive(Clone, Copy)]
 struct CameraFit {
     center_x: f32,
@@ -388,7 +390,7 @@ impl AppState {
     pub fn load_stl_file(&mut self, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
         tracing::info!("STLファイル読み込み開始: {:?}", path);
 
-        let (vertices, indices, _bounds) = crate::app_asset_loader::load_stl(path)?;
+        let (vertices, indices, _bounds) = AppAssetLoaderFacade::load_stl(path)?;
 
         self.camera.reset_to_standard_cad_view();
 
@@ -412,7 +414,7 @@ impl AppState {
         let sample_path = std::env::temp_dir().join("redring_sample.stl");
 
         let (vertices, indices, _bounds) =
-            crate::app_asset_loader::load_sample_stl_with_bounds(&sample_path)?;
+            AppAssetLoaderFacade::load_sample_stl_with_bounds(&sample_path)?;
 
         self.camera.reset_to_standard_cad_view();
 
@@ -433,7 +435,7 @@ impl AppState {
         tracing::info!("デバッグ形状: LineSegment3D表示（EntityManager経由）");
 
         let svg_path = Path::new("tests/fixtures/shapes/line.svg");
-        match crate::app_asset_loader::load_svg(svg_path, None) {
+        match AppAssetLoaderFacade::load_svg(svg_path, None) {
             Ok(vertices) => {
                 tracing::info!("SVG読み込み成功: {} 頂点", vertices.len());
 
@@ -454,7 +456,7 @@ impl AppState {
         tracing::info!("デバッグ形状: Circle3D表示（SVGから）");
 
         let svg_path = Path::new("tests/fixtures/shapes/circle.svg");
-        match crate::app_asset_loader::load_svg(svg_path, None) {
+        match AppAssetLoaderFacade::load_svg(svg_path, None) {
             Ok(vertices) => {
                 tracing::info!("SVG読み込み成功: {} 頂点", vertices.len());
 
@@ -480,7 +482,7 @@ impl AppState {
         tracing::warn!("DEBUG: クリップ空間正方形を表示（SVGから）");
 
         let svg_path = Path::new("tests/fixtures/shapes/clip_square.svg");
-        match crate::app_asset_loader::load_svg(svg_path, None) {
+        match AppAssetLoaderFacade::load_svg(svg_path, None) {
             Ok(vertices) => {
                 tracing::warn!("SVG読み込み成功: {} 頂点", vertices.len());
 
@@ -505,7 +507,7 @@ impl AppState {
         tracing::info!("デバッグ形状: Triangle3D表示（SVGから）");
 
         let svg_path = Path::new("tests/fixtures/shapes/triangle.svg");
-        match crate::app_asset_loader::load_svg(svg_path, None) {
+        match AppAssetLoaderFacade::load_svg(svg_path, None) {
             Ok(vertices) => {
                 tracing::info!("SVG読み込み成功: {} 頂点", vertices.len());
 
@@ -533,7 +535,7 @@ impl AppState {
         tracing::info!("デバッグ形状: Arc3D表示（SVGから）");
 
         let svg_path = Path::new("tests/fixtures/shapes/arc.svg");
-        match crate::app_asset_loader::load_svg(svg_path, None) {
+        match AppAssetLoaderFacade::load_svg(svg_path, None) {
             Ok(vertices) => {
                 tracing::info!("SVG読み込み成功: {} 頂点", vertices.len());
 


### PR DESCRIPTION
## 概要
Issue #258 Phase4 として、app loader/renderer の接続責務を薄い Facade/Factory に集約しました。挙動は変更せず、呼び出し側から責務境界が読み取りやすい構造に整理しています。

## 変更内容
- ドキュメント追加（ドキュメントファースト）
  - `dev/architecture/ISSUE_258_PHASE4_APP_FACTORY_FACADE_DESIGN.md`
- `app_asset_loader`
  - `AppAssetLoaderFacade` を追加
  - 既存関数 API (`load_stl` / `load_sample_stl_with_bounds` / `load_svg`) は互換維持の委譲として維持
- `app_renderer`
  - `AppRendererFactory` を追加
  - stage + overlay 初期化責務を factory 側へ集約
  - 既存 `AppRenderer::new_*` は factory 委譲へ変更（API互換維持）
- 呼び出し側
  - `AppState::new` を `AppRendererFactory::create_draft(...)` へ切替
  - `app_state/debug_scene` の loader 呼び出しを `AppAssetLoaderFacade` 経由へ統一

## チェック
- [x] `cargo fmt`
- [x] `cargo build -p redring`
- [x] `cargo clippy -p redring -- -D warnings`

## 関連
- Refs #258