### PR TITLE
docs: geometry refactor issue follow-up notes

### DIFF
--- a/dev/architecture/ARCHITECTURE.md
+++ b/dev/architecture/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # RedRing アーキテクチャ構成
 
-**最終更新日**: 2025年11月18日
+**最終更新日**: 2026年3月15日
 
 RedRing の幾何計算層とレンダリング層の構成、および現在の課題と解決策について説明します。
 
@@ -8,7 +8,7 @@ RedRing の幾何計算層とレンダリング層の構成、および現在の
 
 ### 幾何計算層
 
-## 🚨 現在の重大な課題（2025年11月18日更新）
+## 🚨 現在の重大な課題（2026年3月15日更新）
 
 ### 系統的な*_core_traits実装問題
 
@@ -16,38 +16,61 @@ RedRing の幾何計算層とレンダリング層の構成、および現在の
 
 - **メソッド名競合**: `center()`, `arc_length()`, `point_at_parameter()` 等
 - **型不一致**: `Point2D<T>` vs `(T, T)` のシグネチャ違い
-- **Foundation Patternの破綱**: 統一アクセスが実現できない
+- **Foundation Patternの破綻**: 統一アクセスが実現できない
 
 **対象形状**: point, vector, circle, ellipse_arc, direction, bbox, ray, line_segment, infinite_line
 
-### アーキテクチャ構成と責務
+### アーキテクチャ再編提案（geo_foundation 廃止）
 
 ```text
-analysis → geo_foundation
-            ↓
-        geo_commons
+foundation/analysis（将来改名候補）
             ↓
         geo_core（低レイヤー・基本型提供）
-            ↓    ↓
-   geo_primitives  geo_nurbs
+            ↓             ↓
+   geo_primitives      geo_nurbs
+      （trait+実装）     （trait+実装）
+            ↘           ↙
+            geo_algorithms（交差/衝突/幾何演算）
+                    ↓
+         application層クレート群
+    （tessellation / simulation / job manager）
 ```
 
 #### クレート責務定義
 
-- **`analysis`**: 数値解析・線形代数・微積分の基盤機能
-- **`geo_foundation`**: 抽象トレイト定義（*_core_traits 等）
-- **`geo_commons`**: 共通幾何計算機能、Foundation橋渡し
+- **`foundation/analysis`**: 線形代数などの純粋な数値解析のみを提供（将来改名検討）
 - **`geo_core`**: **低レイヤー基本型**（Aabb2D/Aabb3D等）- geo_primitives/geo_nurbsから直接アクセス可
-- **`geo_primitives`**: プリミティブ幾何実装（Point, Vector, Circle等）
-- **`geo_nurbs`**: NURBS 曲線・曲面実装
-- **`geo_algorithms`**: 高レベル幾何アルゴリズム
+- **`geo_primitives`**: プリミティブ形状のtrait定義と実装（Point, Vector, Circle等）
+- **`geo_nurbs`**: NURBS形状のtrait定義と実装（Curve/Surface等）
+- **`geo_algorithms`**: `geo_primitives` / `geo_nurbs` を利用した高レベル幾何アルゴリズム（intersect, collision 等）
+- **`application::*`（新設方針）**: テセレーション、シミュレーション、ジョブ管理など業務ユースケース
 - **`geo_io`**: ファイル I/O（STL/OBJ/PLY 等）
 
 #### レイヤー設計の重要ポイント
 
 - **`geo_core`は低レイヤー**: `geo_primitives`と`geo_nurbs`より下位に位置
 - **直接アクセス許可**: `geo_core`からのインポート（特にAabb2D/Aabb3D）は許可
