### PR TITLE
refactor: Issue #281 1st NURBS評価ローダー命名整合

### DIFF
--- a/dev/architecture/ISSUE_281_PHASE1_NURBS_NAMING.md
+++ b/dev/architecture/ISSUE_281_PHASE1_NURBS_NAMING.md
@@ -1,0 +1,40 @@
+# Issue #281 Phase1: ViewModel NURBS命名整合
+
+- 対象Issue: #281
+- 作成日: 2026-02-26
+- スコープ: 命名修正のみ（挙動変更なし）
+
+## 背景
+
+ViewModel層に `nurbs_debug` というモジュール名が残っているが、実装責務は「NURBS評価データの生成・読込」であり、debug接頭辞方針（操作種別）との軸が混在している。
+
+## 目的
+
+- モジュール名を責務ベースへ変更して可読性を向上
+- `debug/sample/dev` 接頭辞方針と整合
+
+## 実施方針（Phase1）
+
+- `viewmodel/converter/src/nurbs_debug.rs` → `nurbs_eval_loader.rs`
+- エラー型名を責務名に追従
+  - `NurbsDebugError` → `NurbsEvalLoaderError`
+- 呼び出し側の最小追従
+  - `view/app/src/app_state/debug_scene/nurbs.rs`
+  - `viewmodel/converter/src/lib.rs`
+- ロジック変更は行わない
+
+## 非対象
+
+- App層の `load_debug_nurbs*` API 改名
+- NURBS評価処理ロジックの変更
+
+## 検証
+
+- `cargo build`
+- `cargo clippy -- -D warnings`
+- `cargo fmt`
+
+## DoD
+
+- 旧モジュール名/型名参照が残っていない
+- 既存挙動を維持したままビルド・Lint・fmt が通る

--- a/view/app/src/app_state/debug_scene/nurbs.rs
+++ b/view/app/src/app_state/debug_scene/nurbs.rs
@@ -18,7 +18,8 @@ impl AppState {
 
         let svg_path = Path::new("tests/fixtures/shapes/nurbs_curve.svg");
         let eval_data =
-            match viewmodel::nurbs_debug::load_nurbs_curve_eval_from_svg(svg_path, tolerance) {
+            match viewmodel::nurbs_eval_loader::load_nurbs_curve_eval_from_svg(svg_path, tolerance)
+            {
                 Ok(data) => data,
                 Err(error) => {
                     tracing::error!("NURBS曲線データ生成失敗: {}", error);
@@ -57,7 +58,7 @@ impl AppState {
             self.unit_system
         );
         let eval_data =
-            match viewmodel::nurbs_debug::create_sample_nurbs_surface_eval(tolerance_value) {
+            match viewmodel::nurbs_eval_loader::create_sample_nurbs_surface_eval(tolerance_value) {
                 Ok(data) => data,
                 Err(error) => {
                     tracing::error!("NURBS曲面データ生成失敗: {}", error);

--- a/viewmodel/converter/src/lib.rs
+++ b/viewmodel/converter/src/lib.rs
@@ -16,7 +16,7 @@
 pub mod cam_sim_visualization_converter;
 pub mod entity_converter;
 pub mod mesh_converter;
-pub mod nurbs_debug;
+pub mod nurbs_eval_loader;
 pub mod nurbs_view;
 pub mod octree_converter;
 pub mod shape_converter;

--- a/viewmodel/converter/src/nurbs_eval_loader.rs
+++ b/viewmodel/converter/src/nurbs_eval_loader.rs
@@ -1,4 +1,4 @@
-//! NURBSデバッグ表示用の評価データ生成
+//! NURBS評価データの読込・生成
 //!
 //! app層が直接geo_*に依存しないよう、
 //! ViewModel層でNURBS評価データを生成します。
@@ -12,9 +12,9 @@ use thiserror::Error;
 
 use crate::nurbs_view::{NurbsCurveEvalData, NurbsSurfaceEvalData};
 
-/// NURBSデバッグ用のエラー
+/// NURBS評価データ読込/生成用のエラー
 #[derive(Error, Debug)]
-pub enum NurbsDebugError {
+pub enum NurbsEvalLoaderError {
     #[error("SVG parsing error: {0}")]
     SvgError(#[from] SvgError),
 
@@ -29,12 +29,12 @@ pub enum NurbsDebugError {
 pub fn load_nurbs_curve_eval_from_svg(
     path: &Path,
     tolerance: f64,
-) -> Result<NurbsCurveEvalData, NurbsDebugError> {
+) -> Result<NurbsCurveEvalData, NurbsEvalLoaderError> {
     let svg_data = parse_svg_file(path)?;
     let nurbs_data = svg_data
         .nurbs_curves
         .first()
-        .ok_or(NurbsDebugError::MissingNurbsCurve)?;
+        .ok_or(NurbsEvalLoaderError::MissingNurbsCurve)?;
 
     let curve = <NurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::new(
         nurbs_data.degree,
@@ -42,7 +42,7 @@ pub fn load_nurbs_curve_eval_from_svg(
         nurbs_data.control_points.clone(),
         nurbs_data.weights.clone(),
     )
-    .map_err(NurbsDebugError::ConstructionError)?;
+    .map_err(NurbsEvalLoaderError::ConstructionError)?;
 
     let settings = ga_tess::AdaptiveTessellationSettings::default_with_tolerance(tolerance);
     let param_list =
@@ -61,7 +61,7 @@ pub fn load_nurbs_curve_eval_from_svg(
 /// サンプルNURBS曲面のGPU評価データを生成
 pub fn create_sample_nurbs_surface_eval(
     tolerance: f64,
-) -> Result<NurbsSurfaceEvalData, NurbsDebugError> {
+) -> Result<NurbsSurfaceEvalData, NurbsEvalLoaderError> {
     // 中央が盛り上がった2次曲面（3x3制御点グリッド）
     let control_points = vec![
         vec![(0.0, 0.0, 0.0), (0.0, 0.5, 0.0), (0.0, 1.0, 0.0)],
@@ -76,7 +76,7 @@ pub fn create_sample_nurbs_surface_eval(
 
     let surface =
         NurbsSurface3D::<f64>::new(control_points, None, u_knots, v_knots, u_degree, v_degree)
-            .map_err(NurbsDebugError::ConstructionError)?;
+            .map_err(NurbsEvalLoaderError::ConstructionError)?;
 
     let settings = ga_tess::AdaptiveTessellationSettings::default_with_tolerance(tolerance);
     let param_grid =


### PR DESCRIPTION
## 概要
Issue #281 の 1st として、ViewModel層 `nurbs_debug` 周辺の命名を責務ベースへ整合しました（挙動変更なし）。

## 変更内容
- ドキュメント先行更新
  - `dev/architecture/ISSUE_281_PHASE1_NURBS_NAMING.md` を追加
- 命名整合（ViewModel）
  - `viewmodel/converter/src/nurbs_debug.rs` → `nurbs_eval_loader.rs`
  - `NurbsDebugError` → `NurbsEvalLoaderError`
  - `viewmodel/converter/src/lib.rs` の公開モジュール名を追従
- 呼び出し追従（View）
  - `view/app/src/app_state/debug_scene/nurbs.rs` の参照先を `viewmodel::nurbs_eval_loader::*` へ更新

## 検証
- `cargo build` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo fmt` ✅

## スコープ
- 命名整合のみ（ロジック変更なし）
