### PR TITLE
refactor: Issue #281 2nd Octree設定型の命名整合

### DIFF
--- a/dev/architecture/ISSUE_281_PHASE2_OCTREE_SETTINGS_NAMING.md
+++ b/dev/architecture/ISSUE_281_PHASE2_OCTREE_SETTINGS_NAMING.md
@@ -1,0 +1,39 @@
+# Issue #281 Phase2: Octree設定命名整合
+
+- 対象Issue: #281
+- 作成日: 2026-02-26
+- スコープ: 命名修正のみ（挙動変更なし）
+
+## 背景
+
+`OctreeDebugVisualizationSettings` は `debug` 接頭辞を持つが、実際の責務は View 層から注入される可視化設定であり、デバッグ専用の一時操作ではない。
+
+## 目的
+
+- 設定型名を責務ベースへ整合し、`debug/sample/dev` 方針との不整合を解消する
+- 既存挙動を維持したまま可読性を向上する
+
+## 実施方針
+
+- `OctreeDebugVisualizationSettings` → `OctreeVisualizationSettings`
+- 追従対象
+  - `viewmodel/converter/src/octree_converter.rs`
+  - `viewmodel/converter/src/cam_sim_visualization_converter.rs`
+  - `view/app/src/app_state.rs`
+- ロジック変更は行わない
+
+## 非対象
+
+- `OctreeVisualizationOptions` / `VoxelVisualizationOptions` の仕様変更
+- sample生成ロジック・描画挙動の変更
+
+## 検証
+
+- `cargo build`
+- `cargo clippy -- -D warnings`
+- `cargo fmt`
+
+## DoD
+
+- 旧型名参照が残っていない
+- 挙動不変でビルド・Lint・fmt が通る

--- a/view/app/src/app_state.rs
+++ b/view/app/src/app_state.rs
@@ -7,7 +7,7 @@ use crate::snapshot_overlay_renderer::SnapshotOverlayStyle;
 use analysis::{LengthUnit, Tolerance};
 use debug_snapshot_state::DebugSnapshotState;
 use std::sync::Arc;
-use viewmodel::octree_converter::OctreeDebugVisualizationSettings;
+use viewmodel::octree_converter::OctreeVisualizationSettings;
 use viewmodel_graphics::{Camera, CameraControlSensitivity};
 use winit::window::Window;
 