-- **循環依存回避**: `geo_foundation` → `geo_core`の依存は禁止（循環依存を防ぐため）
+- **`geo_foundation`廃止**: 形状traitは`geo_primitives`/`geo_nurbs`側へ再配置する
+- **上位責務分離**: tessellation/simulation/job managerは`geo_algorithms`より上位のapplication層へ集約
+- **循環依存回避**: `geo_primitives` ↔ `geo_nurbs` の直接依存は禁止（交差処理は`geo_algorithms`に集約）
+
+### 段階移行計画（提案）
+
+1. **Phase 1: trait移設**
+- `geo_foundation` の形状traitを `geo_primitives` / `geo_nurbs` へ移設
+- 既存利用側を新trait参照へ置換
+
+2. **Phase 2: アルゴリズム統合**
+- `geo_algorithms` に `geo_primitives` と `geo_nurbs` の両依存を明示
+- Intersect/Collision等のクロス形状演算を `geo_algorithms` に統一
+
+3. **Phase 3: application層分離**
+- tessellation/simulation/job manager を application層クレートに移動
+- `geo_algorithms` は純粋幾何アルゴリズム責務に限定
+
+4. **Phase 4: analysis再編**
+- `foundation/analysis` の名称変更を検討
+- 内部実装を純粋数値解析（線形代数等）に整理し、ドメイン責務を排除
 
 ### CAD/CAM 境界ルール（2026年2月更新）
 
@@ -81,17 +104,17 @@ analysis → geo_foundation
 3. **最小限の実装から開始**: 1-2個のメソッドから段階的に実装
 4. **geo_commons機能の活用**: 共通計算で内部実装を再利用
 
-### Foundation Pattern の真の実現
+### 形状API統一の実現（新方針）
 
