### PR TITLE
refactor: phase11 stage boundary and factory consolidation

### DIFF
--- a/view/app/src/app_renderer.rs
+++ b/view/app/src/app_renderer.rs
@@ -1,7 +1,8 @@
-use stage::{DraftStage, OutlineStage, RenderStage, ShadingStage};
+use stage::RenderStage;
 use wgpu::{CommandEncoder, Device, SurfaceConfiguration, TextureView};
 
 use crate::snapshot_overlay_renderer::{SnapshotOverlayRenderer, SnapshotOverlayStyle};
+use crate::stage_factory;
 use crate::view_rect::ViewRect;
 use crate::view_rect_renderer::ViewRectRenderer;
 
@@ -29,17 +30,17 @@ impl AppRendererFactory {
     }
 
     pub fn create_draft(device: &Device, config: &SurfaceConfiguration) -> AppRenderer {
-        let stage = Box::new(DraftStage::new(device, config.format));
+        let stage = stage_factory::create_draft_stage(device, config.format);
         Self::create_with_stage(device, config, stage)
     }
 
     pub fn create_outline(device: &Device, config: &SurfaceConfiguration) -> AppRenderer {
-        let stage = Box::new(OutlineStage::new(device, config.format));
+        let stage = stage_factory::create_outline_stage(device, config.format);
         Self::create_with_stage(device, config, stage)
     }
 
     pub fn create_shading(device: &Device, config: &SurfaceConfiguration) -> AppRenderer {
-        let stage = Box::new(ShadingStage::new(device, config.format));
+        let stage = stage_factory::create_shading_stage(device, config.format);
         Self::create_with_stage(device, config, stage)
     }
 }

--- a/view/app/src/app_state/display_controls.rs
+++ b/view/app/src/app_state/display_controls.rs
@@ -1,7 +1,7 @@
 //! AppState の表示モード・カメラ制御を扱うモジュール。
 
 use super::AppState;
