### PR TITLE
refactor(render): Phase8 mesh Uniform初期化の共通化

### DIFF
--- a/view/render/src/lib.rs
+++ b/view/render/src/lib.rs
@@ -9,6 +9,7 @@ pub mod render_3d;
 pub mod shader;
 pub mod surface;
 pub mod toolpath;
+pub mod uniform_factory;
 pub mod vertex_2d;
 pub mod vertex_3d;
 pub mod wireframe;

--- a/view/render/src/mesh.rs
+++ b/view/render/src/mesh.rs
@@ -1,4 +1,5 @@
 use crate::shader;
+use crate::uniform_factory;
 use crate::vertex_3d::MeshVertex;
 use bytemuck::{Pod, Zeroable};
 use viewmodel_graphics::build_view_projection_matrix;
@@ -51,38 +52,16 @@ impl MeshResources {
     pub fn new(device: &wgpu::Device, format: wgpu::TextureFormat) -> Self {
         let shader = shader::mesh_shader(device);
 
-        // Uniform bind group layout
-        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: None,
-                },
-                count: None,
-            }],
-            label: Some("mesh_bind_group_layout"),
-        });
-
-        // Uniform buffer
         let uniforms = MeshUniforms::default();
-        let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Mesh Uniform Buffer"),
-            contents: bytemuck::cast_slice(&[uniforms]),
-            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-        });
-
-        // Bind group
-        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            layout: &bind_group_layout,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: uniform_buffer.as_entire_binding(),
-            }],
-            label: Some("mesh_bind_group"),
-        });
+        let (bind_group_layout, uniform_buffer, bind_group) =
+            uniform_factory::create_uniform_binding(
+                device,
+                &uniforms,
+                wgpu::ShaderStages::VERTEX_FRAGMENT,
+                "mesh_bind_group_layout",
+                "Mesh Uniform Buffer",
+                "mesh_bind_group",
+            );
 
         // Render pipeline layout
         let render_pipeline_layout =

--- a/view/render/src/uniform_factory.rs
+++ b/view/render/src/uniform_factory.rs
@@ -1,0 +1,43 @@
+use bytemuck::Pod;
+use wgpu::util::DeviceExt;
+
+/// UniformバッファとBindGroup一式を作成する共通ヘルパ。
+pub fn create_uniform_binding<T: Pod>(
+    device: &wgpu::Device,
+    uniforms: &T,
+    visibility: wgpu::ShaderStages,
+    layout_label: &'static str,
+    buffer_label: &'static str,
+    bind_group_label: &'static str,
+) -> (wgpu::BindGroupLayout, wgpu::Buffer, wgpu::BindGroup) {
+    let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        entries: &[wgpu::BindGroupLayoutEntry {
+            binding: 0,
+            visibility,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Uniform,
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        }],
+        label: Some(layout_label),
+    });
+
+    let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some(buffer_label),
+        contents: bytemuck::cast_slice(&[*uniforms]),
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+    });
+
+    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        layout: &bind_group_layout,
+        entries: &[wgpu::BindGroupEntry {
+            binding: 0,
+            resource: uniform_buffer.as_entire_binding(),
+        }],
+        label: Some(bind_group_label),
+    });
+
+    (bind_group_layout, uniform_buffer, bind_group)
+}


### PR DESCRIPTION
## 概要
Issue #258 Phase8（Render Resource 初期化共通化）の1st PRとして、`mesh.rs` の Uniform/BindGroup 初期化重複を共通ヘルパへ寄せました。

## 変更内容
- 追加: `view/render/src/uniform_factory.rs`
  - `create_uniform_binding` を追加
  - Uniformバッファ / BindGroupLayout / BindGroup の生成を共通化
- 更新: `view/render/src/lib.rs`
  - `uniform_factory` モジュールを公開
- 更新: `view/render/src/mesh.rs`
  - `MeshResources::new` の Uniform初期化を `uniform_factory::create_uniform_binding` 経由に変更

## スコープ
- 対象は `mesh.rs` のみ（Phase8の段階適用 1/4）
- 既存公開APIは維持
- 挙動変更なし（構造整理のみ）

## 検証
- `cargo build -p redring` 成功

## 関連
- Ref: #258 (Phase8)
