### PR TITLE
#318 PR-A: contracts骨格 + arc/circle先行切替

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,6 +738,7 @@ name = "geo_foundation"
 version = "0.1.0"
 dependencies = [
  "analysis",
+ "geo_contracts",
 ]
 
 [[package]]

--- a/dev/architecture/ISSUE_318_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_318_IMPLEMENTATION_PREP.md
@@ -314,40 +314,105 @@
 - `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\check_architecture_dependencies_simple.ps1`
 - `rg "geo_foundation::|geo_foundation = \{ path = \"../geo_foundation\" \}" model/ Cargo.toml`
 
-## 6. 最初のPRスコープ（推奨）
+## 6. PR分割（実行計画）
 
-最初の PR は「全面移設」ではなく、以下に限定する。
+`#318` は 3PR で進める。Cross Operation の本格移設は `#332` 側で扱い、
+`#318` では依存置換と最終撤去に必要な最小差分に限定する。
 
-- `geo_contracts` に `classification` と `geometry::core` 骨格を追加
-- `arc` / `circle` 契約だけを先行移設
-- `geo_foundation` では同名 re-export を残して互換層化
-- `geo_primitives` の `arc` / `circle` 関連 import だけを `geo_contracts` に切替
+### PR-A: contracts骨格 + primitives先行切替（arc/circle）
 
-この切り方なら、#318 の方向性を固定しつつ差分を制御できる。
+目的:
 
-## 6.1 最初のPR 作業項目（実行用）
+- `geo_contracts` を形状契約の参照先として成立させる
+- `geo_primitives` の arc/circle 契約参照を先行置換する
+
+完了条件:
+
+- `geo_contracts` に `classification` / `geometry::core` 骨格がある
+- `point/vector/arc/circle` 契約が `geo_contracts` に存在する
+- `geo_primitives` の arc/circle import 切替が完了する
+- `cargo check -p geo_contracts -p geo_foundation -p geo_primitives` が通る
+- `cargo test -p geo_primitives arc_` / `circle_` が通る
+
+注意:
+
+- `conical_surface_3d_collision.rs` / `cylindrical_solid_3d_collision.rs` / `cylindrical_surface_3d_collision.rs` の cross collision 実装移設は `#332` で扱う
+
+### PR-B: nurbs + 利用側クレート置換
+
+目的:
+
+- `geo_nurbs` の契約参照を `geo_contracts` へ移行する
+- `geo_algorithms` / `geo_io` / `geo_entity` / `cam_core` の `geo_foundation` 参照を用途別に置換する
+
+完了条件:
+
+- `geo_nurbs` の NURBS 契約参照が `geo_contracts` 基準
+- 4クレートの `Cargo.toml` から `geo_foundation` 依存を削除
+- `cargo check -p geo_nurbs -p geo_algorithms -p geo_io -p geo_entity -p cam_core` が通る
+
+注意:
+
+- `collision/intersection` の本格移設は `#332` へ分離
+
+### PR-C: 互換層縮退 + 最終撤去判定
+
+目的:
+
+- `geo_foundation` の互換層を最小化し、撤去可能判定を行う
+
+完了条件:
+
+- workspace 内の `geo_foundation::` 参照が説明可能な最小残件またはゼロ
+- `cargo check --workspace` / `cargo test --workspace` が通る
+- 依存チェックスクリプトが通る
+- `model/geo_foundation` 削除準備が整う
+
+## 6.1 PR-A 作業項目（更新）
 
 - [x] `geo_contracts` に `classification` モジュール追加
 - [x] `geo_contracts` に `geometry/core` 骨格追加
 - [x] `point/vector` 契約を `geo_contracts` へ先行移設
 - [x] `arc/circle` 契約を `geo_contracts` へ先行移設
 - [x] `geo_foundation` の同名公開項目を `geo_contracts` 再エクスポートへ変更
-- [ ] `geo_primitives` の arc/circle 系 import を `geo_contracts` に切替
+- [x] `geo_primitives` の arc/circle 系 import を `geo_contracts` に先行切替
 - [x] `cargo check -p geo_contracts -p geo_foundation -p geo_primitives`
-- [ ] `cargo test -p geo_primitives arc_`
-- [ ] `cargo test -p geo_primitives circle_`
+- [x] `cargo test -p geo_primitives arc_`
+- [x] `cargo test -p geo_primitives circle_`
+- [ ] PR-A の差分をコミットしPR化
 
-## 6.2 PRレビュー用 境界チェック
+## 6.2 PR-B 作業項目（新設）
+
+- [ ] `geo_nurbs` の constructor/properties/measure 参照を `geo_contracts` へ置換
+- [ ] `geo_nurbs` README / doctest の旧 import を更新
+- [ ] `geo_algorithms` の `Scalar` / `Tolerance*` / 形状契約参照を用途別に置換
+- [ ] `geo_io` / `geo_entity` / `cam_core` の `geo_foundation` 参照を置換
+- [ ] 4クレートの `Cargo.toml` から `geo_foundation` 依存を削除
+- [ ] `cargo check -p geo_nurbs -p geo_algorithms -p geo_io -p geo_entity -p cam_core`
+
+## 6.3 PR-C 作業項目（新設）
+
+- [ ] `geo_foundation` の互換再エクスポートを最小化
+- [ ] workspace の `geo_foundation::` 参照をゼロ化または `#332` 対象として明文化
+- [ ] `cargo check --workspace`
+- [ ] `cargo test --workspace`
+- [ ] `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\check_architecture_dependencies_simple.ps1`
+- [ ] `Cargo.toml` workspace members から `model/geo_foundation` 削除準備
+
+## 6.4 PRレビュー用 境界チェック
 
 - [ ] `geo_contracts` に計算アルゴリズム本体が入っていない
 - [ ] `geo_contracts` に transform 実装本体が入っていない
 - [ ] `geo_core` に形状固有語依存の trait 実装が増えていない
 - [ ] `geo_primitives` / `geo_nurbs` に共通契約の再定義を追加していない
+- [ ] `collision/intersection` の本格移設差分が `#332` 側に分離されている
 - [ ] 新規 public API が固定境界表（3.0節）に適合している
 
-## 7. 完了条件
+## 7. #318 クローズ条件（更新）
 
-- [ ] `geo_foundation` の公開 API ごとの所有先が明文化されている
 - [ ] `geo_contracts` が形状契約の正規参照先として成立している
-- [ ] `geo_foundation` 依存 6 クレートの切替順が確定している
-- [ ] 最初の PR スコープが縦切りで定義されている
+- [ ] `geo_primitives` / `geo_nurbs` が実装責務中心に整理されている
+- [ ] `geo_foundation` 依存 6 クレートの切替が完了している
+- [ ] `geo_foundation` なしで workspace build/test が通る
+- [ ] 依存チェックスクリプトが通る
+- [ ] `#332` との境界（cross operation 移設対象）が明文化されている

