### PR TITLE
refactor: Phase6-2a render_3d命名をrender_2d対称に統一

### DIFF
--- a/dev/architecture/ISSUE_258_PHASE6_NAMING_REFINEMENT_PREP.md
+++ b/dev/architecture/ISSUE_258_PHASE6_NAMING_REFINEMENT_PREP.md
@@ -121,8 +121,8 @@
 ## 11. ブランチ戦略（Phase6-2 分割推奨）
 
 - 推奨: **Phase6-2 を小粒で分割**
-  - `feature/issue-258-phase6-2a-toolpath-naming-20260226`
-    - 対応A（`ToolPath` 統一 + `load_debug_cutter_path_only` 改名）
+  - `feature/issue-258-phase6-2a-render-naming-20260226`
+    - 対応A（`render_2d` / `render_3d` 命名対称化）
   - `feature/issue-258-phase6-2b-doc-filename-alignment-20260226`
     - 対応B（設計ドキュメント名のリネームとリンク追従）
   - `feature/issue-258-phase6-2c-debug-prefix-policy-20260226`
@@ -170,3 +170,13 @@
 - 注意点
   - 公開 API 名変更になるため、呼び出し元追従を同一コミットで完結
   - ロジック変更を混在させない
+
+## 14. Phase6-2a 着手メモ（2026-02-26）
+
+- 着手ブランチ: `feature/issue-258-phase6-2a-render-naming-20260226`
+- 今回の適用範囲
+  - `view/render/src/render_3d.rs` の命名を `render_2d` 系に合わせて対称化
+  - `view/stage/src/shading.rs` の呼び出し名を追従
+- 非対象（別サブフェーズ）
+  - `Toolpath/ToolPath` 統一
+  - `debug_*` 接頭辞方針の適用

--- a/view/render/src/render_3d.rs
+++ b/view/render/src/render_3d.rs
@@ -4,7 +4,7 @@ use crate::vertex_3d::Vertex3D;
 use wgpu::util::DeviceExt;
 use wgpu::{Buffer, RenderPipeline};
 
-pub struct Renderer3D {
+pub struct Render3dResources {
     /// 3D描画用パイプライン
     pub pipeline: wgpu::RenderPipeline,
     /// 三角形頂点バッファ
@@ -14,7 +14,10 @@ pub struct Renderer3D {
 }
 
 /// 3Dサンプル描画リソースを作成する。
-pub fn create_renderer_3d(device: &wgpu::Device, format: wgpu::TextureFormat) -> Renderer3D {
+pub fn create_render_3d_resources(
+    device: &wgpu::Device,
+    format: wgpu::TextureFormat,
+) -> Render3dResources {
     let vertices: &[Vertex3D] = &[
         Vertex3D {
             position: [-0.5, -0.5, 0.0],
@@ -28,7 +31,7 @@ pub fn create_renderer_3d(device: &wgpu::Device, format: wgpu::TextureFormat) ->
     ];
 
     let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-        label: Some("Renderer3D Vertex Buffer"),
+        label: Some("Render 3D Vertex Buffer"),
         contents: bytemuck::cast_slice(vertices),
         usage: wgpu::BufferUsages::VERTEX,
     });
@@ -40,12 +43,12 @@ pub fn create_renderer_3d(device: &wgpu::Device, format: wgpu::TextureFormat) ->
         &shader,
         format,
         &[Vertex3D::desc()],
-        "Renderer3D",
+        "Render 3D",
     );
 
     let vertex_count = vertices.len() as u32;
 
-    Renderer3D {
+    Render3dResources {
         pipeline,
         vertex_buffer,
         vertex_count,
@@ -53,7 +56,7 @@ pub fn create_renderer_3d(device: &wgpu::Device, format: wgpu::TextureFormat) ->
 }
 
 /// 3D頂点バッファを非インデックスで描画する。
-pub fn draw_renderer_3d<'a>(
+pub fn draw_render_3d<'a>(
     pass: &mut wgpu::RenderPass<'a>,
     pipeline: &'a RenderPipeline,
     vertex_buffer: &'a Buffer,

--- a/view/stage/src/shading.rs
+++ b/view/stage/src/shading.rs
@@ -6,16 +6,16 @@ use wgpu::{
 
 use crate::render_stage::RenderStage;
 
-use render::render_3d::{create_renderer_3d, draw_renderer_3d, Renderer3D};
+use render::render_3d::{create_render_3d_resources, draw_render_3d, Render3dResources};
 
 pub struct ShadingStage {
-    renderer: Renderer3D,
+    renderer: Render3dResources,
     frame_count: u64,
 }
 
 impl ShadingStage {
     pub fn new(device: &wgpu::Device, format: wgpu::TextureFormat) -> Self {
-        let renderer = create_renderer_3d(device, format);
+        let renderer = create_render_3d_resources(device, format);
         Self {
             renderer,
             frame_count: 0,
@@ -50,7 +50,7 @@ impl RenderStage for ShadingStage {
 
         let mut render_pass = encoder.begin_render_pass(&render_pass_desc);
 
-        draw_renderer_3d(
+        draw_render_3d(
             &mut render_pass,
             &self.renderer.pipeline,
             &self.renderer.vertex_buffer,


### PR DESCRIPTION
## 概要
Issue #258 の Phase6-2a として、`render_3d` 側の命名を `render_2d` と対称になるように統一しました（挙動変更なし）。

## 変更内容
- `Renderer3D` → `Render3dResources`
- `create_renderer_3d` → `create_render_3d_resources`
- `draw_renderer_3d` → `draw_render_3d`
- `view/stage/src/shading.rs` の import / 呼び出し箇所を追従
- `dev/architecture/ISSUE_258_PHASE6_NAMING_REFINEMENT_PREP.md` に 2a 実施内容を反映

## 検証
- `cargo build` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo fmt` ✅

## スコープ
- 命名整合性のみ（API 名の整理）
- ロジック・描画挙動は変更なし
