### PR TITLE
refactor(geo_nurbs): migrate Scalar imports to geo_contracts

### DIFF
--- a/model/geo_nurbs/src/curve_3d_extensions.rs
+++ b/model/geo_nurbs/src/curve_3d_extensions.rs
@@ -5,8 +5,8 @@ use crate::adaptive_tessellation::{
     NurbsCurveAdaptiveTessellation,
 };
 use crate::NurbsCurve3D;
+use geo_contracts::Scalar;
 use geo_core::{Aabb3D, Point3D};
-use geo_foundation::Scalar;
 
 /// 境界ボックス計算オプション
 #[derive(Debug, Clone, Copy)]

--- a/model/geo_nurbs/src/curve_3d_foundation.rs
+++ b/model/geo_nurbs/src/curve_3d_foundation.rs
@@ -1,8 +1,9 @@
 //! `NurbsCurve3D` の Foundation パターン実装
 
 use crate::NurbsCurve3D;
+use geo_contracts::Scalar;
 use geo_core::{Aabb3D, Point3D};
-use geo_foundation::{Bounded, ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_foundation::{Bounded, ExtensionFoundation, PrimitiveKind};
 
 impl<T: Scalar> ExtensionFoundation<T> for NurbsCurve3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {

--- a/model/geo_nurbs/src/knot.rs
+++ b/model/geo_nurbs/src/knot.rs
@@ -1,7 +1,7 @@
 //! ノットベクトル操作とバリデーション
 
 use crate::{NurbsError, Result};
-use geo_foundation::Scalar;
+use geo_contracts::Scalar;
 
 /// ノットベクトルの型エイリアス
 pub type KnotVector<T> = Vec<T>;


### PR DESCRIPTION
## 概要
- #318 の次フェーズとして、`geo_nurbs` で `Scalar` の参照先を `geo_foundation` から `geo_contracts` へ移行
- 対象は NURBS 側の基礎/拡張/ノット処理の3ファイル

## 変更ファイル
- `model/geo_nurbs/src/curve_3d_extensions.rs`
- `model/geo_nurbs/src/curve_3d_foundation.rs`
- `model/geo_nurbs/src/knot.rs`

## 検証
- `cargo fmt --all -- --check`
- `cargo check -p geo_nurbs`
- `cargo test -p geo_nurbs`