--- a/dev/architecture/ISSUE_318_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_318_IMPLEMENTATION_PREP.md
@@ -1,0 +1,353 @@
+# Issue #318 実施準備チェックリスト
+
+対象Issue: [#318 geo_foundation廃止完了: geo_contracts導入と参照置換](https://github.com/RedRing2020/RedRing/issues/318)
+
+## 1. 目的
+
+- `geo_foundation` を最終的に削除できる状態まで持っていく
+- 形状契約の正規参照先を `geo_contracts` に一本化する
+- 数値抽象は `analysis`、Transform共通責務は `geo_core` に分離する
+
+## 2. 現在地
+
+- `geo_contracts` クレートは存在するが、現状の公開 API は `Angle` / `Scalar` 再エクスポートのみ
+- `geo_core -> geo_foundation` 依存解消は #317 で完了済み
+- Transform の `geo_core` 基準化は #319 で実装側ほぼ完了
+- `geo_foundation` 直接依存は現時点で 6 クレートに残存
+  - `geo_primitives`
+  - `geo_nurbs`
+  - `geo_algorithms`
+  - `geo_io`
+  - `geo_entity`
+  - `cam_core`
+- `geo_primitives` / `geo_nurbs` では `geo_contracts::{Angle, Scalar}` 利用が部分的に始まっている
+
+## 3. geo_foundation 公開 API の分類方針
+
+## 3.0 固定境界表（本Issueでの判断基準）
+
+| 領域 | 所有クレート | 置くもの | 置かないもの | 代表例 |
+|---|---|---|---|---|
+| 数値抽象 | analysis | 数値型抽象、定数、許容誤差定数 | 形状意味を持つ trait | Angle, Scalar, TolerantEq |
+| 幾何契約 | geo_contracts | 形状定義、形状の最小契約 | 変換アルゴリズム、衝突判定、交差判定の処理本体 | Point2D/Point3D, Vector2D/Vector3D の契約、Circle/Arc 契約 |
+| 共通変換核 | geo_core | 形状非依存の変換 trait とエラー、共通変換補助 | 形状固有の再構築ロジック | AnalysisTransform2D/3D, TransformError |
+| 形状実装 | geo_primitives / geo_nurbs | 形状固有の実装、形状固有制約、再構築ロジック | 共通契約の再定義 | Circle2D の回転適用、NURBS のノット更新 |
+| 横断演算 | geo_algorithms | 複数形状にまたがる計算アルゴリズム | 形状型の所有 | 交差探索、空間探索、サンプリング |
+
+## 3.0.1 point / vector の配置ルール
+
+- Point と Vector は geo_contracts の「幾何契約」に配置する
+- Point と Vector の計算実装は geo_core（共通核）または各実装クレートに置く
+- Point/Vector の contract に transform の処理本体を持たせない
+
+## 3.0.2 transform の配置ルール（曖昧化防止）
+
+| transform 要素 | 所有クレート | 判断基準 |
+|---|---|---|
+| 変換 trait 定義 | geo_core | 形状名が不要で、座標変換の抽象のみを表す |
+| 変換エラー型 | geo_core | どの形状にも共通の失敗モデルである |
+| 変換行列の共通適用補助 | geo_core | 形状固有パラメータに触れない |
+| 形状別 transform 実装 | geo_primitives / geo_nurbs | 半径・法線・ノットなど形状固有パラメータ更新がある |
+| transform 実行時の許容誤差定数 | analysis（定数） + geo_core（利用） | 値の定義は analysis、適用は geo_core |
+
+## 3.0.3 判定ルール（同じ議論を繰り返さないための固定文）
+
+- trait 名やメソッドに形状固有語が必要なら geo_core ではなく実装側に置く
+- trait 本体が形状固有パラメータへアクセスするなら geo_core ではなく実装側に置く
+- 3形状以上で同一意味・同一エラーモデルで使えるなら geo_core を優先する
+- 判定が割れた場合は「共通化しない」をデフォルトにする
+
+### 3.1 analysis 所有で確定しているもの
+
+- `Angle`
+- `Scalar`
+- `TolerantEq`
+- 数学定数・許容誤差定数
+  - `PI`, `TAU`, `DEG_TO_RAD`, `RAD_TO_DEG`
+  - `GEOMETRIC_DISTANCE_TOLERANCE`, `GEOMETRIC_ANGLE_TOLERANCE`
+
+### 3.2 geo_core 所有で確定しているもの
+
+- `AnalysisTransform2D`
+- `AnalysisTransform3D`
+- `AnalysisTransformSupport`
+- `AnalysisTransformVector2D`
+- `AnalysisTransformVector3D`
+- `TransformError` の共通核
+- `SafeTransform` の共通変換責務
+
+### 3.3 geo_contracts へ移す対象
+
+- `classification`
+  - `DimensionClass`
+  - `GeometryPrimitive`
+  - `PrimitiveKind`
+- `geometry::core::*_traits`
+  - 形状の `Constructor`
+  - 形状の `Properties`
+  - 形状の `Measure`
+  - 形状の `Core`
+- NURBS 契約
+  - `NurbsCurve2D*`
+  - `NurbsCurve3D*`
+  - `NurbsSurface3D*`
+
+### 3.4 所有先を要判断とするもの
+
+- `entity::core`
+  - `EntityDisplayProperties`
+  - `EntityIdentity`
+  - `LineEntity3DProperties`
+- `geometry::foundation::extension_foundation`
+  - `Bounded`
+  - `ExtensionFoundation`
+  - `CollectionExtension`
+  - `MeasurableExtension`
+  - `SpatialExtension`
+  - `TransformableExtension`
+- `geometry::extensions`
+  - `BasicCollision`
+  - `BasicIntersection`
+  - `MultipleIntersection`
+  - `BooleanOperations`
+  - `PointDistance`
+  - `SelfIntersection`
+- `tolerance`
+  - `GeometryContext`
+  - `ToleranceSettings`
+- `tolerance_migration`
+  - 将来削除前提のため、新設先へは移さず撤去方針を優先
+
+## 4. 依存元クレート別の残存パターン
+
+### 4.1 geo_primitives
+
+- 形状契約参照が大量に残存
+- `extensions::*` / `core::*_traits` / `tolerance_migration::*` の参照が混在
+- `src/lib.rs` の公開 re-export で `geo_foundation` を正規ルートとして残している
+
+### 4.2 geo_nurbs
+
+- NURBS 契約の `Constructor` / `Properties` / `Measure` 参照が残存
+- README とテスト内 import に旧経路が残存
+
+### 4.3 geo_algorithms
+
+- 主に `Scalar` / `ToleranceSettings` / `ToleranceContext` を使用
+- 一部で NURBS 契約参照も残存
+- 形状契約よりも「数値抽象と許容誤差」の切替が先行課題
+
+### 4.4 geo_io
+
+- `Scalar`
+- `Triangle3DProperties`
+
+### 4.5 geo_entity
+
+- `EntityDisplayProperties`
+- `EntityIdentity`
+- `LineEntity3DProperties`
+- `Scalar`
+
+### 4.6 cam_core
+
+- 現状は `Cargo.toml` 依存と説明文に `geo_foundation` が残る
+- 実コード参照は薄く、後半フェーズでまとめて切る候補
+
+## 5. 推奨実施順
+
+### Phase 0: 契約の棚卸し表を確定
+
+- [ ] `geo_foundation/src/lib.rs` の公開項目を、所有先ごとに表形式で確定
+- [ ] `要判断` 項目について、暫定所属を決める
+
+詳細:
+
+- 入力:
+  - `model/geo_foundation/src/lib.rs` の `pub mod` / `pub use`
+  - `model/**` の `use geo_foundation::...` 参照
+- 作業:
+  - 公開項目を「analysis / geo_contracts / geo_core / 実装側 / 要判断」に分類
+  - 参照クレートごとに利用用途（契約 / tolerance / extension / transform）をタグ付け
+  - `要判断` 項目には暫定所属と理由を1行で記載
+- 完了条件:
+  - 分類表に未分類項目がない
+  - `要判断` にオーナー候補が全て入っている
+
+確認コマンド:
+
+- `cargo check -p geo_foundation`
+- `rg "^pub (mod|use) " model/geo_foundation/src/lib.rs`
+- `rg "geo_foundation::" model/`
+
+### Phase 1: geo_contracts の骨格追加
+
+- [x] `classification` を `geo_contracts` に追加
+- [x] `geometry::core` 相当のモジュール骨格を `geo_contracts` に追加
+- [x] `geo_foundation` 側は一時的に `geo_contracts` から再エクスポートする薄い層へ寄せる
+
+詳細:
+
+- 入力:
+  - `model/geo_foundation/src/classification.rs`
+  - `model/geo_foundation/src/geometry/core/*_traits.rs`
+- 作業:
+  - `geo_contracts` に `classification` / `geometry` / `core` のモジュール階層を追加
+  - 初期移設対象は `point_traits` / `vector_traits` / `arc_traits` / `circle_traits` を優先
+  - `geo_foundation` は直接定義を減らし、`pub use geo_contracts::...` の互換再エクスポートへ寄せる
+  - `geo_contracts` には計算本体・拡張処理を入れない
+- 完了条件:
+  - `geo_contracts` 単体で公開契約が解決できる
+  - `geo_foundation` 側で重複定義が増えていない
+
+確認コマンド:
+
+- `cargo check -p geo_contracts`
+- `cargo check -p geo_foundation`
+- `rg "geo_contracts::" model/geo_foundation/src/lib.rs`
+
+### Phase 2: 代表形状で縦切り検証
+
+- [ ] `arc` / `circle` 系 contract を `geo_contracts` へ移す
+- [ ] `geo_primitives` 側の対応 import を `geo_contracts` 基準へ切替
+- [ ] `cargo check -p geo_primitives`
+- [ ] `cargo test -p geo_primitives`
+
+詳細:
+
+- 入力:
+  - `model/geo_primitives/src/arc_*`
+  - `model/geo_primitives/src/circle_*`
+  - `model/geo_primitives/src/lib.rs` の re-export
+- 作業:
+  - `core::arc_traits` / `core::circle_traits` の参照を段階的に `geo_contracts` へ置換
+  - `TransformError` や Transform trait は `geo_core` のまま維持
+  - `geo_primitives/src/lib.rs` で契約再エクスポート経路を統一
+- 完了条件:
+  - arc/circle 系で `geo_foundation::core::*_traits` 参照がゼロ
+  - arc/circle 系テストが通る
+
+確認コマンド:
+
+- `cargo check -p geo_primitives`
+- `cargo test -p geo_primitives arc_`
+- `cargo test -p geo_primitives circle_`
+- `rg "geo_foundation::(core::arc_traits|core::circle_traits|Arc|Circle)" model/geo_primitives/src`
+
+### Phase 3: NURBS 契約切替
+
+- [ ] `NurbsCurve2D*` / `NurbsCurve3D*` / `NurbsSurface3D*` を `geo_contracts` へ移す
+- [ ] `geo_nurbs` の import を切替
+- [ ] `cargo check -p geo_nurbs`
+- [ ] `cargo test -p geo_nurbs`
+
+詳細:
+
+- 入力:
+  - `model/geo_foundation/src/geometry/core/nurbs_*_traits.rs`
+  - `model/geo_nurbs/src/*.rs`
+- 作業:
+  - NURBS 契約 trait を `geo_contracts` へ移設
+  - `geo_nurbs` の constructor/properties/measure 参照を `geo_contracts` へ置換
+  - README / doctest の import 経路を更新
+- 完了条件:
+  - `geo_nurbs` 内の NURBS 契約参照が `geo_contracts` へ統一
+  - NURBS 関連テストが通る
+
+確認コマンド:
+
+- `cargo check -p geo_nurbs`
+- `cargo test -p geo_nurbs`
+- `rg "geo_foundation::(Nurbs|core::nurbs_)" model/geo_nurbs`
+
+### Phase 4: 利用側クレート整理
+
+- [ ] `geo_algorithms` の `Scalar` / `Tolerance*` / 形状契約参照を整理
+- [ ] `geo_io` / `geo_entity` / `cam_core` の残存参照を除去
+
+詳細:
+
+- 入力:
+  - `model/geo_algorithms/**`
+  - `model/geo_io/**`
+  - `model/geo_entity/**`
+  - `model/cam_core/**`
+- 作業:
+  - `Scalar` / 定数は `analysis` または `geo_contracts` 由来へ切替
+  - 形状契約参照は `geo_contracts` へ切替
+  - transform 共通責務参照は `geo_core` へ切替
+  - `Cargo.toml` から `geo_foundation` 依存を削除
+- 完了条件:
+  - 4クレートの `Cargo.toml` に `geo_foundation` 依存がない
+  - 旧 import がコメント含めて管理可能な範囲に縮小
+
+確認コマンド:
+
+- `cargo check -p geo_algorithms -p geo_io -p geo_entity -p cam_core`
+- `rg "geo_foundation::" model/geo_algorithms model/geo_io model/geo_entity model/cam_core`
+
+### Phase 5: 互換層縮退と削除
+
+- [ ] `geo_foundation` の再エクスポートを極小化
+- [ ] workspace 内の旧 import をゼロにする
+- [ ] `model/geo_foundation` を削除
+
+詳細:
+
+- 入力:
+  - workspace 全クレートの import / dependency
+  - `Cargo.toml` workspace members
+- 作業:
+  - `geo_foundation` を薄い互換層として最小化し、残利用をゼロ化
+  - `Cargo.toml` から `model/geo_foundation` を除去
+  - `model/geo_foundation` ディレクトリを削除
+  - ドキュメントのアーキテクチャ図・依存説明を更新
+- 完了条件:
+  - workspace 内に `geo_foundation::` 参照が存在しない
+  - workspace build/test と依存チェックが通る
+
+確認コマンド:
+
+- `cargo fmt --all -- --check`
+- `cargo check --workspace`
+- `cargo test --workspace`
+- `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\check_architecture_dependencies_simple.ps1`
+- `rg "geo_foundation::|geo_foundation = \{ path = \"../geo_foundation\" \}" model/ Cargo.toml`
+
+## 6. 最初のPRスコープ（推奨）
+
+最初の PR は「全面移設」ではなく、以下に限定する。
+
+- `geo_contracts` に `classification` と `geometry::core` 骨格を追加
+- `arc` / `circle` 契約だけを先行移設
+- `geo_foundation` では同名 re-export を残して互換層化
+- `geo_primitives` の `arc` / `circle` 関連 import だけを `geo_contracts` に切替
+
+この切り方なら、#318 の方向性を固定しつつ差分を制御できる。
+
+## 6.1 最初のPR 作業項目（実行用）
+
+- [x] `geo_contracts` に `classification` モジュール追加
+- [x] `geo_contracts` に `geometry/core` 骨格追加
+- [x] `point/vector` 契約を `geo_contracts` へ先行移設
+- [x] `arc/circle` 契約を `geo_contracts` へ先行移設
+- [x] `geo_foundation` の同名公開項目を `geo_contracts` 再エクスポートへ変更
+- [ ] `geo_primitives` の arc/circle 系 import を `geo_contracts` に切替
+- [x] `cargo check -p geo_contracts -p geo_foundation -p geo_primitives`
+- [ ] `cargo test -p geo_primitives arc_`
+- [ ] `cargo test -p geo_primitives circle_`
+
+## 6.2 PRレビュー用 境界チェック
+
+- [ ] `geo_contracts` に計算アルゴリズム本体が入っていない
+- [ ] `geo_contracts` に transform 実装本体が入っていない
+- [ ] `geo_core` に形状固有語依存の trait 実装が増えていない
+- [ ] `geo_primitives` / `geo_nurbs` に共通契約の再定義を追加していない
+- [ ] 新規 public API が固定境界表（3.0節）に適合している
+
+## 7. 完了条件
+
+- [ ] `geo_foundation` の公開 API ごとの所有先が明文化されている
+- [ ] `geo_contracts` が形状契約の正規参照先として成立している
+- [ ] `geo_foundation` 依存 6 クレートの切替順が確定している
+- [ ] 最初の PR スコープが縦切りで定義されている

--- a/dev/architecture/issues/2026-03-geometry-refactor-01-geo-core-dependency.md
+++ b/dev/architecture/issues/2026-03-geometry-refactor-01-geo-core-dependency.md
@@ -7,12 +7,19 @@
 - 現状は `geo_core` が `geo_foundation` に依存しており、レイヤーが逆転している
 - 今後の `geo_foundation` 廃止計画を成立させるために先行解消が必要
 
+## 現在地
+
+- `model/geo_core/Cargo.toml` から `geo_foundation` 依存は削除済み
+- `geo_core` の依存先は実質 `analysis` と数値ユーティリティのみに整理済み
+- Transform / AABB / Vector trait の `geo_core` 側再配置は完了済み
+- 後続 Issue の前提としては完了しており、未反映なのは workspace 全体 `cargo test` の実績記録のみ
+
 ## タスク
 
-- [ ] `model/geo_core/Cargo.toml` から `geo_foundation` 依存を削除
-- [ ] `geo_core` が必要としている trait/型を再配置（`geo_core` or 呼び出し側）
-- [ ] 依存チェックスクリプトの許可ルールを最終形へ更新
-- [ ] 影響クレート（`geo_primitives`, `geo_nurbs`, `geo_algorithms`）の import を修正
+- [x] `model/geo_core/Cargo.toml` から `geo_foundation` 依存を削除
+- [x] `geo_core` が必要としている trait/型を再配置（`geo_core` or 呼び出し側）
+- [x] 依存チェックスクリプトの許可ルールを最終形へ更新
+- [x] 影響クレート（`geo_primitives`, `geo_nurbs`, `geo_algorithms`）の import を修正
 
 段階実施:
 
@@ -26,11 +33,12 @@
 
 ## 受け入れ条件
 
-- [ ] `geo_core` は `analysis` のみに依存する
-- [ ] `cargo check --workspace` が通る
+- [x] `geo_core` は `analysis` のみに依存する
+- [x] `cargo check --workspace` が通る
 - [ ] `cargo test --workspace` が通る
-- [ ] 依存チェックスクリプトが通る
+- [x] 依存チェックスクリプトが通る
 
 ## 備考
 
 - 破壊的変更を許容し、互換レイヤは最小限とする
+- 現在は「完了済みだが最終検証記録だけ未更新」の状態として扱う

--- a/dev/architecture/issues/2026-03-geometry-refactor-02-transform-two-layer.md
+++ b/dev/architecture/issues/2026-03-geometry-refactor-02-transform-two-layer.md
@@ -10,20 +10,27 @@ Transform責務を2層化する。
 - Transform 実装が分散しており、重複と境界の曖昧さがある
 - `geo_algorithms` はクロス形状演算に集中させ、形状固有Transform責務は持たせない
 
+## 現在地
+
+- `geo_primitives` / `geo_nurbs` の `*_transform.rs` から、`geo_foundation` 経由の `AnalysisTransform*` / `TransformError` 参照は解消済み
+- Transform 共通責務の正規参照先は `geo_core` に移っている
+- 一方で `geo_primitives/src/lib.rs` などの公開 re-export と README / コメント系には旧経路が残っている
+- したがって本Issueは「実装切替は完了、公開面の整理と全体検証が残り」という現在地
+
 ## タスク
 
 ### Phase A: NURBS先行切替
 
-- [ ] `curve_2d_transform.rs` / `curve_3d_transform.rs` / `surface_3d_transform.rs` の `AnalysisTransform*` と `TransformError` を `geo_core` 参照へ切替
-- [ ] `cargo check -p geo_nurbs`
-- [ ] `cargo test -p geo_nurbs`
+- [x] `curve_2d_transform.rs` / `curve_3d_transform.rs` / `surface_3d_transform.rs` の `AnalysisTransform*` と `TransformError` を `geo_core` 参照へ切替
+- [x] `cargo check -p geo_nurbs`
+- [x] `cargo test -p geo_nurbs`
 
 ### Phase B: Primitives展開
 
-- [ ] `model/geo_primitives/src/*_transform.rs`（32ファイル）の `AnalysisTransform*` / `AnalysisTransformSupport` / `TransformError` を `geo_core` 基準へ切替
-- [ ] 既存テストの import 置換
-- [ ] `cargo check -p geo_primitives`
-- [ ] `cargo test -p geo_primitives`
+- [x] `model/geo_primitives/src/*_transform.rs`（32ファイル）の `AnalysisTransform*` / `AnalysisTransformSupport` / `TransformError` を `geo_core` 基準へ切替
+- [x] 既存テストの import 置換
+- [x] `cargo check -p geo_primitives`
+- [x] `cargo test -p geo_primitives`
 
 ### Phase C: 呼び出し側整理
 
@@ -40,9 +47,9 @@ Transform責務を2層化する。
 
 ## 受け入れ条件
 
-- [ ] Transform共通核（trait/エラー/共通変換核）が `geo_core` に集約されている
-- [ ] 形状固有Transformが `geo_primitives` / `geo_nurbs` から利用できる
-- [ ] Transform実装35ファイル（Primitives 32 + NURBS 3）の参照が `geo_core` 基準に統一されている
+- [x] Transform共通核（trait/エラー/共通変換核）が `geo_core` に集約されている
+- [x] 形状固有Transformが `geo_primitives` / `geo_nurbs` から利用できる
+- [x] Transform実装35ファイル（Primitives 32 + NURBS 3）の参照が `geo_core` 基準に統一されている
 - [ ] `cargo fmt --all -- --check` が通る
 - [ ] `cargo check --workspace` が通る
 - [ ] `cargo test --workspace` が通る
@@ -52,3 +59,4 @@ Transform責務を2層化する。
 
 - API変更は破壊的でよい（移行優先）
 - `geo_foundation` 全廃自体は #318 のスコープで扱う
+- 残作業は lib.rs の公開面整理、README / コメント更新、workspace 全体の再検証

--- a/dev/architecture/issues/2026-03-geometry-refactor-03-retire-geo-commons.md
+++ b/dev/architecture/issues/2026-03-geometry-refactor-03-retire-geo-commons.md
@@ -7,33 +7,41 @@
 - `geo_commons` が中間層として残っており、責務と依存が追いにくい
 - `geo_foundation` 廃止と同時に構成を単純化したい
 
+## 現在地
+
+- `geo_commons` は workspace member から既に外れている
+- `Cargo.toml` 上、他クレートからの `geo_commons` 依存は解消済み
+- `geo_foundation` からの `geo_commons` 依存も解消済み
+- 現在残っているのは `model/geo_commons` ディレクトリ自体と、コメント / ドキュメント上の言及整理
+- したがって本Issueは「依存撤去はほぼ完了、残りは物理削除と痕跡整理」という現在地
+
 ## タスク
 
 ### Phase A: API棚卸し
 
 - [x] `geo_commons` 公開関数24件を棚卸し
 - [x] `analysis` / `geo_algorithms` への分類方針を確定
-- [x] 依存元クレート（現状: `geo_foundation` のみ）を確認
+- [x] 依存元クレート（当時 `geo_foundation` のみ）を確認
 
-### Phase B: analysis移管
+### Phase B: 実装移管
 
-- [ ] `metrics::area_volume::*` を `geo_algorithms` へ移管
-- [ ] `approximations::*` を `geo_algorithms` へ移管
-- [ ] `geo_foundation` 側の参照を `geo_algorithms` 基準へ切替
+- [x] `metrics::area_volume::*` を `geo_algorithms` へ移管
+- [x] `approximations::*` を `geo_algorithms` へ移管
+- [x] `geo_foundation` 側の参照を `geo_algorithms` 基準へ切替
 - [ ] `cargo check -p geo_algorithms -p geo_foundation`
 - [ ] `cargo test -p geo_algorithms -p geo_foundation`
 
-### Phase C: geo_algorithms移管
+### Phase C: analysis責務整理
 
-- [ ] `analysis` には形状を含む関数を残さないことを確認
-- [ ] 必要なら `geo_algorithms` 側で数値基盤ヘルパーを整理
+- [x] `analysis` には形状を含む関数を残さないことを確認
+- [x] 必要なら `geo_algorithms` 側で数値基盤ヘルパーを整理
 - [ ] `cargo check -p analysis -p geo_algorithms`
 
 ### Phase D: geo_commons撤去
 
-- [ ] `geo_foundation` の `geo_commons` 依存を削除
+- [x] `geo_foundation` の `geo_commons` 依存を削除
 - [ ] `model/geo_commons` クレートを削除
-- [ ] ワークスペース参照/依存ルールを更新
+- [x] ワークスペース参照/依存ルールを更新
 - [ ] `cargo fmt --all -- --check`
 - [ ] `cargo check --workspace`
 - [ ] `cargo clippy --workspace --all-targets -- -D warnings`
@@ -42,9 +50,9 @@
 
 ## 受け入れ条件
 
-- [ ] ワークスペースに `geo_commons` 依存が存在しない
-- [ ] `analysis` は形状を含まない純粋数値計算のみを保持
-- [ ] 面積/体積/近似/距離を含む形状計算は `geo_*` 側に集約されている
+- [x] ワークスペースに `geo_commons` 依存が存在しない
+- [x] `analysis` は形状を含まない純粋数値計算のみを保持
+- [x] 面積/体積/近似/距離を含む形状計算は `geo_*` 側に集約されている
 - [ ] 移管後APIで既存利用箇所がビルド通過
 - [ ] `cargo fmt --all -- --check` が通る
 - [ ] `cargo clippy --workspace --all-targets -- -D warnings` が通る

--- a/dev/architecture/issues/2026-03-geometry-refactor-04-retire-geo-foundation.md
+++ b/dev/architecture/issues/2026-03-geometry-refactor-04-retire-geo-foundation.md
@@ -1,8 +1,10 @@
 ## 概要
 
-`geo_foundation` を廃止し、**形状定義専用クレート**を新設する。
+`geo_foundation` を廃止し、責務を `geo_contracts` / `geo_core` / `analysis` へ再配置する。
 
-- 形状定義（trait/契約）: 新クレート（`geo_contracts`）
+- 形状定義（trait/契約）: `geo_contracts`
+- 共通変換核・共通エラー: `geo_core`
+- 数値抽象・定数: `analysis`
 - 形状実装: `geo_primitives` / `geo_nurbs`
 
 ## 背景
@@ -11,18 +13,95 @@
 - `geo_primitives` / `geo_nurbs` は実装クレートとして整理したい
 - 旧 `geo_foundation` の責務集中を解消したい
 
+## 現状整理
+
+- `geo_contracts` クレート自体は作成済みだが、現状は `Angle` / `Scalar` 再エクスポート中心で、形状契約の本体移設は未完
+- `geo_primitives` / `geo_nurbs` の一部ファイルでは `geo_contracts::{Angle, Scalar}` 利用が始まっているが、公開 re-export と形状契約の正規参照先はまだ混在している
+- `geo_core -> geo_foundation` 依存解消は #317 で実施済み
+- Transform 共通責務の `geo_core` 側整理は #319 の前提として概ね揃っている
+- 依然として以下 6 クレートが `geo_foundation` に直接依存している
+	- `geo_primitives`
+	- `geo_nurbs`
+	- `geo_algorithms`
+	- `geo_io`
+	- `geo_entity`
+	- `cam_core`
+
+## 実施方針
+
+- `geo_contracts` には形状定義専用の責務だけを移す
+- `Scalar` / `Angle` / `TolerantEq` など数値抽象は `analysis` を正とする
+- Transform trait / error など共通変換責務は `geo_core` を正とする
+- 置換順は、契約移設 -> 実装クレート切替 -> 利用側切替 -> 互換層縮退 -> 最終削除 とする
+- 境界判断は `dev/architecture/ISSUE_318_IMPLEMENTATION_PREP.md` の固定境界表（3.0節）を正とする
+
 ## タスク
 
-- [x] 新クレート `geo_contracts` を作成（trait/契約の移設は継続）
-- [ ] `geo_primitives` / `geo_nurbs` で各traitを実装
-- [ ] 参照側 import を `geo_contracts` 基準へ置換
-- [ ] `geo_foundation` の互換層を段階削除
-- [ ] 最終的に `geo_foundation` クレートを削除
+### Phase 0: 棚卸しと責務分類
+
+- [ ] `geo_foundation` 公開 API を棚卸しし、移設先を `geo_contracts` / `geo_core` / `analysis` に分類
+- [ ] `geo_foundation` を参照している各クレートの import パターンを分類
+	- 形状契約参照
+	- tolerance / constants 参照
+	- transform / extension / collision 参照
+- [ ] `geo_foundation` に残すべきでない項目一覧を文書化
+
+### Phase 1: geo_contracts API 拡充
+
+- [x] 新クレート `geo_contracts` を作成
+- [ ] `geo_foundation::geometry::core::*_traits` にある形状契約を `geo_contracts` 側へ移設または再編
+- [ ] `geo_contracts` の公開 API を、利用側が `geo_foundation` を経由しなくてよい形に整理
+- [ ] `PrimitiveKind` / 分類系の所属先を確定し、必要なら `geo_contracts` へ移す
+- [ ] `cargo check -p geo_contracts`
+
+### Phase 2: 実装クレート切替
+
+- [ ] `geo_primitives` の形状契約 import を `geo_contracts` 基準へ切替
+- [ ] `geo_primitives` の `Cargo.toml` から `geo_foundation` 依存を外せる状態にする
+- [ ] `cargo check -p geo_primitives`
+- [ ] `cargo test -p geo_primitives`
+- [ ] `geo_nurbs` の形状契約 import を `geo_contracts` 基準へ切替
+- [ ] `geo_nurbs` の `Cargo.toml` から `geo_foundation` 依存を外せる状態にする
+- [ ] `cargo check -p geo_nurbs`
+- [ ] `cargo test -p geo_nurbs`
+
+### Phase 3: 利用側クレート切替
+
+- [ ] `geo_algorithms` の `geo_foundation` 参照を用途別に置換
+	- 形状契約 -> `geo_contracts`
+	- 数値抽象 / tolerance -> `analysis` または適切な所有クレート
+	- transform / 共通責務 -> `geo_core`
+- [ ] `geo_io` の三角形契約 / `Scalar` 参照を置換
+- [ ] `geo_entity` の entity 系契約の所属先を整理して置換
+- [ ] `cam_core` の `geo_foundation` 依存を除去
+- [ ] 各クレートの `Cargo.toml` から `geo_foundation` を除去
+
+### Phase 4: 互換層縮退
+
+- [ ] `geo_foundation` を一時的な薄い再エクスポート層に縮退
+- [ ] workspace 内で旧 import ルートが残っていないことを検索で確認
+- [ ] README / examples / コメント内の旧 import も更新
+
+### Phase 5: 最終撤去
+
+- [ ] workspace 全体で `geo_foundation` 参照がゼロであることを確認
+- [ ] workspace members から `model/geo_foundation` を削除
+- [ ] `model/geo_foundation` クレート本体を削除
+- [ ] 関連ドキュメントと依存図を更新
+
+## PR分割案
+
+- PR1: Phase 0-1（棚卸し + `geo_contracts` API 拡充）
+- PR2: Phase 2（`geo_primitives` / `geo_nurbs` 切替）
+- PR3: Phase 3（利用側クレート切替）
+- PR4: Phase 4-5（互換層撤去 + `geo_foundation` 削除 + 全体検証）
 
 ## 受け入れ条件
 
 - [ ] 形状定義の正規参照先が `geo_contracts` へ一本化されている
 - [ ] `geo_primitives` / `geo_nurbs` は実装責務に限定される
+- [ ] 数値抽象は `analysis`、Transform 共通責務は `geo_core` に整理されている
+- [ ] workspace 内の `geo_foundation` 直接参照がゼロになっている
 - [ ] `geo_foundation` なしでワークスペースがビルド可能
 - [ ] `cargo check --workspace` が通る
 - [ ] `cargo test --workspace` が通る
@@ -31,3 +110,6 @@
 ## 備考
 
 - 破壊的変更許容を前提に進める
+- 最初にやるべきなのは `geo_contracts` API 拡充であり、ここを固めずに import 置換を始めない
+- 実施準備の詳細は `dev/architecture/ISSUE_318_IMPLEMENTATION_PREP.md` を参照
+- 実行時は同ファイルの `Phase詳細` と `6.1/6.2` チェックリストをPRテンプレとして利用する

--- a/model/geo_contracts/src/classification.rs
+++ b/model/geo_contracts/src/classification.rs
@@ -1,0 +1,154 @@
+//! Classification contracts for geometry primitives.
+// geo_foundation の分類定義を contracts 層へ段階移設するための先行コピー。
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PrimitiveKind {
+    Point,
+    LineSegment,
+    PolyLine,
+    BezierCurve,
+    NurbsCurve,
+    NurbsCurve2D,
+    NurbsCurve3D,
+    Arc,
+    Ray,
+    InfiniteLine,
+    Circle,
+    Ellipse,
+    Rectangle,
+    Polygon,
+    Triangle,
+    Sphere,
+    SphericalSolid,
+    SphericalSurface,
+    EllipsoidalSolid,
+    EllipsoidalSurface,
+    Cylinder,
+    CylindricalSolid,
+    CylindricalSurface,
+    Cone,
+    ConicalSolid,
+    ConicalSurface,
+    TorusSolid,
+    TorusSurface,
+    Cube,
+    Plane,
+    TriangleMesh,
+    NurbsSurface,
+    NurbsSurface3D,
+    Group,
+    Assembly,
+    BBox,
+    Vector,
+    Mesh,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DimensionClass {
+    Zero,
+    One,
+    Two,
+    Three,
+    Complex,
+}
+
+impl PrimitiveKind {
+    pub fn dimension(&self) -> DimensionClass {
+        match self {
+            PrimitiveKind::Point => DimensionClass::Zero,
+            PrimitiveKind::LineSegment
+            | PrimitiveKind::PolyLine
+            | PrimitiveKind::BezierCurve
+            | PrimitiveKind::NurbsCurve
+            | PrimitiveKind::NurbsCurve2D
+            | PrimitiveKind::NurbsCurve3D
+            | PrimitiveKind::Arc
+            | PrimitiveKind::Ray
+            | PrimitiveKind::InfiniteLine => DimensionClass::One,
+            PrimitiveKind::Circle
+            | PrimitiveKind::Ellipse
+            | PrimitiveKind::Rectangle
+            | PrimitiveKind::Polygon
+            | PrimitiveKind::Triangle
+            | PrimitiveKind::Plane
+            | PrimitiveKind::CylindricalSurface
+            | PrimitiveKind::SphericalSurface
+            | PrimitiveKind::EllipsoidalSurface
+            | PrimitiveKind::ConicalSurface
+            | PrimitiveKind::TorusSurface
+            | PrimitiveKind::NurbsSurface
+            | PrimitiveKind::NurbsSurface3D => DimensionClass::Two,
+            PrimitiveKind::Sphere
+            | PrimitiveKind::SphericalSolid
+            | PrimitiveKind::EllipsoidalSolid
+            | PrimitiveKind::Cylinder
+            | PrimitiveKind::CylindricalSolid
+            | PrimitiveKind::Cone
+            | PrimitiveKind::ConicalSolid
+            | PrimitiveKind::TorusSolid
+            | PrimitiveKind::Cube
+            | PrimitiveKind::TriangleMesh
+            | PrimitiveKind::Mesh => DimensionClass::Three,
+            PrimitiveKind::Group
+            | PrimitiveKind::Assembly
+            | PrimitiveKind::BBox
+            | PrimitiveKind::Vector => DimensionClass::Complex,
+        }
+    }
+
+    pub fn is_curve(&self) -> bool {
+        matches!(self.dimension(), DimensionClass::One)
+    }
+
+    pub fn is_surface(&self) -> bool {
+        matches!(self.dimension(), DimensionClass::Two)
+    }
+
+    pub fn is_solid(&self) -> bool {
+        matches!(self.dimension(), DimensionClass::Three)
+    }
+
+    pub fn is_parametric(&self) -> bool {
+        matches!(
+            self,
+            PrimitiveKind::BezierCurve | PrimitiveKind::NurbsCurve | PrimitiveKind::NurbsSurface
+        )
+    }
+
+    pub fn is_analytical(&self) -> bool {
+        matches!(
+            self,
+            PrimitiveKind::Circle
+                | PrimitiveKind::Ellipse
+                | PrimitiveKind::Sphere
+                | PrimitiveKind::EllipsoidalSolid
+                | PrimitiveKind::EllipsoidalSurface
+                | PrimitiveKind::SphericalSolid
+                | PrimitiveKind::SphericalSurface
+                | PrimitiveKind::Cylinder
+                | PrimitiveKind::CylindricalSolid
+                | PrimitiveKind::CylindricalSurface
+                | PrimitiveKind::Cone
+                | PrimitiveKind::ConicalSolid
+                | PrimitiveKind::ConicalSurface
+                | PrimitiveKind::TorusSolid
+                | PrimitiveKind::TorusSurface
+                | PrimitiveKind::Plane
+        )
+    }
+
+    pub fn is_mesh(&self) -> bool {
+        matches!(
+            self,
+            PrimitiveKind::Polygon | PrimitiveKind::Triangle | PrimitiveKind::TriangleMesh
+        )
+    }
+}
+
+pub trait GeometryPrimitive {
+    fn kind(&self) -> PrimitiveKind;
+
+    fn dimension(&self) -> DimensionClass {
+        self.kind().dimension()
+    }
+}

--- a/model/geo_contracts/src/geometry/core/arc_traits.rs
+++ b/model/geo_contracts/src/geometry/core/arc_traits.rs
@@ -1,0 +1,130 @@
+//! Arc contracts.
+
+use crate::Scalar;
+
+pub trait Arc2DConstructor<T: Scalar> {
+    fn new(center: (T, T), radius: T, start_angle: T, end_angle: T) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn from_three_points(start: (T, T), mid: (T, T), end: (T, T)) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn semicircle(center: (T, T), radius: T) -> Self
+    where
+        Self: Sized;
+
+    fn from_center_and_points(center: (T, T), start: (T, T), end: (T, T)) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn full_circle(center: (T, T), radius: T) -> Self
+    where
+        Self: Sized;
+
+    fn unit_semicircle() -> Self
+    where
+        Self: Sized;
+}
+
+pub trait Arc3DConstructor<T: Scalar> {
+    fn new(
+        center: (T, T, T),
+        radius: T,
+        normal: (T, T, T),
+        start_angle: T,
+        end_angle: T,
+    ) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn xy_arc(center: (T, T, T), radius: T, start_angle: T, end_angle: T) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn from_three_points(start: (T, T, T), mid: (T, T, T), end: (T, T, T)) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn xz_arc(center: (T, T, T), radius: T, start_angle: T, end_angle: T) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn yz_arc(center: (T, T, T), radius: T, start_angle: T, end_angle: T) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn full_circle(center: (T, T, T), normal: (T, T, T), radius: T) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+pub trait Arc2DProperties<T: Scalar> {
+    fn center(&self) -> (T, T);
+    fn radius(&self) -> T;
+    fn start_angle(&self) -> T;
+    fn end_angle(&self) -> T;
+    fn dimension(&self) -> u32;
+    fn angle_span(&self) -> T;
+    fn is_full_circle(&self) -> bool;
+    fn is_semicircle(&self) -> bool;
+}
+
+pub trait Arc3DProperties<T: Scalar> {
+    fn center(&self) -> (T, T, T);
+    fn radius(&self) -> T;
+    fn start_angle(&self) -> T;
+    fn end_angle(&self) -> T;
+    fn dimension(&self) -> u32;
+    fn angle_span(&self) -> T;
+    fn is_full_circle(&self) -> bool;
+    fn is_on_xy_plane(&self) -> bool;
+}
+
+// TODO(#318): Measure 契約は責務分離フェーズで shape definition から分離する。
+pub trait Arc2DMeasure<T: Scalar> {
+    fn measure(&self) -> T;
+    fn start_point(&self) -> (T, T);
+    fn end_point(&self) -> (T, T);
+    fn point_at_parameter(&self, t: T) -> (T, T);
+    fn midpoint(&self) -> (T, T);
+    fn point_at_angle(&self, angle: T) -> (T, T);
+    fn distance_to_point(&self, point: (T, T)) -> T;
+    fn contains_point(&self, point: (T, T)) -> bool;
+}
+
+pub trait Arc3DMeasure<T: Scalar> {
+    fn measure(&self) -> T;
+    fn start_point(&self) -> (T, T, T);
+    fn end_point(&self) -> (T, T, T);
+    fn point_at_parameter(&self, t: T) -> (T, T, T);
+    fn midpoint(&self) -> (T, T, T);
+    fn point_at_angle(&self, angle: T) -> (T, T, T);
+    fn distance_to_point(&self, point: (T, T, T)) -> T;
+    fn contains_point(&self, point: (T, T, T)) -> bool;
+}
+
+pub trait Arc2DSampling<T: Scalar> {
+    fn sample_points(&self, num_points: usize) -> Vec<(T, T)>;
+    fn sample_by_arc_length(&self, arc_length_step: T) -> Vec<(T, T)>;
+}
+
+pub trait Arc2DContainment<T: Scalar> {
+    fn contains_point(&self, point: (T, T)) -> bool;
+    fn contains_angle(&self, angle: T) -> bool;
+    fn point_at_angle(&self, angle: T) -> (T, T);
+}
+
+pub trait Arc2DCore<T: Scalar>: Arc2DConstructor<T> + Arc2DProperties<T> + Arc2DMeasure<T> {}
+pub trait Arc3DCore<T: Scalar>: Arc3DConstructor<T> + Arc3DProperties<T> + Arc3DMeasure<T> {}
+
+impl<T: Scalar, A> Arc2DCore<T> for A where
+    A: Arc2DConstructor<T> + Arc2DProperties<T> + Arc2DMeasure<T>
+{
+}
+
+impl<T: Scalar, A> Arc3DCore<T> for A where
+    A: Arc3DConstructor<T> + Arc3DProperties<T> + Arc3DMeasure<T>
+{
+}

--- a/model/geo_contracts/src/geometry/core/circle_traits.rs
+++ b/model/geo_contracts/src/geometry/core/circle_traits.rs
@@ -1,0 +1,133 @@
+//! Circle contracts.
+
+use crate::Scalar;
+
+pub trait Circle2DConstructor<T: Scalar> {
+    fn new(center: (T, T), radius: T) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn new_with_ref_direction(center: (T, T), radius: T, ref_direction: (T, T)) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn unit_circle() -> Self
+    where
+        Self: Sized;
+
+    fn from_center_and_point(center: (T, T), point_on_circle: (T, T)) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn from_three_points(p1: (T, T), p2: (T, T), p3: (T, T)) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn centered_at_origin(radius: T) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+pub trait Circle3DConstructor<T: Scalar> {
+    fn new(center: (T, T, T), axis: (T, T, T), radius: T) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn new_xy_plane(center: (T, T, T), radius: T) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn unit_circle_xy() -> Self
+    where
+        Self: Sized;
+
+    fn from_center_and_point(
+        center: (T, T, T),
+        axis: (T, T, T),
+        point_on_circle: (T, T, T),
+    ) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn from_three_points(p1: (T, T, T), p2: (T, T, T), p3: (T, T, T)) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn centered_at_origin_xy(radius: T) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn new_xz_plane(center: (T, T, T), radius: T) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn new_yz_plane(center: (T, T, T), radius: T) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+pub trait Circle2DProperties<T: Scalar> {
+    fn center(&self) -> (T, T);
+    fn radius(&self) -> T;
+    fn ref_direction(&self) -> (T, T);
+    fn diameter(&self) -> T;
+    fn dimension(&self) -> u32;
+    fn is_unit_circle(&self) -> bool;
+    fn is_centered_at_origin(&self) -> bool;
+    fn is_degenerate(&self) -> bool;
+}
+
+pub trait Circle3DProperties<T: Scalar> {
+    fn center(&self) -> (T, T, T);
+    fn radius(&self) -> T;
+    fn axis(&self) -> (T, T, T);
+    fn ref_direction(&self) -> (T, T, T);
+    fn dimension(&self) -> u32;
+    fn is_unit_circle(&self) -> bool;
+    fn is_centered_at_origin(&self) -> bool;
+    fn is_degenerate(&self) -> bool;
+    fn is_on_xy_plane(&self) -> bool;
+}
+
+// TODO(#318): Measure 契約は責務分離フェーズで shape definition から分離する。
+pub trait Circle2DMeasure<T: Scalar> {
+    fn circumference(&self) -> T;
+    fn area(&self) -> T;
+    fn contains_point(&self, point: (T, T)) -> bool;
+    fn distance_to_point(&self, point: (T, T)) -> T;
+    fn point_on_circumference(&self, point: (T, T)) -> bool;
+    fn closest_point_to(&self, point: (T, T)) -> (T, T);
+    fn point_at_parameter(&self, t: T) -> (T, T);
+    fn distance_to_circle(&self, other: &Self) -> T;
+}
+
+pub trait Circle3DMeasure<T: Scalar> {
+    fn circumference(&self) -> T;
+    fn area(&self) -> T;
+    fn contains_point(&self, point: (T, T, T)) -> bool;
+    fn distance_to_point(&self, point: (T, T, T)) -> T;
+    fn point_on_circumference(&self, point: (T, T, T)) -> bool;
+    fn closest_point_to(&self, point: (T, T, T)) -> (T, T, T);
+    fn point_at_parameter(&self, t: T) -> (T, T, T);
+    fn distance_to_circle(&self, other: &Self) -> T;
+}
+
+pub trait Circle2DCore<T: Scalar>:
+    Circle2DConstructor<T> + Circle2DProperties<T> + Circle2DMeasure<T>
+{
+}
+
+pub trait Circle3DCore<T: Scalar>:
+    Circle3DConstructor<T> + Circle3DProperties<T> + Circle3DMeasure<T>
+{
+}
+
+impl<T: Scalar, C> Circle2DCore<T> for C where
+    C: Circle2DConstructor<T> + Circle2DProperties<T> + Circle2DMeasure<T>
+{
+}
+
+impl<T: Scalar, C> Circle3DCore<T> for C where
+    C: Circle3DConstructor<T> + Circle3DProperties<T> + Circle3DMeasure<T>
+{
+}

--- a/model/geo_contracts/src/geometry/core/mod.rs
+++ b/model/geo_contracts/src/geometry/core/mod.rs
@@ -1,0 +1,24 @@
+//! Geometry core contracts.
+// 実装ロジックは置かず、shape contract の定義だけを保持する。
+
+pub mod arc_traits;
+pub mod circle_traits;
+pub mod point_traits;
+pub mod vector_traits;
+
+pub use arc_traits::{
+    Arc2DConstructor, Arc2DCore, Arc2DMeasure, Arc2DProperties, Arc3DConstructor, Arc3DCore,
+    Arc3DMeasure, Arc3DProperties,
+};
+pub use circle_traits::{
+    Circle2DConstructor, Circle2DCore, Circle2DMeasure, Circle2DProperties, Circle3DConstructor,
+    Circle3DCore, Circle3DMeasure, Circle3DProperties,
+};
+pub use point_traits::{
+    Point2DConstructor, Point2DCore, Point2DMeasure, Point2DProperties, Point3DConstructor,
+    Point3DCore, Point3DMeasure, Point3DProperties,
+};
+pub use vector_traits::{
+    Vector2DConstructor, Vector2DCore, Vector2DMeasure, Vector2DProperties, Vector3DConstructor,
+    Vector3DCore, Vector3DMeasure, Vector3DProperties,
+};

--- a/model/geo_contracts/src/geometry/core/point_traits.rs
+++ b/model/geo_contracts/src/geometry/core/point_traits.rs
@@ -1,0 +1,122 @@
+//! Point contracts.
+//! Core contract definitions only; transform implementations live outside contracts.
+
+use crate::Scalar;
+use analysis::linalg::vector::{Vector2, Vector3};
+
+pub trait Point2DConstructor<T: Scalar> {
+    fn new(x: T, y: T) -> Self;
+    fn origin() -> Self;
+    fn from_tuple(coords: (T, T)) -> Self;
+
+    fn from_analysis_vector(vector: &Vector2<T>) -> Self;
+    fn from_point(other: &Self) -> Self;
+    fn from_polar(r: T, theta: T) -> Self;
+}
+
+pub trait Point3DConstructor<T: Scalar> {
+    fn new(x: T, y: T, z: T) -> Self;
+    fn origin() -> Self;
+    fn from_tuple(coords: (T, T, T)) -> Self;
+
+    fn from_analysis_vector(vector: &Vector3<T>) -> Self;
+    fn from_point(other: &Self) -> Self;
+    fn from_spherical(r: T, theta: T, phi: T) -> Self;
+}
+
+pub trait Point2DProperties<T: Scalar> {
+    fn x(&self) -> T;
+    fn y(&self) -> T;
+    fn coords(&self) -> [T; 2];
+    fn to_tuple(&self) -> (T, T);
+    fn to_analysis_vector(&self) -> Vector2<T>;
+
+    fn position(&self) -> Self
+    where
+        Self: Sized + Clone,
+    {
+        self.clone()
+    }
+
+    fn dimension(&self) -> u32 {
+        0
+    }
+
+    fn polar_radius(&self) -> T;
+}
+
+pub trait Point3DProperties<T: Scalar> {
+    fn x(&self) -> T;
+    fn y(&self) -> T;
+    fn z(&self) -> T;
+    fn coords(&self) -> [T; 3];
+    fn to_tuple(&self) -> (T, T, T);
+
+    fn to_analysis_vector(&self) -> Vector3<T>;
+
+    fn position(&self) -> Self
+    where
+        Self: Sized + Clone,
+    {
+        self.clone()
+    }
+
+    fn dimension(&self) -> u32 {
+        0
+    }
+}
+
+// TODO(#318): Measure contracts are temporarily colocated and will be split by responsibility.
+pub trait Point2DMeasure<T: Scalar> {
+    fn distance_to(&self, other: &Self) -> T;
+    fn distance_squared_to(&self, other: &Self) -> T;
+    fn distance_from_origin(&self) -> T;
+    fn norm_squared(&self) -> T;
+
+    fn midpoint(&self, other: &Self) -> Self;
+    fn lerp(&self, other: &Self, t: T) -> Self;
+    fn manhattan_distance_to(&self, other: &Self) -> T;
+    fn chebyshev_distance_to(&self, other: &Self) -> T;
+
+    fn area(&self) -> Option<T> {
+        None
+    }
+
+    fn length(&self) -> Option<T> {
+        None
+    }
+}
+
+pub trait Point3DMeasure<T: Scalar> {
+    fn distance_to(&self, other: &Self) -> T;
+    fn distance_squared_to(&self, other: &Self) -> T;
+    fn distance_from_origin(&self) -> T;
+    fn norm_squared(&self) -> T;
+
+    fn midpoint(&self, other: &Self) -> Self;
+    fn lerp(&self, other: &Self, t: T) -> Self;
+    fn manhattan_distance_to(&self, other: &Self) -> T;
+    fn chebyshev_distance_to(&self, other: &Self) -> T;
+
+    fn area(&self) -> Option<T> {
+        None
+    }
+
+    fn volume(&self) -> Option<T> {
+        None
+    }
+
+    fn length(&self) -> Option<T> {
+        None
+    }
+}
+
+pub trait Point2DCore<T: Scalar>:
+    Point2DConstructor<T> + Point2DProperties<T> + Point2DMeasure<T>
+{
+}
+
+pub trait Point3DCore<T: Scalar>:
+    Point3DConstructor<T> + Point3DProperties<T> + Point3DMeasure<T>
+{
+}

--- a/model/geo_contracts/src/geometry/core/vector_traits.rs
+++ b/model/geo_contracts/src/geometry/core/vector_traits.rs
@@ -1,0 +1,150 @@
+//! Vector contracts.
+//! Core contract definitions only; transform implementations live outside contracts.
+
+use crate::Scalar;
+use analysis::linalg::vector::{Vector2, Vector3};
+
+pub trait Vector2DConstructor<T: Scalar> {
+    fn new(x: T, y: T) -> Self;
+    fn zero() -> Self;
+    fn unit_x() -> Self;
+    fn unit_y() -> Self;
+    fn from_tuple(components: (T, T)) -> Self;
+    fn from_analysis_vector(vector: &Vector2<T>) -> Self;
+    fn from_array(components: [T; 2]) -> Self;
+    fn from_polar(magnitude: T, angle: T) -> Self;
+    fn from_vector(other: &Self) -> Self;
+}
+
+pub trait Vector3DConstructor<T: Scalar> {
+    fn new(x: T, y: T, z: T) -> Self;
+    fn zero() -> Self;
+    fn unit_x() -> Self;
+    fn unit_y() -> Self;
+    fn unit_z() -> Self;
+    fn from_tuple(components: (T, T, T)) -> Self;
+    fn from_analysis_vector(vector: &Vector3<T>) -> Self;
+    fn from_array(components: [T; 3]) -> Self;
+    fn from_spherical(magnitude: T, azimuth: T, elevation: T) -> Self;
+    fn from_cylindrical(radial_distance: T, azimuth: T, height: T) -> Self;
+    fn from_vector(other: &Self) -> Self;
+}
+
+pub trait Vector2DProperties<T: Scalar> {
+    fn x(&self) -> T;
+    fn y(&self) -> T;
+    fn components(&self) -> [T; 2];
+    fn to_tuple(&self) -> (T, T);
+    fn to_analysis_vector(&self) -> Vector2<T>;
+    fn length(&self) -> T;
+    fn length_squared(&self) -> T;
+    fn normalize(&self) -> Self;
+    fn try_normalize(&self) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn is_zero(&self) -> bool {
+        self.length_squared().is_zero()
+    }
+
+    fn is_unit(&self) -> bool {
+        let len_sq = self.length_squared();
+        (len_sq - T::ONE).abs() < T::EPSILON
+    }
+
+    fn dimension(&self) -> u32 {
+        1
+    }
+}
+
+pub trait Vector3DProperties<T: Scalar> {
+    fn x(&self) -> T;
+    fn y(&self) -> T;
+    fn z(&self) -> T;
+    fn components(&self) -> [T; 3];
+    fn to_tuple(&self) -> (T, T, T);
+    fn to_analysis_vector(&self) -> Vector3<T>;
+    fn length(&self) -> T;
+    fn length_squared(&self) -> T;
+    fn normalize(&self) -> Self;
+    fn try_normalize(&self) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn is_zero(&self) -> bool {
+        self.length_squared().is_zero()
+    }
+
+    fn is_unit(&self) -> bool {
+        let len_sq = self.length_squared();
+        (len_sq - T::ONE).abs() < T::EPSILON
+    }
+
+    fn dimension(&self) -> u32 {
+        1
+    }
+}
+
+// TODO(#318): Measure contracts are temporarily colocated and will be split by responsibility.
+pub trait Vector2DMeasure<T: Scalar> {
+    fn dot(&self, other: &Self) -> T;
+    fn cross_2d(&self, other: &Self) -> T;
+    fn angle_to(&self, other: &Self) -> Option<T>;
+    fn distance_to(&self, other: &Self) -> T;
+    fn distance_squared_to(&self, other: &Self) -> T;
+    fn magnitude(&self) -> T;
+    fn manhattan_distance(&self) -> T;
+    fn is_parallel_to(&self, other: &Self) -> bool;
+    fn is_perpendicular_to(&self, other: &Self) -> bool;
+    fn project_onto(&self, other: &Self) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn area(&self) -> Option<T> {
+        None
+    }
+
+    fn length(&self) -> Option<T> {
+        Some(self.magnitude())
+    }
+}
+
+pub trait Vector3DMeasure<T: Scalar> {
+    fn dot(&self, other: &Self) -> T;
+    fn cross_3d(&self, other: &Self) -> Self;
+    fn angle_to(&self, other: &Self) -> Option<T>;
+    fn distance_to(&self, other: &Self) -> T;
+    fn distance_squared_to(&self, other: &Self) -> T;
+    fn magnitude(&self) -> T;
+    fn manhattan_distance(&self) -> T;
+    fn is_parallel_to(&self, other: &Self) -> bool;
+    fn is_perpendicular_to(&self, other: &Self) -> bool;
+    fn project_onto(&self, other: &Self) -> Option<Self>
+    where
+        Self: Sized;
+    fn project_onto_plane(&self, normal: &Self) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn area(&self) -> Option<T> {
+        None
+    }
+
+    fn volume(&self) -> Option<T> {
+        None
+    }
+
+    fn length(&self) -> Option<T> {
+        Some(self.magnitude())
+    }
+}
+
+pub trait Vector2DCore<T: Scalar>:
+    Vector2DConstructor<T> + Vector2DProperties<T> + Vector2DMeasure<T>
+{
+}
+
+pub trait Vector3DCore<T: Scalar>:
+    Vector3DConstructor<T> + Vector3DProperties<T> + Vector3DMeasure<T>
+{
+}

--- a/model/geo_contracts/src/geometry/mod.rs
+++ b/model/geo_contracts/src/geometry/mod.rs
@@ -1,0 +1,3 @@
+//! Geometry contract modules.
+
+pub mod core;

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -10,11 +10,11 @@ pub use analysis::abstract_types::{Angle, Scalar};
 pub use classification::{DimensionClass, GeometryPrimitive, PrimitiveKind};
 // Phase 1 では arc/circle 契約のみ先行公開し、以降のPRで段階展開する。
 pub use geometry::core::{
-	Arc2DConstructor, Arc2DCore, Arc2DMeasure, Arc2DProperties, Arc3DConstructor, Arc3DCore,
-	Arc3DMeasure, Arc3DProperties, Circle2DConstructor, Circle2DCore, Circle2DMeasure,
-	Circle2DProperties, Circle3DConstructor, Circle3DCore, Circle3DMeasure, Circle3DProperties,
-	Point2DConstructor, Point2DCore, Point2DMeasure, Point2DProperties, Point3DConstructor,
-	Point3DCore, Point3DMeasure, Point3DProperties, Vector2DConstructor, Vector2DCore,
-	Vector2DMeasure, Vector2DProperties, Vector3DConstructor, Vector3DCore, Vector3DMeasure,
-	Vector3DProperties,
+    Arc2DConstructor, Arc2DCore, Arc2DMeasure, Arc2DProperties, Arc3DConstructor, Arc3DCore,
+    Arc3DMeasure, Arc3DProperties, Circle2DConstructor, Circle2DCore, Circle2DMeasure,
+    Circle2DProperties, Circle3DConstructor, Circle3DCore, Circle3DMeasure, Circle3DProperties,
+    Point2DConstructor, Point2DCore, Point2DMeasure, Point2DProperties, Point3DConstructor,
+    Point3DCore, Point3DMeasure, Point3DProperties, Vector2DConstructor, Vector2DCore,
+    Vector2DMeasure, Vector2DProperties, Vector3DConstructor, Vector3DCore, Vector3DMeasure,
+    Vector3DProperties,
 };

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -3,4 +3,18 @@
 //! This crate will host geometry-facing contracts that are shared across
 //! `geo_primitives`, `geo_nurbs`, and higher-level algorithm crates.
 
+pub mod classification;
+pub mod geometry;
+
 pub use analysis::abstract_types::{Angle, Scalar};
+pub use classification::{DimensionClass, GeometryPrimitive, PrimitiveKind};
+// Phase 1 では arc/circle 契約のみ先行公開し、以降のPRで段階展開する。
+pub use geometry::core::{
+	Arc2DConstructor, Arc2DCore, Arc2DMeasure, Arc2DProperties, Arc3DConstructor, Arc3DCore,
+	Arc3DMeasure, Arc3DProperties, Circle2DConstructor, Circle2DCore, Circle2DMeasure,
+	Circle2DProperties, Circle3DConstructor, Circle3DCore, Circle3DMeasure, Circle3DProperties,
+	Point2DConstructor, Point2DCore, Point2DMeasure, Point2DProperties, Point3DConstructor,
+	Point3DCore, Point3DMeasure, Point3DProperties, Vector2DConstructor, Vector2DCore,
+	Vector2DMeasure, Vector2DProperties, Vector3DConstructor, Vector3DCore, Vector3DMeasure,
+	Vector3DProperties,
+};

--- a/model/geo_foundation/Cargo.toml
+++ b/model/geo_foundation/Cargo.toml
@@ -7,3 +7,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 analysis = { path = "../../foundation/analysis" }
+geo_contracts = { path = "../geo_contracts" }

--- a/model/geo_foundation/src/lib.rs
+++ b/model/geo_foundation/src/lib.rs
@@ -159,11 +159,11 @@ pub mod contracts {
     pub use geo_contracts::geometry::core::{
         Arc2DConstructor, Arc2DCore, Arc2DMeasure, Arc2DProperties, Arc3DConstructor, Arc3DCore,
         Arc3DMeasure, Arc3DProperties, Circle2DConstructor, Circle2DCore, Circle2DMeasure,
-        Circle2DProperties, Circle3DConstructor, Circle3DCore, Circle3DMeasure,
-        Circle3DProperties, Point2DConstructor, Point2DCore, Point2DMeasure,
-        Point2DProperties, Point3DConstructor, Point3DCore, Point3DMeasure, Point3DProperties,
-        Vector2DConstructor, Vector2DCore, Vector2DMeasure, Vector2DProperties,
-        Vector3DConstructor, Vector3DCore, Vector3DMeasure, Vector3DProperties,
+        Circle2DProperties, Circle3DConstructor, Circle3DCore, Circle3DMeasure, Circle3DProperties,
+        Point2DConstructor, Point2DCore, Point2DMeasure, Point2DProperties, Point3DConstructor,
+        Point3DCore, Point3DMeasure, Point3DProperties, Vector2DConstructor, Vector2DCore,
+        Vector2DMeasure, Vector2DProperties, Vector3DConstructor, Vector3DCore, Vector3DMeasure,
+        Vector3DProperties,
     };
 }
 

--- a/model/geo_foundation/src/lib.rs
+++ b/model/geo_foundation/src/lib.rs
@@ -153,6 +153,20 @@ pub use geometry::core::{
     },
 };
 
+// #318 移行用ブリッジ: 既存公開名は維持し、contracts 版は別名前空間で併置する。
+pub mod contracts {
+    pub use geo_contracts::classification::{DimensionClass, GeometryPrimitive, PrimitiveKind};
+    pub use geo_contracts::geometry::core::{
+        Arc2DConstructor, Arc2DCore, Arc2DMeasure, Arc2DProperties, Arc3DConstructor, Arc3DCore,
+        Arc3DMeasure, Arc3DProperties, Circle2DConstructor, Circle2DCore, Circle2DMeasure,
+        Circle2DProperties, Circle3DConstructor, Circle3DCore, Circle3DMeasure,
+        Circle3DProperties, Point2DConstructor, Point2DCore, Point2DMeasure,
+        Point2DProperties, Point3DConstructor, Point3DCore, Point3DMeasure, Point3DProperties,
+        Vector2DConstructor, Vector2DCore, Vector2DMeasure, Vector2DProperties,
+        Vector3DConstructor, Vector3DCore, Vector3DMeasure, Vector3DProperties,
+    };
+}
+
 // Entity Core Traitsを再エクスポート（Entity namespace）
 pub use entity::core::{EntityDisplayProperties, EntityIdentity, LineEntity3DProperties};
 

--- a/model/geo_primitives/src/arc_2d.rs
+++ b/model/geo_primitives/src/arc_2d.rs
@@ -458,7 +458,6 @@ mod tests {
         let end = Angle::from_degrees(90.0);
 
         let arc = Arc2D::from_center_radius(center, radius, start, end).unwrap();
-        use geo_foundation::Arc2DProperties;
         let (cx, cy) = arc.center();
         assert_eq!((cx, cy), (center.x(), center.y()));
         assert_eq!(arc.radius(), radius);

--- a/model/geo_primitives/src/arc_2d_metrics.rs
+++ b/model/geo_primitives/src/arc_2d_metrics.rs
@@ -5,7 +5,7 @@
 
 use crate::Arc2D;
 use geo_contracts::{Angle, Scalar};
-use geo_foundation::core::arc_traits::Arc2DMeasure;
+use geo_contracts::Arc2DMeasure;
 
 // ============================================================================
 // ArcMetrics Trait Implementation

--- a/model/geo_primitives/src/arc_2d_tests.rs
+++ b/model/geo_primitives/src/arc_2d_tests.rs
@@ -217,7 +217,7 @@ mod tests {
         )
         .unwrap();
         let circle = full_arc.to_circle().unwrap();
-        use geo_foundation::Circle2DProperties;
+        use geo_contracts::Circle2DProperties;
         let (cx, cy) = circle.center();
         assert_eq!((cx, cy), (center.x(), center.y()));
         assert_eq!(circle.radius(), 3.0);

--- a/model/geo_primitives/src/arc_2d_transform.rs
+++ b/model/geo_primitives/src/arc_2d_transform.rs
@@ -38,7 +38,7 @@ pub mod analysis_transform {
         matrix: &Matrix3x3<T>,
     ) -> Result<Circle2D<T>, TransformError> {
         // 中心点の変換
-        use geo_foundation::Circle2DProperties;
+        use geo_contracts::Circle2DProperties;
         let (cx, cy) = circle.center();
         let center_vec = Vector2::new(cx, cy);
         let transformed_center_vec = matrix.transform_point_2d(&center_vec);

--- a/model/geo_primitives/src/arc_3d_tests.rs
+++ b/model/geo_primitives/src/arc_3d_tests.rs
@@ -4,7 +4,7 @@
 
 use crate::{Arc3D, Point3D, Vector3D};
 use geo_contracts::Angle;
-use geo_foundation::core::arc_traits::Arc3DProperties;
+use geo_contracts::Arc3DProperties;
 
 #[cfg(test)]
 mod tests {

--- a/model/geo_primitives/src/arc_3d_transform.rs
+++ b/model/geo_primitives/src/arc_3d_transform.rs
@@ -7,7 +7,7 @@
 use crate::{Angle, Arc3D, Direction3D, Point3D};
 use analysis::linalg::{matrix::Matrix4x4, vector::Vector3};
 use geo_contracts::Scalar;
-use geo_foundation::core::arc_traits::Arc3DProperties;
+use geo_contracts::Arc3DProperties;
 use geo_core::{AnalysisTransform3D, TransformError};
 
 /// Arc3D用Analysis Matrix4x4変換モジュール

--- a/scripts/_arch_rules_data.ps1
+++ b/scripts/_arch_rules_data.ps1
@@ -1,0 +1,132 @@
+# RedRing Architecture Rules - Shared Data
+# This file is dot-sourced by check_architecture_dependencies*.ps1
+# DO NOT execute directly.
+
+# ワークスペース全クレートのパス定義
+$ARCH_LAYER_MAPPING = @{
+    analysis       = "foundation/analysis"
+    geo_foundation = "model/geo_foundation"
+    geo_contracts  = "model/geo_contracts"
+    geo_commons    = "model/geo_commons"
+    geo_core       = "model/geo_core"
+    geo_primitives = "model/geo_primitives"
+    geo_algorithms = "model/geo_algorithms"
+    geo_nurbs      = "model/geo_nurbs"
+    geo_io         = "model/geo_io"
+    geo_entity     = "model/geo_entity"
+    cam_core       = "model/cam_core"
+    cam_entity     = "model/cam_entity"
+    cam_sim        = "model/cam_sim"
+    job_runtime    = "model/job_runtime"
+    job_domain     = "model/job_domain"
+    converter      = "viewmodel/converter"
+    graphics       = "viewmodel/graphics"
+    render         = "view/render"
+    stage          = "view/stage"
+    app            = "view/app"
+}
+
+# レイヤー分類
+$ARCH_LAYERS = @{
+    Analysis  = @("analysis")
+    Model     = @("geo_foundation", "geo_contracts", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "job_runtime", "job_domain")
+    ViewModel = @("converter", "graphics")
+    View      = @("render", "stage", "app")
+}
+
+# チェック対象の Model クレート（命名規則）
+$ARCH_REQUIRED_MODEL_CRATES = @("geo_foundation", "geo_contracts", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity")
+
+# 許可依存ルール
+# 最終更新: 2026-03-18
+$ARCH_ALLOWED_DEPS = @{
+    analysis       = @()
+    geo_contracts  = @("analysis")
+    geo_foundation = @("analysis", "geo_commons", "geo_contracts")  # geo_contracts: #318移行期の互換ブリッジ
+    geo_commons    = @("analysis")
+    geo_core       = @("analysis", "geo_entity")
+    geo_primitives = @("geo_foundation", "geo_contracts", "geo_core", "analysis")
+    geo_algorithms = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_nurbs", "analysis")
+    geo_nurbs      = @("geo_foundation", "geo_contracts", "geo_core", "geo_primitives", "analysis")
+    geo_io         = @("geo_foundation", "geo_core", "geo_primitives", "geo_algorithms", "analysis")
+    geo_entity     = @("geo_foundation", "geo_primitives")
+    cam_core       = @("analysis", "geo_foundation", "geo_primitives", "geo_algorithms")
+    cam_entity     = @("cam_core", "geo_entity")
+    cam_sim        = @("analysis", "cam_core", "geo_algorithms", "job_runtime", "job_domain")
+    job_runtime    = @("analysis")
+    job_domain     = @("analysis", "job_runtime")
+    converter      = @("geo_foundation", "geo_algorithms", "geo_io", "cam_core", "cam_entity", "cam_sim", "job_domain", "analysis")
+    graphics       = @("geo_foundation", "geo_core", "geo_primitives", "analysis")
+    render         = @("analysis")
+    stage          = @("render", "analysis")
+    app            = @("converter", "graphics", "render", "stage", "analysis")
+}
+
+# 禁止依存ルール（明示的に違反を検出）
+$ARCH_FORBIDDEN_DEPS = @{
+    geo_foundation = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
+    geo_contracts  = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "job_runtime", "converter", "graphics", "render", "stage", "app")
+    geo_commons    = @("converter", "graphics", "render", "stage", "app", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "cam_core", "cam_entity", "cam_sim", "job_runtime")
+    geo_core       = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
+    geo_primitives = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
+    geo_algorithms = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
+    geo_nurbs      = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
+    geo_io         = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
+    geo_entity     = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
+    cam_core       = @("converter", "graphics", "render", "stage", "app", "geo_entity", "cam_sim")
+    cam_entity     = @("converter", "graphics", "render", "stage", "app", "cam_sim")
+    cam_sim        = @("converter", "graphics", "render", "stage", "app", "geo_entity", "geo_foundation", "geo_core", "geo_primitives", "geo_nurbs", "geo_io", "cam_entity")
+    job_runtime    = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "converter", "graphics", "render", "stage", "app")
+    job_domain     = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "converter", "graphics", "render", "stage", "app")
+    converter      = @("render", "stage", "app")
+    graphics       = @("render", "stage", "app")
+    render         = @("geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "converter", "graphics")
+    stage          = @("geo_foundation", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "converter", "graphics")
+    app            = @("geo_foundation", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim")
+    analysis       = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "job_runtime", "converter", "graphics", "render", "stage", "app")
+}
+
+# 共通関数: Cargo.toml からワークスペース依存を抽出
+function Get-CrateDependenciesShared {
+    param([string]$CratePath)
+
+    $cargoToml = Join-Path $CratePath "Cargo.toml"
+    if (-not (Test-Path $cargoToml)) {
+        return @()
+    }
+
+    $knownCrates = $ARCH_ALLOWED_DEPS.Keys
+    $dependencies = @()
+    $content = Get-Content $cargoToml
+    $inDepsSection = $false
+
+    foreach ($line in $content) {
+        if ($line -match '^\[dependencies\]') {
+            $inDepsSection = $true
+            continue
+        }
+        if ($line -match '^\[.*\]' -and $inDepsSection) {
+            break
+        }
+        if ($inDepsSection -and $line -match '^(\w+)\s*=') {
+            $depName = $matches[1]
+            if ($knownCrates -contains $depName) {
+                $dependencies += $depName
+            }
+        }
+    }
+
+    return $dependencies
+}
+
+# 共通関数: ワークスペースクレートのパスマップを返す
+function Get-WorkspaceCratesShared {
+    $result = @{}
+    foreach ($crateName in $ARCH_LAYER_MAPPING.Keys) {
+        $cratePath = Join-Path (Get-Location) $ARCH_LAYER_MAPPING[$crateName]
+        if (Test-Path $cratePath) {
+            $result[$crateName] = $cratePath
+        }
+    }
+    return $result
+}

--- a/scripts/check_architecture_dependencies.ps1
+++ b/scripts/check_architecture_dependencies.ps1
@@ -17,7 +17,7 @@ $ARCHITECTURE_RULES = @{
         analysis       = @()
 
         # Model: geo_*
-        geo_foundation = @("analysis", "geo_commons")
+        geo_foundation = @("analysis", "geo_commons", "geo_contracts")  # geo_contracts: #318移行期の互換ブリッジ
         geo_contracts  = @("analysis")
         geo_commons    = @("geo_foundation", "analysis")
         geo_core       = @("analysis", "geo_entity") # geo_core -> geo_entity: OK

--- a/scripts/check_architecture_dependencies.ps1
+++ b/scripts/check_architecture_dependencies.ps1
@@ -6,160 +6,25 @@ param(
     [switch]$ExitOnError
 )
 
+# 共有ルールデータ・共通関数を読み込む
+. (Join-Path $PSScriptRoot "_arch_rules_data.ps1")
+
 function Write-Success { param($Message) Write-Host "OK $Message" -ForegroundColor Green }
 function Write-Warning { param($Message) Write-Host "WARN $Message" -ForegroundColor Yellow }
-function Write-Error { param($Message) Write-Host "ERROR $Message" -ForegroundColor Red }
-function Write-Info { param($Message) Write-Host "INFO $Message" -ForegroundColor Cyan }
-
-$ARCHITECTURE_RULES = @{
-    AllowedDependencies = @{
-        # Analysis
-        analysis       = @()
-
-        # Model: geo_*
-        geo_foundation = @("analysis", "geo_commons", "geo_contracts")  # geo_contracts: #318移行期の互換ブリッジ
-        geo_contracts  = @("analysis")
-        geo_commons    = @("geo_foundation", "analysis")
-        geo_core       = @("analysis", "geo_entity") # geo_core -> geo_entity: OK
-        geo_primitives = @("geo_foundation", "geo_contracts", "geo_core", "analysis")
-        geo_algorithms = @("geo_foundation", "geo_core", "geo_primitives", "analysis", "geo_nurbs")
-        geo_nurbs      = @("geo_foundation", "geo_contracts", "geo_core", "geo_primitives", "analysis")
-        geo_io         = @("geo_foundation", "geo_core", "geo_primitives", "geo_algorithms", "analysis")
-        geo_entity     = @("geo_foundation", "geo_primitives")
-
-        # Model: cam_*
-        cam_core       = @("analysis", "geo_foundation", "geo_primitives", "geo_algorithms", "cam_entity") # cam_core -> cam_entity: OK
-        cam_entity     = @("cam_core", "geo_entity")
-        cam_sim        = @("analysis", "cam_core", "geo_algorithms", "job_runtime", "job_domain")
-        job_runtime = @("analysis")
-        job_domain = @("analysis", "job_runtime", "cam_core", "cam_entity", "cam_sim")
-
-        # ViewModel
-        converter      = @("geo_foundation", "geo_algorithms", "geo_io", "cam_core", "cam_entity", "cam_sim", "job_domain", "analysis")
-        graphics       = @("geo_foundation", "geo_core", "geo_primitives", "analysis")
-
-        # View
-        render         = @("analysis")
-        stage          = @("render", "analysis")
-        app            = @("converter", "graphics", "render", "stage", "analysis")
-    }
-
-    ForbiddenDependencies = @{
-        # geo_* -> cam_* is forbidden
-        geo_foundation = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
-        geo_contracts  = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "job_runtime", "converter", "graphics", "render", "stage", "app")
-        geo_commons    = @("converter", "graphics", "render", "stage", "app", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "cam_core", "cam_entity", "cam_sim", "job_runtime")
-        geo_core       = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime") # geo_core -> cam_entity: NG
-        geo_primitives = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
-        geo_algorithms = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
-        geo_nurbs      = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
-        geo_io         = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
-        geo_entity     = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
-
-        # cam_*
-        cam_core       = @("converter", "graphics", "render", "stage", "app", "geo_entity", "cam_sim") # cam_core -> geo_entity: NG
-        cam_entity     = @("converter", "graphics", "render", "stage", "app", "cam_sim")
-        cam_sim        = @("converter", "graphics", "render", "stage", "app", "geo_entity", "geo_foundation", "geo_core", "geo_primitives", "geo_nurbs", "geo_io", "cam_entity")
-        job_runtime = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "converter", "graphics", "render", "stage", "app")
-        job_domain = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "converter", "graphics", "render", "stage", "app")
-
-        # ViewModel -> View forbidden
-        converter      = @("render", "stage", "app")
-        graphics       = @("render", "stage", "app")
-
-        # View -> Model forbidden (current policy)
-        render         = @("geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "converter", "graphics")
-        stage          = @("geo_foundation", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "converter", "graphics")
-        app            = @("geo_foundation", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim")
-
-        # analysis isolation
-        analysis       = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "job_runtime", "converter", "graphics", "render", "stage", "app")
-    }
-
-    NamingRules = @{
-        ModelPrefix = "geo_"
-        RequiredModelCrates = @("geo_foundation", "geo_contracts", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity")
-    }
-}
-
-function Get-CrateDependencies {
-    param([string]$CratePath)
-
-    $cargoToml = Join-Path $CratePath "Cargo.toml"
-    if (-not (Test-Path $cargoToml)) {
-        return @()
-    }
-
-    $dependencies = @()
-    $content = Get-Content $cargoToml
-    $inDepsSection = $false
-
-    foreach ($line in $content) {
-        if ($line -match '^\[dependencies\]') {
-            $inDepsSection = $true
-            continue
-        }
-        if ($line -match '^\[.*\]' -and $inDepsSection) {
-            break
-        }
-        if ($inDepsSection -and $line -match '^(\w+)\s*=') {
-            $depName = $matches[1]
-            if ($ARCHITECTURE_RULES.AllowedDependencies.ContainsKey($depName)) {
-                $dependencies += $depName
-            }
-        }
-    }
-
-    return $dependencies
-}
-
-function Get-WorkspaceCrates {
-    $workspaceCrates = @{}
-
-    $layerMapping = @{
-        analysis       = "foundation/analysis"
-        geo_foundation = "model/geo_foundation"
-        geo_contracts  = "model/geo_contracts"
-        geo_commons    = "model/geo_commons"
-        geo_core       = "model/geo_core"
-        geo_primitives = "model/geo_primitives"
-        geo_algorithms = "model/geo_algorithms"
-        geo_nurbs      = "model/geo_nurbs"
-        geo_io         = "model/geo_io"
-        geo_entity     = "model/geo_entity"
-        cam_core       = "model/cam_core"
-        cam_entity     = "model/cam_entity"
-        cam_sim        = "model/cam_sim"
-        job_runtime = "model/job_runtime"
-        job_domain = "model/job_domain"
-        converter      = "viewmodel/converter"
-        graphics       = "viewmodel/graphics"
-        render         = "view/render"
-        stage          = "view/stage"
-        app            = "view/app"
-    }
-
-    foreach ($crateName in $layerMapping.Keys) {
-        $cratePath = Join-Path (Get-Location) $layerMapping[$crateName]
-        if (Test-Path $cratePath) {
-            $workspaceCrates[$crateName] = $cratePath
-        }
-    }
-
-    return $workspaceCrates
-}
+function Write-Error   { param($Message) Write-Host "ERROR $Message" -ForegroundColor Red }
+function Write-Info    { param($Message) Write-Host "INFO $Message" -ForegroundColor Cyan }
 
 function Test-ArchitectureDependencies {
     Write-Info "RedRing Architecture Dependency Check Start"
     Write-Info "Date: $(Get-Date -Format 'yyyy/MM/dd HH:mm:ss')"
     Write-Host ""
 
-    $errorCount = 0
+    $errorCount   = 0
     $warningCount = 0
-    $workspaceCrates = Get-WorkspaceCrates
+    $workspaceCrates = Get-WorkspaceCratesShared
 
     Write-Info "1. Model Layer Naming Rule Check"
-    foreach ($crateName in $ARCHITECTURE_RULES.NamingRules.RequiredModelCrates) {
+    foreach ($crateName in $ARCH_REQUIRED_MODEL_CRATES) {
         if ($workspaceCrates.ContainsKey($crateName)) {
             Write-Success "Model crate '$crateName' follows correct naming rules"
         }
@@ -172,12 +37,14 @@ function Test-ArchitectureDependencies {
 
     Write-Info "2. Dependency Rule Check"
     foreach ($crateName in $workspaceCrates.Keys) {
-        $cratePath = $workspaceCrates[$crateName]
-        $actualDeps = Get-CrateDependencies $cratePath
+        $cratePath  = $workspaceCrates[$crateName]
+        $actualDeps = Get-CrateDependenciesShared $cratePath
 
         Write-Info "Validating '$crateName' dependencies..."
 
-        $allowedDeps = $ARCHITECTURE_RULES.AllowedDependencies[$crateName]
+        $allowedDeps   = $ARCH_ALLOWED_DEPS[$crateName]
+        $forbiddenDeps = $ARCH_FORBIDDEN_DEPS[$crateName]
+
         foreach ($dep in $actualDeps) {
             if ($allowedDeps -contains $dep) {
                 if ($Verbose) {
@@ -190,7 +57,6 @@ function Test-ArchitectureDependencies {
             }
         }
 
-        $forbiddenDeps = $ARCHITECTURE_RULES.ForbiddenDependencies[$crateName]
         foreach ($dep in $actualDeps) {
             if ($forbiddenDeps -contains $dep) {
                 Write-Error "  ERROR '$crateName' -> '$dep' (explicitly forbidden)"
@@ -205,18 +71,11 @@ function Test-ArchitectureDependencies {
     Write-Host ""
 
     Write-Info "3. Layer Dependency Summary"
-    $layers = @{
-        Analysis  = @("analysis")
-        Model     = @("geo_foundation", "geo_contracts", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "job_runtime", "job_domain")
-        ViewModel = @("converter", "graphics")
-        View      = @("render", "stage", "app")
-    }
-
-    foreach ($layerName in $layers.Keys) {
+    foreach ($layerName in $ARCH_LAYERS.Keys) {
         Write-Info "Layer: $layerName"
-        foreach ($crateName in $layers[$layerName]) {
+        foreach ($crateName in $ARCH_LAYERS[$layerName]) {
             if ($workspaceCrates.ContainsKey($crateName)) {
-                $deps = Get-CrateDependencies $workspaceCrates[$crateName]
+                $deps = Get-CrateDependenciesShared $workspaceCrates[$crateName]
                 if ($deps.Length -gt 0) {
                     Write-Host "    $crateName -> $($deps -join ', ')" -ForegroundColor White
                 }

--- a/scripts/check_architecture_dependencies_simple.ps1
+++ b/scripts/check_architecture_dependencies_simple.ps1
@@ -74,7 +74,7 @@ function Test-ArchitectureDependencies {
     $allowedDeps = @{
         "analysis"       = @()
         "geo_contracts"  = @("analysis")  # analysis の Scalar/Angle を re-export する形状契約クレート
-        "geo_foundation" = @("analysis", "geo_commons")  # geo_commons: 共通計算関数を再エクスポート
+        "geo_foundation" = @("analysis", "geo_commons", "geo_contracts")  # geo_commons: 共通計算関数を再エクスポート; geo_contracts: #318移行期の互換ブリッジ
         "geo_commons"    = @("analysis")  # 独立した計算関数クレート
         "geo_core"       = @("geo_foundation", "analysis")  # トレイト実装 + AABB型
         "geo_primitives" = @("geo_foundation", "geo_contracts", "geo_core", "analysis")  # geo_core の AABB型を使用

--- a/scripts/check_architecture_dependencies_simple.ps1
+++ b/scripts/check_architecture_dependencies_simple.ps1
@@ -1,45 +1,17 @@
-# RedRing Architecture Dependency Check Script
+# RedRing Architecture Dependency Check Script (Simple)
+# Usage: powershell -ExecutionPolicy Bypass -File .\scripts\check_architecture_dependencies_simple.ps1
+
 param(
     [switch]$Verbose,
     [switch]$ExitOnError
 )
 
+# 共有ルールデータ・共通関数を読み込む
+. (Join-Path $PSScriptRoot "_arch_rules_data.ps1")
+
 function Write-ColorText {
     param($Text, $Color = "White")
     Write-Host $Text -ForegroundColor $Color
-}
-
-function Get-CrateDependencies {
-    param([string]$CratePath)
-
-    $cargoToml = Join-Path $CratePath "Cargo.toml"
-    if (-not (Test-Path $cargoToml)) {
-        return @()
-    }
-
-    $dependencies = @()
-    $content = Get-Content $cargoToml
-    $inDepsSection = $false
-
-    foreach ($line in $content) {
-        if ($line -match '^\[dependencies\]') {
-            $inDepsSection = $true
-            continue
-        }
-        if ($line -match '^\[.*\]' -and $inDepsSection) {
-            break
-        }
-        if ($inDepsSection -and $line -match '^(\w+)\s*=') {
-            $depName = $matches[1]
-            # Check if it's a workspace crate
-            $workspaceCrates = @("analysis", "geo_contracts", "geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "job_runtime", "job_domain", "converter", "graphics", "render", "stage", "app")
-            if ($workspaceCrates -contains $depName) {
-                $dependencies += $depName
-            }
-        }
-    }
-
-    return $dependencies
 }
 
 function Test-ArchitectureDependencies {
@@ -47,54 +19,13 @@ function Test-ArchitectureDependencies {
     Write-ColorText "Date: $(Get-Date -Format 'yyyy/MM/dd HH:mm:ss')" "Gray"
     Write-Host ""
 
-    $errorCount = 0
+    $errorCount   = 0
     $warningCount = 0
-
-    # Define workspace structure
-    $workspaceCrates = @{
-        "analysis"       = "foundation\analysis"
-        "geo_contracts"  = "model\geo_contracts"
-        "geo_foundation" = "model\geo_foundation"
-        "geo_commons"    = "model\geo_commons"
-        "geo_core"       = "model\geo_core"
-        "geo_primitives" = "model\geo_primitives"
-        "geo_algorithms" = "model\geo_algorithms"
-        "geo_nurbs"      = "model\geo_nurbs"
-        "geo_io"         = "model\geo_io"
-        "job_runtime"    = "model\job_runtime"
-        "job_domain"     = "model\job_domain"
-        "converter"      = "viewmodel\converter"
-        "graphics"       = "viewmodel\graphics"
-        "render"         = "view\render"
-        "stage"          = "view\stage"
-        "app"            = "view\app"
-    }
-
-    # Define allowed dependencies (Updated: 2025-12-25)
-    $allowedDeps = @{
-        "analysis"       = @()
-        "geo_contracts"  = @("analysis")  # analysis の Scalar/Angle を re-export する形状契約クレート
-        "geo_foundation" = @("analysis", "geo_commons", "geo_contracts")  # geo_commons: 共通計算関数を再エクスポート; geo_contracts: #318移行期の互換ブリッジ
-        "geo_commons"    = @("analysis")  # 独立した計算関数クレート
-        "geo_core"       = @("geo_foundation", "analysis")  # トレイト実装 + AABB型
-        "geo_primitives" = @("geo_foundation", "geo_contracts", "geo_core", "analysis")  # geo_core の AABB型を使用
-        "geo_algorithms" = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_nurbs", "analysis")  # 共通計算関数・NURBS衝突判定のため geo_commons, geo_nurbs を追加
-        "geo_nurbs"      = @("geo_foundation", "geo_contracts", "geo_core", "geo_primitives", "analysis")  # geo_core の AABB型を使用
-        "geo_io"         = @("geo_foundation", "geo_core", "geo_primitives", "geo_algorithms", "analysis")
-        "job_runtime"    = @("analysis")
-        "job_domain"     = @("analysis", "job_runtime")
-        "cam_sim"        = @("analysis", "cam_core", "geo_algorithms", "job_runtime", "job_domain")
-        "converter"      = @("geo_foundation", "geo_algorithms", "geo_io", "job_domain", "analysis")  # geo_algorithms が geo_core/geo_primitives を再エクスポート
-        "graphics"       = @("analysis")
-        "render"         = @("analysis")
-        "stage"          = @("render", "analysis")
-        "app"            = @("converter", "graphics", "render", "stage", "analysis")
-    }
+    $workspaceCrates = Get-WorkspaceCratesShared
 
     Write-ColorText "1. Checking Model layer naming rules..." "Yellow"
-    $modelCrates = @("geo_contracts", "geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io")
-    foreach ($crateName in $modelCrates) {
-        if (Test-Path $workspaceCrates[$crateName]) {
+    foreach ($crateName in $ARCH_REQUIRED_MODEL_CRATES) {
+        if ($workspaceCrates.ContainsKey($crateName)) {
             Write-ColorText "  OK: $crateName follows geo_ prefix rule" "Green"
         }
         else {
@@ -105,58 +36,40 @@ function Test-ArchitectureDependencies {
     Write-Host ""
 
     Write-ColorText "2. Checking dependency rules..." "Yellow"
-    
-    # Debug: geo_foundation の許可依存先を表示
-    Write-ColorText "  DEBUG: geo_foundation allowed deps: $($allowedDeps['geo_foundation'] -join ', ')" "Gray"
-    
+
     foreach ($crateName in $workspaceCrates.Keys) {
-        $cratePath = $workspaceCrates[$crateName]
+        $cratePath  = $workspaceCrates[$crateName]
+        $actualDeps = Get-CrateDependenciesShared $cratePath
+        $allowed    = $ARCH_ALLOWED_DEPS[$crateName]
 
-        if (Test-Path $cratePath) {
-            $actualDeps = Get-CrateDependencies $cratePath
-            $allowed = $allowedDeps[$crateName]
+        Write-ColorText "  Checking: $crateName" "Cyan"
 
-            Write-ColorText "  Checking: $crateName" "Cyan"
-
-            foreach ($dep in $actualDeps) {
-                if ($allowed -contains $dep) {
-                    if ($Verbose) {
-                        Write-ColorText "    OK: $crateName -> $dep (allowed)" "Green"
-                    }
-                }
-                else {
-                    Write-ColorText "    ERROR: $crateName -> $dep (not allowed)" "Red"
-                    $errorCount++
+        foreach ($dep in $actualDeps) {
+            if ($allowed -contains $dep) {
+                if ($Verbose) {
+                    Write-ColorText "    OK: $crateName -> $dep (allowed)" "Green"
                 }
             }
-
-            if ($actualDeps.Length -eq 0) {
-                Write-ColorText "    INFO: No workspace dependencies" "Gray"
+            else {
+                Write-ColorText "    ERROR: $crateName -> $dep (not allowed)" "Red"
+                $errorCount++
             }
         }
-        else {
-            Write-ColorText "  WARN: Crate path not found: $cratePath" "Yellow"
-            $warningCount++
+
+        if ($actualDeps.Length -eq 0) {
+            Write-ColorText "    INFO: No workspace dependencies" "Gray"
         }
     }
     Write-Host ""
 
     Write-ColorText "3. Layer summary:" "Yellow"
-    $layers = @{
-        "Analysis"  = @("analysis")
-        "Model"     = @("geo_contracts", "geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "job_runtime", "job_domain")
-        "ViewModel" = @("converter", "graphics")
-        "View"      = @("render", "stage", "app")
-    }
-
-    foreach ($layerName in $layers.Keys) {
+    foreach ($layerName in $ARCH_LAYERS.Keys) {
         Write-ColorText "  $layerName layer:" "Cyan"
-        foreach ($crateName in $layers[$layerName]) {
-            if (Test-Path $workspaceCrates[$crateName]) {
-                $deps = Get-CrateDependencies $workspaceCrates[$crateName]
+        foreach ($crateName in $ARCH_LAYERS[$layerName]) {
+            if ($workspaceCrates.ContainsKey($crateName)) {
+                $deps = Get-CrateDependenciesShared $workspaceCrates[$crateName]
                 if ($deps.Length -gt 0) {
-                    $depsStr = $deps -join ", "
-                    Write-Host "    $crateName -> $depsStr"
+                    Write-Host "    $crateName -> $($deps -join ', ')"
                 }
                 else {
                     Write-Host "    $crateName -> (no deps)" -ForegroundColor Gray
@@ -190,11 +103,12 @@ function Test-ArchitectureDependencies {
     return @{ "Errors" = $errorCount; "Warnings" = $warningCount }
 }
 
-# Main execution
+# ヘルプ表示
 if ($args -contains "-Help" -or $args -contains "-h") {
-    Write-Host "RedRing Architecture Dependency Check Script" -ForegroundColor Cyan
+    Write-Host "RedRing Architecture Dependency Check Script (Simple)" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "Usage: .\scripts\check_architecture_dependencies.ps1 [options]"
+    Write-Host "Usage:"
+    Write-Host "  .\scripts\check_architecture_dependencies_simple.ps1 [options]"
     Write-Host ""
     Write-Host "Options:"
     Write-Host "  -Verbose      Show detailed dependency information"


### PR DESCRIPTION
## 概要

#318 の 3PR 分割方針に基づく PR-A です。

- `geo_contracts` の骨格追加（classification / geometry::core）
- `point/vector/arc/circle` 契約の先行配置
- `geo_foundation` 側に移行ブリッジを追加
- `geo_primitives` の arc/circle 関連 import を `geo_contracts` へ先行切替

## 変更点

### contracts骨格
- `model/geo_contracts/src/classification.rs` 追加
- `model/geo_contracts/src/geometry/mod.rs` 追加
- `model/geo_contracts/src/geometry/core/mod.rs` 追加
- `model/geo_contracts/src/geometry/core/point_traits.rs` 追加
- `model/geo_contracts/src/geometry/core/vector_traits.rs` 追加
- `model/geo_contracts/src/geometry/core/arc_traits.rs` 追加
- `model/geo_contracts/src/geometry/core/circle_traits.rs` 追加
- `model/geo_contracts/src/lib.rs` 公開面更新

### foundationブリッジ
- `model/geo_foundation/Cargo.toml` に `geo_contracts` 依存追加
- `model/geo_foundation/src/lib.rs` に `contracts` 名前空間ブリッジ追加

### primitives先行切替
- `model/geo_primitives/src/arc_2d_metrics.rs`
- `model/geo_primitives/src/arc_2d_tests.rs`
- `model/geo_primitives/src/arc_2d_transform.rs`
- `model/geo_primitives/src/arc_3d_tests.rs`
- `model/geo_primitives/src/arc_3d_transform.rs`
- `model/geo_primitives/src/arc_2d.rs`（不要 import 整理）

### 計画ドキュメント更新
- `dev/architecture/ISSUE_318_IMPLEMENTATION_PREP.md`
  - PR-A / PR-B / PR-C 分割を明記
  - #332 との境界（cross collision/intersection 本格移設）を明文化

## 検証

- `cargo check -p geo_primitives`
- `cargo test -p geo_primitives arc_`
- `cargo test -p geo_primitives circle_`

## 境界

- collision/intersection の本格的な cross operation 実装移設は #332 で追跡
- 本PRは #318 の依存置換ラインを前進させる最小差分に限定

## 関連

- #318
- #332