### PR TITLE
chore(geo): introduce geo_contracts crate as #318 groundwork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,6 +700,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo_contracts"
+version = "0.1.0"
+dependencies = [
+ "analysis",
+]
+
+[[package]]
 name = "geo_core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "foundation/analysis",  # Foundation層：数値解析クレート（ドメイン非依存基盤）
   "foundation/logging_foundation", # Foundation層：ログ初期化・レート制御基盤
   "model/geo_foundation", # Model層：幾何計算基盤（抽象型・橋渡し）
+  "model/geo_contracts",  # Model層：幾何形状契約（trait定義）
   "model/geo_core",       # Model層：幾何計算基盤
   "model/geo_primitives", # Model層：幾何プリミティブクレート
   "model/geo_algorithms", # Model層：幾何アルゴリズムクレート

--- a/dev/architecture/issues/2026-03-geometry-refactor-04-retire-geo-foundation.md
+++ b/dev/architecture/issues/2026-03-geometry-refactor-04-retire-geo-foundation.md
@@ -13,7 +13,7 @@
 
 ## タスク
 
-- [ ] 新クレート `geo_contracts` を作成し、形状trait/契約を移設
+- [x] 新クレート `geo_contracts` を作成（trait/契約の移設は継続）
 - [ ] `geo_primitives` / `geo_nurbs` で各traitを実装
 - [ ] 参照側 import を `geo_contracts` 基準へ置換
 - [ ] `geo_foundation` の互換層を段階削除

--- a/model/geo_contracts/Cargo.toml
+++ b/model/geo_contracts/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "geo_contracts"
+version = "0.1.0"
+edition = "2021"
+description = "Shape contract definitions for geometric model crates"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+analysis = { path = "../../foundation/analysis" }
+

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -1,0 +1,7 @@
+//! geo_contracts - shape contract definitions.
+//!
+//! This crate will host geometry-facing contracts that are shared across
+//! `geo_primitives`, `geo_nurbs`, and higher-level algorithm crates.
+
+pub use analysis::abstract_types::{Angle, Scalar};
+

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -4,4 +4,3 @@
 //! `geo_primitives`, `geo_nurbs`, and higher-level algorithm crates.
 
 pub use analysis::abstract_types::{Angle, Scalar};
-

--- a/scripts/check_architecture_dependencies.ps1
+++ b/scripts/check_architecture_dependencies.ps1
@@ -18,6 +18,7 @@ $ARCHITECTURE_RULES = @{
 
         # Model: geo_*
         geo_foundation = @("analysis", "geo_commons")
+        geo_contracts  = @("analysis")
         geo_commons    = @("geo_foundation", "analysis")
         geo_core       = @("analysis", "geo_entity") # geo_core -> geo_entity: OK
         geo_primitives = @("geo_foundation", "geo_core", "analysis")
@@ -46,6 +47,7 @@ $ARCHITECTURE_RULES = @{
     ForbiddenDependencies = @{
         # geo_* -> cam_* is forbidden
         geo_foundation = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
+        geo_contracts  = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "job_runtime", "converter", "graphics", "render", "stage", "app")
         geo_commons    = @("converter", "graphics", "render", "stage", "app", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "cam_core", "cam_entity", "cam_sim", "job_runtime")
         geo_core       = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime") # geo_core -> cam_entity: NG
         geo_primitives = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
@@ -76,7 +78,7 @@ $ARCHITECTURE_RULES = @{
 
     NamingRules = @{
         ModelPrefix = "geo_"
-        RequiredModelCrates = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity")
+        RequiredModelCrates = @("geo_foundation", "geo_contracts", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity")
     }
 }
 
@@ -117,6 +119,7 @@ function Get-WorkspaceCrates {
     $layerMapping = @{
         analysis       = "foundation/analysis"
         geo_foundation = "model/geo_foundation"
+        geo_contracts  = "model/geo_contracts"
         geo_commons    = "model/geo_commons"
         geo_core       = "model/geo_core"
         geo_primitives = "model/geo_primitives"
@@ -204,7 +207,7 @@ function Test-ArchitectureDependencies {
     Write-Info "3. Layer Dependency Summary"
     $layers = @{
         Analysis  = @("analysis")
-        Model     = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "job_runtime", "job_domain")
+        Model     = @("geo_foundation", "geo_contracts", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "job_runtime", "job_domain")
         ViewModel = @("converter", "graphics")
         View      = @("render", "stage", "app")
     }


### PR DESCRIPTION
## 概要
- #318 の着手として geo_contracts クレートを新設
- workspace と依存チェックスクリプトに geo_contracts を登録
- #318 進行メモ（retire geo_foundation）に初期ステップ完了を反映

## 変更内容
- model/geo_contracts を追加（初期API: Angle / Scalar の再公開）
- Cargo.toml workspace members へ model/geo_contracts を追加
- scripts/check_architecture_dependencies.ps1 に geo_contracts のルール/マッピングを追加
- dev/architecture/issues/2026-03-geometry-refactor-04-retire-geo-foundation.md のタスク進捗更新

## 検証
- cargo check -p geo_contracts
- powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\check_architecture_dependencies.ps1 -ExitOnError

## 備考
本PRは #318 の第一段階（土台作り）です。trait/契約の本移設は後続PRで段階的に実施します。