### PR TITLE
[Batch Platform] #298 Job Manager基盤実装とcam_sim接続（スタブ）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,7 @@ dependencies = [
  "analysis",
  "cam_core",
  "geo_algorithms",
+ "job_manager_core",
 ]
 
 [[package]]
@@ -1131,6 +1132,10 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "job_manager_core"
+version = "0.1.0"
 
 [[package]]
 name = "jobserver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "model/cam_core",       # Model層：CAM基盤クレート（工具経路・工具定義）
   "model/cam_entity",     # Model層：CAMエンティティクレート（geo_entityアドオン）
   "model/cam_sim",        # Model層：CAMシミュレーション実行クレート
+  "model/job_manager_core", # Model層：共通ジョブマネージャー基盤（CAD/CAM/CAE非依存）
   "viewmodel/converter",  # ViewModel層：データ変換・架け橋
   "viewmodel/graphics",   # ViewModel層：グラフィックス制御（カメラ等）
   "view/render",          # View層：GPU描画基盤

--- a/dev/architecture/ARCHITECTURE.md
+++ b/dev/architecture/ARCHITECTURE.md
@@ -57,6 +57,16 @@ analysis → geo_foundation
 - **禁止**: `geo_core -> cam_entity`
 - **許可**: `geo_core -> geo_entity`
 
+### 共通ジョブマネージャー方針（2026年3月更新）
+
+- **新規共通クレート**: `model/job_manager_core`
+- **目的**: CAD/CAM/CAEに依存しない実行制御（submit/status/cancel/retry）を提供
+- **責務**: `JobType`/`JobStatus`/`RetryPolicy`、状態遷移、イベント、Artifact参照契約
+- **非責務**: CAM計算・切削シミュレーション等のドメイン計算ロジック本体
+- **依存方針**:
+    - `job_manager_core` は `geo_*` / `cam_*` / View系へ依存しない
+    - `cam_*` / 将来のCAE側は `job_manager_core` をアダプタ経由で利用する
+
 ### 依存チェック運用
 
 - 実行コマンド: `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check_architecture_dependencies.ps1 -ExitOnError`

--- a/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
+++ b/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
@@ -244,6 +244,21 @@ RedRingでも同方式は有効な代替案とし、K8s化は明確なゴール�
 - 進捗はイベントで通知（例: `ProgressUpdated`, `ArtifactReady`, `Completed`）
 - モジュール境界として、実行制御と計算ロジックを同一クレートに混在させない
 
+### 14.4 クレート配置方針（#298）
+
+- 共通実行制御は `model/job_manager_core` に配置する
+- `job_manager_core` は CAD/CAM/CAE の計算実装に依存しない
+- CAM/切削の実行接続は `cam_*` 側アダプタで担保する
+- 将来のNC Post/CAEジョブも同一契約へ接続できるよう、`JobType + InputRef -> ResultRef` を維持する
+
+### 14.5 初期接続実装方針（スタブ）
+
+- #298 の初期接続は `model/cam_sim` に `JobExecutor` アダプタを実装する
+- アダプタは `JobType::CamProcessBatch` / `JobType::CuttingSimulationBatch` の2系統を受け付ける
+- 初期段階では実計算を呼ばず、`InputRef` を検証して `ResultRef` を返すスタブ動作とする
+- タイムアウト/リトライ/キャンセルは `job_manager_core` 側の実行制御で検証する
+- 実計算への差し替えは後続Issueで行い、同じ契約を維持したまま移行する
+
 ---
 
 ## 15. Issue分割案（本ドキュメント起点）

--- a/model/cam_sim/Cargo.toml
+++ b/model/cam_sim/Cargo.toml
@@ -12,3 +12,4 @@ categories.workspace = true
 analysis = { path = "../../foundation/analysis" }
 cam_core = { path = "../cam_core" }
 geo_algorithms = { path = "../geo_algorithms" }
+job_manager_core = { path = "../job_manager_core" }

--- a/model/cam_sim/src/job_adapter.rs
+++ b/model/cam_sim/src/job_adapter.rs
@@ -12,7 +12,10 @@ impl CamJobExecutorAdapter {
                 elapsed_millis: 10,
                 result_ref: None,
                 log_ref: Some(format!("log://cam/{}/invalid", job.id.0)),
-                error: Some(format!("invalid input_ref for cam process: {}", job.spec.input_ref)),
+                error: Some(format!(
+                    "invalid input_ref for cam process: {}",
+                    job.spec.input_ref
+                )),
             };
         }
 

