### PR TITLE
feat: geo_nurbsのNURBS trait参照をgeo_contractsへ移行（Issue #318 PR-B）

### DIFF
--- a/model/geo_algorithms/src/collision/primitive_nurbs.rs
+++ b/model/geo_algorithms/src/collision/primitive_nurbs.rs
@@ -595,7 +595,7 @@ mod tests {
 
         // Core Traits経由で生成（Foundation Pattern）
         // シグネチャ: new(degree, knots, control_points: Vec<(T,T,T)>, weights)
-        use geo_foundation::NurbsCurve3DConstructor;
+        use geo_foundation::contracts::NurbsCurve3DConstructor;
         let control_points_tuples = control_points
             .into_iter()
             .map(|v| (v.x(), v.y(), v.z()))

--- a/model/geo_contracts/src/geometry/core/mod.rs
+++ b/model/geo_contracts/src/geometry/core/mod.rs
@@ -3,6 +3,9 @@
 
 pub mod arc_traits;
 pub mod circle_traits;
+pub mod nurbs_curve_2d_traits;
+pub mod nurbs_curve_3d_traits;
+pub mod nurbs_surface_3d_traits;
 pub mod point_traits;
 pub mod vector_traits;
 
@@ -13,6 +16,15 @@ pub use arc_traits::{
 pub use circle_traits::{
     Circle2DConstructor, Circle2DCore, Circle2DMeasure, Circle2DProperties, Circle3DConstructor,
     Circle3DCore, Circle3DMeasure, Circle3DProperties,
+};
+pub use nurbs_curve_2d_traits::{
+    NurbsCurve2DConstructor, NurbsCurve2DCore, NurbsCurve2DMeasure, NurbsCurve2DProperties,
+};
+pub use nurbs_curve_3d_traits::{
+    NurbsCurve3DConstructor, NurbsCurve3DCore, NurbsCurve3DMeasure, NurbsCurve3DProperties,
+};
+pub use nurbs_surface_3d_traits::{
+    NurbsSurface3DConstructor, NurbsSurface3DCore, NurbsSurface3DMeasure, NurbsSurface3DProperties,
 };
 pub use point_traits::{
     Point2DConstructor, Point2DCore, Point2DMeasure, Point2DProperties, Point3DConstructor,

--- a/model/geo_contracts/src/geometry/core/nurbs_curve_2d_traits.rs
+++ b/model/geo_contracts/src/geometry/core/nurbs_curve_2d_traits.rs
@@ -1,0 +1,99 @@
+//! NurbsCurve2D Core Traits - NURBS 2D曲線の3つのCore機能統合
+//!
+//! Core機能（Constructor/Properties/Measure）を形状別に統合
+//! Transform機能は共通のAnalysisTransformトレイトを使用
+
+use crate::Scalar;
+
+// ============================================================================
+// 1. Constructor Traits - NurbsCurve2D生成機能
+// ============================================================================
+
+/// NurbsCurve2D生成のためのConstructorトレイト
+pub trait NurbsCurve2DConstructor<T: Scalar> {
+    /// NURBS曲線を作成
+    ///
+    /// # Arguments
+    /// * `control_points` - 制御点配列 [(x, y), ...]
+    /// * `weights` - 重み配列（Noneの場合は非有理曲線）
+    /// * `knot_vector` - ノットベクトル
+    /// * `degree` - NURBS次数
+    ///
+    /// # Errors
+    /// * 制御点数が次数+1未満の場合
+    /// * ノットベクトルが無効な場合
+    /// * 重み配列のサイズが制御点数と一致しない場合
+    fn new(
+        control_points: &[(T, T)],
+        weights: Option<Vec<T>>,
+        knot_vector: Vec<T>,
+        degree: usize,
+    ) -> Result<Self, String>
+    where
+        Self: Sized;
+
+    /// 制御点のみから非有理NURBS曲線を作成（簡易コンストラクタ）
+    ///
+    /// 自動的にクランプされた均一ノットベクトルを生成
+    fn from_control_points(control_points: &[(T, T)], degree: usize) -> Result<Self, String>
+    where
+        Self: Sized;
+
+    /// 単位線分（(0,0)から(1,0)への直線）
+    fn unit_line() -> Self
+    where
+        Self: Sized;
+}
+
+// ============================================================================
+// 2. Properties Traits - NurbsCurve2D基本情報取得
+// ============================================================================
+
+/// NurbsCurve2D基本プロパティ取得トレイト
+pub trait NurbsCurve2DProperties<T: Scalar> {
+    /// NURBS次数を取得
+    fn degree(&self) -> usize;
+
+    /// 制御点数を取得
+    fn num_control_points(&self) -> usize;
+
+    /// ノットベクトルへの参照を取得
+    fn knot_vector(&self) -> &[T];
+
+    /// 有理曲線かどうかを判定
+    fn is_rational(&self) -> bool;
+
+    /// 曲線の次元数を取得（2D曲線の場合は2）
+    fn dimension(&self) -> usize {
+        2
+    }
+}
+
+// ============================================================================
+// 3. Measure Traits - NurbsCurve2D測定・評価機能
+// ============================================================================
+
+/// NurbsCurve2D測定・評価機能トレイト
+pub trait NurbsCurve2DMeasure<T: Scalar> {
+    /// パラメータ t での曲線上の点を計算
+    fn point_at(&self, t: T) -> (T, T);
+
+    /// パラメータ t での接線ベクトルを計算
+    fn tangent_at(&self, t: T) -> (T, T);
+
+    /// 曲線の長さを計算（数値積分により近似計算）
+    fn length(&self) -> T;
+
+    /// パラメータ t での曲率を計算
+    fn curvature_at(&self, t: T) -> T;
+}
+
+// ============================================================================
+// 4. Core統合トレイト
+// ============================================================================
+
+/// NurbsCurve2DのCore機能を統合するトレイト
+pub trait NurbsCurve2DCore<T: Scalar>:
+    NurbsCurve2DConstructor<T> + NurbsCurve2DProperties<T> + NurbsCurve2DMeasure<T>
+{
+}

--- a/model/geo_contracts/src/geometry/core/nurbs_curve_3d_traits.rs
+++ b/model/geo_contracts/src/geometry/core/nurbs_curve_3d_traits.rs
@@ -1,0 +1,98 @@
+//! NurbsCurve3D Core Traits - NURBS曲線の3つのCore機能統合
+//!
+//! Core機能（Constructor/Properties/Measure）を形状別に統合
+//! Transform機能は共通のAnalysisTransformトレイトを使用
+
+use crate::Scalar;
+
+// ============================================================================
+// 1. Constructor Traits - NURBS Curve生成機能
+// ============================================================================
+
+/// NurbsCurve3D生成のためのConstructorトレイト
+pub trait NurbsCurve3DConstructor<T: Scalar> {
+    /// 基本コンストラクタ（次数、ノット、制御点、重み）
+    ///
+    /// # 引数
+    /// * `degree` - NURBS曲線の次数（1=線形、2=2次、3=3次）
+    /// * `knots` - ノットベクトル
+    /// * `control_points` - 制御点配列（x,y,z座標のタプル）
+    /// * `weights` - 重み配列（Noneの場合は非有理曲線）
+    fn new(
+        degree: usize,
+        knots: Vec<T>,
+        control_points: Vec<(T, T, T)>,
+        weights: Option<Vec<T>>,
+    ) -> Result<Self, String>
+    where
+        Self: Sized;
+
+    /// Bezier曲線として作成（クランプド・ノットベクトル使用）
+    fn from_bezier(control_points: Vec<(T, T, T)>) -> Result<Self, String>
+    where
+        Self: Sized;
+
+    /// 線分として作成（1次NURBS、2制御点）
+    fn line_segment(start: (T, T, T), end: (T, T, T)) -> Result<Self, String>
+    where
+        Self: Sized;
+}
+
+// ============================================================================
+// 2. Properties Traits - NURBS Curve基本情報取得
+// ============================================================================
+
+/// NurbsCurve3D基本プロパティ取得トレイト
+pub trait NurbsCurve3DProperties<T: Scalar> {
+    /// NURBS曲線の次数を取得
+    fn degree(&self) -> usize;
+
+    /// ノットベクトルへの参照を取得
+    fn knot_vector(&self) -> &[T];
+
+    /// 制御点の数を取得
+    fn control_points_count(&self) -> usize;
+
+    /// 重み配列への参照を取得
+    fn weights(&self) -> Option<&[T]>;
+
+    /// 有理曲線かどうかを判定
+    fn is_rational(&self) -> bool;
+
+    /// パラメータ定義域を取得 (u_min, u_max)
+    fn parameter_domain(&self) -> (T, T);
+
+    /// 全制御点座標のflattened配列への参照を取得
+    ///
+    /// [x0, y0, z0, x1, y1, z1, ...] の形式のスライス参照
+    fn coordinates(&self) -> &[T];
+}
+
+// ============================================================================
+// 3. Measure Traits - NURBS Curve計量・評価機能
+// ============================================================================
+
+/// NurbsCurve3D計量・評価トレイト
+pub trait NurbsCurve3DMeasure<T: Scalar> {
+    /// 指定されたパラメータ範囲の曲線長を計算（数値積分）
+    fn arc_length(&self, u_start: T, u_end: T, tolerance: T) -> T;
+
+    /// 曲線全体の長さを計算
+    fn arc_length_total(&self, tolerance: T) -> T;
+
+    /// 指定された曲線長に対応するパラメータ値を計算
+    fn parameter_at_length(&self, arc_length: T, tolerance: T) -> Option<T>;
+
+    /// 指定されたパラメータ値における曲線上の点を評価
+    fn evaluate(&self, u: T) -> Option<(T, T, T)>;
+}
+
+// ============================================================================
+// 4. Core統合トレイト
+// ============================================================================
+
+/// NurbsCurve3DのCore機能を統合するトレイト
+pub trait NurbsCurve3DCore<T: Scalar>:
+    NurbsCurve3DConstructor<T> + NurbsCurve3DProperties<T> + NurbsCurve3DMeasure<T>
+{
+}

--- a/model/geo_contracts/src/geometry/core/nurbs_surface_3d_traits.rs
+++ b/model/geo_contracts/src/geometry/core/nurbs_surface_3d_traits.rs
@@ -1,0 +1,110 @@
+//! NurbsSurface3D Core Traits - NURBSサーフェスの3つのCore機能統合
+//!
+//! Core機能（Constructor/Properties/Measure）を形状別に統合
+//! Transform機能は共通のAnalysisTransformトレイトを使用
+
+use crate::Scalar;
+
+// ============================================================================
+// 1. Constructor Traits - NurbsSurface3D生成機能
+// ============================================================================
+
+/// NurbsSurface3D生成のためのConstructorトレイト
+pub trait NurbsSurface3DConstructor<T: Scalar> {
+    /// NURBSサーフェスを作成
+    ///
+    /// # Arguments
+    /// * `control_points` - 制御点の2次元グリッド [u_count][v_count]
+    /// * `weights` - 重みの2次元グリッド（Noneの場合は非有理サーフェス）
+    /// * `u_knots` - u方向ノットベクトル
+    /// * `v_knots` - v方向ノットベクトル
+    /// * `u_degree` - u方向次数
+    /// * `v_degree` - v方向次数
+    fn new(
+        control_points: Vec<Vec<(T, T, T)>>,
+        weights: Option<Vec<Vec<T>>>,
+        u_knots: Vec<T>,
+        v_knots: Vec<T>,
+        u_degree: usize,
+        v_degree: usize,
+    ) -> Result<Self, String>
+    where
+        Self: Sized;
+
+    /// 制御点グリッドから非有理NURBSサーフェスを作成（簡易コンストラクタ）
+    fn from_control_points(
+        control_points: Vec<Vec<(T, T, T)>>,
+        u_degree: usize,
+        v_degree: usize,
+    ) -> Result<Self, String>
+    where
+        Self: Sized;
+
+    /// 単位平面サーフェス（XY平面上の1×1正方形）
+    fn unit_plane() -> Self
+    where
+        Self: Sized;
+}
+
+// ============================================================================
+// 2. Properties Traits - NurbsSurface3D基本情報取得
+// ============================================================================
+
+/// NurbsSurface3D基本プロパティ取得トレイト
+pub trait NurbsSurface3DProperties<T: Scalar> {
+    /// u方向のNURBS次数を取得
+    fn u_degree(&self) -> usize;
+
+    /// v方向のNURBS次数を取得
+    fn v_degree(&self) -> usize;
+
+    /// u方向の制御点数を取得
+    fn u_count(&self) -> usize;
+
+    /// v方向の制御点数を取得
+    fn v_count(&self) -> usize;
+
+    /// u方向ノットベクトルへの参照を取得
+    fn u_knots(&self) -> &[T];
+
+    /// v方向ノットベクトルへの参照を取得
+    fn v_knots(&self) -> &[T];
+
+    /// 有理サーフェスかどうかを判定
+    fn is_rational(&self) -> bool;
+
+    /// 全制御点座標のflattened配列への参照を取得（u方向優先でflatten）
+    fn coordinates(&self) -> &[T];
+
+    /// 全重みのflattened配列への参照を取得（u方向優先でflatten）
+    fn weights(&self) -> Option<&[T]>;
+}
+
+// ============================================================================
+// 3. Measure Traits - NurbsSurface3D測定・評価機能
+// ============================================================================
+
+/// NurbsSurface3D測定・評価機能トレイト
+pub trait NurbsSurface3DMeasure<T: Scalar> {
+    /// パラメータ座標(u, v)でのサーフェス上の点を計算
+    fn point_at_uv(&self, u: T, v: T) -> (T, T, T);
+
+    /// パラメータ座標(u, v)での法線ベクトルを計算
+    fn normal_at(&self, u: T, v: T) -> (T, T, T);
+
+    /// サーフェスの表面積を計算（数値積分により近似計算）
+    fn surface_area(&self) -> T;
+
+    /// パラメータ座標(u, v)での接線ベクトル(du, dv)を計算
+    fn tangent_vectors_at(&self, u: T, v: T) -> ((T, T, T), (T, T, T));
+}
+
+// ============================================================================
+// 4. Core統合トレイト
+// ============================================================================
+
+/// NurbsSurface3DのCore機能を統合するトレイト
+pub trait NurbsSurface3DCore<T: Scalar>:
+    NurbsSurface3DConstructor<T> + NurbsSurface3DProperties<T> + NurbsSurface3DMeasure<T>
+{
+}

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -18,3 +18,8 @@ pub use geometry::core::{
     Vector2DMeasure, Vector2DProperties, Vector3DConstructor, Vector3DCore, Vector3DMeasure,
     Vector3DProperties,
 };
+pub use geometry::core::{
+    NurbsCurve2DConstructor, NurbsCurve2DCore, NurbsCurve2DMeasure, NurbsCurve2DProperties,
+    NurbsCurve3DConstructor, NurbsCurve3DCore, NurbsCurve3DMeasure, NurbsCurve3DProperties,
+    NurbsSurface3DConstructor, NurbsSurface3DCore, NurbsSurface3DMeasure, NurbsSurface3DProperties,
+};

--- a/model/geo_foundation/src/lib.rs
+++ b/model/geo_foundation/src/lib.rs
@@ -160,10 +160,13 @@ pub mod contracts {
         Arc2DConstructor, Arc2DCore, Arc2DMeasure, Arc2DProperties, Arc3DConstructor, Arc3DCore,
         Arc3DMeasure, Arc3DProperties, Circle2DConstructor, Circle2DCore, Circle2DMeasure,
         Circle2DProperties, Circle3DConstructor, Circle3DCore, Circle3DMeasure, Circle3DProperties,
-        Point2DConstructor, Point2DCore, Point2DMeasure, Point2DProperties, Point3DConstructor,
-        Point3DCore, Point3DMeasure, Point3DProperties, Vector2DConstructor, Vector2DCore,
-        Vector2DMeasure, Vector2DProperties, Vector3DConstructor, Vector3DCore, Vector3DMeasure,
-        Vector3DProperties,
+        NurbsCurve2DConstructor, NurbsCurve2DCore, NurbsCurve2DMeasure, NurbsCurve2DProperties,
+        NurbsCurve3DConstructor, NurbsCurve3DCore, NurbsCurve3DMeasure, NurbsCurve3DProperties,
+        NurbsSurface3DConstructor, NurbsSurface3DCore, NurbsSurface3DMeasure,
+        NurbsSurface3DProperties, Point2DConstructor, Point2DCore, Point2DMeasure,
+        Point2DProperties, Point3DConstructor, Point3DCore, Point3DMeasure, Point3DProperties,
+        Vector2DConstructor, Vector2DCore, Vector2DMeasure, Vector2DProperties,
+        Vector3DConstructor, Vector3DCore, Vector3DMeasure, Vector3DProperties,
     };
 }
 

--- a/model/geo_nurbs/src/curve_2d.rs
+++ b/model/geo_nurbs/src/curve_2d.rs
@@ -5,7 +5,7 @@
 
 use crate::{KnotVector, NurbsError, Result, Scalar};
 use analysis::linalg::vector::Vector2;
-use geo_foundation::{
+use geo_contracts::{
     NurbsCurve2DConstructor, NurbsCurve2DCore, NurbsCurve2DMeasure, NurbsCurve2DProperties,
 };
 
@@ -387,7 +387,7 @@ mod tests {
 
     #[test]
     fn test_nurbs_curve_2d_creation() {
-        use geo_foundation::NurbsCurve2DConstructor;
+        use geo_contracts::NurbsCurve2DConstructor;
         let control_points = &[(0.0, 0.0), (1.0, 1.0), (2.0, 0.0)];
         let weights = Some(vec![1.0, 1.0, 1.0]);
         let knot_vector = vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0];
@@ -408,7 +408,7 @@ mod tests {
 
     #[test]
     fn test_curve_evaluation() {
-        use geo_foundation::NurbsCurve2DConstructor;
+        use geo_contracts::NurbsCurve2DConstructor;
         let control_points = &[(0.0, 0.0), (1.0, 1.0), (2.0, 0.0)];
         let weights = Some(vec![1.0, 1.0, 1.0]);
         let knot_vector = vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0];
@@ -437,7 +437,7 @@ mod tests {
 
     #[test]
     fn test_approximate_length() {
-        use geo_foundation::NurbsCurve2DConstructor;
+        use geo_contracts::NurbsCurve2DConstructor;
         let control_points = &[(0.0, 0.0), (1.0, 0.0), (2.0, 0.0)];
         let weights = Some(vec![1.0, 1.0, 1.0]);
         let knot_vector = vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0];

--- a/model/geo_nurbs/src/curve_2d_foundation.rs
+++ b/model/geo_nurbs/src/curve_2d_foundation.rs
@@ -3,7 +3,8 @@
 //! Extension Traits の実装とテスト
 
 use crate::{NurbsCurve2D, Scalar};
-use geo_foundation::{Bounded, ExtensionFoundation, NurbsCurve2DProperties, PrimitiveKind};
+use geo_contracts::NurbsCurve2DProperties;
+use geo_foundation::{Bounded, ExtensionFoundation, PrimitiveKind};
 
 // ============================================================================
 // Extension Foundation 実装
@@ -52,10 +53,8 @@ impl<T: Scalar> Bounded<T> for NurbsCurve2D<T> {
 mod tests {
     use crate::knot::clamped_knot_vector;
     use crate::NurbsCurve2D;
-    use geo_foundation::{
-        ExtensionFoundation, NurbsCurve2DConstructor, NurbsCurve2DMeasure, NurbsCurve2DProperties,
-        PrimitiveKind,
-    };
+    use geo_contracts::{NurbsCurve2DConstructor, NurbsCurve2DMeasure, NurbsCurve2DProperties};
+    use geo_foundation::{ExtensionFoundation, PrimitiveKind};
 
     // ============================================================================
     // Core Traits Constructor テスト

--- a/model/geo_nurbs/src/curve_2d_transform.rs
+++ b/model/geo_nurbs/src/curve_2d_transform.rs
@@ -8,9 +8,9 @@ use analysis::linalg::{
     matrix::Matrix3x3,
     vector::{Vector2, Vector3},
 };
+use geo_contracts::NurbsCurve2DProperties;
 use geo_contracts::{Angle, Scalar};
 use geo_core::{AnalysisTransform2D, TransformError};
-use geo_foundation::NurbsCurve2DProperties;
 
 /// Matrix3x3による制御点変換の内部実装
 fn transform_control_points<T: Scalar>(
@@ -185,7 +185,7 @@ impl<T: Scalar> NurbsCurve2D<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use geo_foundation::NurbsCurve2DConstructor;
+    use geo_contracts::NurbsCurve2DConstructor;
 
     #[test]
     fn test_translate_analysis_2d() {

--- a/model/geo_nurbs/src/curve_3d.rs
+++ b/model/geo_nurbs/src/curve_3d.rs
@@ -284,7 +284,7 @@ mod tests {
 
     #[test]
     fn test_nurbs_curve_3d_creation() {
-        use geo_foundation::NurbsCurve3DConstructor;
+        use geo_contracts::NurbsCurve3DConstructor;
         let control_points = vec![(0.0, 0.0, 0.0), (1.0, 1.0, 0.0), (2.0, 0.0, 1.0)];
         let weights = Some(vec![1.0, 1.0, 1.0]);
         let knot_vector = vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0];
@@ -305,7 +305,7 @@ mod tests {
 
     #[test]
     fn test_curve_3d_evaluation() {
-        use geo_foundation::NurbsCurve3DConstructor;
+        use geo_contracts::NurbsCurve3DConstructor;
         let control_points = vec![(0.0, 0.0, 0.0), (1.0, 1.0, 1.0), (2.0, 0.0, 0.0)];
         let weights = Some(vec![1.0, 1.0, 1.0]);
         let knot_vector = vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0];
@@ -336,7 +336,7 @@ mod tests {
 
     #[test]
     fn test_tangent_calculation() {
-        use geo_foundation::NurbsCurve3DConstructor;
+        use geo_contracts::NurbsCurve3DConstructor;
         let control_points = vec![(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (2.0, 0.0, 0.0)];
         let weights = Some(vec![1.0, 1.0, 1.0]);
         let knot_vector = vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0];
@@ -359,7 +359,7 @@ mod tests {
 
     #[test]
     fn test_approximate_length_3d() {
-        use geo_foundation::NurbsCurve3DConstructor;
+        use geo_contracts::NurbsCurve3DConstructor;
         let control_points = vec![(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (2.0, 0.0, 0.0)];
         let weights = Some(vec![1.0, 1.0, 1.0]);
         let knot_vector = vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0];
@@ -383,9 +383,7 @@ mod tests {
 // Core Traits Implementation (Foundation Pattern)
 // ============================================================================
 
-use geo_foundation::core::nurbs_curve_3d_traits::{
-    NurbsCurve3DConstructor, NurbsCurve3DMeasure, NurbsCurve3DProperties,
-};
+use geo_contracts::{NurbsCurve3DConstructor, NurbsCurve3DMeasure, NurbsCurve3DProperties};
 
 impl<T: Scalar> NurbsCurve3DConstructor<T> for NurbsCurve3D<T> {
     fn new(

--- a/model/geo_nurbs/src/curve_3d_extensions.rs
+++ b/model/geo_nurbs/src/curve_3d_extensions.rs
@@ -187,7 +187,7 @@ mod tests {
 
     #[test]
     fn test_rough_bbox() {
-        use geo_foundation::NurbsCurve3DConstructor;
+        use geo_contracts::NurbsCurve3DConstructor;
         let control_points = vec![(0.0, 0.0, 0.0), (1.0, 2.0, 0.0), (2.0, 0.0, 0.0)];
 
         let knots = clamped_knot_vector(2, 3);
@@ -209,7 +209,7 @@ mod tests {
 
     #[test]
     fn test_precise_bbox() {
-        use geo_foundation::NurbsCurve3DConstructor;
+        use geo_contracts::NurbsCurve3DConstructor;
         let control_points = vec![(0.0, 0.0, 0.0), (1.0, 2.0, 0.0), (2.0, 0.0, 0.0)];
 
         let knots = clamped_knot_vector(2, 3);
@@ -232,7 +232,7 @@ mod tests {
 
     #[test]
     fn test_adaptive_bbox() {
-        use geo_foundation::NurbsCurve3DConstructor;
+        use geo_contracts::NurbsCurve3DConstructor;
         let control_points = vec![(0.0, 0.0, 0.0), (1.0, 1.0, 0.0), (2.0, 0.0, 0.0)];
 
         let knots = clamped_knot_vector(2, 3);
@@ -261,7 +261,7 @@ mod tests {
 
     #[test]
     fn test_bbox_comparison() {
-        use geo_foundation::NurbsCurve3DConstructor;
+        use geo_contracts::NurbsCurve3DConstructor;
         let control_points = vec![
             (0.0, 0.0, 0.0),
             (1.0, 2.0, 1.0),
@@ -295,7 +295,7 @@ mod tests {
 
     #[test]
     fn test_curve_adaptive_params_line() {
-        use geo_foundation::NurbsCurve3DConstructor;
+        use geo_contracts::NurbsCurve3DConstructor;
 
         let control_points = vec![(0.0, 0.0, 0.0), (1.0, 0.0, 0.0)];
         let knots = clamped_knot_vector(1, 2);

--- a/model/geo_nurbs/src/curve_3d_foundation.rs
+++ b/model/geo_nurbs/src/curve_3d_foundation.rs
@@ -37,7 +37,7 @@ impl<T: Scalar> Bounded<T> for NurbsCurve3D<T> {
     fn aabb(&self) -> Option<Self::Aabb> {
         debug_assert!(self.num_points() > 0, "Control points should not be empty");
         let coords = self.coordinates();
-        let mut points = Vec::with_capacity(self.num_points());
+        let mut points = Vec::new();
         for i in 0..self.num_points() {
             let base = i * 3;
             points.push(Point3D::new(
@@ -58,7 +58,7 @@ mod tests {
 
     #[test]
     fn test_nurbs_curve_3d_foundation() {
-        use geo_foundation::NurbsCurve3DConstructor;
+        use geo_contracts::NurbsCurve3DConstructor;
         // 簡単なNURBS曲線を作成
         let control_points = vec![(0.0, 0.0, 0.0), (1.0, 1.0, 0.0), (2.0, 0.0, 0.0)];
 
@@ -95,7 +95,7 @@ mod tests {
 
     #[test]
     fn test_core_traits_constructor_new() {
-        use geo_foundation::NurbsCurve3DConstructor;
+        use geo_contracts::NurbsCurve3DConstructor;
 
         // トレイト経由で作成（型を明示）
         let degree = 2;
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn test_core_traits_from_bezier() {
-        use geo_foundation::NurbsCurve3DConstructor;
+        use geo_contracts::NurbsCurve3DConstructor;
 
         let control_points = vec![(0.0_f64, 0.0, 0.0), (0.5, 1.0, 0.0), (1.0, 0.0, 0.0)];
         let result =
@@ -130,7 +130,7 @@ mod tests {
 
     #[test]
     fn test_core_traits_line_segment() {
-        use geo_foundation::NurbsCurve3DConstructor;
+        use geo_contracts::NurbsCurve3DConstructor;
 
         let start = (0.0_f64, 0.0, 0.0);
         let end = (1.0, 1.0, 1.0);
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn test_core_traits_properties() {
-        use geo_foundation::{NurbsCurve3DConstructor, NurbsCurve3DProperties};
+        use geo_contracts::{NurbsCurve3DConstructor, NurbsCurve3DProperties};
 
         let curve = <NurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::from_bezier(vec![
             (0.0, 0.0, 0.0),
@@ -164,7 +164,7 @@ mod tests {
 
     #[test]
     fn test_core_traits_measure() {
-        use geo_foundation::{NurbsCurve3DConstructor, NurbsCurve3DMeasure};
+        use geo_contracts::{NurbsCurve3DConstructor, NurbsCurve3DMeasure};
 
         let curve = <NurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(
             (0.0, 0.0, 0.0),

--- a/model/geo_nurbs/src/curve_3d_transform.rs
+++ b/model/geo_nurbs/src/curve_3d_transform.rs
@@ -8,9 +8,9 @@ use analysis::linalg::{
     matrix::Matrix4x4,
     vector::{Vector3, Vector4},
 };
+use geo_contracts::NurbsCurve3DProperties;
 use geo_contracts::{Angle, Scalar};
 use geo_core::{AnalysisTransform3D, TransformError};
-use geo_foundation::NurbsCurve3DProperties;
 
 /// Matrix4x4による制御点変換の内部実装
 fn transform_control_points<T: Scalar>(
@@ -248,7 +248,7 @@ impl<T: Scalar> NurbsCurve3D<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use geo_foundation::{NurbsCurve3DConstructor, NurbsCurve3DProperties};
+    use geo_contracts::{NurbsCurve3DConstructor, NurbsCurve3DProperties};
 
     #[test]
     fn test_translate_analysis() {

--- a/model/geo_nurbs/src/surface_3d.rs
+++ b/model/geo_nurbs/src/surface_3d.rs
@@ -444,7 +444,7 @@ impl<T: Scalar> NurbsSurface3D<T> {
 // Core Traits 実装
 // ============================================================================
 
-use geo_foundation::{
+use geo_contracts::{
     NurbsSurface3DConstructor, NurbsSurface3DCore, NurbsSurface3DMeasure, NurbsSurface3DProperties,
 };
 
@@ -648,7 +648,7 @@ impl<T: Scalar> NurbsSurface3DCore<T> for NurbsSurface3D<T> {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use geo_foundation::NurbsSurface3DConstructor;
+    use geo_contracts::NurbsSurface3DConstructor;
 
     #[test]
     fn test_nurbs_surface_creation() {

--- a/model/geo_nurbs/src/surface_3d_extensions.rs
+++ b/model/geo_nurbs/src/surface_3d_extensions.rs
@@ -73,7 +73,7 @@ impl<T: Scalar> NurbsSurfaceAdaptiveTessellation<T> for NurbsSurface3D<T> {
 mod tests {
     use super::*;
     use crate::clamped_knot_vector;
-    use geo_foundation::NurbsSurface3DConstructor;
+    use geo_contracts::NurbsSurface3DConstructor;
 
     #[test]
     fn test_surface_adaptive_params_plane() {

--- a/model/geo_nurbs/src/surface_3d_foundation.rs
+++ b/model/geo_nurbs/src/surface_3d_foundation.rs
@@ -4,7 +4,8 @@
 
 use crate::NurbsSurface3D;
 use crate::Scalar;
-use geo_foundation::{Bounded, ExtensionFoundation, NurbsSurface3DMeasure, PrimitiveKind};
+use geo_contracts::NurbsSurface3DMeasure;
+use geo_foundation::{Bounded, ExtensionFoundation, PrimitiveKind};
 
 // ============================================================================
 // Extension Foundation 実装
@@ -58,7 +59,7 @@ impl<T: Scalar> Bounded<T> for NurbsSurface3D<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use geo_foundation::{NurbsSurface3DConstructor, NurbsSurface3DProperties};
+    use geo_contracts::{NurbsSurface3DConstructor, NurbsSurface3DProperties};
 
     #[test]
     fn test_constructor_new() {

--- a/model/geo_nurbs/src/surface_3d_transform.rs
+++ b/model/geo_nurbs/src/surface_3d_transform.rs
@@ -8,9 +8,9 @@ use analysis::linalg::{
     matrix::Matrix4x4,
     vector::{Vector3, Vector4},
 };
+use geo_contracts::NurbsSurface3DProperties;
 use geo_contracts::{Angle, Scalar};
 use geo_core::{AnalysisTransform3D, TransformError};
-use geo_foundation::NurbsSurface3DProperties;
 
 /// Matrix4x4による制御点変換の内部実装
 fn transform_control_points<T: Scalar>(
@@ -264,7 +264,7 @@ impl<T: Scalar> NurbsSurface3D<T> {
 mod tests {
     use super::*;
     use geo_contracts::Angle;
-    use geo_foundation::NurbsSurface3DConstructor;
+    use geo_contracts::NurbsSurface3DConstructor;
 
     #[test]
     fn test_translate_analysis() {

--- a/viewmodel/converter/src/nurbs_eval_loader.rs
+++ b/viewmodel/converter/src/nurbs_eval_loader.rs
@@ -6,7 +6,7 @@
 use std::path::Path;
 
 use geo_algorithms::{adaptive_tessellation as ga_tess, NurbsCurve3D, NurbsSurface3D};
-use geo_foundation::{NurbsCurve3DConstructor, NurbsSurface3DConstructor};
+use geo_foundation::contracts::{NurbsCurve3DConstructor, NurbsSurface3DConstructor};
 use geo_io::svg::{parse_svg_file, SvgError};
 use thiserror::Error;
 

--- a/viewmodel/converter/src/nurbs_view.rs
+++ b/viewmodel/converter/src/nurbs_view.rs
@@ -38,7 +38,7 @@ impl NurbsCurveEvalData {
     /// # Returns
     /// GPU評価用のf32変換済みデータ
     pub fn from_curve_params<T: Scalar>(
-        curve: &impl geo_foundation::NurbsCurve3DProperties<T>,
+        curve: &impl geo_foundation::contracts::NurbsCurve3DProperties<T>,
         param_list: &adaptive_tessellation::AdaptiveParamList<T>,
     ) -> Self {
         let degree = curve.degree() as u32;
@@ -108,7 +108,7 @@ impl NurbsCurveEvalData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use geo_foundation::NurbsCurve3DConstructor;
+    use geo_foundation::contracts::NurbsCurve3DConstructor;
     use geo_nurbs::{
         adaptive_tessellation::{AdaptiveTessellationSettings, NurbsCurveAdaptiveTessellation},
         NurbsCurve3D,
@@ -206,7 +206,7 @@ impl NurbsSurfaceEvalData {
     /// # Returns
     /// GPU評価用のf32変換済みデータ（頂点バッファ最適化）
     pub fn from_surface_params<T: Scalar>(
-        surface: &impl geo_foundation::NurbsSurface3DProperties<T>,
+        surface: &impl geo_foundation::contracts::NurbsSurface3DProperties<T>,
         param_grid: &adaptive_tessellation::AdaptiveParamGrid<T>,
     ) -> Self {
         let u_degree = surface.u_degree() as u32;

--- a/viewmodel/converter/src/svg_loader.rs
+++ b/viewmodel/converter/src/svg_loader.rs
@@ -151,7 +151,7 @@ fn nurbs_curve_to_vertices(
     nurbs_data: &NurbsCurveData,
     tolerance: f64,
 ) -> Result<Vec<VertexData>, SvgLoaderError> {
-    use geo_foundation::NurbsCurve3DConstructor;
+    use geo_foundation::contracts::NurbsCurve3DConstructor;
 
     // NURBS曲線を生成
     let curve = <NurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::new(
@@ -168,7 +168,7 @@ fn nurbs_curve_to_vertices(
     let (t_min, t_max) = curve.parameter_domain();
 
     // 曲線の全長を計算
-    use geo_foundation::NurbsCurve3DMeasure;
+    use geo_foundation::contracts::NurbsCurve3DMeasure;
     let arc_length = curve.arc_length_total(tolerance);
 
     // 分割数を決定（曲線長÷トレランス、最小10、最大10000）


### PR DESCRIPTION
## 概要
Issue #318 のPR-Bとして、NURBS系トレイトを `geo_contracts` に追加し、`geo_nurbs` 側の参照を `geo_foundation` から `geo_contracts` へ切り替えました。

## 変更内容
- `model/geo_contracts/src/geometry/core/` に以下を追加
  - `nurbs_curve_2d_traits.rs`
  - `nurbs_curve_3d_traits.rs`
  - `nurbs_surface_3d_traits.rs`
- `model/geo_contracts/src/geometry/core/mod.rs` にNURBSモジュール・re-exportを追加
- `model/geo_contracts/src/lib.rs` にNURBSトレイト公開を追加
- `model/geo_foundation/src/lib.rs` の `contracts` ブリッジにNURBSトレイトを追加
- `model/geo_nurbs/src/*.rs` のNURBSトレイト参照を `geo_contracts` へ置換
  - `Bounded` / `ExtensionFoundation` / `PrimitiveKind` などは `geo_foundation` のまま維持

## 検証
- `cargo check -p geo_contracts -p geo_nurbs` : ✅
- `cargo test -p geo_nurbs` : ✅ (66 tests + doc tests 2)
- `cargo fmt` : ✅

## 補足
- 既存のFoundation Pattern構造を維持したまま、契約定義の参照先のみを段階的に移行しています。