### PR TITLE
refactor(render): Phase7 render_2d/render_3d の重複削減

### DIFF
--- a/view/render/src/pipeline.rs
+++ b/view/render/src/pipeline.rs
@@ -6,10 +6,13 @@ use wgpu::{
 
 #[allow(dead_code)]
 pub struct PipelineBundle {
+    /// 生成されたレンダーパイプライン本体
     pub pipeline: RenderPipeline,
+    /// パイプラインレイアウト
     pub layout: PipelineLayout,
 }
 
+/// 汎用パイプラインを生成するヘルパ（bind group layout 指定版）
 pub fn create_pipeline(
     device: &Device,
     shader: &ShaderModule,
@@ -66,13 +69,68 @@ pub fn create_pipeline(
     }
 }
 
+/// bind group を持たない基本的な TriangleList パイプラインを生成する。
+pub fn create_basic_triangle_pipeline(
+    device: &Device,
+    shader: &ShaderModule,
+    format: TextureFormat,
+    vertex_layouts: &[wgpu::VertexBufferLayout<'_>],
+    label_prefix: &str,
+) -> RenderPipeline {
+    let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+        label: Some(&format!("{} Pipeline Layout", label_prefix)),
+        bind_group_layouts: &[],
+        push_constant_ranges: &[],
+    });
+
+    device.create_render_pipeline(&RenderPipelineDescriptor {
+        label: Some(&format!("{} Pipeline", label_prefix)),
+        layout: Some(&pipeline_layout),
+        vertex: VertexState {
+            module: shader,
+            entry_point: Some("vs_main"),
+            buffers: vertex_layouts,
+            compilation_options: Default::default(),
+        },
+        fragment: Some(FragmentState {
+            module: shader,
+            entry_point: Some("fs_main"),
+            targets: &[Some(wgpu::ColorTargetState {
+                format,
+                blend: Some(wgpu::BlendState::REPLACE),
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+            compilation_options: Default::default(),
+        }),
+        primitive: PrimitiveState {
+            topology: wgpu::PrimitiveTopology::TriangleList,
+            ..Default::default()
+        },
+        depth_stencil: None,
+        multisample: MultisampleState::default(),
+        multiview: None,
+        cache: None,
+    })
+}
+
+/// インデックスなし描画を行う共通ヘルパ。
+pub fn draw_non_indexed(
+    render_pass: &mut wgpu::RenderPass<'_>,
+    pipeline: &wgpu::RenderPipeline,
+    vertex_buffer: &wgpu::Buffer,
+    vertex_count: u32,
+) {
+    render_pass.set_pipeline(pipeline);
+    render_pass.set_vertex_buffer(0, vertex_buffer.slice(..));
+    render_pass.draw(0..vertex_count, 0..1);
+}
+
+/// ワイヤーフレーム描画用ヘルパ。
 pub fn draw_wireframe<'a>(
     render_pass: &mut wgpu::RenderPass<'a>,
     pipeline: &'a wgpu::RenderPipeline,
     vertex_buffer: &'a wgpu::Buffer,
     vertex_count: u32,
 ) {
-    render_pass.set_pipeline(pipeline);
-    render_pass.set_vertex_buffer(0, vertex_buffer.slice(..));
-    render_pass.draw(0..vertex_count, 0..1);
+    draw_non_indexed(render_pass, pipeline, vertex_buffer, vertex_count);
 }

--- a/view/render/src/render_2d.rs
+++ b/view/render/src/render_2d.rs
@@ -1,3 +1,4 @@
+use crate::pipeline;
 use crate::shader::render_2d_shader;
 use crate::vertex_2d::Vertex2D;
 use std::sync::Arc;
@@ -5,12 +6,17 @@ use wgpu::util::DeviceExt;
 use wgpu::{Buffer, RenderPipeline};
 
 pub struct Render2dResources {
+    /// 頂点更新時に利用するデバイス参照
     pub device: Arc<wgpu::Device>,
+    /// 2D描画用パイプライン
     pub pipeline: wgpu::RenderPipeline,
+    /// 三角形頂点バッファ
     pub vertex_buffer: wgpu::Buffer,
+    /// 描画頂点数
     pub vertex_count: u32,
 }
 
+/// 2Dサンプル描画リソースを作成する。
 pub fn create_render_2d_resources(
     device: &Arc<wgpu::Device>,
     format: wgpu::TextureFormat,
@@ -35,40 +41,13 @@ pub fn create_render_2d_resources(
 
     let shader = render_2d_shader(device);
 
-    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-        label: Some("Render 2D Pipeline Layout"),
-        bind_group_layouts: &[],
-        push_constant_ranges: &[],
-    });
-
-    let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-        label: Some("Render 2D Render Pipeline"),
-        layout: Some(&pipeline_layout),
-        vertex: wgpu::VertexState {
-            module: &shader,
-            entry_point: Some("vs_main"),
-            buffers: &[Vertex2D::desc()],
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-        },
-        fragment: Some(wgpu::FragmentState {
-            module: &shader,
-            entry_point: Some("fs_main"),
-            targets: &[Some(wgpu::ColorTargetState {
-                format,
-                blend: Some(wgpu::BlendState::REPLACE),
-                write_mask: wgpu::ColorWrites::ALL,
-            })],
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-        }),
-        primitive: wgpu::PrimitiveState {
-            topology: wgpu::PrimitiveTopology::TriangleList,
-            ..Default::default()
-        },
-        depth_stencil: None,
-        multisample: wgpu::MultisampleState::default(),
-        multiview: None,
-        cache: None,
-    });
+    let pipeline = pipeline::create_basic_triangle_pipeline(
+        device,
+        &shader,
+        format,
+        &[Vertex2D::desc()],
+        "Render 2D",
+    );
 
     let vertex_count = vertices.len() as u32;
 
