### PR TITLE
docs: add release note template and update release plan

### DIFF
--- a/dev/RELEASE_NOTE_TEMPLATE.md
+++ b/dev/RELEASE_NOTE_TEMPLATE.md
@@ -67,3 +67,19 @@
 - タグ: `vX.Y.Z`
 - 次サイクルに持ち越す項目:
   - 
+
+## Initial Release Checklist (v0.1.0)
+
+初回リリース時は以下を必須チェックとして使用する。
+
+- [ ] **Version**: `v0.1.0` を確定
+- [ ] **Release Date**: 公開日を確定
+- [ ] **Related PRs**: 主要PR（統合・CI修正・運用文書）を列挙
+- [ ] **Summary**: 3〜5行で今回の到達点を要約
+- [ ] **Highlights**: `Added / Changed / Fixed` を最低1項目ずつ記載
+- [ ] **Breaking Changes**: なし/ありを明示（ありの場合は影響範囲を具体化）
+- [ ] **Migration Guide**: 利用者の移行手順（必要な場合）
+- [ ] **Validation**: テンプレートのチェック項目を全て実施して結果反映
+- [ ] **Known Issues**: 既知の制約を明記（なければ「なし」）
+- [ ] **Tag**: `main` マージ後に `v0.1.0` タグ作成を確認
+- [ ] **CHANGELOG**: `Unreleased` から `0.1.0` への反映を確認

--- a/dev/RELEASE_NOTE_TEMPLATE.md
+++ b/dev/RELEASE_NOTE_TEMPLATE.md
@@ -1,0 +1,69 @@
+# RELEASE NOTE TEMPLATE
+
+> このテンプレートは RedRing のリリースノート作成用です。
+> リリース時にコピーして、`dev/releases/` または GitHub Release 本文に転記してください。
+
+## Release Information
+
+- Version: `vX.Y.Z`
+- Release Date: `YYYY-MM-DD`
+- Target Branch: `main`
+- Related Milestone: `<milestone-name>`
+- Related PRs: `#...`
+
+## Summary
+
+今回リリースの要約を 3〜5 行で記載。
+
+## Highlights
+
+### Added
+
+- 
+
+### Changed
+
+- 
+
+### Fixed
+
+- 
+
+### Deprecated
+
+- 
+
+### Removed
+
+- 
+
+## Breaking Changes
+
+- なし / あり（内容を明記）
+
+## Migration Guide
+
+既存利用者が必要な移行手順を記載。
+
+1. 
+2. 
+3. 
+
+## Validation
+
+- [ ] `cargo build`
+- [ ] `cargo test --workspace`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo fmt --all -- --check`
+- [ ] `./scripts/check_architecture_dependencies_simple.ps1`
+- [ ] `mdbook build`
+
+## Known Issues
+
+- 
+
+## Notes
+
+- タグ: `vX.Y.Z`
+- 次サイクルに持ち越す項目:
+  - 

--- a/dev/architecture/RELEASE_VERSION_PLAN_2026Q1.md
+++ b/dev/architecture/RELEASE_VERSION_PLAN_2026Q1.md
@@ -49,13 +49,12 @@
 
 - 公式なタグ戦略の合意（初回タグ名・バンプ規則）
 - CHANGELOG 運用方式（Keep a Changelog 形式など）の確定
-- リリースノートテンプレートの固定化
 
 ### 直近TODO（優先順）
 
 - [x] `VERSIONING_POLICY.md` をルートに作成（SemVer + 0.x例外）
 - [x] `CHANGELOG.md` を追加（Unreleased セクション開始）
-- [ ] リリースノートのテンプレートを `dev/` に追加
+- [x] リリースノートのテンプレートを `dev/` に追加（`dev/RELEASE_NOTE_TEMPLATE.md`）
 - [ ] 次回 `develop -> main` 統合時に初回タグを運用開始
 
 ## 6. 補足


### PR DESCRIPTION
## 概要
リリース運用を継続できるよう、リリースノートテンプレートを追加し、
版数計画ドキュメントのTODO状態を更新します。

## 変更内容
- `dev/RELEASE_NOTE_TEMPLATE.md` を新規追加
- `dev/architecture/RELEASE_VERSION_PLAN_2026Q1.md` のTODOを更新
  - リリースノートテンプレート追加タスクを完了化

## 目的
- リリースノート作成手順の標準化
- リリース計画ドキュメントの進捗整合

## 備考
- ドキュメント変更のみ（コード変更なし）