### PR TITLE
docs: add release governance baseline (CHANGELOG + VERSIONING_POLICY)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+このプロジェクトの主な変更はこのファイルに記録します。
+
+形式は [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) を参考にし、
+バージョンは [Semantic Versioning](https://semver.org/lang/ja/) に従います。
+
+## [Unreleased]
+
+### Added
+- `dev/architecture/RELEASE_VERSION_PLAN_2026Q1.md` を追加し、リリース版数計画を明文化。
+- `VERSIONING_POLICY.md` を追加し、0.x運用時の版数ルールを明文化。
+
+### Changed
+- `main` / `develop` 間の同期運用手順を明確化（リリース統合後の逆同期含む）。
+
+### Fixed
+- `book.toml` の非対応キー `multilingual` を削除し、`mdbook build` の設定エラーを修正。
+
+## [0.1.0] - TBD
+
+### Added
+- 初回リリース（内容は確定後に追記）。

--- a/VERSIONING_POLICY.md
+++ b/VERSIONING_POLICY.md
@@ -1,0 +1,52 @@
+# Versioning Policy
+
+## 目的
+
+RedRing のリリース版数を一貫して運用するための基準を定義します。
+
+## 基本方針
+
+- バージョン体系は Semantic Versioning（SemVer）を採用する。
+- 0.x 期間は API/仕様が変化しうる前提で、互換性破壊を許容する。
+- リリースの判定単位は原則リポジトリ全体（統合）とする。
+
+## 0.x 運用ルール
+
+### タグ
+
+- 初回タグは `v0.1.0` を基準とする。
+- タグは `main` への統合後に付与する。
+
+### 版数の上げ方
+
+- 後方互換を維持した機能追加: `PATCH` を上げる（例: `0.1.0 -> 0.1.1`）。
+- 互換性に影響する仕様変更・大規模整理: `MINOR` を上げる（例: `0.1.1 -> 0.2.0`）。
+- ドキュメント修正のみ: 必要に応じて据え置き、または `PATCH`。
+
+## クレート版数
+
+- 変更があったクレートのみ版数更新する。
+- 変更がないクレートの一律 bump は行わない。
+
+## リリース前チェック
+
+1. `cargo build`
+2. `cargo test --workspace`
+3. `cargo clippy --workspace --all-targets -- -D warnings`
+4. `cargo fmt --all -- --check`
+5. `./scripts/check_architecture_dependencies_simple.ps1`
+6. `mdbook build`
+
+## 運用フロー
+
+1. `develop` で対象PRを確定（リリース範囲固定）
+2. `develop -> main` 統合PRを作成
+3. CIグリーンとレビュー承認を確認
+4. `main` マージ後にタグ付与
+5. `CHANGELOG.md` の `Unreleased` を確定版に反映
+6. GitHub Release を作成
+
+## 改定
+
+この文書は運用実績に基づいて更新する。
+更新時は PR で変更理由を明記する。

--- a/dev/architecture/RELEASE_VERSION_PLAN_2026Q1.md
+++ b/dev/architecture/RELEASE_VERSION_PLAN_2026Q1.md
@@ -10,7 +10,7 @@
 - リポジトリの Git tag は現時点で **未作成**。
 - `origin/main` と `origin/develop` は乖離あり（`develop` 側に未統合コミットが存在）。
 
-## 2. 版数ポリシー（提案）
+## 2. 版数ポリシー（運用初版）
 
 ### 2.1 リポジトリ全体（アプリ/統合）
 
@@ -34,7 +34,7 @@
 5. `./scripts/check_architecture_dependencies_simple.ps1`
 6. `mdbook build`
 
-## 4. リリース運用フロー（提案）
+## 4. リリース運用フロー（運用初版）
 
 1. `develop` のリリース対象期間を確定（Issue/PRを凍結）
 2. `develop -> main` 統合PRを作成
@@ -53,13 +53,12 @@
 
 ### 直近TODO（優先順）
 
-- [ ] `VERSIONING_POLICY.md` をルートに作成（SemVer + 0.x例外）
-- [ ] `CHANGELOG.md` を追加（Unreleased セクション開始）
+- [x] `VERSIONING_POLICY.md` をルートに作成（SemVer + 0.x例外）
+- [x] `CHANGELOG.md` を追加（Unreleased セクション開始）
 - [ ] リリースノートのテンプレートを `dev/` に追加
 - [ ] 次回 `develop -> main` 統合時に初回タグを運用開始
 
 ## 6. 補足
 
-この文書は「初回リリース運用を開始するための草案」です。
-正式化時は、GitHub Project / Issue で承認履歴を残し、
-本ファイルを更新して運用版に昇格させてください。
+この文書は「初回リリース運用のベースライン（運用初版）」です。
+運用実績に応じて `VERSIONING_POLICY.md` と整合を取りながら更新してください。


### PR DESCRIPTION
## 概要
リリース運用の基準を明文化するため、ドキュメント基盤を追加・更新します。

## 変更内容
- `CHANGELOG.md` 新規追加（Unreleased セクション開始）
- `VERSIONING_POLICY.md` 新規追加（SemVer/0.x運用ルール）
- `dev/architecture/RELEASE_VERSION_PLAN_2026Q1.md` を草案から運用初版へ更新

## 目的
- バージョン判断基準の統一
- リリース前ゲートの明文化
- `develop -> main` 統合時の運用ブレを防止

## 備考
- 本PRはドキュメントのみ（コード変更なし）