### PR TITLE
refactor: introduce stage common infrastructure (Phase10)

### DIFF
--- a/view/stage/src/lib.rs
+++ b/view/stage/src/lib.rs
@@ -6,6 +6,7 @@ pub mod octree_stage;
 pub mod outline;
 pub mod render_stage;
 pub mod shading;
+pub mod stage_common;
 pub mod toolpath_stage;
 
 pub use draft::DraftStage;

--- a/view/stage/src/nurbs_curve_stage.rs
+++ b/view/stage/src/nurbs_curve_stage.rs
@@ -4,12 +4,12 @@
 //! GPU上でNURBS曲線を直接評価・描画します。
 
 use logging_foundation::{frame_interval_from_env, should_log_every_n_frames};
-use render::nurbs_eval::{NurbsCurveEvalResources, NurbsEvalUniforms};
+use render::nurbs_eval::NurbsCurveEvalResources;
 use std::any::Any;
 use std::sync::atomic::{AtomicU64, Ordering};
-use viewmodel_graphics::build_view_projection_matrix;
 use wgpu::{CommandEncoder, Device, Queue, TextureFormat, TextureView};
 
+use crate::stage_common::build_nurbs_eval_uniforms;
 use crate::RenderStage;
 
 static NURBS_CURVE_STAGE_RENDER_LOG_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -80,17 +80,7 @@ impl NurbsCurveStage {
         proj_matrix: [[f32; 4]; 4],
     ) {
         if let Some(resources) = &self.resources {
-            let view_proj = build_view_projection_matrix(view_matrix, proj_matrix);
-
-            let uniforms = NurbsEvalUniforms {
-                view_proj,
-                model: [
-                    [1.0, 0.0, 0.0, 0.0],
-                    [0.0, 1.0, 0.0, 0.0],
-                    [0.0, 0.0, 1.0, 0.0],
-                    [0.0, 0.0, 0.0, 1.0],
-                ],
-            };
+            let uniforms = build_nurbs_eval_uniforms(view_matrix, proj_matrix);
 
             resources.update_uniforms(queue, &uniforms);
         }

--- a/view/stage/src/nurbs_surface_stage.rs
+++ b/view/stage/src/nurbs_surface_stage.rs
@@ -4,12 +4,12 @@
 //! GPU上でNURBS曲面を直接評価・描画します。
 
 use logging_foundation::{frame_interval_from_env, should_log_every_n_frames};
-use render::nurbs_eval::{NurbsEvalUniforms, NurbsSurfaceEvalResources};
+use render::nurbs_eval::NurbsSurfaceEvalResources;
 use std::any::Any;
 use std::sync::atomic::{AtomicU64, Ordering};
-use viewmodel_graphics::build_view_projection_matrix;
 use wgpu::{CommandEncoder, Device, Queue, TextureFormat, TextureView};
 
+use crate::stage_common::build_nurbs_eval_uniforms;
 use crate::RenderStage;
 
 static NURBS_SURFACE_STAGE_RENDER_LOG_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -105,16 +105,7 @@ impl NurbsSurfaceStage {
         proj_matrix: [[f32; 4]; 4],
     ) {
         if let Some(ref resources) = self.resources {
-            let view_proj = build_view_projection_matrix(view_matrix, proj_matrix);
-            let uniforms = NurbsEvalUniforms {
-                view_proj,
-                model: [
-                    [1.0, 0.0, 0.0, 0.0],
-                    [0.0, 1.0, 0.0, 0.0],
-                    [0.0, 0.0, 1.0, 0.0],
-                    [0.0, 0.0, 0.0, 1.0],
-                ],
-            };
+            let uniforms = build_nurbs_eval_uniforms(view_matrix, proj_matrix);
             resources.update_uniforms(queue, &uniforms);
         }
     }

--- a/view/stage/src/octree_stage.rs
+++ b/view/stage/src/octree_stage.rs
@@ -22,14 +22,14 @@
 //! ```
 
 use logging_foundation::{frame_interval_from_env, should_log_every_n_frames};
-use render::toolpath::{ToolPathResources, ToolPathUniforms, ToolPathVertex};
+use render::toolpath::{ToolPathResources, ToolPathVertex};
 use std::any::Any;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 use viewmodel::octree_converter::WireframeVertex;
-use viewmodel_graphics::build_view_projection_matrix;
 use wgpu::{CommandEncoder, Device, TextureFormat, TextureView};
 
+use crate::stage_common::{build_toolpath_uniforms, create_depth_texture};
 use crate::RenderStage;
 
 static OCTREE_STAGE_RENDER_LOG_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -67,7 +67,8 @@ impl OctreeStage {
     pub fn new(device: &Device, format: TextureFormat) -> Self {
         let resources = ToolPathResources::new(device, format);
         let size = (800, 600);
-        let (depth_texture, depth_view) = Self::create_depth_texture(device, size);
+        let (depth_texture, depth_view) =
+            create_depth_texture(device, size, "Octree Depth Texture");
 
         Self {
             resources,
@@ -82,29 +83,6 @@ impl OctreeStage {
             depth_view,
             surface_size: size,
         }
-    }
-
-    fn create_depth_texture(
-        device: &Device,
-        size: (u32, u32),
-    ) -> (wgpu::Texture, wgpu::TextureView) {
-        let depth_texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("Octree Depth Texture"),
-            size: wgpu::Extent3d {
-                width: size.0,
-                height: size.1,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Depth32Float,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
-            view_formats: &[],
-        });
-
-        let depth_view = depth_texture.create_view(&wgpu::TextureViewDescriptor::default());
-        (depth_texture, depth_view)
     }
 
     /// ワイヤーフレームデータを設定（色無しバージョン）
@@ -338,16 +316,7 @@ impl RenderStage for OctreeStage {
             proj_matrix[0][3]
         );
 
-        let view_proj = build_view_projection_matrix(view_matrix, proj_matrix);
-        let uniforms = ToolPathUniforms {
-            view_proj,
-            model: [
-                [1.0, 0.0, 0.0, 0.0],
-                [0.0, 1.0, 0.0, 0.0],
-                [0.0, 0.0, 1.0, 0.0],
-                [0.0, 0.0, 0.0, 1.0],
-            ],
-        };
+        let uniforms = build_toolpath_uniforms(view_matrix, proj_matrix);
         self.resources.update_uniforms(queue, &uniforms);
     }
 

--- a/view/stage/src/stage_common.rs
+++ b/view/stage/src/stage_common.rs
@@ -1,0 +1,60 @@
+use render::nurbs_eval::NurbsEvalUniforms;
+use render::toolpath::ToolPathUniforms;
+use viewmodel_graphics::build_view_projection_matrix;
+
+pub const IDENTITY_MODEL_MATRIX: [[f32; 4]; 4] = [
+    [1.0, 0.0, 0.0, 0.0],
+    [0.0, 1.0, 0.0, 0.0],
+    [0.0, 0.0, 1.0, 0.0],
+    [0.0, 0.0, 0.0, 1.0],
+];
+
+pub fn create_depth_texture(
+    device: &wgpu::Device,
+    size: (u32, u32),
+    label: &'static str,
+) -> (wgpu::Texture, wgpu::TextureView) {
+    let depth_texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some(label),
+        size: wgpu::Extent3d {
+            width: size.0,
+            height: size.1,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Depth32Float,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+        view_formats: &[],
+    });
+
+    let depth_view = depth_texture.create_view(&wgpu::TextureViewDescriptor::default());
+    (depth_texture, depth_view)
+}
+
+pub fn build_toolpath_uniforms_from_view_proj(view_proj: [[f32; 4]; 4]) -> ToolPathUniforms {
+    ToolPathUniforms {
+        view_proj,
+        model: IDENTITY_MODEL_MATRIX,
+    }
+}
+
+pub fn build_toolpath_uniforms(
+    view_matrix: [[f32; 4]; 4],
+    proj_matrix: [[f32; 4]; 4],
+) -> ToolPathUniforms {
+    let view_proj = build_view_projection_matrix(view_matrix, proj_matrix);
+    build_toolpath_uniforms_from_view_proj(view_proj)
+}
+
+pub fn build_nurbs_eval_uniforms(
+    view_matrix: [[f32; 4]; 4],
+    proj_matrix: [[f32; 4]; 4],
+) -> NurbsEvalUniforms {
+    let view_proj = build_view_projection_matrix(view_matrix, proj_matrix);
+    NurbsEvalUniforms {
+        view_proj,
+        model: IDENTITY_MODEL_MATRIX,
+    }
+}