--- a/model/cam_sim/src/job_adapter.rs
+++ b/model/cam_sim/src/job_adapter.rs
@@ -1,0 +1,59 @@
+use job_manager_core::{JobExecutionResult, JobExecutor, JobRecord, JobStatus, JobType};
+
+/// cam_sim から JobManager へ接続する初期アダプタ
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CamJobExecutorAdapter;
+
+impl CamJobExecutorAdapter {
+    fn run_cam_process(&self, job: &JobRecord) -> JobExecutionResult {
+        if !job.spec.input_ref.starts_with("input://cam/") {
+            return JobExecutionResult {
+                status: JobStatus::Failed,
+                elapsed_millis: 10,
+                result_ref: None,
+                log_ref: Some(format!("log://cam/{}/invalid", job.id.0)),
+                error: Some(format!("invalid input_ref for cam process: {}", job.spec.input_ref)),
+            };
+        }
+
+        JobExecutionResult {
+            status: JobStatus::Succeeded,
+            elapsed_millis: 200,
+            result_ref: Some(format!("result://cam/{}/ok", job.id.0)),
+            log_ref: Some(format!("log://cam/{}/ok", job.id.0)),
+            error: None,
+        }
+    }
+
+    fn run_cutting_simulation(&self, job: &JobRecord) -> JobExecutionResult {
+        if !job.spec.input_ref.starts_with("input://sim/") {
+            return JobExecutionResult {
+                status: JobStatus::Failed,
+                elapsed_millis: 10,
+                result_ref: None,
+                log_ref: Some(format!("log://sim/{}/invalid", job.id.0)),
+                error: Some(format!(
+                    "invalid input_ref for cutting simulation: {}",
+                    job.spec.input_ref
+                )),
+            };
+        }
+
+        JobExecutionResult {
+            status: JobStatus::Succeeded,
+            elapsed_millis: 300,
+            result_ref: Some(format!("result://sim/{}/ok", job.id.0)),
+            log_ref: Some(format!("log://sim/{}/ok", job.id.0)),
+            error: None,
+        }
+    }
+}
+
+impl JobExecutor for CamJobExecutorAdapter {
+    fn execute(&self, job: &JobRecord) -> JobExecutionResult {
+        match job.spec.job_type {
+            JobType::CamProcessBatch => self.run_cam_process(job),
+            JobType::CuttingSimulationBatch => self.run_cutting_simulation(job),
+        }
+    }
+}

--- a/model/cam_sim/src/lib.rs
+++ b/model/cam_sim/src/lib.rs
@@ -5,10 +5,13 @@
 //! Phase 1a では 3軸固定・フラットエンドミル限定の最小実装を提供します。
 
 mod error;
+mod job_adapter;
 mod simulator;
 
 /// シミュレーション実行時のエラー型。
 pub use error::SimulationError;
