### PR TITLE
refactor(geo_primitives): migrate direction Angle/Scalar to geo_contr…

### DIFF
--- a/model/geo_primitives/src/direction_2d.rs
+++ b/model/geo_primitives/src/direction_2d.rs
@@ -5,9 +5,9 @@
 
 use crate::Vector2D;
 use analysis::linalg::vector::Vector2;
-use geo_foundation::{
-    core::direction_traits::{Direction2DConstructor, Direction2DMeasure, Direction2DProperties},
-    Scalar,
+use geo_contracts::Scalar;
+use geo_foundation::core::direction_traits::{
+    Direction2DConstructor, Direction2DMeasure, Direction2DProperties,
 };
 use std::ops::{Deref, DerefMut};
 

--- a/model/geo_primitives/src/direction_2d_extensions.rs
+++ b/model/geo_primitives/src/direction_2d_extensions.rs
@@ -4,7 +4,7 @@
 //! Core機能は direction_2d.rs を参照
 
 use crate::Direction2D;
-use geo_foundation::Scalar;
+use geo_contracts::{Angle, Scalar};
 
 // ============================================================================
 // Extension Methods (Coreにない新機能のみ)
@@ -47,11 +47,7 @@ impl<T: Scalar> Direction2D<T> {
     }
 
     /// Angle型を使用した方向判定（角度またはラジアン指定可能）
-    pub fn is_same_direction_within_angle(
-        &self,
-        other: &Self,
-        angle_tolerance: geo_foundation::Angle<T>,
-    ) -> bool {
+    pub fn is_same_direction_within_angle(&self, other: &Self, angle_tolerance: Angle<T>) -> bool {
         let angle_diff = self.angle_between(other);
         angle_diff <= angle_tolerance.to_radians()
     }
@@ -60,7 +56,7 @@ impl<T: Scalar> Direction2D<T> {
     pub fn is_opposite_direction_within_angle(
         &self,
         other: &Self,
-        angle_tolerance: geo_foundation::Angle<T>,
+        angle_tolerance: Angle<T>,
     ) -> bool {
         let angle_diff = self.angle_between(other);
         // πラジアン（180度）に近いかを判定

--- a/model/geo_primitives/src/direction_2d_extensions_tests.rs
+++ b/model/geo_primitives/src/direction_2d_extensions_tests.rs
@@ -61,7 +61,7 @@ mod tests {
         let dir2 = Direction2D::from_angle_radians(0.001); // 0.001ラジアン ≈ 0.057度の誤差
 
         // 新しいAngle型を使用したAPI（推奨）
-        use geo_foundation::Angle;
+        use geo_contracts::Angle;
 
         // ラジアン指定での角度許容誤差
         assert!(dir1.is_same_direction_within_angle(&dir2, Angle::from_radians(0.002))); // 0.002ラジアン許容誤差
@@ -83,7 +83,7 @@ mod tests {
         let right = Direction2D::<TestType>::positive_x();
         let left = Direction2D::<TestType>::negative_x();
 
-        use geo_foundation::Angle;
+        use geo_contracts::Angle;
         assert!(right.is_opposite_direction_within_angle(&left, Angle::from_degrees(1.0)));
     }
 
@@ -111,7 +111,7 @@ mod tests {
     #[test]
     fn test_angle_api_usage_examples() {
         // 新しいAngle型APIの使用例をテスト
-        use geo_foundation::Angle;
+        use geo_contracts::Angle;
 
         let dir1 = Direction2D::<TestType>::positive_x();
         let dir2 = Direction2D::from_angle_radians(0.017453); // 約1度の誤差

--- a/model/geo_primitives/src/direction_3d.rs
+++ b/model/geo_primitives/src/direction_3d.rs
@@ -3,7 +3,7 @@
 //! 3次元方向ベクトルの基本実装とコンストラクタ、アクセサメソッド
 
 use crate::Vector3D;
-use geo_foundation::Scalar;
+use geo_contracts::Scalar;
 use std::ops::{Deref, DerefMut, Mul, Neg};
 
 /// 3次元方向ベクトル（正規化済み）

--- a/model/geo_primitives/src/direction_3d_extensions.rs
+++ b/model/geo_primitives/src/direction_3d_extensions.rs
@@ -4,7 +4,7 @@
 //! Core機能は direction_3d.rs を参照
 
 use crate::{Direction3D, Vector3D};
-use geo_foundation::{Angle, Scalar};
+use geo_contracts::{Angle, Scalar};
 
 // ============================================================================
 // Core trait implementations (moved from core)

--- a/model/geo_primitives/src/direction_3d_extensions_tests.rs
+++ b/model/geo_primitives/src/direction_3d_extensions_tests.rs
@@ -5,7 +5,7 @@
 #[cfg(test)]
 mod tests {
     use crate::{Direction3D, Vector3D};
-    use geo_foundation::Scalar;
+    use geo_contracts::Scalar;
 
     type TestType = f64;
 
@@ -40,7 +40,7 @@ mod tests {
         let dir2 = Direction3D::new(small_error.cos(), small_error.sin(), 0.0).unwrap();
 
         // 新しいAngle型を使用したAPI（推奨）
-        use geo_foundation::Angle;
+        use geo_contracts::Angle;
 
         // ラジアン指定での角度許容誤差
         assert!(dir1.is_same_direction_within_angle(&dir2, Angle::from_radians(0.002))); // 0.002ラジアン許容誤差
@@ -64,7 +64,7 @@ mod tests {
         let positive_x = Direction3D::<TestType>::positive_x();
         let negative_x = Direction3D::<TestType>::negative_x();
 
-        use geo_foundation::Angle;
+        use geo_contracts::Angle;
         assert!(
             positive_x.is_opposite_direction_within_angle(&negative_x, Angle::from_degrees(1.0))
         );


### PR DESCRIPTION
## 概要
- #318 の次フェーズとして、Direction 系で `Angle` / `Scalar` の参照を `geo_foundation` から `geo_contracts` へ移行
- `geo_foundation` の direction trait 参照は維持しつつ、基礎型の依存を段階的に縮小

## 変更ファイル
- `model/geo_primitives/src/direction_2d.rs`
- `model/geo_primitives/src/direction_3d.rs`
- `model/geo_primitives/src/direction_2d_extensions.rs`
- `model/geo_primitives/src/direction_3d_extensions.rs`
- `model/geo_primitives/src/direction_2d_extensions_tests.rs`
- `model/geo_primitives/src/direction_3d_extensions_tests.rs`

## 検証
- `cargo fmt --all -- --check`
- `cargo check -p geo_primitives`
- `cargo test -p geo_primitives direction_`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check_architecture_dependencies.ps1 -ExitOnError`