-**目標**: 全てのアクセスをFoundationトレイト経由に統一
+**目標**: 全てのアクセスを「各形状クレート内trait」経由に統一
 
 ```rust
-// ✅ 目標: Foundation経由のみアクセス可能
-use geo_foundation::EllipseArc2DMeasure;
+// ✅ 目標: 形状クレート内trait経由のみアクセス可能
+use geo_primitives::EllipseArc2DMeasure;
 
 let arc = EllipseArc2D::new(...);
-let length = arc.arc_length(); // Foundation実装を呼び出し
-let point = arc.point_at_parameter(0.5); // Foundation実装を呼び出し
+let length = arc.arc_length(); // trait実装を呼び出し
+let point = arc.point_at_parameter(0.5); // trait実装を呼び出し
 
 // ❌ 禁止: レガシー直接アクセス
 // arc.legacy_method() // コンパイルエラー
@@ -133,10 +156,10 @@ redring ← stage ← render
 
 ## 🎆 期待される成果
 
-- **統一アクセス**: 全てのAPIがFoundationトレイト経由
+- **統一アクセス**: 全てのAPIが各形状クレートのtrait経由
 - **型安全性**: コンパイル時のインターフェース統一
 - **保守性向上**: 明確な責務分離と依存関係
-- **拡張性**: 新しい形状や機能の追加が容易
+- **拡張性**: 新しい形状追加は各形状クレート、クロス演算は`geo_algorithms`に集約
 
 ## 🔗 関連ドキュメント
 

--- a/dev/architecture/GEOMETRY_REFACTOR_ISSUE_DRAFT.md
+++ b/dev/architecture/GEOMETRY_REFACTOR_ISSUE_DRAFT.md
@@ -1,0 +1,110 @@
+# Geometry Layer Refactor Issue Draft
+
+## 0. 方針サマリ
+
+今回の再編は次の4点を最優先で進める。
+
+1. `geo_core` の依存逆転解消（`geo_core -> geo_foundation` を撤去）
+2. Transform の2層化（共通核を `geo_core`、形状適用を `geo_primitives` / `geo_nurbs`）
+3. `geo_commons` の分解移管（`analysis` と `geo_algorithms` へ）
+4. `geo_foundation` の段階的廃止完了
+
+---
+
+## 1. 設計判断
+
+### 1.1 Transformの配置
+
+- 最適解は「`geo_primitives` / `geo_nurbs` に形状Transformを置く」＋「共通行列・座標変換を `geo_core` に置く」の2層構成
+- `geo_algorithms` はクロス形状演算（intersect/collision）へ集中し、形状固有Transformは持たない
+
+### 1.2 geo_commonsの扱い
+
+- `geo_commons` は独立クレートとしては廃止可能
+- 純粋数値近似・数学関数は `foundation/analysis` へ移管
+- 形状横断の演算ロジックは `geo_algorithms` へ移管
+
+### 1.3 geo_coreの再定義
+
+- `geo_core` は最下層として再定義する
+- 許容依存は `foundation/analysis` のみ
+- `geo_core -> geo_foundation` の依存は解消する
+
+---
+
+## 2. 起票対象Issue（4件）
+
+### Issue 1
+
+- タイトル案: `geo_core依存逆転解消: geo_core -> geo_foundation を撤去`
+- 目的: `geo_core` を最下層クレートとして成立させる
+- 主タスク:
+  - `geo_core` の `geo_foundation` 依存除去
+  - 必要trait/型の再配置（`geo_core` or 呼び出し側）
+  - 依存チェックスクリプト更新
+- DoD:
+  - `geo_core/Cargo.toml` から `geo_foundation` が消える
+  - ワークスペースのビルド/テスト/依存チェック通過
+
+### Issue 2
+
+- タイトル案: `Transform再編: geo_core共通核 + geo_primitives/geo_nurbs形状実装の2層化`
+- 目的: Transform責務の重複と分散を解消する
+- 主タスク:
+  - 共通変換ユーティリティを `geo_core` に統一
+  - 形状固有Transform APIを `geo_primitives`/`geo_nurbs` に統一
+  - 既存呼び出し側の import / API 更新
+- DoD:
+  - Transform共通核が `geo_core` に集約
+  - 形状固有Transformが `geo_primitives`/`geo_nurbs` で提供
+
+### Issue 3
+
+- タイトル案: `geo_commons廃止: analysis/geo_algorithms への分解移管`
+- 目的: 中間層を削減し責務を明確化する
+- 主タスク:
+  - `geo_commons` の公開API棚卸し
+  - 数値近似を `analysis` へ移管
+  - 形状横断計算を `geo_algorithms` へ移管
+  - `geo_foundation` 経由の再エクスポート整理
+- DoD:
+  - `geo_commons` 依存がワークスペースから消える
+  - 移管後APIで既存利用箇所がビルド通過
+
+### Issue 4
+
+- タイトル案: `geo_foundation廃止完了: geo_contracts導入と参照置換`
+- 目的: Foundation集中を解消し、形状定義と実装の責務を分離する
+- 主タスク:
+  - `geo_contracts` を新設し、形状trait/契約を移設
+  - `geo_primitives` / `geo_nurbs` は実装責務に限定
+  - `geo_foundation` 参照箇所を段階置換し互換レイヤ削除
+- DoD:
+  - 形状定義の正規参照先が `geo_contracts` に統一
+  - `geo_foundation` が不要クレートとして削除可能
+  - 依存ルール違反なく全体テスト通過
+
+---
+
+## 3. 共通完了条件
+
+- [ ] `cargo check --workspace`
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- [ ] `cargo test --workspace`
+- [ ] `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\check_architecture_dependencies.ps1 -ExitOnError`
+
+---
+
+## 4. 合意が必要な前提
+
+- 破壊的変更を許容する（互換レイヤを最小化）
+- 依存境界の健全性を、短期互換性より優先する
+
+---
+
+## 5. 起票結果（2026-03-16）
+
+- #317 `geo_core依存逆転解消: geo_core -> geo_foundation を撤去`
+- #318 `geo_foundation廃止完了: geo_contracts導入と参照置換`
+- #319 `Transform再編: geo_core共通核 + geo_primitives/geo_nurbs形状実装の2層化`
+- #320 `geo_commons廃止: analysis/geo_algorithms への分解移管`

--- a/dev/architecture/ISSUE_319_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_319_IMPLEMENTATION_PREP.md
@@ -1,0 +1,120 @@
+# Issue #319 実施準備チェックリスト
+
+対象Issue: [#319 Transform再編: geo_core共通核 + geo_primitives/geo_nurbs形状実装の2層化](https://github.com/RedRing2020/RedRing/issues/319)
+
+## 1. 目的
+
+- Transformの共通責務を `geo_core` に統一する
+- 形状固有のTransform実装を `geo_primitives` / `geo_nurbs` に明確化する
+- `geo_foundation` 経由のTransform参照を段階的に除去し、#318の前提を揃える
+
+## 2. 現状調査（Transform実装の依存）
+
+`*_transform.rs` の棚卸し結果:
+
+- `model/geo_primitives/src/*_transform.rs`: 32ファイル
+- `model/geo_nurbs/src/*_transform.rs`: 3ファイル
+- 合計35ファイルすべてで `geo_foundation` 参照あり
+
+代表的な参照パターン:
+
+- `AnalysisTransform2D` / `AnalysisTransform3D`
+- `TransformError`
+- `AnalysisTransformSupport`
+
+## 3. 実施方針
+
+### 3.1 2層ルール
+
+- 共通ルール（trait定義/エラー/共通変換核）: `geo_core`
+- 形状適用（各形状の変換実装）: `geo_primitives` / `geo_nurbs`
+- クロス形状演算: `geo_algorithms`（本Issueでは対象外）
+
+### 3.2 変更方針
+
+- 先に import 参照を `geo_core` 基準に切り替える
+- 変換アルゴリズム本体は極力維持して、責務境界の整理を優先する
+- 破壊的変更は許容するが、1PRあたりの差分は小さく分割する
+
+## 4. 段階タスク（推奨）
+
+### Phase A: NURBS側のTransform切替（小PR）
+
+- [ ] `curve_2d_transform.rs` / `curve_3d_transform.rs` / `surface_3d_transform.rs` の `AnalysisTransform*` と `TransformError` を `geo_core` 参照へ切替
+- [ ] `cargo check -p geo_nurbs`
+- [ ] `cargo test -p geo_nurbs`
+
+### Phase B: Primitives側のTransform切替（中PR）
+
+- [ ] `model/geo_primitives/src/*_transform.rs`（32ファイル）の `AnalysisTransform*` / `AnalysisTransformSupport` / `TransformError` を `geo_core` 基準へ切替
+- [ ] 既存テストの import 置換
+- [ ] `cargo check -p geo_primitives`
+- [ ] `cargo test -p geo_primitives`
+
+### Phase C: 呼び出し側と公開APIの整理（小PR）
+
+- [ ] `geo_primitives` / `geo_nurbs` の `lib.rs` 再エクスポートを `geo_core` 基準へ更新
+- [ ] `README` とサンプルのTransform importを更新
+- [ ] 互換コメント/旧経路注記の整理
+
+### Phase D: ワークスペース検証（小PR）
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo check --workspace`
+- [ ] `cargo test --workspace`
+- [ ] `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\check_architecture_dependencies.ps1 -ExitOnError`
+
+## 5. スコープ外（本Issueではやらない）
+
+- `geo_foundation` 全廃（#318で実施）
+- `geo_commons` 分解移管（#320で実施）
+- `geo_algorithms` の責務再編そのもの
+
+## 6. リスクと対策
+
+- リスク: import切替で trait 境界が崩れ、大量コンパイルエラーが発生
+  - 対策: Phase Aで3ファイル先行し、切替パターンを固定してからPhase Bへ展開
+
+- リスク: `AnalysisTransformSupport` 実装漏れでAPI互換が壊れる
+  - 対策: `impl AnalysisTransformSupport` の存在確認を機械検索で実施
+
+- リスク: READMEやサンプルだけ古い import のまま残る
+  - 対策: Phase Cで `rg "geo_foundation::AnalysisTransform|geo_foundation::TransformError"` を最終チェック
+
+## 7. 完了条件（#319）
+
+- [ ] `geo_primitives` / `geo_nurbs` のTransform実装が `geo_core` のTransform trait/エラー参照で統一
+- [ ] Transform共通責務が `geo_core` に集約されている
+- [ ] ワークスペースの `fmt/check/test` と依存チェックスクリプトが通る
+
+## 8. 調査追記（2026-03-16）
+
+### 8.1 実装現況の確認結果
+
+- `geo_nurbs` / `geo_primitives` の Transform 実装は `geo_core` の `AnalysisTransform*` / `TransformError` 参照へ移行済み
+- 検証結果:
+  - `cargo check -p geo_nurbs`: pass
+  - `cargo test -p geo_nurbs`: pass
+  - `cargo check -p geo_primitives`: pass
+  - `cargo test -p geo_primitives`: pass
+  - `scripts/check_architecture_dependencies.ps1 -ExitOnError`: pass
+
+### 8.2 将来リファクタに向けた共通化候補（`geo_core`）
+
+- 2D/3D の行列生成ヘルパー（translation/rotation/scale）
+- 変換前バリデーション（ゼロスケール/ゼロ軸のガード）
+- 複合変換の行列組み立て（`apply_composite_transform` の共通核）
+- 同次座標変換の安全適用（`w == 0` ガードを含む）
+- `TransformError` のメッセージ規約と生成パターン
+
+### 8.3 共通化しない方針（各形状に残す）
+
+- 形状意味に依存する制約（例: 非一様スケール可否）
+- 形状固有の再構築ロジック（半径/法線/ノット/次数などの更新）
+- 形状固有の妥当性判定と補正
+
+### 8.4 判断ルール（明文化）
+
+- 3形状以上で同一意味・同一挙動・同一エラーモデルが成立するものだけ共通化する
+- 上記条件を満たさないものは重複を許容し、形状実装側に残す
+- 本Issueでは「全面抽象化」は行わず、「必要最小限の共通化」に限定する

--- a/dev/architecture/ISSUE_320_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_320_IMPLEMENTATION_PREP.md
@@ -1,0 +1,102 @@
+# Issue #320 実施準備チェックリスト
+
+対象Issue: [#320 geo_commons廃止: analysis/geo_algorithms への分解移管](https://github.com/RedRing2020/RedRing/issues/320)
+
+## 1. 目的
+
+- `geo_commons` を廃止して中間層を削減する
+- `analysis` を「形状を含まない純粋数値計算」に限定する
+- 形状を含む計算（面積/体積/距離/近似）を `geo_*` 側へ移管する
+
+## 2. 現状調査（2026-03-16）
+
+依存:
+
+- `model/geo_foundation/Cargo.toml` のみが `geo_commons` に依存
+
+参照元:
+
+- 実コード参照は `geo_foundation` 経由が中心
+- 主な参照箇所:
+  - `model/geo_foundation/src/commons/mod.rs`
+  - `model/geo_foundation/src/commons/ellipse_calculation_traits.rs`
+  - `model/geo_foundation/src/geometry/core/linesegment_traits.rs`
+
+公開関数（24件）:
+
+- `approximations/ellipse.rs` : 8件
+- `approximations/curves.rs` : 3件
+- `metrics/area_volume.rs` : 8件
+- `metrics/distance.rs` : 5件
+
+## 3. 移管方針（更新）
+
+`analysis` の責務（形状を含まない）:
+
+- 線形代数
+- 数値積分
+- 方程式ソルバー
+- 汎用数学ユーティリティ
+
+`geo_*` 側へ移管（形状を含む計算）:
+
+- `metrics::area_volume::*`
+- `approximations::ellipse::*`
+- `approximations::curves::*`
+- `metrics::distance::*`
+  - `ellipse_2d_distance_to_point`
+  - `ellipse_3d_distance_to_point`
+  - `sphere_to_infinite_line_distance`
+  - `sphere_to_ray_distance`
+  - `sphere_to_line_segment_distance`
+  - `line_segment_to_aabb_distance`
+
+## 4. 段階タスク（推奨）
+
+### Phase A: API棚卸し確定（小PR）
+
+- [x] `geo_commons` 公開関数一覧と依存参照を確定
+- [x] `analysis` / `geo_algorithms` への分類方針を確定
+
+### Phase B: analysis移管（中PR）
+
+- [ ] `metrics::area_volume::*` を `geo_algorithms` へ移管
+- [ ] `approximations::*` を `geo_algorithms` へ移管
+- [ ] `geo_foundation` 側ブリッジを `geo_algorithms` 基準へ切替
+- [ ] `cargo check -p geo_algorithms -p geo_foundation`
+- [ ] `cargo test -p geo_algorithms -p geo_foundation`
+
+### Phase C: analysis責務の整理（小PR）
+
+- [ ] 形状を含む関数が `analysis` に混入していないことを確認
+- [ ] 必要なら `geo_algorithms` で数値基盤（積分/solver）を利用する薄いヘルパーを整理
+- [ ] `cargo check -p analysis -p geo_algorithms`
+
+### Phase D: geo_commons撤去（小PR）
+
+- [ ] `geo_foundation` の `geo_commons` 依存を削除
+- [ ] `model/geo_commons` クレートを削除
+- [ ] ワークスペース参照と依存ルールを更新
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo check --workspace`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace`
+- [ ] `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\check_architecture_dependencies.ps1 -ExitOnError`
+
+## 5. リスクと対策
+
+- リスク: `geo_foundation` の再エクスポート互換が壊れる
+  - 対策: Phase Bで呼び出し側importを先に置換し、最後に `geo_commons` を削除
+
+- リスク: `analysis` にドメイン依存コードが混入する
+  - 対策: `analysis` には形状意味を持つ関数を置かない
+
+- リスク: `geo_algorithms` へ移管後に依存境界違反
+  - 対策: 移管PRごとに依存チェックスクリプトを実行する
+
+## 6. 完了条件（#320）
+
+- [ ] ワークスペースから `geo_commons` 依存が消える
+- [ ] `analysis` は形状を含まない純粋数値計算のみを保持
+- [ ] 面積/体積/近似/距離など形状計算は `geo_*` 側（`geo_algorithms`中心）に集約
+- [ ] ワークスペース全体の `fmt/check/clippy/test` と依存チェックが通る

--- a/dev/architecture/issues/2026-03-geometry-refactor-02-transform-two-layer.md
+++ b/dev/architecture/issues/2026-03-geometry-refactor-02-transform-two-layer.md
@@ -1,0 +1,54 @@
+## 概要
+
+Transform責務を2層化する。
+
+- 共通変換核: `geo_core`
+- 形状ごとのTransform API/実装: `geo_primitives` / `geo_nurbs`
+
+## 背景
+
+- Transform 実装が分散しており、重複と境界の曖昧さがある
+- `geo_algorithms` はクロス形状演算に集中させ、形状固有Transform責務は持たせない
+
+## タスク
+
+### Phase A: NURBS先行切替
+
+- [ ] `curve_2d_transform.rs` / `curve_3d_transform.rs` / `surface_3d_transform.rs` の `AnalysisTransform*` と `TransformError` を `geo_core` 参照へ切替
+- [ ] `cargo check -p geo_nurbs`
+- [ ] `cargo test -p geo_nurbs`
+
+### Phase B: Primitives展開
+
+- [ ] `model/geo_primitives/src/*_transform.rs`（32ファイル）の `AnalysisTransform*` / `AnalysisTransformSupport` / `TransformError` を `geo_core` 基準へ切替
+- [ ] 既存テストの import 置換
+- [ ] `cargo check -p geo_primitives`
+- [ ] `cargo test -p geo_primitives`
+
+### Phase C: 呼び出し側整理
+
+- [ ] `geo_primitives` / `geo_nurbs` の `lib.rs` 再エクスポートを `geo_core` 基準へ更新
+- [ ] README / examples の Transform import を更新
+- [ ] 旧経路コメントや暫定注記を整理
+
+### Phase D: 全体検証
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo check --workspace`
+- [ ] `cargo test --workspace`
+- [ ] `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\check_architecture_dependencies.ps1 -ExitOnError`
+
+## 受け入れ条件
+
+- [ ] Transform共通核（trait/エラー/共通変換核）が `geo_core` に集約されている
+- [ ] 形状固有Transformが `geo_primitives` / `geo_nurbs` から利用できる
+- [ ] Transform実装35ファイル（Primitives 32 + NURBS 3）の参照が `geo_core` 基準に統一されている
+- [ ] `cargo fmt --all -- --check` が通る
+- [ ] `cargo check --workspace` が通る
+- [ ] `cargo test --workspace` が通る
+- [ ] 依存チェックスクリプトが通る
+
+## 備考
+
+- API変更は破壊的でよい（移行優先）
+- `geo_foundation` 全廃自体は #318 のスコープで扱う

--- a/dev/architecture/issues/2026-03-geometry-refactor-03-retire-geo-commons.md
+++ b/dev/architecture/issues/2026-03-geometry-refactor-03-retire-geo-commons.md
@@ -1,0 +1,57 @@
+## 概要
+
+`geo_commons` を廃止し、責務を `analysis` と `geo_algorithms` に分解移管する。
+
+## 背景
+
+- `geo_commons` が中間層として残っており、責務と依存が追いにくい
+- `geo_foundation` 廃止と同時に構成を単純化したい
+
+## タスク
+
+### Phase A: API棚卸し
+
+- [x] `geo_commons` 公開関数24件を棚卸し
+- [x] `analysis` / `geo_algorithms` への分類方針を確定
+- [x] 依存元クレート（現状: `geo_foundation` のみ）を確認
+
+### Phase B: analysis移管
+
+- [ ] `metrics::area_volume::*` を `geo_algorithms` へ移管
+- [ ] `approximations::*` を `geo_algorithms` へ移管
+- [ ] `geo_foundation` 側の参照を `geo_algorithms` 基準へ切替
+- [ ] `cargo check -p geo_algorithms -p geo_foundation`
+- [ ] `cargo test -p geo_algorithms -p geo_foundation`
+
+### Phase C: geo_algorithms移管
+
+- [ ] `analysis` には形状を含む関数を残さないことを確認
+- [ ] 必要なら `geo_algorithms` 側で数値基盤ヘルパーを整理
+- [ ] `cargo check -p analysis -p geo_algorithms`
+
+### Phase D: geo_commons撤去
+
+- [ ] `geo_foundation` の `geo_commons` 依存を削除
+- [ ] `model/geo_commons` クレートを削除
+- [ ] ワークスペース参照/依存ルールを更新
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo check --workspace`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace`
+- [ ] `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\check_architecture_dependencies.ps1 -ExitOnError`
+
+## 受け入れ条件
+
+- [ ] ワークスペースに `geo_commons` 依存が存在しない
+- [ ] `analysis` は形状を含まない純粋数値計算のみを保持
+- [ ] 面積/体積/近似/距離を含む形状計算は `geo_*` 側に集約されている
+- [ ] 移管後APIで既存利用箇所がビルド通過
+- [ ] `cargo fmt --all -- --check` が通る
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` が通る
+- [ ] `cargo check --workspace` が通る
+- [ ] `cargo test --workspace` が通る
+
+## 備考
+
+- 分割移管の途中で中間PRを許容する
+- 実施詳細は `dev/architecture/ISSUE_320_IMPLEMENTATION_PREP.md` を参照

--- a/dev/architecture/issues/2026-03-geometry-refactor-04-retire-geo-foundation.md
+++ b/dev/architecture/issues/2026-03-geometry-refactor-04-retire-geo-foundation.md
@@ -1,0 +1,33 @@
+## 概要
+
+`geo_foundation` を廃止し、**形状定義専用クレート**を新設する。
+
+- 形状定義（trait/契約）: 新クレート（`geo_contracts`）
+- 形状実装: `geo_primitives` / `geo_nurbs`
+
+## 背景
+
+- 形状定義と実装を分離して責務を明確化したい
+- `geo_primitives` / `geo_nurbs` は実装クレートとして整理したい
+- 旧 `geo_foundation` の責務集中を解消したい
+
+## タスク
+
+- [ ] 新クレート `geo_contracts` を作成し、形状trait/契約を移設
+- [ ] `geo_primitives` / `geo_nurbs` で各traitを実装
+- [ ] 参照側 import を `geo_contracts` 基準へ置換
+- [ ] `geo_foundation` の互換層を段階削除
+- [ ] 最終的に `geo_foundation` クレートを削除
+
+## 受け入れ条件
+
+- [ ] 形状定義の正規参照先が `geo_contracts` へ一本化されている
+- [ ] `geo_primitives` / `geo_nurbs` は実装責務に限定される
+- [ ] `geo_foundation` なしでワークスペースがビルド可能
+- [ ] `cargo check --workspace` が通る
+- [ ] `cargo test --workspace` が通る
+- [ ] 依存チェックスクリプトが通る
+
+## 備考
+
+- 破壊的変更許容を前提に進める


### PR DESCRIPTION
## 概要
- Geometryレイヤ再編（#319/#320/#318）に向けた検討結果をドキュメントとして追加
- #319 の調査結果と、共通化/非共通化の判断基準を明文化
- Issue下書き（#319, #320, #318対応）とアーキテクチャ方針更新を反映

## 変更ファイル
- dev/architecture/ARCHITECTURE.md
- dev/architecture/GEOMETRY_REFACTOR_ISSUE_DRAFT.md
- dev/architecture/ISSUE_319_IMPLEMENTATION_PREP.md
- dev/architecture/ISSUE_320_IMPLEMENTATION_PREP.md
- dev/architecture/issues/2026-03-geometry-refactor-02-transform-two-layer.md
- dev/architecture/issues/2026-03-geometry-refactor-03-retire-geo-commons.md
- dev/architecture/issues/2026-03-geometry-refactor-04-retire-geo-foundation.md

## 補足
- 本PRは実装変更ではなく、Issue検討後の方針整理・調査記録の追加です。