### PR TITLE
refactor(render): Phase8 line Uniform初期化の共通化

### DIFF
--- a/view/render/src/line.rs
+++ b/view/render/src/line.rs
@@ -1,4 +1,5 @@
 use crate::shader;
+use crate::uniform_factory;
 use crate::vertex_3d::MeshVertex;
 use bytemuck::{Pod, Zeroable};
 use logging_foundation::{frame_interval_from_env, should_log_every_n_frames};
@@ -62,38 +63,16 @@ impl LineResources {
     pub fn new(device: &wgpu::Device, format: wgpu::TextureFormat) -> Self {
         let shader = shader::line_shader(device);
 
-        // Uniform bind group layout
-        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: None,
-                },
-                count: None,
-            }],
-            label: Some("line_bind_group_layout"),
-        });
-
-        // Uniform buffer
         let uniforms = LineUniforms::default();
-        let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Line Uniform Buffer"),
-            contents: bytemuck::cast_slice(&[uniforms]),
-            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-        });
-
-        // Bind group
-        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            layout: &bind_group_layout,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: uniform_buffer.as_entire_binding(),
-            }],
-            label: Some("line_bind_group"),
-        });
+        let (bind_group_layout, uniform_buffer, bind_group) =
+            uniform_factory::create_uniform_binding(
+                device,
+                &uniforms,
+                wgpu::ShaderStages::VERTEX_FRAGMENT,
+                "line_bind_group_layout",
+                "Line Uniform Buffer",
+                "line_bind_group",
+            );
 
         // Render pipeline layout
         let render_pipeline_layout =


### PR DESCRIPTION
## 概要
Issue #258 Phase8 の 2/4 として、`line.rs` の Uniform/BindGroup 初期化重複を共通ヘルパへ移行しました。

## 変更内容
- 更新: `view/render/src/line.rs`
  - `LineResources::new` の Uniform/BindGroup 初期化を
    `uniform_factory::create_uniform_binding` 経由に変更

## スコープ
- 対象は `line.rs` のみ（Phase8 段階適用 2/4）
- 既存公開APIは維持
- 挙動変更なし（構造整理のみ）

## 検証
- `cargo build -p redring` 成功

## 関連
- Ref: #258 (Phase8)