-use stage::{MeshStage, NurbsSurfaceStage, OctreeStage};
+use stage::{MeshStage, OctreeStage};
 
 impl AppState {
     /// カメラをリセット
@@ -103,21 +103,8 @@ impl AppState {
         }
 
         let stage = self.renderer.get_stage_mut();
-
-        if let Some(mesh_stage) = stage.as_any_mut().downcast_mut::<MeshStage>() {
-            mesh_stage.toggle_wireframe();
-            let mode = if mesh_stage.is_wireframe() {
-                "ワイヤーフレーム"
-            } else {
-                "ソリッド"
-            };
-            tracing::info!("表示モードを{}に切り替え", mode);
-            return;
-        }
-
-        if let Some(nurbs_stage) = stage.as_any_mut().downcast_mut::<NurbsSurfaceStage>() {
-            nurbs_stage.toggle_wireframe();
-            let mode = if nurbs_stage.is_wireframe() {
+        if let Some(is_wireframe) = stage.toggle_wireframe_mode() {
+            let mode = if is_wireframe {
                 "ワイヤーフレーム"
             } else {
                 "ソリッド"

--- a/view/app/src/app_state/input_actions.rs
+++ b/view/app/src/app_state/input_actions.rs
@@ -1,7 +1,6 @@
 //! AppState のキーボード入力ハンドリングを扱うモジュール。
 
 use super::AppState;
-use stage::OctreeStage;
 
 impl AppState {
     /// キーボード入力を処理
@@ -102,14 +101,10 @@ impl AppState {
                     let mut handled = false;
                     {
                         let stage = self.renderer.get_stage_mut();
-                        if let Some(octree_stage) = stage.as_any_mut().downcast_mut::<OctreeStage>()
+                        if let Some((current_depth, max_depth)) =
+                            stage.cycle_octree_depth(&self.graphic.device)
                         {
-                            octree_stage.cycle_next_depth(&self.graphic.device);
-                            tracing::info!(
-                                "Octree深さ表示: {}/{}",
-                                octree_stage.current_depth(),
-                                octree_stage.max_depth()
-                            );
+                            tracing::info!("Octree深さ表示: {}/{}", current_depth, max_depth);
                             handled = true;
                         }
                     }
@@ -122,9 +117,7 @@ impl AppState {
                     let mut handled = false;
                     {
                         let stage = self.renderer.get_stage_mut();
-                        if let Some(octree_stage) = stage.as_any_mut().downcast_mut::<OctreeStage>()
-                        {
-                            octree_stage.start_depth_animation();
+                        if stage.start_octree_depth_animation() {
                             tracing::info!("Octree深さアニメーション再生開始");
                             handled = true;
                         }
@@ -133,9 +126,7 @@ impl AppState {
                     if !handled {
                         self.load_debug_octree();
                         let stage = self.renderer.get_stage_mut();
-                        if let Some(octree_stage) = stage.as_any_mut().downcast_mut::<OctreeStage>()
-                        {
-                            octree_stage.start_depth_animation();
+                        if stage.start_octree_depth_animation() {
                             tracing::info!("Octree深さアニメーション再生開始");
                         }
                     }

--- a/view/app/src/app_state/settings_accessors/snapshot_settings.rs
+++ b/view/app/src/app_state/settings_accessors/snapshot_settings.rs
@@ -1,5 +1,4 @@
 use crate::app_state::{AppState, SnapshotShadedColorSettings};
-use stage::MeshStage;
 
 impl AppState {
     /// Snapshotシェーディング時のワークソリッド色を設定
@@ -8,9 +7,7 @@ impl AppState {
 
         if self.debug_snapshot.shaded_mode {
             let stage = self.renderer.get_stage_mut();
-            if let Some(mesh_stage) = stage.as_any_mut().downcast_mut::<MeshStage>() {
-                mesh_stage.set_mesh_base_color(color);
-            }
+            stage.set_mesh_base_color(color);
         }
     }
 

--- a/view/app/src/app_state/snapshot_playback.rs
+++ b/view/app/src/app_state/snapshot_playback.rs
@@ -2,7 +2,6 @@
 
 use super::AppState;
 use crate::view_rect::ViewRect;
-use stage::{MeshStage, OctreeStage};
 
 impl AppState {
     /// デバッグ用: cam_sim 実行結果をスナップショット系列として読み込む
@@ -81,27 +80,29 @@ impl AppState {
             let (vertices, indices) = snapshot_solids[frame_index].clone();
 
             let stage = self.renderer.get_stage_mut();
-            let Some(mesh_stage) = stage.as_any_mut().downcast_mut::<MeshStage>() else {
-                return;
-            };
-            mesh_stage.set_mesh_data(&self.graphic.device, vertices, indices);
-            mesh_stage.set_mesh_base_color(self.snapshot_shaded_color_settings.work_solid_color);
-            mesh_stage.clear_overlay_line_data();
-
             let toolpath_lines = self
                 .debug_snapshot
                 .toolpath_lines
                 .clone()
                 .unwrap_or_default();
-            if let Some(tool_lines_per_frame) = &self.debug_snapshot.tool_lines {
+            let tool_lines = if let Some(tool_lines_per_frame) = &self.debug_snapshot.tool_lines {
                 let overlay_index = frame_index.min(tool_lines_per_frame.len().saturating_sub(1));
-                let tool_lines = tool_lines_per_frame[overlay_index].clone();
-                if !tool_lines.is_empty() {
-                    mesh_stage.set_overlay_tool_line_data(&self.graphic.device, tool_lines);
-                }
-            }
-            if !toolpath_lines.is_empty() {
-                mesh_stage.set_overlay_toolpath_line_data(&self.graphic.device, toolpath_lines);
+                tool_lines_per_frame[overlay_index].clone()
+            } else {
+                Vec::new()
+            };
+
+            let applied = stage.apply_snapshot_solid_frame(
+                &self.graphic.device,
+                vertices,
+                indices,
+                self.snapshot_shaded_color_settings.work_solid_color,
+                toolpath_lines,
+                tool_lines,
+            );
+
+            if !applied {
+                return;
             }
             return;
         }
@@ -119,14 +120,14 @@ impl AppState {
             .min(snapshot_wireframes.len().saturating_sub(1));
 
         let stage = self.renderer.get_stage_mut();
-        let Some(octree_stage) = stage.as_any_mut().downcast_mut::<OctreeStage>() else {
-            return;
-        };
-
-        if octree_stage.max_depth().saturating_add(1) != snapshot_wireframes.len() {
-            octree_stage.set_depth_levels(&self.graphic.device, snapshot_wireframes.clone());
+        let applied = stage.apply_snapshot_wireframe_frame(
+            &self.graphic.device,
+            snapshot_wireframes.clone(),
+            frame_index,
+        );
+        if !applied {
+            tracing::debug!("snapshot wireframe frameの適用対象ステージではありません");
         }
-        octree_stage.set_depth(&self.graphic.device, frame_index);
     }
 
     pub(super) fn log_current_snapshot_frame(&mut self, emit_log: bool) {

--- a/view/app/src/app_state/stage_orchestration.rs
+++ b/view/app/src/app_state/stage_orchestration.rs
@@ -2,7 +2,7 @@
 
 use super::AppState;
 use crate::stage_factory;
-use stage::{MeshStage, OctreeStage, RenderStage};
+use stage::{MeshStage, RenderStage};
 
 impl AppState {
     fn set_stage_and_update_camera(&mut self, stage: Box<dyn RenderStage>) {
@@ -35,9 +35,7 @@ impl AppState {
         self.renderer.update();
         {
             let stage = self.renderer.get_stage_mut();
-            if let Some(octree_stage) = stage.as_any_mut().downcast_mut::<OctreeStage>() {
-                octree_stage.tick_animation(&self.graphic.device);
-            }
+            stage.update_with_device(&self.graphic.device);
         }
 
         self.update_camera_uniforms();

--- a/view/stage/src/mesh_stage.rs
+++ b/view/stage/src/mesh_stage.rs
@@ -363,4 +363,37 @@ impl RenderStage for MeshStage {
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
     }
+
+    fn toggle_wireframe_mode(&mut self) -> Option<bool> {
+        self.toggle_wireframe();
+        Some(self.is_wireframe())
+    }
+
+    fn set_mesh_base_color(&mut self, color: [f32; 4]) -> bool {
+        self.set_mesh_base_color(color);
+        true
+    }
+
+    fn apply_snapshot_solid_frame(
+        &mut self,
+        device: &wgpu::Device,
+        vertices: Vec<render::vertex_3d::MeshVertex>,
+        indices: Vec<u32>,
+        base_color: [f32; 4],
+        toolpath_lines: Vec<render::vertex_3d::MeshVertex>,
+        tool_lines: Vec<render::vertex_3d::MeshVertex>,
+    ) -> bool {
+        self.set_mesh_data(device, vertices, indices);
+        self.set_mesh_base_color(base_color);
+        self.clear_overlay_line_data();
+
+        if !tool_lines.is_empty() {
+            self.set_overlay_tool_line_data(device, tool_lines);
+        }
+        if !toolpath_lines.is_empty() {
+            self.set_overlay_toolpath_line_data(device, toolpath_lines);
+        }
+
+        true
+    }
 }

--- a/view/stage/src/nurbs_surface_stage.rs
+++ b/view/stage/src/nurbs_surface_stage.rs
@@ -198,4 +198,9 @@ impl RenderStage for NurbsSurfaceStage {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
+
+    fn toggle_wireframe_mode(&mut self) -> Option<bool> {
+        self.toggle_wireframe();
+        Some(self.is_wireframe())
+    }
 }

--- a/view/stage/src/octree_stage.rs
+++ b/view/stage/src/octree_stage.rs
@@ -323,6 +323,39 @@ impl RenderStage for OctreeStage {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
+
+    fn update_with_device(&mut self, device: &wgpu::Device) {
+        self.tick_animation(device);
+    }
+
+    fn cycle_octree_depth(&mut self, device: &wgpu::Device) -> Option<(usize, usize)> {
+        self.cycle_next_depth(device);
+        Some((self.current_depth(), self.max_depth()))
+    }
+
+    fn start_octree_depth_animation(&mut self) -> bool {
+        self.start_depth_animation();
+        true
+    }
+
+    fn apply_snapshot_wireframe_frame(
+        &mut self,
+        device: &wgpu::Device,
+        snapshot_wireframes: Vec<Vec<WireframeVertex>>,
+        frame_index: usize,
+    ) -> bool {
+        if snapshot_wireframes.is_empty() {
+            return false;
+        }
+
+        if self.max_depth().saturating_add(1) != snapshot_wireframes.len() {
+            self.set_depth_levels(device, snapshot_wireframes.clone());
+        }
+
+        let index = frame_index.min(snapshot_wireframes.len().saturating_sub(1));
+        self.set_depth(device, index);
+        true
+    }
 }
 
 #[cfg(test)]

--- a/view/stage/src/render_stage.rs
+++ b/view/stage/src/render_stage.rs
@@ -30,6 +30,54 @@ pub trait RenderStage {
     /// 状態更新（デフォルトは空）
     fn update(&mut self) {}
 
+    /// Device依存の状態更新（デフォルトは空）
+    fn update_with_device(&mut self, _device: &wgpu::Device) {
+        self.update();
+    }
+
+    /// Octree深さを1段進める（未対応ならNone）
+    fn cycle_octree_depth(&mut self, _device: &wgpu::Device) -> Option<(usize, usize)> {
+        None
+    }
+
+    /// Octree深さアニメーション開始（未対応ならfalse）
+    fn start_octree_depth_animation(&mut self) -> bool {
+        false
+    }
+
+    /// ワイヤーフレーム表示切替（未対応ならNone）
+    fn toggle_wireframe_mode(&mut self) -> Option<bool> {
+        None
+    }
+
+    /// メッシュ基本色設定（未対応ならfalse）
+    fn set_mesh_base_color(&mut self, _color: [f32; 4]) -> bool {
+        false
+    }
+
+    /// Snapshotのソリッドフレームを適用（未対応ならfalse）
+    fn apply_snapshot_solid_frame(
+        &mut self,
+        _device: &wgpu::Device,
+        _vertices: Vec<render::vertex_3d::MeshVertex>,
+        _indices: Vec<u32>,
+        _base_color: [f32; 4],
+        _toolpath_lines: Vec<render::vertex_3d::MeshVertex>,
+        _tool_lines: Vec<render::vertex_3d::MeshVertex>,
+    ) -> bool {
+        false
+    }
+
+    /// Snapshotのワイヤーフレームフレームを適用（未対応ならfalse）
+    fn apply_snapshot_wireframe_frame(
+        &mut self,
+        _device: &wgpu::Device,
+        _snapshot_wireframes: Vec<Vec<viewmodel::octree_converter::WireframeVertex>>,
+        _frame_index: usize,
+    ) -> bool {
+        false
+    }
+
     /// Anyトレイトへのダウンキャスト用
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }


### PR DESCRIPTION
## 概要
Issue #258 の Phase11（Stage境界整理と生成経路一本化）として、`app`↔`stage` 境界の capability 化と factory 経路の統一を実施しました。

## 変更内容
- `RenderStage` に capability メソッドを追加（デフォルト実装あり）
  - `update_with_device`
  - `cycle_octree_depth`
  - `start_octree_depth_animation`
  - `toggle_wireframe_mode`
  - `set_mesh_base_color`
  - `apply_snapshot_solid_frame`
  - `apply_snapshot_wireframe_frame`
- Stage側で capability 実装を追加
  - `OctreeStage` / `MeshStage` / `NurbsSurfaceStage`
- `app_state` 側の downcast 呼び出しを capability 呼び出しへ置換
  - `stage_orchestration.rs`
  - `input_actions.rs`
  - `display_controls.rs`
  - `settings_accessors/snapshot_settings.rs`
  - `snapshot_playback.rs`
- 生成経路の統一
  - `AppRendererFactory` から `stage_factory` を利用する形に統一

## 期待効果
- `app_state` での型依存を削減し、`RenderStage` 境界を明確化
- Stage生成責務の重複を減らし、変更影響範囲を縮小

## 検証
- `cargo build` 成功
- `cargo clippy -- -D warnings` 成功
- `cargo fmt` 実行済み

## 関連
- Issue #258 (Phase11)