@@ -80,13 +59,12 @@ pub fn create_render_2d_resources(
     }
 }
 
+/// 2D頂点バッファを非インデックスで描画する。
 pub fn draw_render_2d<'a>(
     pass: &mut wgpu::RenderPass<'a>,
     pipeline: &'a RenderPipeline,
     vertex_buffer: &'a Buffer,
     vertex_count: u32,
 ) {
-    pass.set_pipeline(pipeline);
-    pass.set_vertex_buffer(0, vertex_buffer.slice(..));
-    pass.draw(0..vertex_count, 0..1);
+    pipeline::draw_non_indexed(pass, pipeline, vertex_buffer, vertex_count);
 }

--- a/view/render/src/render_3d.rs
+++ b/view/render/src/render_3d.rs
@@ -1,3 +1,4 @@
+use crate::pipeline;
 use crate::shader::render_3d_shader;
 use crate::vertex_3d::Vertex3D;
 use std::sync::Arc;
@@ -5,12 +6,17 @@ use wgpu::util::DeviceExt;
 use wgpu::{Buffer, RenderPipeline};
 
 pub struct Renderer3D {
+    /// 頂点更新時に利用するデバイス参照
     pub device: Arc<wgpu::Device>,
+    /// 3D描画用パイプライン
     pub pipeline: wgpu::RenderPipeline,
+    /// 三角形頂点バッファ
     pub vertex_buffer: wgpu::Buffer,
+    /// 描画頂点数
     pub vertex_count: u32,
 }
 
+/// 3Dサンプル描画リソースを作成する。
 pub fn create_renderer_3d(device: &Arc<wgpu::Device>, format: wgpu::TextureFormat) -> Renderer3D {
     let vertices: &[Vertex3D] = &[
         Vertex3D {
@@ -32,40 +38,13 @@ pub fn create_renderer_3d(device: &Arc<wgpu::Device>, format: wgpu::TextureForma
 
     let shader = render_3d_shader(device);
 
-    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-        label: Some("Renderer3D Pipeline Layout"),
-        bind_group_layouts: &[],
-        push_constant_ranges: &[],
-    });
-
-    let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-        label: Some("Renderer3D Pipeline"),
-        layout: Some(&pipeline_layout),
-        vertex: wgpu::VertexState {
-            module: &shader,
-            entry_point: Some("vs_main"),
-            buffers: &[Vertex3D::desc()],
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-        },
-        fragment: Some(wgpu::FragmentState {
-            module: &shader,
-            entry_point: Some("fs_main"),
-            targets: &[Some(wgpu::ColorTargetState {
-                format,
-                blend: Some(wgpu::BlendState::REPLACE),
-                write_mask: wgpu::ColorWrites::ALL,
-            })],
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-        }),
-        primitive: wgpu::PrimitiveState {
-            topology: wgpu::PrimitiveTopology::TriangleList,
-            ..Default::default()
-        },
-        depth_stencil: None, // 後で追加可能
-        multisample: wgpu::MultisampleState::default(),
-        multiview: None,
-        cache: None,
-    });
+    let pipeline = pipeline::create_basic_triangle_pipeline(
+        device,
+        &shader,
+        format,
+        &[Vertex3D::desc()],
+        "Renderer3D",
+    );
 
     let vertex_count = vertices.len() as u32;
 
@@ -77,13 +56,12 @@ pub fn create_renderer_3d(device: &Arc<wgpu::Device>, format: wgpu::TextureForma
     }
 }
 
+/// 3D頂点バッファを非インデックスで描画する。
 pub fn draw_renderer_3d<'a>(
     pass: &mut wgpu::RenderPass<'a>,
     pipeline: &'a RenderPipeline,
     vertex_buffer: &'a Buffer,
     vertex_count: u32,
 ) {
-    pass.set_pipeline(pipeline);
-    pass.set_vertex_buffer(0, vertex_buffer.slice(..));
-    pass.draw(0..vertex_count, 0..1);
+    pipeline::draw_non_indexed(pass, pipeline, vertex_buffer, vertex_count);
 }


### PR DESCRIPTION
## 概要
Issue #258 の Phase7 として、`view/render` の 2D/3D 初期描画パスにある重複コードを共通化しました。

## 変更内容
- `view/render/src/pipeline.rs`
  - `create_basic_triangle_pipeline` を追加（bind group なしの基本 TriangleList パイプライン生成）
  - `draw_non_indexed` を追加（非インデックス描画共通ヘルパ）
  - `draw_wireframe` を `draw_non_indexed` 経由に統一
  - 公開要素に簡潔なコメントを追加
- `view/render/src/render_2d.rs`
  - パイプライン生成処理を共通ヘルパ利用へ変更
  - draw処理を共通ヘルパ利用へ変更
  - 構造体/関数に簡潔なコメントを追加
- `view/render/src/render_3d.rs`
  - パイプライン生成処理を共通ヘルパ利用へ変更
  - draw処理を共通ヘルパ利用へ変更
  - 構造体/関数に簡潔なコメントを追加

## 互換性・スコープ
- 既存の公開API名は維持
- 挙動変更なし（構造リファクタリングのみ）

## 検証
- `cargo build -p redring` 成功

## 関連
- Ref: #258 (Phase7)