--- a/view/stage/src/toolpath_stage.rs
+++ b/view/stage/src/toolpath_stage.rs
@@ -22,11 +22,11 @@
 //! ```
 
 use logging_foundation::{frame_interval_from_env, should_log_every_n_frames};
-use render::toolpath::{ToolPathResources, ToolPathUniforms, ToolPathVertex};
+use render::toolpath::{ToolPathResources, ToolPathVertex};
 use std::sync::atomic::{AtomicU64, Ordering};
-use viewmodel_graphics::build_view_projection_matrix;
 use wgpu::{CommandEncoder, Device, Queue, TextureFormat, TextureView};
 
+use crate::stage_common::{build_toolpath_uniforms, build_toolpath_uniforms_from_view_proj};
 use crate::RenderStage;
 
 static TOOLPATH_STAGE_RENDER_LOG_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -60,7 +60,8 @@ impl ToolPathStage {
 
         // 初期深度テクスチャ（800x600）
         let size = (800, 600);
-        let (depth_texture, depth_view) = Self::create_depth_texture(device, size);
+        let (depth_texture, depth_view) =
+            crate::stage_common::create_depth_texture(device, size, "ToolPath Depth Texture");
 
         Self {
             resources,
@@ -69,30 +70,6 @@ impl ToolPathStage {
             depth_view,
             surface_size: size,
         }
-    }
-
-    /// 深度テクスチャを作成
-    fn create_depth_texture(
-        device: &Device,
-        size: (u32, u32),
-    ) -> (wgpu::Texture, wgpu::TextureView) {
-        let depth_texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("ToolPath Depth Texture"),
-            size: wgpu::Extent3d {
-                width: size.0,
-                height: size.1,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Depth32Float,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
-            view_formats: &[],
-        });
-
-        let depth_view = depth_texture.create_view(&wgpu::TextureViewDescriptor::default());
-        (depth_texture, depth_view)
     }
 
     /// 工具経路データを設定