+/// Job Manager接続用アダプタ。
+pub use job_adapter::CamJobExecutorAdapter;
 /// シミュレーション実行APIとスナップショット関連型。
 pub use simulator::{
     CuttingSimulator, PathPosition, SimulationSnapshot, SimulationSnapshotExport, SnapshotInterval,

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -195,8 +195,18 @@ fn test_job_adapter_runs_cam_and_sim_jobs() {
 
     assert_eq!(cam.status, JobStatus::Succeeded);
     assert_eq!(sim.status, JobStatus::Succeeded);
-    assert!(cam.result_ref.as_deref().unwrap_or_default().starts_with("result://cam/"));
-    assert!(sim.result_ref.as_deref().unwrap_or_default().starts_with("result://sim/"));
+    assert!(
+        cam.result_ref
+            .as_deref()
+            .unwrap_or_default()
+            .starts_with("result://cam/")
+    );
+    assert!(
+        sim.result_ref
+            .as_deref()
+            .unwrap_or_default()
+            .starts_with("result://sim/")
+    );
 }
 
 #[test]

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -1,8 +1,9 @@
 use cam_core::{ContourLevelPath, CuttingDirection, SegmentType, Tool, ToolPath};
 use geo_algorithms::{Aabb3D, Point3D};
 use geo_algorithms::{LineSegment3D, octree::VoxelOctree};
+use job_manager_core::{JobManager, JobSpec, JobStatus, JobType, RetryPolicy};
 
-use crate::{CuttingSimulator, SimulationError, SnapshotInterval};
+use crate::{CamJobExecutorAdapter, CuttingSimulator, SimulationError, SnapshotInterval};
 
 #[test]
 fn test_simulate_line_segments_removes_material() {
@@ -165,4 +166,59 @@ fn test_snapshot_exports_f64_maps_snapshot_fields() {
     assert_eq!(first.segment_index, 0);
     assert!((0.0..=1.0).contains(&first.segment_t));
     assert!(first.remaining_volume_mm3.is_finite());
+}
+
+#[test]
+fn test_job_adapter_runs_cam_and_sim_jobs() {
+    let mut manager = JobManager::new();
+    let adapter = CamJobExecutorAdapter;
+
+    let cam_id = manager.submit(JobSpec {
+        job_type: JobType::CamProcessBatch,
+        input_ref: "input://cam/sample".to_string(),
+        timeout_secs: 30,
+        retry_policy: RetryPolicy::default(),
+    });
+
+    let sim_id = manager.submit(JobSpec {
+        job_type: JobType::CuttingSimulationBatch,
+        input_ref: "input://sim/sample".to_string(),
+        timeout_secs: 30,
+        retry_policy: RetryPolicy::default(),
+    });
+
+    manager.execute_with(cam_id, &adapter).unwrap();
+    manager.execute_with(sim_id, &adapter).unwrap();
+
+    let cam = manager.get(cam_id).unwrap();
+    let sim = manager.get(sim_id).unwrap();
+
+    assert_eq!(cam.status, JobStatus::Succeeded);
+    assert_eq!(sim.status, JobStatus::Succeeded);
+    assert!(cam.result_ref.as_deref().unwrap_or_default().starts_with("result://cam/"));
+    assert!(sim.result_ref.as_deref().unwrap_or_default().starts_with("result://sim/"));
+}
+
+#[test]
+fn test_job_adapter_rejects_invalid_input_ref() {
+    let mut manager = JobManager::new();
+    let adapter = CamJobExecutorAdapter;
+
+    let id = manager.submit(JobSpec {
+        job_type: JobType::CuttingSimulationBatch,
+        input_ref: "input://cam/wrong".to_string(),
+        timeout_secs: 30,
+        retry_policy: RetryPolicy::default(),
+    });
+
+    manager.execute_with(id, &adapter).unwrap();
+
+    let job = manager.get(id).unwrap();
+    assert_eq!(job.status, JobStatus::Failed);
+    assert!(
+        job.last_error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("invalid input_ref")
+    );
 }

--- a/model/job_manager_core/Cargo.toml
+++ b/model/job_manager_core/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "job_manager_core"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]

--- a/model/job_manager_core/src/events.rs
+++ b/model/job_manager_core/src/events.rs
@@ -15,10 +15,7 @@ pub enum JobEvent {
         message: Option<String>,
     },
     /// 成果物準備完了イベント
-    ArtifactReady {
-        job_id: JobId,
-        result_ref: String,
-    },
+    ArtifactReady { job_id: JobId, result_ref: String },
     /// 終了イベント
     Completed {
         job_id: JobId,

--- a/model/job_manager_core/src/events.rs
+++ b/model/job_manager_core/src/events.rs
@@ -1,0 +1,29 @@
+use crate::types::{JobId, JobStatus};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum JobEvent {
+    /// 状態変更イベント
+    StatusChanged {
+        job_id: JobId,
+        from: JobStatus,
+        to: JobStatus,
+    },
+    /// 進捗更新イベント
+    ProgressUpdated {
+        job_id: JobId,
+        progress: f32,
+        message: Option<String>,
+    },
+    /// 成果物準備完了イベント
+    ArtifactReady {
+        job_id: JobId,
+        result_ref: String,
+    },
+    /// 終了イベント
+    Completed {
+        job_id: JobId,
+        status: JobStatus,
+        result_ref: Option<String>,
+        log_ref: Option<String>,
+    },
+}

--- a/model/job_manager_core/src/executor.rs
+++ b/model/job_manager_core/src/executor.rs
@@ -1,0 +1,14 @@
+use crate::types::{JobRecord, JobStatus};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JobExecutionResult {
+    pub status: JobStatus,
+    pub elapsed_millis: u64,
+    pub result_ref: Option<String>,
+    pub log_ref: Option<String>,
+    pub error: Option<String>,
+}
+
+pub trait JobExecutor {
+    fn execute(&self, job: &JobRecord) -> JobExecutionResult;
+}

--- a/model/job_manager_core/src/lib.rs
+++ b/model/job_manager_core/src/lib.rs
@@ -10,6 +10,4 @@ pub mod types;
 pub use events::JobEvent;
 pub use executor::{JobExecutionResult, JobExecutor};
 pub use manager::JobManager;
-pub use types::{
-    JobError, JobId, JobRecord, JobSpec, JobStatus, JobType, RetryPolicy,
-};
+pub use types::{JobError, JobId, JobRecord, JobSpec, JobStatus, JobType, RetryPolicy};

--- a/model/job_manager_core/src/lib.rs
+++ b/model/job_manager_core/src/lib.rs
@@ -1,0 +1,15 @@
+//! 共通ジョブマネージャー基盤
+//!
+//! 実行制御（submit/status/cancel/retry）とイベント契約を提供
+
+pub mod events;
+pub mod executor;
+pub mod manager;
+pub mod types;
+
+pub use events::JobEvent;
+pub use executor::{JobExecutionResult, JobExecutor};
+pub use manager::JobManager;
+pub use types::{
+    JobError, JobId, JobRecord, JobSpec, JobStatus, JobType, RetryPolicy,
+};

--- a/model/job_manager_core/src/manager.rs
+++ b/model/job_manager_core/src/manager.rs
@@ -1,0 +1,411 @@
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+use crate::events::JobEvent;
+use crate::executor::JobExecutor;
+use crate::types::{JobError, JobId, JobRecord, JobSpec, JobStatus};
+
+#[derive(Debug, Default)]
+pub struct JobManager {
+    jobs: HashMap<JobId, JobRecord>,
+    event_queue: Vec<JobEvent>,
+    next_id: u64,
+}
+
+impl JobManager {
+    /// 空のマネージャーを生成
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// ジョブを登録してIDを返す
+    pub fn submit(&mut self, spec: JobSpec) -> JobId {
+        self.next_id += 1;
+        let id = JobId(self.next_id);
+        let now = SystemTime::now();
+
+        let record = JobRecord {
+            id,
+            spec,
+            status: JobStatus::Queued,
+            attempts: 0,
+            created_at: now,
+            updated_at: now,
+            result_ref: None,
+            log_ref: None,
+            last_error: None,
+        };
+
+        self.jobs.insert(id, record);
+        id
+    }
+
+    /// 現在状態を取得
+    pub fn status(&self, id: JobId) -> Result<JobStatus, JobError> {
+        let record = self.jobs.get(&id).ok_or(JobError::JobNotFound(id))?;
+        Ok(record.status)
+    }
+
+    /// ジョブ情報を取得
+    pub fn get(&self, id: JobId) -> Result<&JobRecord, JobError> {
+        self.jobs.get(&id).ok_or(JobError::JobNotFound(id))
+    }
+
+    /// ジョブ一覧をID順で取得
+    pub fn list(&self) -> Vec<&JobRecord> {
+        let mut records: Vec<&JobRecord> = self.jobs.values().collect();
+        records.sort_by_key(|r| r.id.0);
+        records
+    }
+
+    /// 待機中ジョブを実行中へ遷移
+    pub fn start(&mut self, id: JobId) -> Result<(), JobError> {
+        self.transition(id, JobStatus::Running)
+    }
+
+    /// 待機中または実行中ジョブをキャンセル
+    pub fn cancel(&mut self, id: JobId) -> Result<(), JobError> {
+        self.transition(id, JobStatus::Canceled)
+    }
+
+    /// 正常終了へ遷移し、参照情報を保存
+    pub fn mark_succeeded(
+        &mut self,
+        id: JobId,
+        result_ref: Option<String>,
+        log_ref: Option<String>,
+    ) -> Result<(), JobError> {
+        self.transition(id, JobStatus::Succeeded)?;
+        let record = self.jobs.get_mut(&id).ok_or(JobError::JobNotFound(id))?;
+        record.result_ref = result_ref.clone();
+        record.log_ref = log_ref.clone();
+        self.event_queue.push(JobEvent::Completed {
+            job_id: id,
+            status: JobStatus::Succeeded,
+            result_ref,
+            log_ref,
+        });
+        Ok(())
+    }
+
+    /// 失敗終了へ遷移し、エラーと参照情報を保存
+    pub fn mark_failed(
+        &mut self,
+        id: JobId,
+        error: String,
+        log_ref: Option<String>,
+    ) -> Result<(), JobError> {
+        self.transition(id, JobStatus::Failed)?;
+        let record = self.jobs.get_mut(&id).ok_or(JobError::JobNotFound(id))?;
+        record.last_error = Some(error);
+        record.log_ref = log_ref.clone();
+        self.event_queue.push(JobEvent::Completed {
+            job_id: id,
+            status: JobStatus::Failed,
+            result_ref: None,
+            log_ref,
+        });
+        Ok(())
+    }
+
+    /// 失敗ジョブを再投入
+    pub fn retry(&mut self, id: JobId) -> Result<(), JobError> {
+        let record = self.jobs.get_mut(&id).ok_or(JobError::JobNotFound(id))?;
+
+        if record.status != JobStatus::Failed {
+            return Err(JobError::InvalidTransition {
+                from: record.status,
+                to: JobStatus::Queued,
+            });
+        }
+
+        if record.attempts >= record.spec.retry_policy.max_retries {
+            return Err(JobError::RetryLimitExceeded {
+                attempts: record.attempts,
+                max_retries: record.spec.retry_policy.max_retries,
+            });
+        }
+
+        record.attempts += 1;
+        let from = record.status;
+        record.status = JobStatus::Queued;
+        record.updated_at = SystemTime::now();
+        record.last_error = None;
+        self.event_queue.push(JobEvent::StatusChanged {
+            job_id: id,
+            from,
+            to: JobStatus::Queued,
+        });
+        Ok(())
+    }
+
+    /// 進捗更新イベントを追加
+    pub fn emit_progress(&mut self, id: JobId, progress: f32, message: Option<String>) {
+        self.event_queue.push(JobEvent::ProgressUpdated {
+            job_id: id,
+            progress,
+            message,
+        });
+    }
+
+    /// 成果物準備完了イベントを追加
+    pub fn emit_artifact_ready(&mut self, id: JobId, result_ref: String) {
+        self.event_queue.push(JobEvent::ArtifactReady {
+            job_id: id,
+            result_ref,
+        });
+    }
+
+    /// スタブ実行器でジョブを1件実行
+    pub fn execute_with<E: JobExecutor>(
+        &mut self,
+        id: JobId,
+        executor: &E,
+    ) -> Result<(), JobError> {
+        self.start(id)?;
+
+        let snapshot = self.jobs.get(&id).ok_or(JobError::JobNotFound(id))?.clone();
+        let execution = executor.execute(&snapshot);
+
+        let timeout_millis = snapshot.spec.timeout_secs.saturating_mul(1000);
+        if execution.elapsed_millis > timeout_millis {
+            return self.mark_failed(
+                id,
+                format!(
+                    "timeout exceeded: elapsed={}ms, timeout={}ms",
+                    execution.elapsed_millis, timeout_millis
+                ),
+                execution.log_ref,
+            );
+        }
+
+        match execution.status {
+            JobStatus::Succeeded => {
+                if let Some(result_ref) = execution.result_ref.clone() {
+                    self.emit_artifact_ready(id, result_ref);
+                }
+                self.mark_succeeded(id, execution.result_ref, execution.log_ref)
+            }
+            JobStatus::Failed => self.mark_failed(
+                id,
+                execution
+                    .error
+                    .unwrap_or_else(|| "executor returned failed status".to_string()),
+                execution.log_ref,
+            ),
+            JobStatus::Canceled => self.cancel(id),
+            JobStatus::Queued | JobStatus::Running => Err(JobError::InvalidTransition {
+                from: JobStatus::Running,
+                to: execution.status,
+            }),
+        }
+    }
+
+    /// 保留イベントを取り出して空にする
+    pub fn take_events(&mut self) -> Vec<JobEvent> {
+        std::mem::take(&mut self.event_queue)
+    }
+
+    fn transition(&mut self, id: JobId, to: JobStatus) -> Result<(), JobError> {
+        let record = self.jobs.get_mut(&id).ok_or(JobError::JobNotFound(id))?;
+
+        if record.status.is_terminal() {
+            return Err(JobError::AlreadyTerminal(record.status));
+        }
+
+        let valid = matches!(
+            (record.status, to),
+            (JobStatus::Queued, JobStatus::Running)
+                | (JobStatus::Queued, JobStatus::Canceled)
+                | (JobStatus::Running, JobStatus::Succeeded)
+                | (JobStatus::Running, JobStatus::Failed)
+                | (JobStatus::Running, JobStatus::Canceled)
+        );
+
+        if !valid {
+            return Err(JobError::InvalidTransition {
+                from: record.status,
+                to,
+            });
+        }
+
+        let from = record.status;
+        record.status = to;
+        record.updated_at = SystemTime::now();
+
+        self.event_queue.push(JobEvent::StatusChanged {
+            job_id: id,
+            from,
+            to,
+        });
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::executor::{JobExecutionResult, JobExecutor};
+    use crate::types::{JobSpec, JobType, RetryPolicy};
+
+    use super::*;
+
+    fn sample_spec() -> JobSpec {
+        JobSpec {
+            job_type: JobType::CamProcessBatch,
+            input_ref: "input://sample".to_string(),
+            timeout_secs: 60,
+            retry_policy: RetryPolicy {
+                max_retries: 1,
+                backoff_millis: 100,
+            },
+        }
+    }
+
+    fn simulation_spec() -> JobSpec {
+        JobSpec {
+            job_type: JobType::CuttingSimulationBatch,
+            input_ref: "input://sim".to_string(),
+            timeout_secs: 60,
+            retry_policy: RetryPolicy {
+                max_retries: 1,
+                backoff_millis: 100,
+            },
+        }
+    }
+
+    struct StubExecutor {
+        elapsed_millis: u64,
+        succeed: bool,
+    }
+
+    impl JobExecutor for StubExecutor {
+        fn execute(&self, job: &JobRecord) -> JobExecutionResult {
+            let result_ref = match job.spec.job_type {
+                JobType::CamProcessBatch => Some("result://cam".to_string()),
+                JobType::CuttingSimulationBatch => Some("result://sim".to_string()),
+            };
+
+            if self.succeed {
+                JobExecutionResult {
+                    status: JobStatus::Succeeded,
+                    elapsed_millis: self.elapsed_millis,
+                    result_ref,
+                    log_ref: Some("log://ok".to_string()),
+                    error: None,
+                }
+            } else {
+                JobExecutionResult {
+                    status: JobStatus::Failed,
+                    elapsed_millis: self.elapsed_millis,
+                    result_ref: None,
+                    log_ref: Some("log://ng".to_string()),
+                    error: Some("stub failure".to_string()),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn submit_start_success_flow_works() {
+        let mut manager = JobManager::new();
+        let id = manager.submit(sample_spec());
+
+        assert_eq!(manager.status(id).unwrap(), JobStatus::Queued);
+        manager.start(id).unwrap();
+        manager
+            .mark_succeeded(id, Some("result://ok".to_string()), None)
+            .unwrap();
+
+        let final_status = manager.status(id).unwrap();
+        assert_eq!(final_status, JobStatus::Succeeded);
+    }
+
+    #[test]
+    fn failed_job_can_retry_within_limit() {
+        let mut manager = JobManager::new();
+        let id = manager.submit(sample_spec());
+
+        manager.start(id).unwrap();
+        manager
+            .mark_failed(id, "temporary error".to_string(), None)
+            .unwrap();
+
+        manager.retry(id).unwrap();
+        assert_eq!(manager.status(id).unwrap(), JobStatus::Queued);
+    }
+
+    #[test]
+    fn stub_executor_runs_two_job_types() {
+        let mut manager = JobManager::new();
+        let cam_id = manager.submit(sample_spec());
+        let sim_id = manager.submit(simulation_spec());
+        let executor = StubExecutor {
+            elapsed_millis: 300,
+            succeed: true,
+        };
+
+        manager.execute_with(cam_id, &executor).unwrap();
+        manager.execute_with(sim_id, &executor).unwrap();
+
+        let cam = manager.get(cam_id).unwrap();
+        let sim = manager.get(sim_id).unwrap();
+        assert_eq!(cam.status, JobStatus::Succeeded);
+        assert_eq!(sim.status, JobStatus::Succeeded);
+        assert_eq!(cam.result_ref.as_deref(), Some("result://cam"));
+        assert_eq!(sim.result_ref.as_deref(), Some("result://sim"));
+    }
+
+    #[test]
+    fn timeout_retry_cancel_flow_works_with_stub() {
+        let mut manager = JobManager::new();
+        let mut spec = sample_spec();
+        spec.timeout_secs = 1;
+        spec.retry_policy.max_retries = 2;
+        let id = manager.submit(spec);
+
+        let slow_executor = StubExecutor {
+            elapsed_millis: 2_000,
+            succeed: true,
+        };
+
+        manager.execute_with(id, &slow_executor).unwrap();
+        assert_eq!(manager.status(id).unwrap(), JobStatus::Failed);
+
+        manager.retry(id).unwrap();
+        assert_eq!(manager.status(id).unwrap(), JobStatus::Queued);
+
+        manager.cancel(id).unwrap();
+        assert_eq!(manager.status(id).unwrap(), JobStatus::Canceled);
+    }
+
+    #[test]
+    fn progress_artifact_completed_events_can_be_taken() {
+        let mut manager = JobManager::new();
+        let id = manager.submit(sample_spec());
+        let executor = StubExecutor {
+            elapsed_millis: 100,
+            succeed: true,
+        };
+
+        manager.emit_progress(id, 0.5, Some("half".to_string()));
+        manager.execute_with(id, &executor).unwrap();
+
+        let events = manager.take_events();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, JobEvent::ProgressUpdated { job_id, .. } if *job_id == id))
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, JobEvent::ArtifactReady { job_id, .. } if *job_id == id))
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, JobEvent::Completed { job_id, .. } if *job_id == id))
+        );
+    }
+}

