### PR TITLE
refactor(geo_primitives): migrate linear Angle/Scalar imports to geo_…

### DIFF
--- a/model/geo_primitives/src/infinite_line_2d.rs
+++ b/model/geo_primitives/src/infinite_line_2d.rs
@@ -3,7 +3,7 @@
 //! Foundation統一システムに基づくInfiniteLine2Dの必須機能のみ
 
 use crate::{Direction2D, Point2D, Vector2D};
-use geo_foundation::Scalar;
+use geo_contracts::Scalar;
 
 /// 2次元無限直線（Core実装）
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/model/geo_primitives/src/infinite_line_2d_extensions.rs
+++ b/model/geo_primitives/src/infinite_line_2d_extensions.rs
@@ -3,7 +3,8 @@
 //! Extension Foundation パターンに基づく InfiniteLine2D の拡張実装
 
 use crate::{InfiniteLine2D, Point2D, Vector2D};
-use geo_foundation::{tolerance_migration::DefaultTolerances, Angle, Scalar};
+use geo_contracts::{Angle, Scalar};
+use geo_foundation::tolerance_migration::DefaultTolerances;
 
 // ============================================================================
 // Extension Methods Implementation

--- a/model/geo_primitives/src/infinite_line_2d_foundation.rs
+++ b/model/geo_primitives/src/infinite_line_2d_foundation.rs
@@ -3,7 +3,8 @@
 //! ExtensionFoundation トレイトの実装
 
 use crate::InfiniteLine2D;
