### PR TITLE
#318 geo_primitives arc/circleでAngle・Scalar参照をgeo_contractsへ移行

### DIFF
--- a/model/geo_primitives/src/arc_2d_collision.rs
+++ b/model/geo_primitives/src/arc_2d_collision.rs
@@ -4,7 +4,8 @@
 //! Arc2D と他の幾何形状との組み合わせを実装
 
 use crate::{Arc2D, Circle2D, Point2D};
-use geo_foundation::{Arc2DProperties, BasicCollision, Circle2DProperties, Scalar};
+use geo_contracts::Scalar;
+use geo_foundation::{Arc2DProperties, BasicCollision, Circle2DProperties};
 
 // ============================================================================
 // BasicCollision Implementations

--- a/model/geo_primitives/src/arc_2d_extensions.rs
+++ b/model/geo_primitives/src/arc_2d_extensions.rs
@@ -4,7 +4,8 @@
 //! 基本機能は arc_2d.rs を参照
 
 use crate::{arc_2d::Arc2D, Circle2D, Point2D};
-use geo_foundation::{tolerance_migration::DefaultTolerances, Angle, Scalar};
+use geo_contracts::{Angle, Scalar};
+use geo_foundation::tolerance_migration::DefaultTolerances;
 
 impl<T: Scalar> Arc2D<T> {
     // ========================================================================

--- a/model/geo_primitives/src/arc_2d_foundation.rs
+++ b/model/geo_primitives/src/arc_2d_foundation.rs
@@ -3,7 +3,8 @@
 //! ExtensionFoundation トレイトの実装
 
 use crate::Arc2D;
-use geo_foundation::{ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::Scalar;
+use geo_foundation::{ExtensionFoundation, PrimitiveKind};
 
 impl<T: Scalar> ExtensionFoundation<T> for Arc2D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {

--- a/model/geo_primitives/src/arc_2d_metrics.rs
+++ b/model/geo_primitives/src/arc_2d_metrics.rs
@@ -4,7 +4,8 @@
 //! 他の幾何プリミティブでも共通利用可能な抽象化
 
 use crate::Arc2D;
-use geo_foundation::{core::arc_traits::Arc2DMeasure, Angle, Scalar};
+use geo_contracts::{Angle, Scalar};
+use geo_foundation::core::arc_traits::Arc2DMeasure;
 
 // ============================================================================
 // ArcMetrics Trait Implementation
@@ -82,3 +83,4 @@ impl<T: Scalar> Arc2D<T> {
         self.radius_internal() * (T::ONE - half_angle.cos())
     }
 }
+

--- a/model/geo_primitives/src/arc_2d_tests.rs
+++ b/model/geo_primitives/src/arc_2d_tests.rs
@@ -3,7 +3,8 @@
 //! 基本機能のみテスト：作成、アクセサ、基本プロパティ
 
 use crate::{Arc2D, Point2D, Vector2D};
-use geo_foundation::{core::arc_traits::Arc2DMeasure, Arc2DProperties, Angle};
+use geo_contracts::Angle;
+use geo_foundation::{core::arc_traits::Arc2DMeasure, Arc2DProperties};
 
 #[cfg(test)]
 mod tests {
@@ -250,3 +251,4 @@ mod tests {
         assert!((start.y() - 0.0f32).abs() < 1e-6);
     }
 }
+

--- a/model/geo_primitives/src/arc_3d_collision.rs
+++ b/model/geo_primitives/src/arc_3d_collision.rs
@@ -3,7 +3,8 @@
 //! 3次元円弧の衝突判定実装
 
 use crate::{Arc3D, InfiniteLine3D, LineSegment3D, Point3D, Ray3D};
-use geo_foundation::{extensions::BasicCollision, Scalar};
+use geo_contracts::Scalar;
+use geo_foundation::extensions::BasicCollision;
 
 // ============================================================================
 // Arc3D vs Point3D

--- a/model/geo_primitives/src/arc_3d_extensions.rs
+++ b/model/geo_primitives/src/arc_3d_extensions.rs
@@ -3,7 +3,8 @@
 //! 3次元円弧の拡張メソッド：点計算、コンストラクタ、幾何解析など
 
 use crate::{Angle, Arc3D, Direction3D, Point3D, Vector3D};
-use geo_foundation::{tolerance_migration::DefaultTolerances, Scalar};
+use geo_contracts::Scalar;
+use geo_foundation::tolerance_migration::DefaultTolerances;
 
 impl<T: Scalar> Arc3D<T> {
     /// 3点を通る円弧を作成

--- a/model/geo_primitives/src/arc_3d_foundation.rs
+++ b/model/geo_primitives/src/arc_3d_foundation.rs
@@ -1,8 +1,9 @@
 //! Arc3D の Foundation トレイト実装
 
 use crate::Arc3D;
+use geo_contracts::Scalar;
 use geo_core::Aabb3D;
-use geo_foundation::{Bounded, ExtensionFoundation, PrimitiveKind, Scalar, TolerantEq};
+use geo_foundation::{Bounded, ExtensionFoundation, PrimitiveKind, TolerantEq};
 
 // ============================================================================
 // Foundation Trait Implementation
@@ -77,8 +78,8 @@ mod tests {
         let center = Point3D::new(0.0, 0.0, 0.0);
         let normal = Direction3D::from_vector(Vector3D::new(0.0, 0.0, 1.0)).unwrap();
         let start_dir = Direction3D::from_vector(Vector3D::new(1.0, 0.0, 0.0)).unwrap();
-        let start_angle = geo_foundation::Angle::from_radians(0.0);
-        let end_angle = geo_foundation::Angle::from_radians(std::f64::consts::PI);
+        let start_angle = geo_contracts::Angle::from_radians(0.0);
+        let end_angle = geo_contracts::Angle::from_radians(std::f64::consts::PI);
         let arc = Arc3D::new(center, 5.0, normal, start_dir, start_angle, end_angle).unwrap();
 
         assert_eq!(arc.primitive_kind(), PrimitiveKind::Arc);
@@ -95,8 +96,8 @@ mod tests {
         let center = Point3D::new(0.0, 0.0, 0.0);
         let normal = Direction3D::from_vector(Vector3D::new(0.0, 0.0, 1.0)).unwrap();
         let start_dir = Direction3D::from_vector(Vector3D::new(1.0, 0.0, 0.0)).unwrap();
-        let start_angle = geo_foundation::Angle::from_radians(0.0);
-        let end_angle = geo_foundation::Angle::from_radians(std::f64::consts::PI);
+        let start_angle = geo_contracts::Angle::from_radians(0.0);
+        let end_angle = geo_contracts::Angle::from_radians(std::f64::consts::PI);
 
         let arc1 = Arc3D::new(center, 5.0, normal, start_dir, start_angle, end_angle).unwrap();
         let arc2 = Arc3D::new(center, 5.0, normal, start_dir, start_angle, end_angle).unwrap();

--- a/model/geo_primitives/src/arc_3d_intersection.rs
+++ b/model/geo_primitives/src/arc_3d_intersection.rs
@@ -3,7 +3,8 @@
 //! 3次元円弧の交差計算実装
 
 use crate::{Arc3D, InfiniteLine3D, LineSegment3D, Point3D, Ray3D};
-use geo_foundation::{extensions::BasicIntersection, Scalar};
+use geo_contracts::Scalar;
+use geo_foundation::extensions::BasicIntersection;
 
 // ============================================================================
 // Arc3D vs Point3D

--- a/model/geo_primitives/src/arc_3d_tests.rs
+++ b/model/geo_primitives/src/arc_3d_tests.rs
@@ -3,7 +3,8 @@
 //! 基本機能のみテスト：作成、アクセサ、基本プロパティ
 
 use crate::{Arc3D, Point3D, Vector3D};
-use geo_foundation::{core::arc_traits::Arc3DProperties, Angle};
+use geo_contracts::Angle;
+use geo_foundation::core::arc_traits::Arc3DProperties;
 
 #[cfg(test)]
 mod tests {
@@ -234,3 +235,4 @@ mod tests {
         assert!((start.y() - 0.0f32).abs() < 1e-6);
     }
 }
+

--- a/model/geo_primitives/src/circle_2d_extensions.rs
+++ b/model/geo_primitives/src/circle_2d_extensions.rs
@@ -3,7 +3,7 @@
 //! Extension Foundation パターンに基づく Circle2D の拡張実装
 
 use crate::{Circle2D, Point2D, Vector2D};
-use geo_foundation::Scalar;
+use geo_contracts::Scalar;
 
 // ============================================================================
 // Extension Methods Implementation

--- a/model/geo_primitives/src/circle_2d_metrics.rs
+++ b/model/geo_primitives/src/circle_2d_metrics.rs
@@ -1,7 +1,7 @@
 //! Circle2D 計量関連機能（ジェネリック版）
 
 use crate::{Circle2D, Point2D};
-use geo_foundation::Scalar;
+use geo_contracts::Scalar;
 
 impl<T: Scalar> Circle2D<T> {
     /// 直径を取得

--- a/model/geo_primitives/src/circle_3d_collision.rs
+++ b/model/geo_primitives/src/circle_3d_collision.rs
@@ -3,7 +3,8 @@
 //! 3次元円の衝突判定実装
 
 use crate::{Circle3D, InfiniteLine3D, LineSegment3D, Point3D, Ray3D, Vector3D};
-use geo_foundation::{extensions::BasicCollision, Scalar};
+use geo_contracts::Scalar;
+use geo_foundation::extensions::BasicCollision;
 
 // ============================================================================
 // Circle3D vs Point3D

--- a/model/geo_primitives/src/circle_3d_extensions.rs
+++ b/model/geo_primitives/src/circle_3d_extensions.rs
@@ -3,7 +3,8 @@
 //! 3次元円の拡張メソッド：軸取得、点の計算、距離計算、平面基底計算など
 
 use crate::{Circle3D, Direction3D, Point3D, Vector3D};
-use geo_foundation::{tolerance_migration::DefaultTolerances, Scalar};
+use geo_contracts::Scalar;
+use geo_foundation::tolerance_migration::DefaultTolerances;
 
 impl<T: Scalar> Circle3D<T> {
     /// 円平面のU軸（基準軸）を取得

--- a/model/geo_primitives/src/circle_3d_foundation.rs
+++ b/model/geo_primitives/src/circle_3d_foundation.rs
@@ -1,8 +1,9 @@
 //! Circle3D の Foundation トレイト実装
 
 use crate::Circle3D;
+use geo_contracts::Scalar;
 use geo_core::Aabb3D;
-use geo_foundation::{Bounded, ExtensionFoundation, PrimitiveKind, Scalar, TolerantEq};
+use geo_foundation::{Bounded, ExtensionFoundation, PrimitiveKind, TolerantEq};
 
 // ============================================================================
 // Foundation Trait Implementation

--- a/model/geo_primitives/src/circle_3d_intersection.rs
+++ b/model/geo_primitives/src/circle_3d_intersection.rs
@@ -3,7 +3,8 @@
 //! 3次元円の交差計算実装
 
 use crate::{Circle3D, InfiniteLine3D, LineSegment3D, Point3D, Ray3D};
-use geo_foundation::{extensions::BasicIntersection, Scalar};
+use geo_contracts::Scalar;
+use geo_foundation::extensions::BasicIntersection;
 
 // ============================================================================
 // Circle3D vs Point3D

--- a/scripts/check_architecture_dependencies_simple.ps1
+++ b/scripts/check_architecture_dependencies_simple.ps1
@@ -32,7 +32,7 @@ function Get-CrateDependencies {
         if ($inDepsSection -and $line -match '^(\w+)\s*=') {
             $depName = $matches[1]
             # Check if it's a workspace crate
-            $workspaceCrates = @("analysis", "geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "job_runtime", "job_domain", "converter", "graphics", "render", "stage", "app")
+            $workspaceCrates = @("analysis", "geo_contracts", "geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "job_runtime", "job_domain", "converter", "graphics", "render", "stage", "app")
             if ($workspaceCrates -contains $depName) {
                 $dependencies += $depName
             }
@@ -53,6 +53,7 @@ function Test-ArchitectureDependencies {
     # Define workspace structure
     $workspaceCrates = @{
         "analysis"       = "foundation\analysis"
+        "geo_contracts"  = "model\geo_contracts"
         "geo_foundation" = "model\geo_foundation"
         "geo_commons"    = "model\geo_commons"
         "geo_core"       = "model\geo_core"
@@ -72,12 +73,13 @@ function Test-ArchitectureDependencies {
     # Define allowed dependencies (Updated: 2025-12-25)
     $allowedDeps = @{
         "analysis"       = @()
+        "geo_contracts"  = @("analysis")  # analysis の Scalar/Angle を re-export する形状契約クレート
         "geo_foundation" = @("analysis", "geo_commons")  # geo_commons: 共通計算関数を再エクスポート
         "geo_commons"    = @("analysis")  # 独立した計算関数クレート
         "geo_core"       = @("geo_foundation", "analysis")  # トレイト実装 + AABB型
-        "geo_primitives" = @("geo_foundation", "geo_core", "analysis")  # geo_core の AABB型を使用
+        "geo_primitives" = @("geo_foundation", "geo_contracts", "geo_core", "analysis")  # geo_core の AABB型を使用
         "geo_algorithms" = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_nurbs", "analysis")  # 共通計算関数・NURBS衝突判定のため geo_commons, geo_nurbs を追加
-        "geo_nurbs"      = @("geo_foundation", "geo_core", "geo_primitives", "analysis")  # geo_core の AABB型を使用
+        "geo_nurbs"      = @("geo_foundation", "geo_contracts", "geo_core", "geo_primitives", "analysis")  # geo_core の AABB型を使用
         "geo_io"         = @("geo_foundation", "geo_core", "geo_primitives", "geo_algorithms", "analysis")
         "job_runtime"    = @("analysis")
         "job_domain"     = @("analysis", "job_runtime")
@@ -90,7 +92,7 @@ function Test-ArchitectureDependencies {
     }
 
     Write-ColorText "1. Checking Model layer naming rules..." "Yellow"
-    $modelCrates = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io")
+    $modelCrates = @("geo_contracts", "geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io")
     foreach ($crateName in $modelCrates) {
         if (Test-Path $workspaceCrates[$crateName]) {
             Write-ColorText "  OK: $crateName follows geo_ prefix rule" "Green"
@@ -142,7 +144,7 @@ function Test-ArchitectureDependencies {
     Write-ColorText "3. Layer summary:" "Yellow"
     $layers = @{
         "Analysis"  = @("analysis")
-        "Model"     = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "job_runtime", "job_domain")
+        "Model"     = @("geo_contracts", "geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "job_runtime", "job_domain")
         "ViewModel" = @("converter", "graphics")
         "View"      = @("render", "stage", "app")
     }


### PR DESCRIPTION
## 概要
#318の次フェーズとして、geo_primitivesのarc/circle関連でAngle/Scalarの参照元をgeo_foundationからgeo_contractsへ移行しました。

## 変更内容
- rc_2d_*群のAngle/Scalar importをgeo_contractsへ変更
- rc_3d_*群のAngle/Scalar importをgeo_contractsへ変更
- circle_2d_*群のScalar importをgeo_contractsへ変更
- circle_3d_*群のScalar importをgeo_contractsへ変更
- 置換時に発生したimport崩れを修正し、cargo fmtを適用

## 確認項目
- cargo fmt --all -- --check
- cargo check -p geo_primitives
- cargo test -p geo_primitives arc_
- cargo test -p geo_primitives circle_
- ./scripts/check_architecture_dependencies.ps1

## 影響範囲
- 対象はmodel/geo_primitivesのarc/circle関連ファイルのみ
- APIや振る舞い変更はなく、型参照の整理が主目的です
