### PR TITLE
refactor: Phase6-2c ToolPath命名を統一

### DIFF
--- a/dev/architecture/ISSUE_258_PHASE6_NAMING_REFINEMENT_PREP.md
+++ b/dev/architecture/ISSUE_258_PHASE6_NAMING_REFINEMENT_PREP.md
@@ -125,7 +125,7 @@
     - 対応A（`render_2d` / `render_3d` 命名対称化）
   - `feature/issue-258-phase6-2b-doc-filename-alignment-20260226`（完了 / PR #278）
     - 対応B（設計ドキュメント名のリネームとリンク追従）
-  - `feature/issue-258-phase6-2c-toolpath-naming-20260226`
+  - `feature/issue-258-phase6-2c-toolpath-naming-20260226`（実装完了 / PR未作成）
     - 対応A（`ToolPath` 統一 + `load_debug_cutter_path_only` 改名）
   - `feature/issue-258-phase6-2d-debug-prefix-policy-20260226`
     - 対応C（命名規約定義 + 必要最小の適用）
@@ -200,7 +200,7 @@
   - `mdbook build` でリンク整合性を確認
   - 変更はドキュメントのみ（コード無変更）
 
-## 16. 次修正（Phase6-2c）準備メモ（2026-02-26）
+## 16. Phase6-2c 完了メモ（2026-02-26）
 
 - 目的
   - `toolpath` 周辺の命名軸を `ToolPath` 語彙へ統一し、読みやすさを向上（挙動変更なし）
@@ -217,7 +217,11 @@
 - 非対象
   - `toolpath.rs`（モジュール名）など snake_case 命名の Rust 規約範囲は変更しない
   - `debug_*` 接頭辞方針の再編は 2d で扱う
-- 実施後チェック
-  - `cargo build`
-  - `cargo clippy -- -D warnings`
-  - `cargo fmt`
+- 実施結果
+  - 型名: `ToolpathDebugData` → `ToolPathDebugData`
+  - 関数名: `load_debug_cutter_path_only` → `load_debug_toolpath_only`
+  - 追従: `input_actions.rs` の呼び出し更新
+- 検証結果
+  - `cargo build` 成功
+  - `cargo clippy -- -D warnings` 成功
+  - `cargo fmt` 実行済み

--- a/dev/architecture/ISSUE_258_PHASE6_NAMING_REFINEMENT_PREP.md
+++ b/dev/architecture/ISSUE_258_PHASE6_NAMING_REFINEMENT_PREP.md
@@ -123,7 +123,7 @@
 - 推奨: **Phase6-2 を小粒で分割**
   - `feature/issue-258-phase6-2a-render-naming-20260226`（完了 / PR #277）
     - 対応A（`render_2d` / `render_3d` 命名対称化）
-  - `feature/issue-258-phase6-2b-doc-filename-alignment-20260226`
+  - `feature/issue-258-phase6-2b-doc-filename-alignment-20260226`（完了 / PR #278）
     - 対応B（設計ドキュメント名のリネームとリンク追従）
   - `feature/issue-258-phase6-2c-toolpath-naming-20260226`
     - 対応A（`ToolPath` 統一 + `load_debug_cutter_path_only` 改名）
@@ -184,7 +184,7 @@
   - `Toolpath/ToolPath` 統一
   - `debug_*` 接頭辞方針の適用
 
-## 15. 次修正（Phase6-2b）準備メモ（2026-02-26）
+## 15. Phase6-2b 完了メモ（2026-02-26）
 
 - 目的
   - 旧語彙が残る設計ドキュメントのファイル名を現行語彙へ整合
@@ -199,3 +199,25 @@
   - `**/*.md` の旧ファイル名参照を追従更新
   - `mdbook build` でリンク整合性を確認
   - 変更はドキュメントのみ（コード無変更）
