### PR TITLE
refactor: Phase9 render quality hardening for issue #258

### DIFF
--- a/dev/architecture/ISSUE_258_PHASE9_RENDER_QUALITY_HARDENING.md
+++ b/dev/architecture/ISSUE_258_PHASE9_RENDER_QUALITY_HARDENING.md
@@ -46,3 +46,31 @@
 
 - リスク: ログ削減で調査性が落ちる
 - 対策: 環境変数で頻度制御可能な形で残す
+
+## 7. 事前確認結果（2026-02-26）
+
+- `view/render/src/nurbs_eval.rs`
+  - `tracing::info!` を 4 箇所確認（フレーム更新系の出力）。
+  - Phase9 では `debug!/trace!` への変更、または間引きログ化を検討対象とする。
+- `view/render/src/render_2d.rs`
+  - `pub device: Arc<wgpu::Device>` を保持していることを確認。
+- `view/render/src/render_3d.rs`
+  - `pub device: Arc<wgpu::Device>` を保持していることを確認。
+- `view/render/src/mesh_convert.rs`
+  - テストは `test_mvvm_mesh_conversion` のみで、実データ検証が未実装（プレースホルダ状態）。
+
+## 8. Phase9準備チェックリスト
+
+- [ ] ログ方針を確定（`info!` を削減し、必要な診断性を維持）
+- [ ] `Render2D` / `Render3D` の `device` 保持の実利用箇所を確認
+- [ ] `mesh_convert` に最小実データの変換テスト追加方針を確定
+- [ ] `wireframe.rs` の未使用要素を洗い出し（削除候補のみ整理）
+- [ ] 検証コマンドの実行順序を固定（build → clippy）
+
+## 9. 推奨実装順序（Phase9本体）
+
+1. `nurbs_eval.rs` のログレベル最適化（影響範囲が局所的）
+2. `mesh_convert.rs` の最小変換テスト追加（品質担保の先行）
+3. `render_2d.rs` / `render_3d.rs` の `Arc<Device>` 保持見直し
+4. `wireframe.rs` の未使用要素整理
+5. `cargo build -p redring` / `cargo clippy -p redring -- -D warnings` で最終確認

