### PR TITLE
refactor(render): Phase8 nurbs Uniform初期化の共通化

### DIFF
--- a/view/render/src/nurbs_eval.rs
+++ b/view/render/src/nurbs_eval.rs
@@ -3,8 +3,8 @@
 //! CPU側で生成した適応パラメータリストを用いて、
 //! GPU上でNURBS曲線を直接評価・描画するためのリソース管理。
 
-use bytemuck::{Pod, Zeroable};
 use crate::uniform_factory;
+use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
 
 /// NURBS評価用Uniform（カメラ行列）

--- a/view/render/src/nurbs_eval.rs
+++ b/view/render/src/nurbs_eval.rs
@@ -4,6 +4,7 @@
 //! GPU上でNURBS曲線を直接評価・描画するためのリソース管理。
 
 use bytemuck::{Pod, Zeroable};
+use crate::uniform_factory;
 use wgpu::util::DeviceExt;
 
 /// NURBS評価用Uniform（カメラ行列）
@@ -86,37 +87,16 @@ impl NurbsCurveEvalResources {
             ),
         });
 
-        // === @group(0): Uniform (view_proj, model) ===
-        let uniform_bind_group_layout =
-            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                entries: &[wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                }],
-                label: Some("nurbs_uniform_bind_group_layout"),
-            });
-
         let uniforms = NurbsEvalUniforms::default();
-        let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("NURBS Eval Uniform Buffer"),
-            contents: bytemuck::cast_slice(&[uniforms]),
-            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-        });
-
-        let uniform_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            layout: &uniform_bind_group_layout,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: uniform_buffer.as_entire_binding(),
-            }],
-            label: Some("nurbs_uniform_bind_group"),
-        });
+        let (uniform_bind_group_layout, uniform_buffer, uniform_bind_group) =
+            uniform_factory::create_uniform_binding(
+                device,
+                &uniforms,
+                wgpu::ShaderStages::VERTEX_FRAGMENT,
+                "nurbs_uniform_bind_group_layout",
+                "NURBS Eval Uniform Buffer",
+                "nurbs_uniform_bind_group",
+            );
 
         // === @group(1): NURBS Data (Storage Buffers) ===
         let param_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -401,37 +381,16 @@ impl NurbsSurfaceEvalResources {
             ),
         });
 
-        // === @group(0): Uniform (view_proj, model) ===
-        let uniform_bind_group_layout =
-            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                entries: &[wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                }],
-                label: Some("nurbs_surface_uniform_bind_group_layout"),
-            });
-
         let uniforms = NurbsEvalUniforms::default();
-        let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("NURBS Surface Uniform Buffer"),
-            contents: bytemuck::cast_slice(&[uniforms]),
-            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-        });
-
-        let uniform_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            layout: &uniform_bind_group_layout,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: uniform_buffer.as_entire_binding(),
-            }],
-            label: Some("nurbs_surface_uniform_bind_group"),
-        });
+        let (uniform_bind_group_layout, uniform_buffer, uniform_bind_group) =
+            uniform_factory::create_uniform_binding(
+                device,
+                &uniforms,
+                wgpu::ShaderStages::VERTEX_FRAGMENT,
+                "nurbs_surface_uniform_bind_group_layout",
+                "NURBS Surface Uniform Buffer",
+                "nurbs_surface_uniform_bind_group",
+            );
 
         // === 頂点バッファ: (u,v)パラメータをインターリーブド配列で格納 ===
         let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {


### PR DESCRIPTION
## 概要
Issue #258 Phase8 の 4/4 として、`nurbs_eval.rs` の Uniform/BindGroup 初期化重複を共通ヘルパへ移行しました。

## 変更内容
- 更新: `view/render/src/nurbs_eval.rs`
  - `NurbsCurveEvalResources::new` の Uniform初期化を
    `uniform_factory::create_uniform_binding` 経由に変更
  - `NurbsSurfaceEvalResources::new` の Uniform初期化を
    `uniform_factory::create_uniform_binding` 経由に変更

## スコープ
- 対象は `nurbs_eval.rs` の Uniform系初期化のみ（Phase8 段階適用 4/4）
- NURBS固有のStorage Buffer / BindGroup構成は変更なし
- 既存公開APIは維持
- 挙動変更なし（構造整理のみ）

## 検証
- `cargo build -p redring` 成功

## 関連
- Ref: #258 (Phase8)