--- a/model/job_manager_core/src/types.rs
+++ b/model/job_manager_core/src/types.rs
@@ -1,0 +1,123 @@
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::time::SystemTime;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// 登録済みジョブを識別するID
+pub struct JobId(pub u64);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JobType {
+    /// 加工計画ジョブ
+    CamProcessBatch,
+    /// シミュレーションジョブ
+    CuttingSimulationBatch,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JobStatus {
+    /// 受け付け済みで未実行
+    Queued,
+    /// 実行中
+    Running,
+    /// 正常終了
+    Succeeded,
+    /// 異常終了
+    Failed,
+    /// キャンセル済み
+    Canceled,
+}
+
+impl JobStatus {
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Succeeded | Self::Failed | Self::Canceled)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// リトライ設定
+pub struct RetryPolicy {
+    /// 最大リトライ回数
+    pub max_retries: u32,
+    /// リトライ間隔（ミリ秒）
+    pub backoff_millis: u64,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            backoff_millis: 1000,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// ジョブ投入時の入力定義
+pub struct JobSpec {
+    /// 実行種別
+    pub job_type: JobType,
+    /// 入力参照
+    pub input_ref: String,
+    /// タイムアウト秒
+    pub timeout_secs: u64,
+    /// リトライ設定
+    pub retry_policy: RetryPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// ジョブの実行状態
+pub struct JobRecord {
+    /// ジョブID
+    pub id: JobId,
+    /// 投入時の設定
+    pub spec: JobSpec,
+    /// 現在状態
+    pub status: JobStatus,
+    /// 実施済みリトライ回数
+    pub attempts: u32,
+    /// 作成時刻
+    pub created_at: SystemTime,
+    /// 最終更新時刻
+    pub updated_at: SystemTime,
+    /// 結果参照
+    pub result_ref: Option<String>,
+    /// ログ参照
+    pub log_ref: Option<String>,
+    /// 直近エラー
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JobError {
+    /// 指定ジョブが存在しない
+    JobNotFound(JobId),
+    /// 状態遷移が許可されていない
+    InvalidTransition { from: JobStatus, to: JobStatus },
+    /// リトライ上限超過
+    RetryLimitExceeded { attempts: u32, max_retries: u32 },
+    /// すでに終端状態
+    AlreadyTerminal(JobStatus),
+}
+
+impl Display for JobError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::JobNotFound(id) => write!(f, "job not found: {}", id.0),
+            Self::InvalidTransition { from, to } => {
+                write!(f, "invalid transition: {:?} -> {:?}", from, to)
+            }
+            Self::RetryLimitExceeded {
+                attempts,
+                max_retries,
+            } => write!(
+                f,
+                "retry limit exceeded: attempts={}, max_retries={}",
+                attempts, max_retries
+            ),
+            Self::AlreadyTerminal(status) => write!(f, "job already terminal: {:?}", status),
+        }
+    }
+}
+
+impl Error for JobError {}

--- a/scripts/check_architecture_dependencies.ps1
+++ b/scripts/check_architecture_dependencies.ps1
@@ -29,7 +29,8 @@ $ARCHITECTURE_RULES = @{
         # Model: cam_*
         cam_core       = @("analysis", "geo_foundation", "geo_primitives", "geo_algorithms", "cam_entity") # cam_core -> cam_entity: OK
         cam_entity     = @("cam_core", "geo_entity")
-        cam_sim        = @("analysis", "cam_core", "geo_algorithms")
+        cam_sim        = @("analysis", "cam_core", "geo_algorithms", "job_manager_core")
+        job_manager_core = @("analysis")
 
         # ViewModel
         converter      = @("geo_foundation", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "analysis")
@@ -43,19 +44,20 @@ $ARCHITECTURE_RULES = @{
 
     ForbiddenDependencies = @{
         # geo_* -> cam_* is forbidden
-        geo_foundation = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim")
-        geo_commons    = @("converter", "graphics", "render", "stage", "app", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "cam_core", "cam_entity", "cam_sim")
-        geo_core       = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim") # geo_core -> cam_entity: NG
-        geo_primitives = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim")
-        geo_algorithms = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim")
-        geo_nurbs      = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim")
-        geo_io         = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim")
-        geo_entity     = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim")
+        geo_foundation = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_manager_core")
+        geo_commons    = @("converter", "graphics", "render", "stage", "app", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "cam_core", "cam_entity", "cam_sim", "job_manager_core")
+        geo_core       = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_manager_core") # geo_core -> cam_entity: NG
+        geo_primitives = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_manager_core")
+        geo_algorithms = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_manager_core")
+        geo_nurbs      = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_manager_core")
+        geo_io         = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_manager_core")
+        geo_entity     = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_manager_core")
 
         # cam_*
         cam_core       = @("converter", "graphics", "render", "stage", "app", "geo_entity", "cam_sim") # cam_core -> geo_entity: NG
         cam_entity     = @("converter", "graphics", "render", "stage", "app", "cam_sim")
         cam_sim        = @("converter", "graphics", "render", "stage", "app", "geo_entity", "geo_foundation", "geo_core", "geo_primitives", "geo_nurbs", "geo_io", "cam_entity")
+        job_manager_core = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "converter", "graphics", "render", "stage", "app")
 
         # ViewModel -> View forbidden
         converter      = @("render", "stage", "app")
@@ -67,7 +69,7 @@ $ARCHITECTURE_RULES = @{
         app            = @("geo_foundation", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim")
 
         # analysis isolation
-        analysis       = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "converter", "graphics", "render", "stage", "app")
+        analysis       = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "job_manager_core", "converter", "graphics", "render", "stage", "app")
     }
 
     NamingRules = @{
@@ -123,6 +125,7 @@ function Get-WorkspaceCrates {
         cam_core       = "model/cam_core"
         cam_entity     = "model/cam_entity"
         cam_sim        = "model/cam_sim"
+        job_manager_core = "model/job_manager_core"
         converter      = "viewmodel/converter"
         graphics       = "viewmodel/graphics"
         render         = "view/render"
@@ -198,7 +201,7 @@ function Test-ArchitectureDependencies {
     Write-Info "3. Layer Dependency Summary"
     $layers = @{
         Analysis  = @("analysis")
-        Model     = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim")
+        Model     = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "job_manager_core")
         ViewModel = @("converter", "graphics")
         View      = @("render", "stage", "app")
     }


### PR DESCRIPTION
## 概要
#298 向けに、ドメイン非依存の Job Manager 基盤 `model/job_manager_core` を追加し、`model/cam_sim` からの接続（スタブ）まで実装しました。

## 変更内容
- `model/job_manager_core` 新規追加
  - `JobType` / `JobStatus` / `RetryPolicy` / `JobSpec` / `JobRecord` / `JobError`
  - `JobManager`（submit/status/cancel/retry、状態遷移、イベントキュー）
  - `JobExecutor` 契約と `execute_with` 実行導線
  - タイムアウト判定（`elapsed_millis` vs `timeout_secs`）
- `model/cam_sim` に `CamJobExecutorAdapter` 追加
  - `CamProcessBatch` / `CuttingSimulationBatch` の2系統受け付け
  - 初期接続はスタブ（`InputRef` 検証 + `ResultRef` 返却）
- 依存/構成更新
  - workspace member へ `model/job_manager_core` 追加
  - `cam_sim` から `job_manager_core` 依存追加
  - 依存ルールスクリプト更新
- ドキュメント更新
  - `dev/architecture/ARCHITECTURE.md`
  - `dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md`（14.5 初期接続方針を追記）

## テスト
- `cargo test -p job_manager_core` ✅
- `cargo test -p cam_sim` ✅
- `cargo check --workspace` ✅
- `scripts/check_architecture_dependencies.ps1 -ExitOnError` ✅

## 補足
- #298 の接続実装は本PRで対応
- 名称整理（`job_manager_core -> job_runtime`）は後続Issue #307 で分離対応

Closes #298