@@ -122,15 +99,7 @@ impl ToolPathStage {
     /// - `queue`: wgpu Queue
     /// - `view_proj_matrix`: ビュー・プロジェクション結合行列
     pub fn update_camera(&mut self, queue: &Queue, view_proj_matrix: [[f32; 4]; 4]) {
-        let uniforms = ToolPathUniforms {
-            view_proj: view_proj_matrix,
-            model: [
-                [1.0, 0.0, 0.0, 0.0],
-                [0.0, 1.0, 0.0, 0.0],
-                [0.0, 0.0, 1.0, 0.0],
-                [0.0, 0.0, 0.0, 1.0],
-            ],
-        };
+        let uniforms = build_toolpath_uniforms_from_view_proj(view_proj_matrix);
 
         self.resources.update_uniforms(queue, &uniforms);
     }
@@ -148,8 +117,8 @@ impl ToolPathStage {
         view_matrix: [[f32; 4]; 4],
         proj_matrix: [[f32; 4]; 4],
     ) {
-        let view_proj = build_view_projection_matrix(view_matrix, proj_matrix);
-        self.update_camera(queue, view_proj);
+        let uniforms = build_toolpath_uniforms(view_matrix, proj_matrix);
+        self.resources.update_uniforms(queue, &uniforms);
     }
 
     /// データが設定されているか確認


### PR DESCRIPTION
## 概要
Issue #258 の Phase10（Stage共通基盤導入）として、`view/stage` 内の重複処理を `stage_common` に集約しました。

## 変更内容
- `view/stage/src/stage_common.rs` を新規追加
  - 深度テクスチャ生成ヘルパ
  - ToolPath用 uniform 構築ヘルパ
  - NURBS評価用 uniform 構築ヘルパ
  - 単位行列を `const` (`IDENTITY_MODEL_MATRIX`) で定義
- `view/stage/src/lib.rs`
  - `pub mod stage_common;` を追加
- `view/stage/src/toolpath_stage.rs`
  - 深度テクスチャ生成を共通ヘルパへ移行
  - camera uniform 構築を共通ヘルパへ移行
- `view/stage/src/octree_stage.rs`
  - 深度テクスチャ生成を共通ヘルパへ移行
  - camera uniform 構築を共通ヘルパへ移行
- `view/stage/src/nurbs_curve_stage.rs`
  - camera uniform 構築を共通ヘルパへ移行
- `view/stage/src/nurbs_surface_stage.rs`
  - camera uniform 構築を共通ヘルパへ移行

## 検証
- `cargo clippy -- -D warnings` 成功
- `cargo fmt` 実行済み
- `cargo build` 成功

## 補足
- 挙動変更なし（リファクタリングのみ）
- `RenderStage` trait 境界は変更していません