### PR TITLE
refactor(view/app): Issue #258 Phase5-1 mouse input境界整理

### DIFF
--- a/dev/architecture/ISSUE_258_PHASE5_MANAGER_AND_LOADER_POLICY.md
+++ b/dev/architecture/ISSUE_258_PHASE5_MANAGER_AND_LOADER_POLICY.md
@@ -64,3 +64,14 @@
 - 小PR分割で段階適用する
 - 各段階で `cargo fmt` / `cargo build -p redring` / `cargo clippy -p redring -- -D warnings` を通す
 - 命名変更（Phase6）は責務分割PRと混ぜない
+
+## 4. Phase5-1 実施手順（2026-02-26）
+
+1. `MouseInput` の外部公開を「状態遷移API」中心へ寄せる
+	- `operation` / `ctrl_pressed` の直接参照を getter 経由へ置換
+	- 操作中断は専用メソッド（例: `cancel_operation`）経由へ統一
+2. `app_state/mouse_actions` の直接代入を廃止する
+	- `self.mouse_input.operation = ...` を禁止し、`MouseInput` API で遷移させる
+3. DeviceEvent経路は現行挙動を維持し、責務境界のみ整理する
+	- `AppState` 側はカメラ適用/スクラブ制御に限定
+	- `MouseInput` 側は操作状態の判定・保持に限定

--- a/view/app/src/app_state/mouse_actions.rs
+++ b/view/app/src/app_state/mouse_actions.rs
@@ -24,14 +24,14 @@ impl AppState {
                             self.load_debug_simulation_snapshots();
                         }
                         self.snapshot_scrub_active = true;
-                        self.mouse_input.operation = crate::mouse_input::MouseOperation::None;
+                        self.mouse_input.cancel_operation();
                         self.set_snapshot_cursor_from_x(cursor.0, true);
                         tracing::debug!("左クリック: snapshotスクラブ開始");
                         return;
                     }
                 }
 
-                if self.mouse_input.ctrl_pressed {
+                if self.mouse_input.is_ctrl_pressed() {
                     self.arcball_drag_start = self.cursor_position;
                     let viewport_width = self.graphic.config.width as f32;
                     let viewport_height = self.graphic.config.height as f32;
@@ -93,7 +93,7 @@ impl AppState {
             return;
         }
 
-        if self.mouse_input.operation == crate::mouse_input::MouseOperation::Rotate {
+        if self.mouse_input.operation() == crate::mouse_input::MouseOperation::Rotate {
             tracing::debug!(
                 "🖱️ CursorMoved(rotate): last={:?} current=({:.1},{:.1}) start={:?}",
                 self.last_cursor_position,
@@ -110,7 +110,7 @@ impl AppState {
 
     /// Ctrl+ホイールでズーム
     pub fn handle_mouse_wheel(&mut self, delta: winit::event::MouseScrollDelta) {
-        if !self.mouse_input.ctrl_pressed {
+        if !self.mouse_input.is_ctrl_pressed() {
             return;
         }
 
@@ -143,7 +143,7 @@ impl AppState {
 
         let (delta_x, delta_y) = (delta.0 as f32, delta.1 as f32);
 
-        match self.mouse_input.operation {
+        match self.mouse_input.operation() {
             MouseOperation::Rotate => {
                 let viewport_width = self.graphic.config.width as f32;
                 let viewport_height = self.graphic.config.height as f32;

--- a/view/app/src/mouse_input.rs
+++ b/view/app/src/mouse_input.rs
@@ -13,15 +13,15 @@ pub enum MouseOperation {
 #[derive(Debug, Clone)]
 pub struct MouseInput {
     /// 現在の操作種類
-    pub operation: MouseOperation,
+    operation: MouseOperation,
     /// 前回のマウス位置
-    pub last_position: Option<(f32, f32)>,
+    last_position: Option<(f32, f32)>,
     /// Ctrlキーが押されているか
-    pub ctrl_pressed: bool,
+    ctrl_pressed: bool,
     /// 各マウスボタンの状態
-    pub left_pressed: bool,
-    pub middle_pressed: bool,
-    pub right_pressed: bool,
+    left_pressed: bool,
+    middle_pressed: bool,
+    right_pressed: bool,
 }
 
 impl MouseInput {
@@ -129,6 +129,22 @@ impl MouseInput {
     /// 操作が有効かどうか
     pub fn is_active(&self) -> bool {
         self.operation != MouseOperation::None
+    }
+
+    /// 現在の操作種類を取得
+    pub fn operation(&self) -> MouseOperation {
+        self.operation
+    }
+
+    /// Ctrlキー押下状態を取得
+    pub fn is_ctrl_pressed(&self) -> bool {
+        self.ctrl_pressed
+    }
+
+    /// 現在の操作を中断
+    pub fn cancel_operation(&mut self) {
+        self.operation = MouseOperation::None;
+        self.last_position = None;
     }
 }
 


### PR DESCRIPTION
## 概要
Issue #258 の Phase5-1 として、`mouse_input` と `app_state/mouse_actions` の責務境界を明確化しました。挙動は維持し、`AppState` から `MouseInput` 内部状態への直接代入/直接参照を排除しています。

## 変更内容
- ドキュメント更新（Phase5-1 実施手順追記）
  - `dev/architecture/ISSUE_258_PHASE5_MANAGER_AND_LOADER_POLICY.md`
- `mouse_input`
  - 内部状態フィールドを非公開化（`operation`, `ctrl_pressed`, ほか）
  - getter追加: `operation()`, `is_ctrl_pressed()`
  - 操作中断API追加: `cancel_operation()`
- `app_state/mouse_actions`
  - `self.mouse_input.operation = ...` を廃止し `cancel_operation()` 呼び出しへ置換
  - `ctrl_pressed` / `operation` 参照を getter 経由へ統一

## チェック
- [x] `cargo fmt`
- [x] `cargo build -p redring`
- [x] `cargo clippy -p redring -- -D warnings`

## 関連
- Refs #258