--- a/view/render/src/mesh_convert.rs
+++ b/view/render/src/mesh_convert.rs
@@ -15,15 +15,22 @@ pub fn triangle_mesh_to_mesh_vertices_generic(
 
 #[cfg(test)]
 mod tests {
+    use super::triangle_mesh_to_mesh_vertices_generic;
+    use viewmodel::mesh_converter::VertexData;
+
     #[test]
     fn test_mvvm_mesh_conversion() {
-        // 基本的な機能テスト：viewmodel経由でのメッシュ変換
-        // 実際のテストは統合テスト時に実行
+        let vertex_data = vec![
+            VertexData::new([1.0, 2.0, 3.0], [0.0, 0.0, 1.0]),
+            VertexData::new([-1.0, 0.5, 0.25], [0.0, 1.0, 0.0]),
+        ];
 
-        // テストデータ作成が viewmodel に依存するため、
-        // この段階では変換関数の存在確認のみ
+        let converted = triangle_mesh_to_mesh_vertices_generic(vertex_data);
 
-        // これは将来的に適切な VertexData で
-        // テストデータを作成して実行される予定
+        assert_eq!(converted.len(), 2);
+        assert_eq!(converted[0].position, [1.0, 2.0, 3.0]);
+        assert_eq!(converted[0].normal, [0.0, 0.0, 1.0]);
+        assert_eq!(converted[1].position, [-1.0, 0.5, 0.25]);
+        assert_eq!(converted[1].normal, [0.0, 1.0, 0.0]);
     }
 }

--- a/view/render/src/nurbs_eval.rs
+++ b/view/render/src/nurbs_eval.rs
@@ -309,7 +309,7 @@ impl NurbsCurveEvalResources {
     /// # Arguments
     /// * `render_pass` - wgpuレンダーパス
     pub fn render<'a>(&'a self, render_pass: &mut wgpu::RenderPass<'a>) {
-        tracing::info!(
+        tracing::debug!(
             "📊 NurbsCurveEvalResources.render(): pipeline設定、頂点数={}",
             self.num_eval_points
         );
@@ -319,7 +319,7 @@ impl NurbsCurveEvalResources {
         render_pass.set_bind_group(1, &self.nurbs_bind_group, &[]);
         render_pass.draw(0..self.num_eval_points, 0..1);
 
-        tracing::info!(
+        tracing::debug!(
             "📊 NurbsCurveEvalResources.render(): draw call実行 (0..{})",
             self.num_eval_points
         );
@@ -696,7 +696,7 @@ impl NurbsSurfaceEvalResources {
                 wgpu::IndexFormat::Uint32,
             );
             render_pass.draw_indexed(0..self.num_wireframe_indices, 0, 0..1);
-            tracing::info!(
+            tracing::debug!(
                 "📊 NurbsSurfaceEvalResources.render(): wireframe, {} indices",
                 self.num_wireframe_indices
             );
@@ -705,7 +705,7 @@ impl NurbsSurfaceEvalResources {
             render_pass
                 .set_index_buffer(self.solid_index_buffer.slice(..), wgpu::IndexFormat::Uint32);
             render_pass.draw_indexed(0..self.num_solid_indices, 0, 0..1);
-            tracing::info!(
+            tracing::debug!(
                 "📊 NurbsSurfaceEvalResources.render(): solid, {} indices ({} triangles)",
                 self.num_solid_indices,
                 self.num_solid_indices / 3

--- a/view/render/src/render_2d.rs
+++ b/view/render/src/render_2d.rs
@@ -1,13 +1,10 @@
 use crate::pipeline;
 use crate::shader::render_2d_shader;
 use crate::vertex_2d::Vertex2D;
-use std::sync::Arc;
 use wgpu::util::DeviceExt;
 use wgpu::{Buffer, RenderPipeline};
 
 pub struct Render2dResources {
-    /// 頂点更新時に利用するデバイス参照
-    pub device: Arc<wgpu::Device>,
     /// 2D描画用パイプライン
     pub pipeline: wgpu::RenderPipeline,
     /// 三角形頂点バッファ
@@ -18,7 +15,7 @@ pub struct Render2dResources {
 
 /// 2Dサンプル描画リソースを作成する。
 pub fn create_render_2d_resources(
-    device: &Arc<wgpu::Device>,
+    device: &wgpu::Device,
     format: wgpu::TextureFormat,
 ) -> Render2dResources {
     let vertices: &[Vertex2D] = &[
@@ -52,7 +49,6 @@ pub fn create_render_2d_resources(
     let vertex_count = vertices.len() as u32;
 
     Render2dResources {
-        device: device.clone(),
         pipeline,
         vertex_buffer,
         vertex_count,

--- a/view/render/src/render_3d.rs
+++ b/view/render/src/render_3d.rs
@@ -1,13 +1,10 @@
 use crate::pipeline;
 use crate::shader::render_3d_shader;
 use crate::vertex_3d::Vertex3D;
-use std::sync::Arc;
 use wgpu::util::DeviceExt;
 use wgpu::{Buffer, RenderPipeline};
 
 pub struct Renderer3D {
-    /// 頂点更新時に利用するデバイス参照
-    pub device: Arc<wgpu::Device>,
     /// 3D描画用パイプライン
     pub pipeline: wgpu::RenderPipeline,
     /// 三角形頂点バッファ
@@ -17,7 +14,7 @@ pub struct Renderer3D {
 }
 
 /// 3Dサンプル描画リソースを作成する。
-pub fn create_renderer_3d(device: &Arc<wgpu::Device>, format: wgpu::TextureFormat) -> Renderer3D {
+pub fn create_renderer_3d(device: &wgpu::Device, format: wgpu::TextureFormat) -> Renderer3D {
     let vertices: &[Vertex3D] = &[
         Vertex3D {
             position: [-0.5, -0.5, 0.0],
@@ -49,7 +46,6 @@ pub fn create_renderer_3d(device: &Arc<wgpu::Device>, format: wgpu::TextureForma
     let vertex_count = vertices.len() as u32;
 
     Renderer3D {
-        device: device.clone(),
         pipeline,
         vertex_buffer,
         vertex_count,

--- a/view/render/src/wireframe.rs
+++ b/view/render/src/wireframe.rs
@@ -2,26 +2,6 @@ use crate::shader::wireframe_shader;
 use wgpu::util::DeviceExt;
 use wgpu::{Buffer, Device, RenderPipeline};
 
-#[repr(C)]
-#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-pub struct VertexWireframe {
-    pub position: [f32; 3],
-}
-
-impl VertexWireframe {
-    pub fn desc() -> wgpu::VertexBufferLayout<'static> {
-        wgpu::VertexBufferLayout {
-            array_stride: std::mem::size_of::<Self>() as u64,
-            step_mode: wgpu::VertexStepMode::Vertex,
-            attributes: &[wgpu::VertexAttribute {
-                format: wgpu::VertexFormat::Float32x3,
-                offset: 0,
-                shader_location: 0,
-            }],
-        }
-    }
-}
-
 pub struct WireframeResources {
     pub pipeline: wgpu::RenderPipeline,
     pub vertex_buffer: wgpu::Buffer,

--- a/view/stage/src/draft.rs
+++ b/view/stage/src/draft.rs
@@ -81,13 +81,13 @@ impl RenderStage for DraftStage {
             },
         ];
 
-        self.resources.vertex_buffer = self
-            .device
-            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some("Animated Vertex Buffer"),
-                contents: bytemuck::cast_slice(&animated_vertices),
-                usage: wgpu::BufferUsages::VERTEX,
-            });
+        self.resources.vertex_buffer =
+            self.device
+                .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some("Animated Vertex Buffer"),
+                    contents: bytemuck::cast_slice(&animated_vertices),
+                    usage: wgpu::BufferUsages::VERTEX,
+                });
 
         self.resources.vertex_count = animated_vertices.len() as u32;
     }

--- a/view/stage/src/draft.rs
+++ b/view/stage/src/draft.rs
@@ -13,15 +13,17 @@ use render::render_2d::{draw_render_2d, Render2dResources};
 use render::vertex_2d::Vertex2D;
 
 pub struct DraftStage {
+    device: Arc<wgpu::Device>,
     resources: Render2dResources,
     frame_count: u64,
 }
 
 impl DraftStage {
     pub fn new(device: &wgpu::Device, format: wgpu::TextureFormat) -> Self {
-        let resources =
-            render::render_2d::create_render_2d_resources(&Arc::new(device.clone()), format);
+        let device = Arc::new(device.clone());
+        let resources = render::render_2d::create_render_2d_resources(device.as_ref(), format);
         Self {
+            device,
             resources,
             frame_count: 0,
         }
@@ -79,9 +81,9 @@ impl RenderStage for DraftStage {
             },
         ];
 
-        let device = &self.resources.device;
-        self.resources.vertex_buffer =
-            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        self.resources.vertex_buffer = self
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
                 label: Some("Animated Vertex Buffer"),
                 contents: bytemuck::cast_slice(&animated_vertices),
                 usage: wgpu::BufferUsages::VERTEX,

--- a/view/stage/src/shading.rs
+++ b/view/stage/src/shading.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use wgpu::{
     CommandEncoder, LoadOp, Operations, RenderPassColorAttachment, RenderPassDescriptor, StoreOp,
     TextureView,
@@ -17,7 +15,7 @@ pub struct ShadingStage {
 
 impl ShadingStage {
     pub fn new(device: &wgpu::Device, format: wgpu::TextureFormat) -> Self {
-        let renderer = create_renderer_3d(&Arc::new(device.clone()), format);
+        let renderer = create_renderer_3d(device, format);
         Self {
             renderer,
             frame_count: 0,


### PR DESCRIPTION
## 概要
Issue #258 の Phase9（render品質改善）として、挙動不変で品質改善を実施しました。

- `nurbs_eval` のフレーム毎 `tracing::info!` を `tracing::debug!` へ変更（ログノイズ抑制）
- `mesh_convert` のプレースホルダテストを実データ検証テストへ置換
- `render_2d` / `render_3d` の `Arc<Device>` 保持を見直し
  - 2D: `Render2dResources` から削除し `DraftStage` 側で保持
  - 3D: `Renderer3D` から削除
- `wireframe` の未使用 `VertexWireframe` 定義を削除
- Phase9準備ドキュメントを更新

## 変更ファイル
- `dev/architecture/ISSUE_258_PHASE9_RENDER_QUALITY_HARDENING.md`
- `view/render/src/nurbs_eval.rs`
- `view/render/src/mesh_convert.rs`
- `view/render/src/render_2d.rs`
- `view/render/src/render_3d.rs`
- `view/render/src/wireframe.rs`
- `view/stage/src/draft.rs`
- `view/stage/src/shading.rs`

## 検証
- `cargo fmt`
- `cargo build`
- `cargo clippy -- -D warnings`

## 関連
- Closes #258