-use geo_foundation::{ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::Scalar;
+use geo_foundation::{ExtensionFoundation, PrimitiveKind};
 
 impl<T: Scalar> ExtensionFoundation<T> for InfiniteLine2D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {

--- a/model/geo_primitives/src/infinite_line_3d_extensions.rs
+++ b/model/geo_primitives/src/infinite_line_3d_extensions.rs
@@ -3,7 +3,7 @@
 //! Extension Foundation パターンに基づく InfiniteLine3D の拡張実装
 
 use crate::{Direction3D, InfiniteLine3D, Point2D, Point3D, Vector2D, Vector3D};
-use geo_foundation::Scalar;
+use geo_contracts::Scalar;
 
 // ============================================================================
 // Extension Methods Implementation

--- a/model/geo_primitives/src/infinite_line_3d_foundation.rs
+++ b/model/geo_primitives/src/infinite_line_3d_foundation.rs
@@ -3,7 +3,8 @@
 //! ExtensionFoundation トレイトの実装
 
 use crate::InfiniteLine3D;
-use geo_foundation::{ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::Scalar;
+use geo_foundation::{ExtensionFoundation, PrimitiveKind};
 
 impl<T: Scalar> ExtensionFoundation<T> for InfiniteLine3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {

--- a/model/geo_primitives/src/line_segment_2d_foundation.rs
+++ b/model/geo_primitives/src/line_segment_2d_foundation.rs
@@ -3,7 +3,8 @@
 //! ExtensionFoundation トレイトの実装
 
 use crate::LineSegment2D;
-use geo_foundation::{ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::Scalar;
+use geo_foundation::{ExtensionFoundation, PrimitiveKind};
 
 impl<T: Scalar> ExtensionFoundation<T> for LineSegment2D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {

--- a/model/geo_primitives/src/line_segment_2d_tests.rs
+++ b/model/geo_primitives/src/line_segment_2d_tests.rs
@@ -1,7 +1,8 @@
 //! LineSegment2D のテスト
 
 use crate::{LineSegment2D, Point2D, Vector2D};
-use geo_foundation::{core_foundation::*, Angle, Scalar};
+use geo_contracts::{Angle, Scalar};
+use geo_foundation::core_foundation::*;
 
 // BasicTransformの実装を有効にするため
 #[allow(unused_imports)]

--- a/model/geo_primitives/src/line_segment_3d_extensions.rs
+++ b/model/geo_primitives/src/line_segment_3d_extensions.rs
@@ -4,7 +4,8 @@
 //! Core機能は line_segment_3d.rs を参照
 
 use crate::{LineSegment3D, Point3D, Vector3D};
-use geo_foundation::{core_foundation::*, Scalar};
+use geo_contracts::Scalar;
+use geo_foundation::core_foundation::*;
 
 // ============================================================================
 // Core trait implementations

--- a/model/geo_primitives/src/line_segment_3d_foundation.rs
+++ b/model/geo_primitives/src/line_segment_3d_foundation.rs
@@ -3,7 +3,8 @@
 //! ExtensionFoundation トレイトの実装
 
 use crate::LineSegment3D;
-use geo_foundation::{ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::Scalar;
+use geo_foundation::{ExtensionFoundation, PrimitiveKind};
 
 impl<T: Scalar> ExtensionFoundation<T> for LineSegment3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {

--- a/model/geo_primitives/src/ray_2d_extensions.rs
+++ b/model/geo_primitives/src/ray_2d_extensions.rs
@@ -4,7 +4,7 @@
 //! Core Foundation では提供しない拡張機能のみ
 
 use crate::{Direction2D, InfiniteLine2D, LineSegment2D, Point2D, Ray2D, Vector2D};
-use geo_foundation::{Angle, Scalar};
+use geo_contracts::{Angle, Scalar};
 
 impl<T: Scalar> Ray2D<T> {
     // === 特殊作成メソッド ===

--- a/model/geo_primitives/src/ray_2d_foundation.rs
+++ b/model/geo_primitives/src/ray_2d_foundation.rs
@@ -3,7 +3,8 @@
 //! ExtensionFoundation トレイトの実装
 
 use crate::Ray2D;
-use geo_foundation::{ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::Scalar;
+use geo_foundation::{ExtensionFoundation, PrimitiveKind};
 
 impl<T: Scalar> ExtensionFoundation<T> for Ray2D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {

--- a/model/geo_primitives/src/ray_3d_extensions.rs
+++ b/model/geo_primitives/src/ray_3d_extensions.rs
@@ -4,7 +4,7 @@
 //! Core機能は ray_3d.rs を参照
 
 use crate::{InfiniteLine3D, Point3D, Ray3D, Vector3D};
-use geo_foundation::Scalar;
+use geo_contracts::Scalar;
 
 // ============================================================================
 // Display Implementation

--- a/model/geo_primitives/src/ray_3d_foundation.rs
+++ b/model/geo_primitives/src/ray_3d_foundation.rs
@@ -1,7 +1,8 @@
 //! Ray3D の Foundation トレイト実装
 
 use crate::Ray3D;
-use geo_foundation::{ExtensionFoundation, PrimitiveKind, Scalar, TolerantEq};
+use geo_contracts::Scalar;
+use geo_foundation::{ExtensionFoundation, PrimitiveKind, TolerantEq};
 
 // ============================================================================
 // Foundation Trait Implementation

--- a/model/geo_primitives/src/ray_3d_tests.rs
+++ b/model/geo_primitives/src/ray_3d_tests.rs
@@ -1,7 +1,7 @@
 //! Ray3D テストモジュール
 
 use crate::{Point3D, Ray3D, Vector3D};
-use geo_foundation::Scalar;
+use geo_contracts::Scalar;
 
 // BasicTransformの実装を有効にするため
 #[allow(unused_imports)]


### PR DESCRIPTION
## 概要
- #318 の次フェーズとして、線形プリミティブ群（line/ray/infinite_line）で `Angle` / `Scalar` 参照を `geo_contracts` へ移行
- `geo_foundation` の trait 参照は維持しつつ、基礎型依存のみ段階移行

## 変更ファイル
- `model/geo_primitives/src/infinite_line_2d.rs`
- `model/geo_primitives/src/infinite_line_2d_extensions.rs`
- `model/geo_primitives/src/infinite_line_2d_foundation.rs`
- `model/geo_primitives/src/infinite_line_3d_extensions.rs`
- `model/geo_primitives/src/infinite_line_3d_foundation.rs`
- `model/geo_primitives/src/line_segment_2d_foundation.rs`
- `model/geo_primitives/src/line_segment_2d_tests.rs`
- `model/geo_primitives/src/line_segment_3d_extensions.rs`
- `model/geo_primitives/src/line_segment_3d_found
