### PR TITLE
docs: post-geo_foundation cleanup in model docs

### DIFF
--- a/model/geo_contracts/src/geometry/operations/collision.rs
+++ b/model/geo_contracts/src/geometry/operations/collision.rs
@@ -1,6 +1,5 @@
 //! 衝突検出・距離計算のtrait定義
 //!
-//! `geo_foundation::extensions` の衝突検出トレイトを `geo_contracts` へ移設。
 //! 実装は `geo_algorithms::collision` 以下に配置される。
 
 use analysis::abstract_types::Scalar;

--- a/model/geo_contracts/src/geometry/operations/intersection.rs
+++ b/model/geo_contracts/src/geometry/operations/intersection.rs
@@ -1,6 +1,5 @@
 //! 交点計算のtrait定義
 //!
-//! `geo_foundation::extensions` の交点計算トレイトを `geo_contracts` へ移設。
 //! 実装は `geo_algorithms::intersection` 以下に配置される。
 
 use analysis::abstract_types::Scalar;

--- a/model/geo_nurbs/README.md
+++ b/model/geo_nurbs/README.md
@@ -40,7 +40,7 @@ Foundation Patternに完全準拠し、統一された型安全なインター�
 すべてのNURBS型は以下のCore Traitsを実装：
 
 ```rust
-use geo_foundation::{
+use geo_contracts::{
     NurbsCurve3DConstructor, NurbsCurve3DProperties, NurbsCurve3DMeasure
 };
 
@@ -61,7 +61,7 @@ let length = <NurbsCurve3D<f64> as NurbsCurve3DMeasure<f64>>::arc_length_total(&
 ### Extension Traits（拡張機能）
 
 ```rust
-use geo_foundation::{ExtensionFoundation, Bounded};
+use geo_contracts::{Bounded, ExtensionFoundation};
 
 // PrimitiveKind取得
 let kind = curve.primitive_kind(); // PrimitiveKind::NurbsCurve3D
@@ -97,7 +97,7 @@ let scaled = curve.uniform_scale_analysis(&curve, 2.0)?;
 
 ```rust
 use geo_nurbs::NurbsCurve2D;
-use geo_foundation::NurbsCurve2DConstructor;
+use geo_contracts::NurbsCurve2DConstructor;
 
 // 制御点（2D座標）
 let control_points = &[(0.0, 0.0), (1.0, 1.0), (2.0, 0.0)];
@@ -120,7 +120,7 @@ println!("Point at t=0.5: ({}, {})", point.x(), point.y());
 ```rust
 use geo_nurbs::NurbsCurve3D;
 use geo_core::AnalysisTransform3D;
-use geo_foundation::NurbsCurve3DConstructor;
+use geo_contracts::NurbsCurve3DConstructor;
 use analysis::vector::Vector3;
 
 // 線分を作成
@@ -143,7 +143,7 @@ let rotated = translated.rotate_analysis(&axis, angle)?;
 
 ```rust
 use geo_nurbs::NurbsSurface3D;
-use geo_foundation::{NurbsSurface3DConstructor, NurbsSurface3DMeasure};
+use geo_contracts::{NurbsSurface3DConstructor, NurbsSurface3DMeasure};
 
 // 単位平面を生成
 let surface = <NurbsSurface3D<f64> as NurbsSurface3DConstructor<f64>>::unit_plane();
@@ -209,7 +209,7 @@ geo_nurbs/src/
 ## アーキテクチャ依存関係
 
 ```text
-analysis → geo_foundation
+analysis → geo_contracts
             ↓
         geo_core (Point2D, Point3D, Aabb2D, Aabb3D)
             ↓


### PR DESCRIPTION
## 概要
geo_foundation 廃止後のモデル層ドキュメント表記を整理し、現行方針に合わせて最小差分でクリーンアップしました。

## 変更内容
- `geo_contracts` operation trait定義のヘッダコメントから移設経緯文を削除（現行定義に集中）
- `model/geo_nurbs/README.md` の import 例を `geo_foundation` から `geo_contracts` へ更新
- `model/geo_nurbs/README.md` の依存関係図を `analysis -> geo_contracts -> geo_core -> geo_nurbs` に更新

## 変更ファイル
- `model/geo_contracts/src/geometry/operations/collision.rs`
- `model/geo_contracts/src/geometry/operations/intersection.rs`
- `model/geo_nurbs/README.md`

## 検証
- `cargo fmt`
- `cargo check -p geo_contracts`

## 関連
- #319
