### PR TITLE
feat(#350): expand 2D pair-base entry points in geo_algorithms

### DIFF
--- a/dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md
@@ -1,0 +1,96 @@
+# Issue #350 実施準備チェックリスト
+
+対象Issue: [#350 [Phase C][#347] 2D collision/intersection trait実装をgeo_algorithmsへ移管](https://github.com/RedRing2020/RedRing/issues/350)
+
+## 1. 目的
+
+- 2D 形状間の collision/intersection trait実装責務を `geo_algorithms` に集約する
+- `geo_primitives` は形状コア実装に責務を絞り、複数形状演算の実装を段階的に削減する
+- `geo_algorithms` 実装ファイルでは `use crate::...` の再エクスポート経由を維持する
+
+## 2. 現状調査（2026-03-21）
+
+- `model/geo_primitives/src/*_collision.rs`: 28ファイル
+- `model/geo_primitives/src/*_intersection.rs`: 28ファイル
+- `model/geo_algorithms/src/collision/primitive_2d.rs`: 既存あり
+- `model/geo_algorithms/src/intersection/primitive_2d.rs`: 既存あり
+- 親Issue #347 の分割Issueは #350（2D）, #348（3D）, #349（混在）, #351（削除・回帰）
+
+## 3. #350 の対象範囲
+
+### 対象
+
+- 2D形状ペアの collision/intersection 実装
+- 代表候補:
+  - `Arc2D`
+  - `Circle2D`
+  - `Ellipse2D`
+  - `InfiniteLine2D`
+  - `LineSegment2D`
+  - `Ray2D`
+  - `Triangle2D`
+
+### 非対象
+
+- 3D形状ペア移管（#348）
+- NURBS/Primitive 混在移管（#349）
+- 旧実装の大規模削除と回帰テストの総仕上げ（#351）
+
+## 4. 実施方針
+
+- 先に `geo_algorithms` 側の 2D 実装を充足させる
+- 呼び出し側が `geo_algorithms` 実装を使う状態を確認してから `geo_primitives` 側の重複削減範囲を確定する
+- 1PR で全削除までは狙わず、#350 では「実装移管と参照整合」を優先する
+
+## 5. 推奨着手順
+
+### Phase A: 棚卸し
+
+- [ ] `primitive_2d.rs` で既に扱っている形状ペアと未移管ペアを一覧化
+- [ ] `geo_primitives/src/*_collision.rs` / `*_intersection.rs` 側で 2D trait実装の所在を確認
+- [ ] テスト所在を確認し、移設が必要か参照維持で足りるか判断
+
+### Phase B: geo_algorithms 側実装補完
+
+- [ ] `model/geo_algorithms/src/collision/primitive_2d.rs` を補完
+- [ ] `model/geo_algorithms/src/intersection/primitive_2d.rs` を補完
+- [ ] 必要な型再エクスポートがあれば `model/geo_algorithms/src/lib.rs` を更新
+- [ ] `geo_algorithms` 実装ファイル内の import は `use crate::...` に統一
+
+### Phase C: 呼び出し整合
+
+- [ ] 2D trait実装の解決先が `geo_algorithms` 側になるよう調整
+- [ ] `geo_primitives` 側に残すべき shape-local helper と削減候補を切り分け
+- [ ] #351 に回す削除候補を明文化
+
+### Phase D: 検証
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo check --workspace`
+- [ ] `cargo test --workspace`
+- [ ] `cargo clippy -p geo_algorithms -- -D warnings`
+- [ ] `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check_architecture_dependencies.ps1 -ExitOnError`
+
+## 6. リスクと対策
+
+- リスク: `geo_primitives` と `geo_algorithms` に同一 trait実装が併存し、衝突する
+  - 対策: 先に trait実装の定義位置を機械検索で確認し、1ペアずつ移管する
+
+- リスク: `geo_algorithms` 実装側で `use geo_primitives::...` が再発する
+  - 対策: `lib.rs` 再エクスポートを先に整え、実装ファイルは `use crate::...` のみ許可する
+
+- リスク: 2D と 3D を同時に触って差分が肥大化する
+  - 対策: #350 は 2D ペアに限定し、3D/混在は別Issueへ分離維持する
+
+## 7. 完了条件
+
+- [ ] 2D collision/intersection trait実装の主要責務が `geo_algorithms` に寄る
+- [ ] `geo_algorithms` の 2D 実装で必要な型・import 経路が安定する
+- [ ] #351 に送る削除対象が明確化される
+- [ ] `fmt/check/test/clippy` と依存チェックスクリプトが通る
+
+## 8. 準備完了時点の判断
+
+- 次の実装着手 Issue は #350 を優先する
+- ブランチは `issue-350-execution-prep` を準備済み
+- 実装開始ブランチは、この準備PRマージ後に `issue-350-collision-2d-execution` を推奨する

--- a/dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md
@@ -16,6 +16,14 @@
 - `model/geo_algorithms/src/intersection/primitive_2d.rs`: 既存あり
 - 親Issue #347 の分割Issueは #350（2D）, #348（3D）, #349（混在）, #351（削除・回帰）
 
+### 2.1 実装制約の確認
+
+- `BasicCollision` / `BasicIntersection` / `MultipleIntersection` は `geo_contracts` 側trait定義
+- 2D形状型は `geo_primitives` 側型定義
+- Rust の orphan rules により、`geo_algorithms` でこれらの trait を対象型へ直接実装することはできない
+- さらに依存方向は `geo_algorithms -> geo_primitives` であり、`geo_primitives -> geo_algorithms` は導入できない
+- したがって #350 の現実的な第一段階は、`geo_algorithms` に free-function / pair-base ロジックを集約し、`geo_primitives` 側trait実装の縮退候補を棚卸しすることになる
+
 ## 3. #350 の対象範囲
 
 ### 対象
@@ -38,9 +46,10 @@
 
 ## 4. 実施方針
 
-- 先に `geo_algorithms` 側の 2D 実装を充足させる
-- 呼び出し側が `geo_algorithms` 実装を使う状態を確認してから `geo_primitives` 側の重複削減範囲を確定する
-- 1PR で全削除までは狙わず、#350 では「実装移管と参照整合」を優先する
+- 先に `geo_algorithms` 側の 2D free-function / pair-base 実装を充足させる
+- trait実装そのものの物理移管ではなく、どのロジックを `geo_algorithms` 正本へ寄せられるかを優先して整理する
+- `geo_primitives` 側trait実装は、削除可能になるまでの暫定ラッパーまたは旧経路として段階的に縮退させる
+- 1PR で全削除までは狙わず、#350 では「ロジック集約先の明確化」と「削減対象の確定」を優先する
 
 ## 5. 推奨着手順
 
@@ -48,19 +57,21 @@
 
 - [ ] `primitive_2d.rs` で既に扱っている形状ペアと未移管ペアを一覧化
 - [ ] `geo_primitives/src/*_collision.rs` / `*_intersection.rs` 側で 2D trait実装の所在を確認
+- [ ] orphan rules と依存方向の制約に照らして「直接移管不可」な点を明文化
 - [ ] テスト所在を確認し、移設が必要か参照維持で足りるか判断
 
 ### Phase B: geo_algorithms 側実装補完
 
 - [ ] `model/geo_algorithms/src/collision/primitive_2d.rs` を補完
 - [ ] `model/geo_algorithms/src/intersection/primitive_2d.rs` を補完
+- [ ] `pair_base.rs` に寄せられる共通ロジックを抽出
 - [ ] 必要な型再エクスポートがあれば `model/geo_algorithms/src/lib.rs` を更新
 - [ ] `geo_algorithms` 実装ファイル内の import は `use crate::...` に統一
 
 ### Phase C: 呼び出し整合
 
-- [ ] 2D trait実装の解決先が `geo_algorithms` 側になるよう調整
-- [ ] `geo_primitives` 側に残すべき shape-local helper と削減候補を切り分け
+- [ ] `geo_primitives` 側に残すべき trait実装ラッパーと shape-local helper を切り分け
+- [ ] `geo_algorithms` を正本ロジックとみなせる形状ペアを確定
 - [ ] #351 に回す削除候補を明文化
 
 ### Phase D: 検証
@@ -74,7 +85,10 @@
 ## 6. リスクと対策
 
 - リスク: `geo_primitives` と `geo_algorithms` に同一 trait実装が併存し、衝突する
-  - 対策: 先に trait実装の定義位置を機械検索で確認し、1ペアずつ移管する
+  - 対策: trait実装の直接移管は行わず、まず free-function / pair-base の正本化で整理する
+
+- リスク: Issue 文言どおりに「trait実装を geo_algorithms へ移管」と解釈すると、orphan rules と依存方向に反する
+  - 対策: #350 では「ロジック集約先の移管」と「trait実装縮退候補の整理」に読み替え、必要なら親Issue #347 の受け入れ条件を補足する
 
 - リスク: `geo_algorithms` 実装側で `use geo_primitives::...` が再発する
   - 対策: `lib.rs` 再エクスポートを先に整え、実装ファイルは `use crate::...` のみ許可する
@@ -94,3 +108,46 @@
 - 次の実装着手 Issue は #350 を優先する
 - ブランチは `issue-350-execution-prep` を準備済み
 - 実装開始ブランチは、この準備PRマージ後に `issue-350-collision-2d-execution` を推奨する
+
+## 9. 初回棚卸しメモ
+
+### 9.1 `geo_algorithms` 側で既にある 2D collision 関数
+
+- `circle2d_point2d_collides`
+- `circle2d_circle2d_collides`
+- `line_segment2d_point2d_distance`
+- `line_segment2d_circle2d_collides`
+- `arc2d_point2d_collides`
+- `arc2d_circle2d_collides`
+- `ray2d_point2d_collides`
+- `ray2d_circle2d_collides`
+- `ray2d_line_segment2d_collides`
+- `triangle2d_circle2d_collides`
+- `triangle2d_triangle2d_collides`
+
+### 9.2 `geo_algorithms` 側で既にある 2D intersection 関数
+
+- `circle2d_point2d_intersection`
+- `circle2d_circle2d_intersections_algo`
+- `circle2d_line_segment2d_intersections_algo`
+- `arc2d_circle2d_intersections_algo`
+- `line_segment2d_circle2d_intersections_algo`
+- `line_segment2d_arc2d_intersections_algo`
+- `line_segment2d_line_segment2d_intersection_algo`
+- `ray2d_line_segment2d_intersection`
+- `ray2d_circle2d_intersections`
+- `triangle2d_line_segment2d_intersections`
+- `ray2d_ellipse2d_intersection`
+- `arc2d_point2d_intersection`
+
+### 9.3 `geo_primitives` 側に依然として残っている代表的な 2D trait実装
+
+- `Circle2D`: Point / Circle / LineSegment
+- `Arc2D`: Point / Circle
+- `LineSegment2D`: Point / Circle / Arc / LineSegment
+- `Ray2D`: Point / Circle / Arc / LineSegment / Triangle / Ellipse / Ray
+- `InfiniteLine2D`: Point / Circle / Arc / LineSegment / Triangle / Ellipse / Ray / InfiniteLine
+- `Triangle2D`: Point / Circle / Arc / LineSegment / Triangle
+- `Ellipse2D`, `EllipseArc2D`: 2D複数形状ペア
+
+この差から、#350 の最初の実装差分は `Circle2D` / `Arc2D` / `LineSegment2D` / `Ray2D` / `Triangle2D` 周辺を優先すると小さく始めやすい。

--- a/dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md
@@ -2,6 +2,8 @@
 
 対象Issue: [#350 [Phase C][#347] 2D collision/intersection trait実装をgeo_algorithmsへ移管](https://github.com/RedRing2020/RedRing/issues/350)
 
+関連設計論点: `dev/architecture/issues/2026-03-geometry-refactor-05-collision-intersection-responsibility.md`
+
 ## 1. 目的
 
 - 2D 形状間の collision/intersection trait実装責務を `geo_algorithms` に集約する

--- a/dev/architecture/issues/2026-03-geometry-refactor-05-collision-intersection-responsibility.md
+++ b/dev/architecture/issues/2026-03-geometry-refactor-05-collision-intersection-responsibility.md
@@ -1,0 +1,53 @@
+## 概要
+
+collision/intersection の責務モデルを Foundation パターン（Core / Extension / Transform）から切り分けて再定義する。
+
+## 背景
+
+- 現行の `geo_contracts` trait と `geo_primitives` 形状型の組み合わせでは、`geo_algorithms` への trait実装の物理移管は Rust の orphan rules により成立しない
+- 依存方向も `geo_algorithms -> geo_primitives` であり、`geo_primitives -> geo_algorithms` を入れずに trait実装の正本位置を動かすことはできない
+- 一方で、pair-base / free-function ベースの形状ペアロジックを `geo_algorithms` 側の正本とみなす方針自体は妥当である
+- したがって問題は「pair-base 方針」ではなく、「collision/intersection を Foundation パターンの延長として扱う前提」にある
+
+## 問題設定
+
+- Core / Extension / Transform は単一形状責務の整理としては機能している
+- collision/intersection は複数形状間アルゴリズムであり、単一形状中心の Foundation パターンにそのまま載せると責務境界が歪む
+- その結果、以下が衝突する
+  - trait定義の所在
+  - 実装の所在
+  - crate依存方向
+  - orphan rules
+
+## 目的
+
+- collision/intersection を Foundation パターンの対象外または別系統責務として明文化する
+- `geo_contracts` / `geo_algorithms` / `geo_primitives` の責務境界を再定義する
+- #347 / #350 / #348 / #349 / #351 を破綻なく進められる実施基準を作る
+
+## 検討ポイント
+
+- `geo_contracts` に置くべきものは何か
+- `geo_algorithms` を pair-base / free-function 正本とする場合の公開APIをどう定義するか
+- `geo_primitives` 側trait実装を互換ラッパーとして残すのか、別の呼び出しモデルへ移行するのか
+- 削除完了条件を「trait実装の移管」ではなく「ロジック正本の移行」に読み替えるべきか
+
+## 非対象
+
+- 個別の 2D / 3D / NURBS 実装差分
+- 即時の crate 分割や依存逆転導入
+- 既存 pair-base ロジックの撤回
+
+## 成果物
+
+- collision/intersection の責務モデル案
+- #347 系列に適用する受け入れ条件の読み替え案
+- #350 / #348 / #349 / #351 の進め方ガイド
+
+## 関連
+
+- #347 Phase C: collision/intersection trait実装をgeo_algorithmsへ移管
+- #350 2D collision/intersection 移管
+- #348 3D collision/intersection 移管
+- #349 NURBS/Primitive 混在整理
+- #351 旧実装削除と回帰テスト整備

--- a/model/geo_algorithms/src/collision/primitive_2d.rs
+++ b/model/geo_algorithms/src/collision/primitive_2d.rs
@@ -213,3 +213,54 @@ fn edges_intersect<T: Scalar>(
     let upper = T::ONE + tolerance;
     t1 >= lower && t1 <= upper && t2 >= lower && t2 <= upper
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        circle2d_circle2d_collides, circle2d_point2d_collides, line_segment2d_circle2d_collides,
+        triangle2d_triangle2d_collides,
+    };
+    use crate::{Circle2D, LineSegment2D, Point2D, Triangle2D};
+
+    #[test]
+    fn circle_point_collision_detects_boundary_point() {
+        let circle = Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap();
+        let point = Point2D::new(1.0, 0.0);
+
+        assert!(circle2d_point2d_collides(&circle, &point, 1e-9));
+    }
+
+    #[test]
+    fn circle_circle_collision_detects_overlap() {
+        let circle1 = Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap();
+        let circle2 = Circle2D::new(Point2D::new(1.5, 0.0), 1.0).unwrap();
+
+        assert!(circle2d_circle2d_collides(&circle1, &circle2, 1e-9));
+    }
+
+    #[test]
+    fn line_segment_circle_collision_detects_crossing_segment() {
+        let segment = LineSegment2D::new(Point2D::new(-2.0, 0.0), Point2D::new(2.0, 0.0)).unwrap();
+        let circle = Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap();
+
+        assert!(line_segment2d_circle2d_collides(&segment, &circle, 1e-9));
+    }
+
+    #[test]
+    fn triangle_triangle_collision_detects_edge_crossing() {
+        let triangle1 = Triangle2D::new(
+            Point2D::new(0.0, 0.0),
+            Point2D::new(2.0, 0.0),
+            Point2D::new(1.0, 2.0),
+        )
+        .unwrap();
+        let triangle2 = Triangle2D::new(
+            Point2D::new(1.0, -1.0),
+            Point2D::new(3.0, 1.0),
+            Point2D::new(1.0, 1.0),
+        )
+        .unwrap();
+
+        assert!(triangle2d_triangle2d_collides(&triangle1, &triangle2, 1e-9));
+    }
+}

--- a/model/geo_algorithms/src/collision/primitive_2d.rs
+++ b/model/geo_algorithms/src/collision/primitive_2d.rs
@@ -6,6 +6,8 @@
 //! 注意: orphan rules により、ここでは trait 実装ではなく
 //! 形状ペア関数を提供する。
 
+use crate::intersection::pair_base::line_segment2d_arc2d_intersections;
+use crate::intersection::primitive_2d::triangle2d_line_segment2d_intersections;
 use crate::{Arc2D, Circle2D, LineSegment2D, Point2D, Ray2D, Triangle2D, Vector2D};
 use geo_contracts::{
     Arc2DProperties, Circle2DProperties, LineSegment2DProperties, Scalar, Triangle2DProperties,
@@ -104,6 +106,21 @@ pub fn arc2d_circle2d_collides<T: Scalar>(
     center_distance <= radii_sum + tolerance && center_distance >= radii_diff - tolerance
 }
 
+pub fn circle2d_arc2d_collides<T: Scalar>(
+    circle: &Circle2D<T>,
+    arc: &Arc2D<T>,
+    tolerance: T,
+) -> bool {
+    arc2d_circle2d_collides(arc, circle, tolerance)
+}
+
+pub fn line_segment2d_arc2d_collides<T: Scalar>(
+    segment: &LineSegment2D<T>,
+    arc: &Arc2D<T>,
+) -> bool {
+    !line_segment2d_arc2d_intersections(segment, arc).is_empty()
+}
+
 pub fn ray2d_point2d_collides<T: Scalar>(ray: &Ray2D<T>, point: &Point2D<T>, tolerance: T) -> bool {
     ray.contains_point(point, tolerance)
 }
@@ -191,6 +208,14 @@ pub fn triangle2d_triangle2d_collides<T: Scalar>(
     false
 }
 
+pub fn triangle2d_line_segment2d_collides<T: Scalar>(
+    triangle: &Triangle2D<T>,
+    segment: &LineSegment2D<T>,
+    tolerance: T,
+) -> bool {
+    !triangle2d_line_segment2d_intersections(triangle, segment, tolerance).is_empty()
+}
+
 fn edges_intersect<T: Scalar>(
     p1: Point2D<T>,
     p2: Point2D<T>,
@@ -217,10 +242,11 @@ fn edges_intersect<T: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::{
-        circle2d_circle2d_collides, circle2d_point2d_collides, line_segment2d_circle2d_collides,
-        triangle2d_triangle2d_collides,
+        circle2d_arc2d_collides, circle2d_circle2d_collides, circle2d_point2d_collides,
+        line_segment2d_arc2d_collides, line_segment2d_circle2d_collides,
+        triangle2d_line_segment2d_collides, triangle2d_triangle2d_collides,
     };
-    use crate::{Circle2D, LineSegment2D, Point2D, Triangle2D};
+    use crate::{Arc2D, Circle2D, LineSegment2D, Point2D, Triangle2D};
 
     #[test]
     fn circle_point_collision_detects_boundary_point() {
@@ -262,5 +288,38 @@ mod tests {
         .unwrap();
 
         assert!(triangle2d_triangle2d_collides(&triangle1, &triangle2, 1e-9));
+    }
+
+    #[test]
+    fn line_segment_arc_collision_detects_crossing_segment() {
+        let arc = Arc2D::new(
+            Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap(),
+            crate::Angle::from_degrees(0.0),
+            crate::Angle::from_degrees(180.0),
+        )
+        .unwrap();
+        let segment = LineSegment2D::new(Point2D::new(-2.0, 0.0), Point2D::new(2.0, 0.0)).unwrap();
+
+        assert!(line_segment2d_arc2d_collides(&segment, &arc));
+        assert!(circle2d_arc2d_collides(
+            &Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap(),
+            &arc,
+            1e-9
+        ));
+    }
+
+    #[test]
+    fn triangle_line_segment_collision_detects_intersection() {
+        let triangle = Triangle2D::new(
+            Point2D::new(0.0, 0.0),
+            Point2D::new(2.0, 0.0),
+            Point2D::new(1.0, 2.0),
+        )
+        .unwrap();
+        let segment = LineSegment2D::new(Point2D::new(1.0, -1.0), Point2D::new(1.0, 1.0)).unwrap();
+
+        assert!(triangle2d_line_segment2d_collides(
+            &triangle, &segment, 1e-9
+        ));
     }
 }

--- a/model/geo_algorithms/src/intersection/primitive_2d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_2d.rs
@@ -242,3 +242,49 @@ fn edge_segment_intersection<T: Scalar>(
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        circle2d_circle2d_intersections_algo, circle2d_point2d_intersection,
+        line_segment2d_line_segment2d_intersection_algo, ray2d_circle2d_intersections,
+    };
+    use crate::{Circle2D, LineSegment2D, Point2D, Ray2D, Vector2D};
+
+    #[test]
+    fn circle_point_intersection_returns_same_point() {
+        let circle = Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap();
+        let point = Point2D::new(1.0, 0.0);
+
+        let intersection = circle2d_point2d_intersection(&circle, &point, 1e-9);
+        assert_eq!(intersection, Some(point));
+    }
+
+    #[test]
+    fn circle_circle_intersection_returns_two_points() {
+        let circle1 = Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap();
+        let circle2 = Circle2D::new(Point2D::new(1.0, 0.0), 1.0).unwrap();
+
+        let intersections = circle2d_circle2d_intersections_algo(&circle1, &circle2);
+        assert_eq!(intersections.len(), 2);
+    }
+
+    #[test]
+    fn line_segment_line_segment_intersection_returns_crossing_point() {
+        let segment1 = LineSegment2D::new(Point2D::new(0.0, 0.0), Point2D::new(2.0, 0.0)).unwrap();
+        let segment2 = LineSegment2D::new(Point2D::new(1.0, -1.0), Point2D::new(1.0, 1.0)).unwrap();
+
+        let intersection = line_segment2d_line_segment2d_intersection_algo(&segment1, &segment2);
+        assert_eq!(intersection, Some(Point2D::new(1.0, 0.0)));
+    }
+
+    #[test]
+    fn ray_circle_intersection_returns_forward_hits_only() {
+        let ray = Ray2D::new(Point2D::new(-2.0, 0.0), Vector2D::new(1.0, 0.0)).unwrap();
+        let circle = Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap();
+
+        let intersections = ray2d_circle2d_intersections(&ray, &circle, 1e-9);
+        assert_eq!(intersections.len(), 2);
+        assert!(intersections.iter().all(|point| point.x() >= -1.0));
+    }
+}

--- a/model/geo_algorithms/src/intersection/primitive_2d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_2d.rs
@@ -51,6 +51,13 @@ pub fn arc2d_circle2d_intersections_algo<T: Scalar>(
     arc2d_circle2d_intersections(arc, circle)
 }
 
+pub fn circle2d_arc2d_intersections_algo<T: Scalar>(
+    circle: &Circle2D<T>,
+    arc: &Arc2D<T>,
+) -> Vec<Point2D<T>> {
+    arc2d_circle2d_intersections(arc, circle)
+}
+
 pub fn line_segment2d_circle2d_intersections_algo<T: Scalar>(
     segment: &LineSegment2D<T>,
     circle: &Circle2D<T>,
@@ -61,6 +68,13 @@ pub fn line_segment2d_circle2d_intersections_algo<T: Scalar>(
 pub fn line_segment2d_arc2d_intersections_algo<T: Scalar>(
     segment: &LineSegment2D<T>,
     arc: &Arc2D<T>,
+) -> Vec<Point2D<T>> {
+    line_segment2d_arc2d_intersections(segment, arc)
+}
+
+pub fn arc2d_line_segment2d_intersections_algo<T: Scalar>(
+    arc: &Arc2D<T>,
+    segment: &LineSegment2D<T>,
 ) -> Vec<Point2D<T>> {
     line_segment2d_arc2d_intersections(segment, arc)
 }
@@ -246,10 +260,11 @@ fn edge_segment_intersection<T: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::{
+        arc2d_line_segment2d_intersections_algo, circle2d_arc2d_intersections_algo,
         circle2d_circle2d_intersections_algo, circle2d_point2d_intersection,
         line_segment2d_line_segment2d_intersection_algo, ray2d_circle2d_intersections,
     };
-    use crate::{Circle2D, LineSegment2D, Point2D, Ray2D, Vector2D};
+    use crate::{Arc2D, Circle2D, LineSegment2D, Point2D, Ray2D, Vector2D};
 
     #[test]
     fn circle_point_intersection_returns_same_point() {
@@ -286,5 +301,33 @@ mod tests {
         let intersections = ray2d_circle2d_intersections(&ray, &circle, 1e-9);
         assert_eq!(intersections.len(), 2);
         assert!(intersections.iter().all(|point| point.x() >= -1.0));
+    }
+
+    #[test]
+    fn circle_arc_intersection_symmetric_entry_point_returns_hits() {
+        let circle = Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap();
+        let arc = Arc2D::new(
+            Circle2D::new(Point2D::new(1.0, 0.0), 1.0).unwrap(),
+            crate::Angle::from_degrees(0.0),
+            crate::Angle::from_degrees(360.0),
+        )
+        .unwrap();
+
+        let intersections = circle2d_arc2d_intersections_algo(&circle, &arc);
+        assert!(!intersections.is_empty());
+    }
+
+    #[test]
+    fn arc_line_segment_intersection_symmetric_entry_point_returns_hits() {
+        let arc = Arc2D::new(
+            Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap(),
+            crate::Angle::from_degrees(0.0),
+            crate::Angle::from_degrees(180.0),
+        )
+        .unwrap();
+        let segment = LineSegment2D::new(Point2D::new(-2.0, 0.0), Point2D::new(2.0, 0.0)).unwrap();
+
+        let intersections = arc2d_line_segment2d_intersections_algo(&arc, &segment);
+        assert!(!intersections.is_empty());
     }
 }


### PR DESCRIPTION
## 概要
Issue #350 の実装を、pair-base / free-function 正本化の方針で進めました。

- `geo_algorithms` の 2D collision/intersection entry point を段階補完
- entry point の回帰テストを追加
- 設計論点（責務モデル・返り値意味論）は別Issueへ切り出し

## 変更内容
### 1. 設計論点の切り出し（ドキュメント）
- `dev/architecture/issues/2026-03-geometry-refactor-05-collision-intersection-responsibility.md`
- `dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md` 更新
- 関連Issue: #356

### 2. 2D pair-base entry point のテスト追加
- `model/geo_algorithms/src/collision/primitive_2d.rs`
- `model/geo_algorithms/src/intersection/primitive_2d.rs`

### 3. 2D collision entry point 補完
- `circle2d_arc2d_collides`
- `line_segment2d_arc2d_collides`
- `triangle2d_line_segment2d_collides`
- 追加テスト

### 4. 2D intersection entry point 補完
- `circle2d_arc2d_intersections_algo`
- `arc2d_line_segment2d_intersections_algo`
- 追加テスト

## コミット（分割）
- `8a36301` docs(#350,#356): separate responsibility model issue
- `2e72468` test(#350): cover 2d pair-base entry points
- `50206ac` feat(#350): add 2d collision pair-base entry points
- `e3c3171` feat(#350): add 2d intersection symmetric entry points

## 検証
- `cargo fmt`
- `cargo test -p geo_algorithms`
- `cargo clippy -p geo_algorithms -- -D warnings`
- `cargo check --workspace`
- `cargo test --workspace`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\check_architecture_dependencies.ps1 -ExitOnError`

## 補足
- intersection の返り値意味論（空集合 vs 重複/無限交点）は別Issueで検討
- 関連Issue: #357