### PR TITLE
fix(docs): mdBook設定の互換性修正（book.toml）

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -2,7 +2,6 @@
 authors = ["RedRing Development Team"]
 description = "RedRing CAD/CAM Platform Documentation - 高性能CAD/CAMソフトウェア開発プラットフォーム"
 language = "ja"
-multilingual = false
 src = "manual"
 title = "RedRing Documentation"
 


### PR DESCRIPTION
## 概要
`mdbook build` で発生していた設定パースエラーを修正します。

## 原因
- `book.toml` の `multilingual` キーが現行 mdBook で未サポート
- エラー: `unknown field multilingual`

## 変更
- `book.toml` から `multilingual = false` を削除

## 確認
- `mdbook build` ✅（ローカル実行）

## 目的
- main 系 CI のドキュメントビルド失敗を解消
- 続く `main -> develop` 同期PRの前提を安定化