### PR TITLE
feat(#319): align transform public API and docs

### DIFF
--- a/manual/core_extension_examples.md
+++ b/manual/core_extension_examples.md
@@ -28,8 +28,9 @@ println!("contains: {}", contains);
 ## Analysis Transform（幾何変換拡張）
 
 ```rust
+use analysis::Angle;
 use analysis::linalg::vector::Vector3;
-use geo_foundation::{AnalysisTransform3D, Angle};
+use geo_primitives::AnalysisTransform3D;
 
 let translation = Vector3::new(1.0, 2.0, 3.0);
 let translated = mesh.translate_analysis(&translation)?;

--- a/manual/transform.md
+++ b/manual/transform.md
@@ -1,6 +1,6 @@
 # Transform システム
 
-RedRingの幾何変換システムについて説明します。現在は`analysis`クレートのMatrix4x4とVectorを直接使用した効率的な変換システムを提供しています。
+RedRingの幾何変換システムについて説明します。Transform trait 定義とエラー型は `geo_core` に集約され、各図形クレートはそれらを再公開して利用します。
 
 ## 設計思想
 
@@ -8,7 +8,7 @@ RedRingの幾何変換システムについて説明します。現在は`analys
 
 - **Analysis統合**: `analysis`クレートのMatrix4x4/Vector3を直接使用
 - **型変換効率**: geo_primitives⇔analysis間の最適化された変換
-- **Foundation準拠**: ExtensionFoundationパターンとの統合
+- **2層責務分離**: 共通Transform責務は `geo_core`、形状適用は各図形クレート
 - **エラーハンドリング**: TransformErrorによる安全な変換操作
 
 ### シンプルな構成
@@ -35,7 +35,7 @@ RedRingの幾何変換システムについて説明します。現在は`analys
 ```rust
 pub trait AnalysisTransform3D<T: Scalar> {
     type Matrix4x4;  // analysis::Matrix4x4
-    type Angle;      // geo_foundation::Angle
+    type Angle;      // analysis::Angle
     type Output;     // 通常はSelf
 
     // 直接Matrix変換
@@ -134,7 +134,7 @@ impl<T: Scalar> Point3D<T> {
 統一されたTransformErrorによる堅牢なエラー処理：
 
 ```rust
-use geo_foundation::TransformError;
+use geo_core::TransformError;
 
 match mesh.rotate_analysis(&center, &axis, angle) {
     Ok(rotated) => { /* 成功 */ }
@@ -190,7 +190,7 @@ match mesh.rotate_analysis(&center, &axis, angle) {
 // 現在のシンプルな設計
 trait AnalysisTransform3D<T: Scalar> {
     type Matrix4x4;  // analysis::Matrix4x4<T>
-    type Angle;      // geo_foundation::Angle<T>
+    type Angle;      // analysis::Angle<T>
     type Output;     // 通常はSelf
 
     // 直接Matrix変換

--- a/manual/transform_examples.md
+++ b/manual/transform_examples.md
@@ -5,9 +5,9 @@ Transform システムの代表的な利用例をまとめます。
 ## 基本変換
 
 ```rust
+use analysis::Angle;
 use analysis::linalg::vector::Vector3;
-use geo_foundation::{AnalysisTransform3D, Angle};
-use geo_primitives::TriangleMesh3D;
+use geo_primitives::{AnalysisTransform3D, TriangleMesh3D};
 
 let mesh = TriangleMesh3D::new(vertices, indices)?;
 
@@ -42,7 +42,9 @@ let result_uniform = mesh.apply_composite_transform_uniform(
 ## Matrix 直接操作
 
 ```rust
+use analysis::Angle;
 use analysis::linalg::matrix::Matrix4x4;
+use analysis::linalg::vector::Vector3;
 
 let custom_matrix = Matrix4x4::identity()
     * Matrix4x4::translation_3d(&Vector3::new(1.0, 2.0, 3.0))

--- a/model/geo_nurbs/README.md
+++ b/model/geo_nurbs/README.md
@@ -76,8 +76,9 @@ let bbox = curve.aabb()?; // Aabb3D<T>
 ### Transform Traits（変換操作）
 
 ```rust
-use geo_core::AnalysisTransform3D;
+use analysis::Angle;
 use analysis::vector::Vector3;
+use geo_nurbs::AnalysisTransform3D;
 
 // 平行移動
 let translated = curve.translate_analysis(&Vector3::new(1.0, 2.0, 3.0))?;
@@ -85,7 +86,7 @@ let translated = curve.translate_analysis(&Vector3::new(1.0, 2.0, 3.0))?;
 // 回転
 let axis = Vector3::new(0.0, 0.0, 1.0);
 let angle = Angle::from_degrees(90.0);
-let rotated = curve.rotate_analysis(&axis, angle)?;
+let rotated = curve.rotate_analysis(&curve, &axis, angle)?;
 
 // スケール
 let scaled = curve.uniform_scale_analysis(&curve, 2.0)?;
@@ -118,10 +119,10 @@ println!("Point at t=0.5: ({}, {})", point.x(), point.y());
 ### 3次元NURBS曲線の変換
 
 ```rust
-use geo_nurbs::NurbsCurve3D;
-use geo_core::AnalysisTransform3D;
-use geo_contracts::NurbsCurve3DConstructor;
+use analysis::Angle;
 use analysis::vector::Vector3;
+use geo_contracts::NurbsCurve3DConstructor;
+use geo_nurbs::{AnalysisTransform3D, NurbsCurve3D};
 
 // 線分を作成
 let curve = <NurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(
@@ -136,7 +137,7 @@ let translated = curve.translate_analysis(&translation)?;
 // Z軸周りに90度回転
 let axis = Vector3::new(0.0, 0.0, 1.0);
 let angle = Angle::from_degrees(90.0);
-let rotated = translated.rotate_analysis(&axis, angle)?;
+let rotated = translated.rotate_analysis(&translated, &axis, angle)?;
 ```
 
 ### NURBS曲面の作成と法線計算

--- a/model/geo_nurbs/src/lib.rs
+++ b/model/geo_nurbs/src/lib.rs
@@ -31,6 +31,9 @@ pub mod weight_storage;
 
 // Analysis ライブラリの Scalar トレイトを使用
 pub use analysis::Scalar;
+pub use geo_core::{
+    AnalysisTransform2D, AnalysisTransform3D, AnalysisTransformSupport, TransformError,
+};
 
 // 主要な型を再エクスポート
 pub use adaptive_tessellation::{

--- a/model/geo_primitives/src/lib.rs
+++ b/model/geo_primitives/src/lib.rs
@@ -5,8 +5,10 @@
 
 // 新実装用モジュール（次元中立設計）
 // 共通型とエラー
-// Transformエラー型はgeo_coreを正規参照先とする
-pub use geo_core::TransformError;
+// Transform trait とエラー型は geo_core を正規参照先とし、このクレートでも再公開する
+pub use geo_core::{
+    AnalysisTransform2D, AnalysisTransform3D, AnalysisTransformSupport, TransformError,
+};
 
 // 3D プリミティブ
 pub mod arc_3d;


### PR DESCRIPTION
## 概要
Issue #319 の Phase C として、Transform の公開 API とドキュメントの整合を実施しました。

- `geo_primitives` / `geo_nurbs` で `geo_core` の Transform trait 群と `TransformError` を再公開
- Transform 利用例の import を各図形クレートの公開面に合わせて更新
- NURBS README の `rotate_analysis` 使用例を実シグネチャに合わせて修正

## 変更内容
- model/geo_primitives/src/lib.rs
- model/geo_nurbs/src/lib.rs
- model/geo_nurbs/README.md
- manual/core_extension_examples.md
- manual/transform_examples.md
- manual/transform.md

## 検証
- `cargo fmt`
- `cargo clippy -p geo_primitives -p geo_nurbs -- -D warnings`
- `cargo check -p geo_primitives -p geo_nurbs`
- `cargo test -p geo_primitives -p geo_nurbs`
- `cargo check --workspace`
- `cargo test --workspace`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\check_architecture_dependencies.ps1 -ExitOnError`

すべて通過済みです。