### PR TITLE
ci: add Docker non-root smoke checks for develop (#297)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+.git/
+.github/
+.vscode/
+.vscodeignore
+.trunk/
+
+# Build outputs and generated docs
+target/
+docs/
+book/
+
+# Runtime logs
+logs/
+
+# Local environment
+.env
+.env.*
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/.github/workflows/develop_ci.yml
+++ b/.github/workflows/develop_ci.yml
@@ -63,6 +63,104 @@ jobs:
           cargo doc --workspace --no-deps --verbose
           echo "✅ Documentation built successfully (develop branch - no deployment)"
 
+  docker-build-batch-runner:
+    name: Docker Build Batch Runner
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -f Dockerfile.batch -t redring-batch-runner:ci .
+
+      - name: Capture image digest
+        run: |
+          IMAGE_DIGEST=$(docker image inspect redring-batch-runner:ci --format '{{index .RepoDigests 0}}' || true)
+          if [ -z "$IMAGE_DIGEST" ]; then
+            IMAGE_ID=$(docker image inspect redring-batch-runner:ci --format '{{.Id}}')
+            IMAGE_DIGEST="redring-batch-runner@${IMAGE_ID}"
+          fi
+          echo "$IMAGE_DIGEST" > image-digest.txt
+
+      - name: Upload image digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image-digest
+          path: image-digest.txt
+
+  docker-smoke-test-nonroot:
+    name: Docker Smoke Test (Non-root)
+    runs-on: ubuntu-latest
+    needs: [docker-build-batch-runner]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build Docker image for smoke test
+        run: docker build -f Dockerfile.batch -t redring-batch-runner:ci .
+
+      - name: Prepare smoke test directories
+        run: mkdir -p tmp/input tmp/output tmp/logs
+
+      - name: Run CAM smoke test
+        run: |
+          docker run --rm \
+            --user 10001:10001 \
+            --read-only \
+            -v "$PWD/tests/fixtures/batch:/work/input:ro" \
+            -v "$PWD/tmp/output:/work/output" \
+            -v "$PWD/tmp/logs:/work/logs" \
+            redring-batch-runner:ci \
+            --job-type cam --input /work/input/min_cam.json --output /work/output --logs /work/logs
+
+      - name: Run SIM smoke test
+        run: |
+          docker run --rm \
+            --user 10001:10001 \
+            --read-only \
+            -v "$PWD/tests/fixtures/batch:/work/input:ro" \
+            -v "$PWD/tmp/output:/work/output" \
+            -v "$PWD/tmp/logs:/work/logs" \
+            redring-batch-runner:ci \
+            --job-type sim --input /work/input/min_sim.json --output /work/output --logs /work/logs
+
+      - name: Verify non-root execution
+        run: |
+          grep -q 'uid=10001 gid=10001' tmp/logs/cam.log
+          grep -q 'uid=10001 gid=10001' tmp/logs/sim.log
+
+      - name: Upload smoke test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-smoke-artifacts
+          path: |
+            tmp/output/*.json
+            tmp/logs/*.log
+
+  docker-security-scan:
+    name: Docker Security Scan
+    runs-on: ubuntu-latest
+    needs: [docker-build-batch-runner]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build Docker image for scan
+        run: docker build -f Dockerfile.batch -t redring-batch-runner:ci .
+
+      - name: Run Trivy scan (HIGH/CRITICAL fail)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: redring-batch-runner:ci
+          format: table
+          vuln-type: os,library
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: 1
+
   architecture-dependency-check:
     uses: ./.github/workflows/common_architecture_check.yml
     with:
@@ -72,7 +170,7 @@ jobs:
   check-no-deployment:
     name: Development Branch Status
     runs-on: ubuntu-latest
-    needs: [build-test, architecture-dependency-check]
+    needs: [build-test, docker-build-batch-runner, docker-smoke-test-nonroot, docker-security-scan, architecture-dependency-check]
 
     steps:
       - name: Development branch notification

--- a/.github/workflows/develop_ci.yml
+++ b/.github/workflows/develop_ci.yml
@@ -102,7 +102,9 @@ jobs:
         run: docker build -f Dockerfile.batch -t redring-batch-runner:ci .
 
       - name: Prepare smoke test directories
-        run: mkdir -p tmp/input tmp/output tmp/logs
+        run: |
+          mkdir -p tmp/input tmp/output tmp/logs
+          sudo chown -R 10001:10001 tmp/output tmp/logs
 
       - name: Run CAM smoke test
         run: |

--- a/.github/workflows/develop_ci.yml
+++ b/.github/workflows/develop_ci.yml
@@ -154,14 +154,15 @@ jobs:
         run: docker build -f Dockerfile.batch -t redring-batch-runner:ci .
 
       - name: Run Trivy scan (HIGH/CRITICAL fail)
-        uses: aquasecurity/trivy-action@0.28.0
-        with:
-          image-ref: redring-batch-runner:ci
-          format: table
-          vuln-type: os,library
-          severity: HIGH,CRITICAL
-          ignore-unfixed: true
-          exit-code: 1
+        run: |
+          docker pull aquasec/trivy:0.57.1
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            aquasec/trivy:0.57.1 image \
+            --severity HIGH,CRITICAL \
+            --ignore-unfixed \
+            --exit-code 1 \
+            redring-batch-runner:ci
 
   architecture-dependency-check:
     uses: ./.github/workflows/common_architecture_check.yml

--- a/Dockerfile.batch
+++ b/Dockerfile.batch
@@ -1,0 +1,19 @@
+FROM debian:bookworm-slim
+
+# Runtime-only minimal image for batch execution smoke tests.
+RUN groupadd -g 10001 redring \
+    && useradd -u 10001 -g 10001 -m -s /usr/sbin/nologin redring \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends bash ca-certificates tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work
+
+COPY scripts/batch_runner_stub.sh /usr/local/bin/redring-batch-runner
+RUN chmod 0555 /usr/local/bin/redring-batch-runner \
+    && mkdir -p /work/input /work/output /work/logs \
+    && chown -R 10001:10001 /work
+
+USER 10001:10001
+
+ENTRYPOINT ["/usr/local/bin/redring-batch-runner"]

--- a/Dockerfile.batch
+++ b/Dockerfile.batch
@@ -1,11 +1,8 @@
-FROM debian:bookworm-slim
+FROM alpine:3.20
 
 # Runtime-only minimal image for batch execution smoke tests.
-RUN groupadd -g 10001 redring \
-    && useradd -u 10001 -g 10001 -m -s /usr/sbin/nologin redring \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends bash ca-certificates tzdata \
-    && rm -rf /var/lib/apt/lists/*
+RUN addgroup -S -g 10001 redring \
+    && adduser -S -D -u 10001 -G redring -h /home/redring -s /sbin/nologin redring
 
 WORKDIR /work
 

--- a/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
+++ b/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
@@ -266,3 +266,273 @@ RedRingでも同方式は有効な代替案とし、K8s化は明確なゴール�
 - 夜間失敗サマリー
 - ジョブ遅延/失敗率の可視化
 - 翌朝確認を前提とした通知フロー
+
+---
+
+## 16. Docker実行イメージ設計（#297向け）
+
+本章は、Job Manager が実行するコンテナの最小構成とセキュリティ基準を定義する。
+
+### 16.1 設計方針（最小構成）
+
+- 目的は「ヘッドレス計算の再現実行」であり、開発ツール一式を本番実行イメージに含めない
+- イメージは `builder` と `runtime` の multi-stage を前提とする
+- runtime は必要最小限の依存のみを含み、シェルやパッケージマネージャを極力持たせない
+- 1コンテナ1プロセスを原則とし、Job Manager は実行と監視に専念する
+
+最小ランタイム構成（論理）:
+
+- `redring-batch-runner`（CAM/切削共通ランナー）
+- 読み取り専用の実行バイナリ
+- 入出力マウントポイント（`/work/input`, `/work/output`, `/work/logs`）
+- 実行時設定は環境変数ではなく、可能な限りジョブ定義（InputRef）経由で受け渡す
+
+### 16.2 非root実行とコンテナセキュリティ基準
+
+必須:
+
+- コンテナプロセスは root 以外の固定UID/GIDで実行する
+- `allowPrivilegeEscalation: false` を前提とする
+- Linux capabilities は `drop: ["ALL"]` を基本とする
+- ルートファイルシステムは read-only を基本とし、書き込みは `/work/output` と `/work/logs` のみ
+- 機密情報はイメージに埋め込まず、実行基盤のシークレット参照で注入する
+- イメージは digest pin（`image@sha256:...`）で実行し、タグ参照のみの実行を禁止する
+
+推奨:
+
+- ベースイメージはLTS系に限定し、定期スキャン（CVE High/Critical）をCIゲート化する
+- `seccomp` は default 以上、可能なら RuntimeDefault を強制する
+- 依存ライブラリSBOMを生成し、アーティファクトとして保存する
+
+### 16.3 Job Manager との責務接続
+
+- Job Manager は「どのイメージを、どの入力参照で実行するか」を決定する
+- コンテナ内の計算ロジック詳細（CAMアルゴリズム実装）は Model 側責務とし、Job Manager は介入しない
+- 契約は既存方針どおり `JobType + InputRef -> ResultRef` を維持する
+- 実行結果は終了コード + 成果物参照 + 構造化ログで返却し、Job Manager が状態遷移に反映する
+
+### 16.4 Docker対象の実施環境定義
+
+1. ローカル検証環境（Developer Local）
+- 目的: 再現確認、最小ジョブの手動実行
+- 要件: 同一イメージdigestでの起動、入力/出力ディレクトリの明示マウント
+
+2. CI検証環境（GitHub Actions等）
+- 目的: build/test/run の自動検証
+- 要件: イメージビルド、最小ジョブ実行、ログ/成果物保存、脆弱性スキャン
+
+3. 本番バッチ環境（Kubernetes）
+- 目的: 夜間バッチの実運用
+- 要件: 非root実行強制、read-only rootfs、リソース制限、再実行ポリシー、監査ログ保持
+
+環境ごとの差分は「リソース量」「並列度」「資格情報の供給方法」に限定し、
+実行イメージとジョブ契約は共通化する。
+
+### 16.5 受け入れ条件（#297設計観点）
+
+- [ ] 非root固定UID/GIDで CAM/切削の最小ジョブが両方成功する
+- [ ] 同一入力で local/CI/K8s の結果差異が許容範囲内である
+- [ ] High/Critical 脆弱性がCIで検知された場合にリリースを停止できる
+- [ ] 実行イメージのdigest、SBOM、実行ログを追跡可能である
+
+---
+
+## 17. 実装準備設計（ドラフト）
+
+本章は、#297を着手するための具体的な実装ドラフトを示す。
+
+### 17.1 Dockerfile構成案（multi-stage）
+
+`builder` ステージ:
+
+- Rust stable でワークスペースビルド
+- テストに必要な最小アセットのみ同梱
+- 出力バイナリを `redring-batch-runner` として配置
+
+`runtime` ステージ:
+
+- 最小ベースイメージ（LTS）
+- 固定 UID/GID（例: 10001:10001）ユーザー作成
+- `USER 10001:10001` で実行
+- `WORKDIR /work`
+- `/work/output` と `/work/logs` のみ書き込み可能
+- エントリポイントはバッチランナー固定（シェル起動を前提にしない）
+
+初期実装で避けるもの:
+
+- Docker-in-Docker
+- 特権モード
+- ルート権限での暫定運用
+- 実行時 `apt install` のような可変依存解決
+
+### 17.2 CIワークフロー構成案（Docker専用ジョブ）
+
+既存 `develop_ci.yml` に追加するジョブ候補:
+
+1. `docker-build-batch-runner`
+- Dockerイメージをbuild
+- イメージdigestを出力
+
+2. `docker-smoke-test-nonroot`
+- 非rootで最小CAMジョブを1件実行
+- 非rootで最小切削シミュレーションジョブを1件実行
+- `/work/output` と `/work/logs` に成果物が生成されることを検証
+
+3. `docker-security-scan`
+- イメージ脆弱性スキャン（High/Criticalでfail）
+- SBOM生成とアーティファクト保存
+
+4. `docker-archive-artifacts`
+- 実行ログ
+- 成果物ハッシュ一覧
+- イメージdigest
+
+依存関係:
+
+- `docker-smoke-test-nonroot` は `docker-build-batch-runner` 成功後
+- `docker-security-scan` は `docker-build-batch-runner` 成功後
+- どれか失敗時は develop CI 全体を fail にする
+
+### 17.3 Job Manager が扱う最小実行契約
+
+最小ジョブ入力:
+
+```text
+JobType: CamProcessBatch | CuttingSimulationBatch
+ImageRef: ghcr.io/redring2020/redring-batch-runner@sha256:...
+InputRef: object storage path or immutable artifact id
+OutputRef: destination path
+TimeoutSec: integer
+RetryPolicy: maxRetries + backoff
+```
+
+最小ジョブ出力:
+
+```text
+Status: succeeded | failed | canceled
+ExitCode: integer
+ResultRef: artifact reference
+LogRef: structured log reference
+Digest: executed image digest
+```
+
+### 17.4 #297着手時の実施順序（推奨）
+
+1. Dockerfile作成（非root + multi-stage）
+2. ローカルで最小ジョブ2種の動作確認（CAM/切削）
+3. develop CIへDockerジョブ追加
+4. 脆弱性スキャンとSBOMをCIゲート化
+5. 受け入れ条件チェックリストをIssue #297に反映
+
+### 17.5 設計上の保留事項
+
+- ランナー実体を既存クレートに置くか、新規バッチ用クレートを作るか
+- GPU依存ジョブを将来導入する場合のイメージ分離方針
+- CIの実行時間増加に対するキャッシュ戦略
+
+---
+
+## 18. 参考スニペット（実装時の叩き台）
+
+以下は設計意図を示す参考スニペットであり、そのまま本番適用する前に監査する。
+
+### 18.1 Dockerfile（非root + multi-stage）
+
+```dockerfile
+FROM rust:1.86-bookworm AS builder
+WORKDIR /src
+COPY . .
+RUN cargo build --workspace --release
+
+FROM debian:bookworm-slim AS runtime
+RUN groupadd -g 10001 redring && useradd -u 10001 -g 10001 -m -s /usr/sbin/nologin redring
+WORKDIR /work
+COPY --from=builder /src/target/release/redring-batch-runner /usr/local/bin/redring-batch-runner
+RUN mkdir -p /work/output /work/logs && chown -R 10001:10001 /work
+USER 10001:10001
+ENTRYPOINT ["/usr/local/bin/redring-batch-runner"]
+```
+
+注記:
+
+- 現在ワークスペースに `redring-batch-runner` バイナリは未定義のため、実体配置は別途決定する
+- rootfs read-only は実行基盤側（K8s/CI）で強制する
+
+### 18.2 GitHub Actions ジョブ断片（非rootスモークテスト）
+
+```yaml
+docker-build-batch-runner:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - name: Build image
+      run: docker build -t redring-batch-runner:ci .
+
+docker-smoke-test-nonroot:
+  runs-on: ubuntu-latest
+  needs: [docker-build-batch-runner]
+  steps:
+    - uses: actions/checkout@v4
+    - name: CAM smoke test
+      run: |
+        docker run --rm \
+          --user 10001:10001 \
+          --read-only \
+          -v ${{ github.workspace }}/tmp/input:/work/input:ro \
+          -v ${{ github.workspace }}/tmp/output:/work/output \
+          -v ${{ github.workspace }}/tmp/logs:/work/logs \
+          redring-batch-runner:ci \
+          --job-type cam --input /work/input/min_cam.json --output /work/output
+```
+
+### 18.3 Kubernetes securityContext 断片
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+```
+
+運用ルール:
+
+- securityContext の緩和は例外申請制とし、恒久設定にしない
+- 例外を入れる場合は理由・期間・代替策をIssueで明文化する
+
+---
+
+## 19. 最小版実装（現ブランチ）
+
+本設計に対応する最小版として、以下を追加した。
+
+- `Dockerfile.batch`
+- `.dockerignore`
+- `scripts/batch_runner_stub.sh`
+
+ローカル確認例:
+
+```bash
+docker build -f Dockerfile.batch -t redring-batch-runner:local .
+
+mkdir -p tmp/input tmp/output tmp/logs
+echo '{"example":true}' > tmp/input/min_cam.json
+
+docker run --rm \
+  --user 10001:10001 \
+  --read-only \
+  -v "$PWD/tmp/input:/work/input:ro" \
+  -v "$PWD/tmp/output:/work/output" \
+  -v "$PWD/tmp/logs:/work/logs" \
+  redring-batch-runner:local \
+  --job-type cam --input /work/input/min_cam.json --output /work/output
+```
+
+確認ポイント:
+
+- 非root UID/GID で実行されること
+- `/work/output` に結果JSONが出力されること
+- `/work/logs` に実行ログが出力されること

--- a/scripts/batch_runner_stub.sh
+++ b/scripts/batch_runner_stub.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+JOB_TYPE=""
+INPUT_PATH=""
+OUTPUT_DIR="/work/output"
+LOG_DIR="/work/logs"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --job-type)
+      JOB_TYPE="$2"
+      shift 2
+      ;;
+    --input)
+      INPUT_PATH="$2"
+      shift 2
+      ;;
+    --output)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --logs)
+      LOG_DIR="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$JOB_TYPE" ]]; then
+  echo "--job-type is required (cam|sim)" >&2
+  exit 2
+fi
+
+if [[ -z "$INPUT_PATH" ]]; then
+  echo "--input is required" >&2
+  exit 2
+fi
+
+if [[ "$JOB_TYPE" != "cam" && "$JOB_TYPE" != "sim" ]]; then
+  echo "Unsupported --job-type: $JOB_TYPE" >&2
+  exit 2
+fi
+
+if [[ ! -f "$INPUT_PATH" ]]; then
+  echo "Input not found: $INPUT_PATH" >&2
+  exit 3
+fi
+
+mkdir -p "$OUTPUT_DIR" "$LOG_DIR"
+
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+OUT_FILE="$OUTPUT_DIR/${JOB_TYPE}_result.json"
+LOG_FILE="$LOG_DIR/${JOB_TYPE}.log"
+
+{
+  echo "[$STARTED_AT] start job_type=$JOB_TYPE input=$INPUT_PATH"
+  echo "uid=$(id -u) gid=$(id -g)"
+} > "$LOG_FILE"
+
+cat > "$OUT_FILE" <<EOF
+{
+  "job_type": "$JOB_TYPE",
+  "input": "$INPUT_PATH",
+  "status": "succeeded",
+  "runner": "redring-batch-runner-stub",
+  "executed_at_utc": "$STARTED_AT"
+}
+EOF
+
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] completed output=$OUT_FILE" >> "$LOG_FILE"
+
+echo "completed: $OUT_FILE"

--- a/scripts/batch_runner_stub.sh
+++ b/scripts/batch_runner_stub.sh
@@ -1,12 +1,12 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 JOB_TYPE=""
 INPUT_PATH=""
 OUTPUT_DIR="/work/output"
 LOG_DIR="/work/logs"
 
-while [[ $# -gt 0 ]]; do
+while [ "$#" -gt 0 ]; do
   case "$1" in
     --job-type)
       JOB_TYPE="$2"
@@ -31,22 +31,22 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "$JOB_TYPE" ]]; then
+if [ -z "$JOB_TYPE" ]; then
   echo "--job-type is required (cam|sim)" >&2
   exit 2
 fi
 
-if [[ -z "$INPUT_PATH" ]]; then
+if [ -z "$INPUT_PATH" ]; then
   echo "--input is required" >&2
   exit 2
 fi
 
-if [[ "$JOB_TYPE" != "cam" && "$JOB_TYPE" != "sim" ]]; then
+if [ "$JOB_TYPE" != "cam" ] && [ "$JOB_TYPE" != "sim" ]; then
   echo "Unsupported --job-type: $JOB_TYPE" >&2
   exit 2
 fi
 
-if [[ ! -f "$INPUT_PATH" ]]; then
+if [ ! -f "$INPUT_PATH" ]; then
   echo "Input not found: $INPUT_PATH" >&2
   exit 3
 fi

--- a/tests/fixtures/batch/min_cam.json
+++ b/tests/fixtures/batch/min_cam.json
@@ -1,0 +1,7 @@
+{
+  "job": "cam",
+  "version": 1,
+  "input": {
+    "workpiece": "fixture-cam-min"
+  }
+}

--- a/tests/fixtures/batch/min_sim.json
+++ b/tests/fixtures/batch/min_sim.json
@@ -1,0 +1,7 @@
+{
+  "job": "sim",
+  "version": 1,
+  "input": {
+    "workpiece": "fixture-sim-min"
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal Docker runtime files for batch runner smoke tests
- add develop CI Docker jobs (build, non-root smoke, security scan)
- add batch smoke fixtures for cam/sim
- extend batch platform design doc with minimal implementation details

## Changes
- `.github/workflows/develop_ci.yml`
  - `docker-build-batch-runner`
  - `docker-smoke-test-nonroot`
  - `docker-security-scan`
  - include Docker jobs in final status gate
- `Dockerfile.batch`
- `.dockerignore`
- `scripts/batch_runner_stub.sh`
- `tests/fixtures/batch/min_cam.json`
- `tests/fixtures/batch/min_sim.json`
- `dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md`

## Security points
- non-root fixed UID/GID execution (10001:10001)
- read-only rootfs assumption for runtime
- Trivy scan fail gate on HIGH/CRITICAL

Refs: #297