+
+## 16. 次修正（Phase6-2c）準備メモ（2026-02-26）
+
+- 目的
+  - `toolpath` 周辺の命名軸を `ToolPath` 語彙へ統一し、読みやすさを向上（挙動変更なし）
+- 主要対象
+  - `view/app/src/app_state/debug_scene/toolpath.rs`
+  - `view/app/src/app_state/input_actions.rs`
+- 変更候補（最小差分）
+  - 型名: `ToolpathDebugData` → `ToolPathDebugData`
+  - 関数名:
+    - `build_toolpath_debug_data` の戻り型追従
+    - `apply_toolpath_debug_data` の引数型追従
+    - `load_debug_cutter_path_only` → `load_debug_toolpath_only`
+  - 呼び出し側: `input_actions.rs` のキー入力ハンドラ追従
+- 非対象
+  - `toolpath.rs`（モジュール名）など snake_case 命名の Rust 規約範囲は変更しない
+  - `debug_*` 接頭辞方針の再編は 2d で扱う
+- 実施後チェック
+  - `cargo build`
+  - `cargo clippy -- -D warnings`
+  - `cargo fmt`

--- a/view/app/src/app_state/debug_scene/toolpath.rs
+++ b/view/app/src/app_state/debug_scene/toolpath.rs
@@ -6,7 +6,7 @@ use render::vertex_3d::{convert_vertex_data_to_mesh_vertices, MeshVertex};
 use stage::{MeshStage, OctreeStage};
 use viewmodel::snapshot_converter::{CamSimulationSnapshotInput, DomainSnapshotSeries};
 
-struct ToolpathDebugData {
+struct ToolPathDebugData {
     snapshot_series: DomainSnapshotSeries<CamSimulationSnapshotInput>,
     snapshot_wireframes: Vec<Vec<viewmodel::octree_converter::WireframeVertex>>,
     snapshot_solids: Vec<(Vec<MeshVertex>, Vec<u32>)>,
@@ -17,7 +17,7 @@ struct ToolpathDebugData {
 }
 
 impl AppState {
-    fn build_toolpath_debug_data(&self) -> Result<ToolpathDebugData, String> {
+    fn build_toolpath_debug_data(&self) -> Result<ToolPathDebugData, String> {
         use viewmodel::cam_sim_visualization_converter::create_sample_cam_simulation_visualization_bundle_with_settings;
 
         let bundle = create_sample_cam_simulation_visualization_bundle_with_settings(
@@ -71,7 +71,7 @@ impl AppState {
             })
             .collect();
 
-        Ok(ToolpathDebugData {
+        Ok(ToolPathDebugData {
             snapshot_series: bundle.snapshot_series,
             snapshot_wireframes: bundle.snapshot_wireframes,
             snapshot_solids,
@@ -82,7 +82,7 @@ impl AppState {
         })
     }
 
-    fn apply_toolpath_debug_data(&mut self, data: ToolpathDebugData) {
+    fn apply_toolpath_debug_data(&mut self, data: ToolPathDebugData) {
         let stage_wireframes = data.snapshot_wireframes.clone();
 
         self.debug_snapshot.series = Some(data.snapshot_series);
@@ -137,7 +137,7 @@ impl AppState {
     }
 
     /// デバッグ用：カッターパスのみを表示（pキー）
-    pub fn load_debug_cutter_path_only(&mut self) {
+    pub fn load_debug_toolpath_only(&mut self) {
         use viewmodel::toolpath_converter::{
             create_sample_toolpath, toolpath_to_vertices, ToolPathVisualizationSettings,
         };

--- a/view/app/src/app_state/input_actions.rs
+++ b/view/app/src/app_state/input_actions.rs
@@ -132,7 +132,7 @@ impl AppState {
                     }
                 }
                 "p" => {
-                    self.load_debug_cutter_path_only();
+                    self.load_debug_toolpath_only();
                 }
                 "P" => {
                     self.load_debug_toolpath();


### PR DESCRIPTION
## 概要
Issue #258 Phase6-2c として、`toolpath` 周辺の命名を `ToolPath` 語彙へ統一しました（挙動変更なし）。

## 変更内容
- `ToolpathDebugData` → `ToolPathDebugData`
- `load_debug_cutter_path_only` → `load_debug_toolpath_only`
- `view/app/src/app_state/input_actions.rs` の呼び出しを追従
- `dev/architecture/ISSUE_258_PHASE6_NAMING_REFINEMENT_PREP.md` に 2c 完了内容を反映

## 検証
- `cargo build` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo fmt` ✅

## スコープ
- 命名整合のみ（ロジック変更なし）