@@ -77,7 +77,7 @@ pub struct AppState {
     pub display_tolerance: Tolerance,
 
     /// Octree可視化設定（setting画面向けの保持値）
-    pub octree_visualization_settings: OctreeDebugVisualizationSettings,
+    pub octree_visualization_settings: OctreeVisualizationSettings,
 
     /// ビュー操作設定（setting画面向けの保持値）
     pub viewing_operation_settings: ViewingOperationSettings,
@@ -122,7 +122,7 @@ impl AppState {
             // CAD標準設定
             unit_system: LengthUnit::Millimeter,
             display_tolerance: Tolerance::default(), // 0.01mm
-            octree_visualization_settings: OctreeDebugVisualizationSettings::default(),
+            octree_visualization_settings: OctreeVisualizationSettings::default(),
             viewing_operation_settings,
             snapshot_overlay_style: SnapshotOverlayStyle::default(),
             snapshot_shaded_color_settings: SnapshotShadedColorSettings::default(),

--- a/viewmodel/converter/src/cam_sim_visualization_converter.rs
+++ b/viewmodel/converter/src/cam_sim_visualization_converter.rs
@@ -14,7 +14,7 @@ use std::f64::consts::TAU;
 
 use crate::mesh_converter::VertexData;
 use crate::octree_converter::{
-    voxel_octree_to_wireframe, OctreeDebugVisualizationSettings, VoxelVisualizationOptions,
+    voxel_octree_to_wireframe, OctreeVisualizationSettings, VoxelVisualizationOptions,
     WireframeVertex,
 };
 use crate::snapshot_converter::{
@@ -503,7 +503,7 @@ fn apply_cutting_progress(
 /// デバッグ用：テストToolPath + Tool + ワークOctreeで切削シミュレーションを実行し、
 /// 可視化に必要な深さ別ワイヤーフレームとスナップショット系列を返す。
 pub fn create_sample_cam_simulation_visualization_bundle_with_settings(
-    settings: &OctreeDebugVisualizationSettings,
+    settings: &OctreeVisualizationSettings,
 ) -> Result<CamSimulationVisualizationBundle, SimulationError> {
     let toolpath = create_sample_toolpath();
     let tool = Tool::flat_end_mill("endmill_3mm".to_string(), 10.0, 50.0);
@@ -600,7 +600,7 @@ mod tests {
 
     #[test]
     fn test_create_sample_cam_simulation_visualization_bundle_with_settings() {
-        let settings = OctreeDebugVisualizationSettings {
+        let settings = OctreeVisualizationSettings {
             max_depth: 3,
             gradient_start: [0.2, 1.0, 1.0],
             gradient_end: [1.0, 0.4, 0.4],

--- a/viewmodel/converter/src/octree_converter.rs
+++ b/viewmodel/converter/src/octree_converter.rs
@@ -73,7 +73,7 @@ pub struct VoxelVisualizationOptions {
 
 /// Octreeデバッグ可視化設定（View側から保持・注入する想定）
 #[derive(Clone, Debug)]
-pub struct OctreeDebugVisualizationSettings {
+pub struct OctreeVisualizationSettings {
     /// 可視化する最大深さ
     pub max_depth: usize,
 
@@ -87,7 +87,7 @@ pub struct OctreeDebugVisualizationSettings {
     pub octree_tolerance: OctreeTolerance<f64>,
 }
 
-impl Default for OctreeDebugVisualizationSettings {
+impl Default for OctreeVisualizationSettings {
     fn default() -> Self {
         Self {
             max_depth: 4,
@@ -471,16 +471,16 @@ pub fn create_sample_voxel_octree_wireframe_levels(max_depth: usize) -> Vec<Vec<
 pub fn create_sample_voxel_octree_wireframe_colored_levels(
     max_depth: usize,
 ) -> Vec<Vec<WireframeVertex>> {
-    let settings = OctreeDebugVisualizationSettings {
+    let settings = OctreeVisualizationSettings {
         max_depth,
-        ..OctreeDebugVisualizationSettings::default()
+        ..OctreeVisualizationSettings::default()
     };
     create_sample_voxel_octree_wireframe_colored_levels_with_settings(&settings)
 }
 
 /// デバッグ用：設定付きで深さごとのサンプルVoxelOctreeワイヤーフレーム（色付き）を生成
 pub fn create_sample_voxel_octree_wireframe_colored_levels_with_settings(
-    settings: &OctreeDebugVisualizationSettings,
+    settings: &OctreeVisualizationSettings,
 ) -> Vec<Vec<WireframeVertex>> {
     use geo_algorithms::Point3D;
 
@@ -554,7 +554,7 @@ pub fn create_sample_voxel_octree_wireframe_colored_levels_with_settings(
 /// `cam_sim` と同じ平端掃引円柱カーネル（`remove_material_swept_cylinder`）を使い、
 /// 可視確認用の頂点データを返します。
 pub fn create_sample_swept_cylinder_wireframe_colored_levels_with_settings(
-    settings: &OctreeDebugVisualizationSettings,
+    settings: &OctreeVisualizationSettings,
 ) -> Vec<Vec<WireframeVertex>> {
     use geo_algorithms::{LineSegment3D, Point3D};
 
@@ -737,9 +737,9 @@ mod tests {
 
     #[test]
     fn test_create_sample_swept_cylinder_wireframe_colored_levels_with_settings() {
-        let settings = OctreeDebugVisualizationSettings {
+        let settings = OctreeVisualizationSettings {
             max_depth: 3,
-            ..OctreeDebugVisualizationSettings::default()
+            ..OctreeVisualizationSettings::default()
         };
 
         let levels = create_sample_swept_cylinder_wireframe_colored_levels_with_settings(&settings);
@@ -749,7 +749,7 @@ mod tests {
 
     #[test]
     fn test_octree_debug_visualization_settings_default() {
-        let settings = OctreeDebugVisualizationSettings::default();
+        let settings = OctreeVisualizationSettings::default();
         assert_eq!(settings.max_depth, 4);
         assert!(settings.gradient_start[1] > settings.gradient_start[0]);
         assert!(settings.gradient_end[0] > settings.gradient_end[1]);


### PR DESCRIPTION
## 概要
Issue #281 の 2nd として、`OctreeDebugVisualizationSettings` を責務ベースの型名へ整合しました（挙動変更なし）。

## 変更内容
- ドキュメント先行更新
  - `dev/architecture/ISSUE_281_PHASE2_OCTREE_SETTINGS_NAMING.md` を追加
- 命名整合
  - `OctreeDebugVisualizationSettings` → `OctreeVisualizationSettings`
  - 追従箇所:
    - `viewmodel/converter/src/octree_converter.rs`
    - `viewmodel/converter/src/cam_sim_visualization_converter.rs`
    - `view/app/src/app_state.rs`

## 検証
- `cargo build` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo fmt` ✅

## スコープ
- 命名整合のみ（ロジック変更なし）

Closes #281
