### PR TITLE
feat(#348): start 3D migration with prep doc and symmetric triangle entry points

### DIFF
--- a/dev/architecture/ISSUE_348_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_348_IMPLEMENTATION_PREP.md
@@ -1,0 +1,99 @@
+# Issue #348 実施準備チェックリスト
+
+対象Issue: [#348 [Phase C][#347] 3D collision/intersection trait実装をgeo_algorithmsへ移管](https://github.com/RedRing2020/RedRing/issues/348)
+
+関連Issue:
+- #356 collision/intersection責務整理（Foundationパターン対象外の再定義）
+- #357 intersection返り値意味論（空集合と重複の区別）
+
+## 1. 目的
+
+- 3D形状ペアの collision/intersection ロジックを `geo_algorithms` 側の正本に寄せる
+- `geo_primitives` は形状コア実装へ責務を絞り、3Dの重複経路を段階削減する
+- `geo_algorithms` 実装ファイルでは `use crate::...` の再エクスポート経由を維持する
+
+## 2. 現状調査（2026-03-21）
+
+- `model/geo_primitives/src/*_3d_collision.rs`: 20ファイル
+- `model/geo_primitives/src/*_3d_intersection.rs`: 20ファイル
+- `model/geo_algorithms/src/collision/primitive_3d.rs`: 既存あり（free-function受け皿）
+- `model/geo_algorithms/src/intersection/primitive_3d.rs`: 既存あり（free-function受け皿）
+
+### 2.1 実装制約の確認
+
+- `BasicCollision` / `BasicIntersection` / `MultipleIntersection` は `geo_contracts` 側trait定義
+- 3D形状型は `geo_primitives` 側型定義
+- Rust orphan rules により、`geo_algorithms` で対象traitを対象型へ直接実装することはできない
+- 依存方向は `geo_algorithms -> geo_primitives` であり、`geo_primitives -> geo_algorithms` は導入しない
+- したがって #348 は「trait実装の物理移管」ではなく、`geo_algorithms` free-function / pair-base を正本として補完する段階実施が現実的
+
+## 3. #348 の対象範囲
+
+### 対象
+
+- 3D形状ペアの collision/intersection 実装補完と正本化
+- 代表候補:
+  - `Arc3D`, `Circle3D`, `Ellipse3D`, `EllipseArc3D`
+  - `Plane3D`, `LineSegment3D`, `Ray3D`, `InfiniteLine3D`
+  - `Spherical*`, `Conical*`, `Cylindrical*`, `Ellipsoidal*`, `Torus*`
+  - `Triangle3D`, `TriangleMesh3D`
+
+### 非対象
+
+- NURBS/Primitive 混在（#349）
+- 旧実装の大規模削除と全回帰整備（#351）
+- 返り値モデル再設計（#357）
+
+## 4. 実施方針
+
+- 先に `geo_algorithms` 側 3D entry point の欠落ペアを補完する
+- `pair_base.rs` に寄せられる共通ロジックは抽出し、重複を減らす
+- `geo_primitives` 側trait実装は即時削除せず、#351 で削減対象を明示して段階実施する
+- 1PRでの全面移管は狙わず、小さな追加と検証を積み上げる
+
+## 5. 推奨着手順
+
+### Phase A: 棚卸し
+
+- [ ] `primitive_3d.rs` で既存形状ペアと未整備ペアを一覧化
+- [ ] `geo_primitives/src/*_3d_collision.rs` / `*_3d_intersection.rs` 側の3D trait実装を棚卸し
+- [ ] orphan rules / 依存方向の制約を #348 の作業ログに明記
+
+### Phase B: geo_algorithms 側実装補完
+
+- [ ] `model/geo_algorithms/src/collision/primitive_3d.rs` の未整備 entry point を追加
+- [ ] `model/geo_algorithms/src/intersection/primitive_3d.rs` の未整備 entry point を追加
+- [ ] `pair_base.rs` へ寄せられる共通ロジックを抽出
+- [ ] 実装ファイル内 import を `use crate::...` へ統一
+
+### Phase C: 呼び出し整合
+
+- [ ] `geo_primitives` 側に残す互換ラッパーと削除候補を切り分け
+- [ ] #351 に回す削除対象を明文化
+
+### Phase D: 検証
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo check --workspace`
+- [ ] `cargo test --workspace`
+- [ ] `cargo clippy -p geo_algorithms -- -D warnings`
+- [ ] `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check_architecture_dependencies.ps1 -ExitOnError`
+
+## 6. 最初の実装単位（小さく始める）
+
+- collision: 線形要素（`Plane3D`, `Ray3D`, `LineSegment3D`, `InfiniteLine3D`）の対称entry point不足を先に補完
+- intersection: 既存 `pair_base` 委譲関数の対称ラッパーを先に揃える
+- テスト: point系に加え、線形要素同士の回帰ケースを `primitive_3d.rs` に追加
+
+## 7. 完了条件
+
+- [ ] 3D主要ペアのロジック入口が `geo_algorithms` で把握可能になっている
+- [ ] `geo_algorithms` の import/依存経路が安定している
+- [ ] #351 に引き渡す削除候補が明確化されている
+- [ ] `fmt/check/test/clippy` と依存チェックスクリプトが通る
+
+## 8. 準備完了時点の判断
+
+- 次の実装着手Issueは #348 を優先
+- 実装ブランチは `issue-348-collision-3d-execution` を推奨
+- 初回PRは「3D線形要素の対称entry point補完 + テスト追加」を最小スコープとする

--- a/model/geo_algorithms/src/collision/primitive_3d.rs
+++ b/model/geo_algorithms/src/collision/primitive_3d.rs
@@ -398,12 +398,28 @@ pub fn triangle3d_line_segment3d_collides<T: Scalar>(
     triangle.intersects(segment, tolerance)
 }
 
+pub fn line_segment3d_triangle3d_collides<T: Scalar>(
+    segment: &LineSegment3D<T>,
+    triangle: &Triangle3D<T>,
+    tolerance: T,
+) -> bool {
+    triangle3d_line_segment3d_collides(triangle, segment, tolerance)
+}
+
 pub fn triangle3d_ray3d_collides<T: Scalar>(
     triangle: &Triangle3D<T>,
     ray: &Ray3D<T>,
     tolerance: T,
 ) -> bool {
     triangle.intersects(ray, tolerance)
+}
+
+pub fn ray3d_triangle3d_collides<T: Scalar>(
+    ray: &Ray3D<T>,
+    triangle: &Triangle3D<T>,
+    tolerance: T,
+) -> bool {
+    triangle3d_ray3d_collides(triangle, ray, tolerance)
 }
 
 pub fn triangle3d_triangle3d_collides<T: Scalar>(
@@ -664,9 +680,11 @@ mod tests {
         arc3d_point3d_collides, circle3d_point3d_collides, cylindrical_solid3d_point3d_collides,
         cylindrical_surface3d_point3d_collides, ellipse3d_point3d_collides,
         infinite_line3d_point3d_collides, line_segment3d_point3d_collides,
-        plane3d_point3d_collides, ray3d_point3d_collides, spherical_solid3d_point3d_collides,
+        line_segment3d_triangle3d_collides, plane3d_point3d_collides, ray3d_point3d_collides,
+        ray3d_triangle3d_collides, spherical_solid3d_point3d_collides,
         torus_solid3d_point3d_collides, torus_surface3d_point3d_collides,
-        triangle3d_point3d_collides, triangle_mesh3d_point3d_collides,
+        triangle3d_line_segment3d_collides, triangle3d_point3d_collides, triangle3d_ray3d_collides,
+        triangle_mesh3d_point3d_collides,
     };
     use crate::{
         Angle, Arc3D, Circle3D, CylindricalSolid3D, CylindricalSurface3D, Direction3D, Ellipse3D,
@@ -914,5 +932,28 @@ mod tests {
             &Point3D::new(0.2, 0.2, 0.3),
             1e-6
         ));
+    }
+
+    #[test]
+    fn symmetric_triangle_collision_wrappers_match_base_functions() {
+        let tri = Triangle3D::new(
+            Point3D::new(0.0, 0.0, 0.0),
+            Point3D::new(1.0, 0.0, 0.0),
+            Point3D::new(0.0, 1.0, 0.0),
+        )
+        .unwrap();
+        let seg =
+            LineSegment3D::new(Point3D::new(0.2, 0.2, -1.0), Point3D::new(0.2, 0.2, 1.0)).unwrap();
+        let ray = Ray3D::new(Point3D::new(0.2, 0.2, 1.0), Vector3D::new(0.0, 0.0, -1.0)).unwrap();
+
+        let tol = 1e-6;
+        assert_eq!(
+            line_segment3d_triangle3d_collides(&seg, &tri, tol),
+            triangle3d_line_segment3d_collides(&tri, &seg, tol)
+        );
+        assert_eq!(
+            ray3d_triangle3d_collides(&ray, &tri, tol),
+            triangle3d_ray3d_collides(&tri, &ray, tol)
+        );
     }
 }

--- a/model/geo_algorithms/src/collision/primitive_3d.rs
+++ b/model/geo_algorithms/src/collision/primitive_3d.rs
@@ -691,9 +691,15 @@ mod tests {
         InfiniteLine3D, LineSegment3D, Plane3D, Point3D, Ray3D, SphericalSolid3D, TorusSolid3D,
         TorusSurface3D, Triangle3D, TriangleMesh3D, Vector3D,
     };
+    use geo_contracts::ToleranceSettings;
+
+    fn standard_distance_tol() -> f64 {
+        ToleranceSettings::<f64>::standard().distance_tolerance
+    }
 
     #[test]
     fn arc_point_collision_checks_angle_range() {
+        let tol = standard_distance_tol();
         let arc = Arc3D::new(
             Point3D::new(0.0, 0.0, 0.0),
             2.0,
@@ -707,12 +713,13 @@ mod tests {
         let on_arc = Point3D::new(2.0, 0.0, 0.0);
         let out_of_angle = Point3D::new(-2.0, 0.0, 0.0);
 
-        assert!(arc3d_point3d_collides(&arc, &on_arc, 1e-6));
-        assert!(!arc3d_point3d_collides(&arc, &out_of_angle, 1e-6));
+        assert!(arc3d_point3d_collides(&arc, &on_arc, tol));
+        assert!(!arc3d_point3d_collides(&arc, &out_of_angle, tol));
     }
 
     #[test]
     fn ellipse_point_collision_uses_distance() {
+        let tol = standard_distance_tol();
         let ellipse = Ellipse3D::new(
             Point3D::new(0.0, 0.0, 0.0),
             3.0,
@@ -725,12 +732,13 @@ mod tests {
         let on_ellipse = Point3D::new(3.0, 0.0, 0.0);
         let outside_plane = Point3D::new(0.0, 0.0, 0.5);
 
-        assert!(ellipse3d_point3d_collides(&ellipse, &on_ellipse, 1e-6));
-        assert!(!ellipse3d_point3d_collides(&ellipse, &outside_plane, 1e-6));
+        assert!(ellipse3d_point3d_collides(&ellipse, &on_ellipse, tol));
+        assert!(!ellipse3d_point3d_collides(&ellipse, &outside_plane, tol));
     }
 
     #[test]
     fn torus_surface_point_collision_uses_surface_distance() {
+        let tol = standard_distance_tol();
         let torus = TorusSurface3D::new(
             Point3D::new(0.0, 0.0, 0.0),
             Direction3D::new(0.0, 0.0, 1.0).unwrap(),
@@ -743,16 +751,13 @@ mod tests {
         let on_surface = Point3D::new(4.0, 0.0, 0.0);
         let inside_tube = Point3D::new(3.0, 0.0, 0.0);
 
-        assert!(torus_surface3d_point3d_collides(&torus, &on_surface, 1e-6));
-        assert!(!torus_surface3d_point3d_collides(
-            &torus,
-            &inside_tube,
-            1e-6
-        ));
+        assert!(torus_surface3d_point3d_collides(&torus, &on_surface, tol));
+        assert!(!torus_surface3d_point3d_collides(&torus, &inside_tube, tol));
     }
 
     #[test]
     fn circle_plane_ray_line_point_collisions_use_geometric_checks() {
+        let tol = standard_distance_tol();
         let circle = Circle3D::new(
             Point3D::new(0.0, 0.0, 0.0),
             Direction3D::new(0.0, 0.0, 1.0).unwrap(),
@@ -762,36 +767,36 @@ mod tests {
         assert!(circle3d_point3d_collides(
             &circle,
             &Point3D::new(2.0, 0.0, 0.0),
-            1e-6
+            tol
         ));
         assert!(!circle3d_point3d_collides(
             &circle,
             &Point3D::new(1.0, 0.0, 0.0),
-            1e-6
+            tol
         ));
 
         let plane = Plane3D::xy_plane(0.0);
         assert!(plane3d_point3d_collides(
             &plane,
             &Point3D::new(0.0, 0.0, 0.0),
-            1e-6
+            tol
         ));
         assert!(!plane3d_point3d_collides(
             &plane,
             &Point3D::new(0.0, 0.0, 1.0),
-            1e-6
+            tol
         ));
 
         let ray = Ray3D::new(Point3D::new(0.0, 0.0, 0.0), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
         assert!(ray3d_point3d_collides(
             &ray,
             &Point3D::new(2.0, 0.0, 0.0),
-            1e-6
+            tol
         ));
         assert!(!ray3d_point3d_collides(
             &ray,
             &Point3D::new(-1.0, 0.0, 0.0),
-            1e-6
+            tol
         ));
 
         let segment =
@@ -799,12 +804,12 @@ mod tests {
         assert!(line_segment3d_point3d_collides(
             &segment,
             &Point3D::new(0.5, 0.0, 0.0),
-            1e-6
+            tol
         ));
         assert!(!line_segment3d_point3d_collides(
             &segment,
             &Point3D::new(2.0, 0.0, 0.0),
-            1e-6
+            tol
         ));
 
         let line = InfiniteLine3D::from_two_points(
@@ -815,17 +820,18 @@ mod tests {
         assert!(infinite_line3d_point3d_collides(
             &line,
             &Point3D::new(10.0, 0.0, 0.0),
-            1e-6
+            tol
         ));
         assert!(!infinite_line3d_point3d_collides(
             &line,
             &Point3D::new(0.0, 1.0, 0.0),
-            1e-6
+            tol
         ));
     }
 
     #[test]
     fn triangle_ellipsoid_and_torus_solid_point_collisions() {
+        let tol = standard_distance_tol();
         let tri = Triangle3D::new(
             Point3D::new(0.0, 0.0, 0.0),
             Point3D::new(1.0, 0.0, 0.0),
@@ -835,12 +841,12 @@ mod tests {
         assert!(triangle3d_point3d_collides(
             &tri,
             &Point3D::new(0.2, 0.2, 0.0),
-            1e-6
+            tol
         ));
         assert!(!triangle3d_point3d_collides(
             &tri,
             &Point3D::new(0.2, 0.2, 0.4),
-            1e-6
+            tol
         ));
 
         let torus_solid = TorusSolid3D::new(
@@ -854,17 +860,18 @@ mod tests {
         assert!(torus_solid3d_point3d_collides(
             &torus_solid,
             &Point3D::new(3.0, 0.0, 0.0),
-            1e-6
+            tol
         ));
         assert!(!torus_solid3d_point3d_collides(
             &torus_solid,
             &Point3D::new(0.0, 0.0, 0.0),
-            1e-6
+            tol
         ));
     }
 
     #[test]
     fn spherical_and_cylindrical_point_collisions_use_distance_based_checks() {
+        let tol = standard_distance_tol();
         let sphere = SphericalSolid3D::new(
             Point3D::new(0.0, 0.0, 0.0),
             Vector3D::new(0.0, 0.0, 1.0),
@@ -875,12 +882,12 @@ mod tests {
         assert!(spherical_solid3d_point3d_collides(
             &sphere,
             &Point3D::new(1.0, 0.0, 0.0),
-            1e-6
+            tol
         ));
         assert!(!spherical_solid3d_point3d_collides(
             &sphere,
             &Point3D::new(4.0, 0.0, 0.0),
-            1e-6
+            tol
         ));
 
         let cyl_solid =
@@ -888,12 +895,12 @@ mod tests {
         assert!(cylindrical_solid3d_point3d_collides(
             &cyl_solid,
             &Point3D::new(0.5, 0.0, 1.0),
-            1e-6
+            tol
         ));
         assert!(!cylindrical_solid3d_point3d_collides(
             &cyl_solid,
             &Point3D::new(2.0, 0.0, 1.0),
-            1e-6
+            tol
         ));
 
         let cyl_surface =
@@ -901,17 +908,18 @@ mod tests {
         assert!(cylindrical_surface3d_point3d_collides(
             &cyl_surface,
             &Point3D::new(1.0, 0.0, 0.5),
-            1e-6
+            tol
         ));
         assert!(!cylindrical_surface3d_point3d_collides(
             &cyl_surface,
             &Point3D::new(2.0, 0.0, 0.5),
-            1e-6
+            tol
         ));
     }
 
     #[test]
     fn triangle_mesh_point_collision_checks_member_triangles() {
+        let tol = standard_distance_tol();
         let mesh = TriangleMesh3D::new(
             vec![
                 Point3D::new(0.0, 0.0, 0.0),
@@ -925,17 +933,18 @@ mod tests {
         assert!(triangle_mesh3d_point3d_collides(
             &mesh,
             &Point3D::new(0.2, 0.2, 0.0),
-            1e-6
+            tol
         ));
         assert!(!triangle_mesh3d_point3d_collides(
             &mesh,
             &Point3D::new(0.2, 0.2, 0.3),
-            1e-6
+            tol
         ));
     }
 
     #[test]
     fn symmetric_triangle_collision_wrappers_match_base_functions() {
+        let tol = standard_distance_tol();
         let tri = Triangle3D::new(
             Point3D::new(0.0, 0.0, 0.0),
             Point3D::new(1.0, 0.0, 0.0),
@@ -946,7 +955,6 @@ mod tests {
             LineSegment3D::new(Point3D::new(0.2, 0.2, -1.0), Point3D::new(0.2, 0.2, 1.0)).unwrap();
         let ray = Ray3D::new(Point3D::new(0.2, 0.2, 1.0), Vector3D::new(0.0, 0.0, -1.0)).unwrap();
 
-        let tol = 1e-6;
         assert_eq!(
             line_segment3d_triangle3d_collides(&seg, &tri, tol),
             triangle3d_line_segment3d_collides(&tri, &seg, tol)

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -340,12 +340,28 @@ pub fn triangle3d_line_segment3d_intersection<T: Scalar>(
     pair_base::triangle3d_line_segment3d_intersection(triangle, segment)
 }
 
+pub fn line_segment3d_triangle3d_intersection<T: Scalar>(
+    segment: &LineSegment3D<T>,
+    triangle: &Triangle3D<T>,
+    tolerance: T,
+) -> Option<Point3D<T>> {
+    triangle3d_line_segment3d_intersection(triangle, segment, tolerance)
+}
+
 pub fn triangle3d_ray3d_intersection<T: Scalar>(
     triangle: &Triangle3D<T>,
     ray: &Ray3D<T>,
     _tolerance: T,
 ) -> Option<Point3D<T>> {
     pair_base::triangle3d_ray3d_intersection(triangle, ray)
+}
+
+pub fn ray3d_triangle3d_intersection<T: Scalar>(
+    ray: &Ray3D<T>,
+    triangle: &Triangle3D<T>,
+    tolerance: T,
+) -> Option<Point3D<T>> {
+    triangle3d_ray3d_intersection(triangle, ray, tolerance)
 }
 
 // ── TriangleMesh3D ────────────────────────────────────────────────────────────
@@ -514,8 +530,10 @@ mod tests {
         arc3d_point3d_intersection, circle3d_point3d_intersection,
         cylindrical_surface3d_point3d_intersection, ellipse3d_point3d_intersection,
         infinite_line3d_point3d_intersection, line_segment3d_point3d_intersection,
-        plane3d_point3d_intersection, ray3d_point3d_intersection,
-        torus_surface3d_point3d_intersection, triangle3d_point3d_intersection,
+        line_segment3d_triangle3d_intersection, plane3d_point3d_intersection,
+        ray3d_point3d_intersection, ray3d_triangle3d_intersection,
+        torus_surface3d_point3d_intersection, triangle3d_line_segment3d_intersection,
+        triangle3d_point3d_intersection, triangle3d_ray3d_intersection,
         triangle_mesh3d_point3d_intersection,
     };
     use crate::{
@@ -740,6 +758,29 @@ mod tests {
         assert_eq!(
             triangle_mesh3d_point3d_intersection(&mesh, &off_triangle, 1e-6),
             None
+        );
+    }
+
+    #[test]
+    fn symmetric_triangle_intersection_wrappers_match_base_functions() {
+        let tri = Triangle3D::new(
+            Point3D::new(0.0, 0.0, 0.0),
+            Point3D::new(1.0, 0.0, 0.0),
+            Point3D::new(0.0, 1.0, 0.0),
+        )
+        .unwrap();
+        let seg =
+            LineSegment3D::new(Point3D::new(0.2, 0.2, -1.0), Point3D::new(0.2, 0.2, 1.0)).unwrap();
+        let ray = Ray3D::new(Point3D::new(0.2, 0.2, 1.0), Vector3D::new(0.0, 0.0, -1.0)).unwrap();
+
+        let tol = 1e-6;
+        assert_eq!(
+            line_segment3d_triangle3d_intersection(&seg, &tri, tol),
+            triangle3d_line_segment3d_intersection(&tri, &seg, tol)
+        );
+        assert_eq!(
+            ray3d_triangle3d_intersection(&ray, &tri, tol),
+            triangle3d_ray3d_intersection(&tri, &ray, tol)
         );
     }
 }

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -541,13 +541,18 @@ mod tests {
         LineSegment3D, Plane3D, Point3D, Ray3D, TorusSurface3D, Triangle3D, TriangleMesh3D,
         Vector3D,
     };
+    use geo_contracts::ToleranceSettings;
+
+    fn standard_distance_tol() -> f64 {
+        ToleranceSettings::<f64>::standard().distance_tolerance
+    }
 
     #[test]
     fn plane_point_intersection_returns_same_point() {
         let plane = Plane3D::xy_plane(0.0_f64);
         let point = Point3D::new(1.0, -2.0, 0.0);
 
-        let result = plane3d_point3d_intersection(&plane, &point, 1e-6);
+        let result = plane3d_point3d_intersection(&plane, &point, standard_distance_tol());
 
         assert_eq!(result, Some(point));
     }
@@ -559,10 +564,13 @@ mod tests {
         let behind_ray = Point3D::new(-1.0, 0.0, 0.0);
 
         assert_eq!(
-            ray3d_point3d_intersection(&ray, &on_ray, 1e-6),
+            ray3d_point3d_intersection(&ray, &on_ray, standard_distance_tol()),
             Some(on_ray)
         );
-        assert_eq!(ray3d_point3d_intersection(&ray, &behind_ray, 1e-6), None);
+        assert_eq!(
+            ray3d_point3d_intersection(&ray, &behind_ray, standard_distance_tol()),
+            None
+        );
     }
 
     #[test]
@@ -573,11 +581,15 @@ mod tests {
         let outside_segment = Point3D::new(3.0, 0.0, 0.0);
 
         assert_eq!(
-            line_segment3d_point3d_intersection(&segment, &on_segment, 1e-6),
+            line_segment3d_point3d_intersection(&segment, &on_segment, standard_distance_tol()),
             Some(on_segment)
         );
         assert_eq!(
-            line_segment3d_point3d_intersection(&segment, &outside_segment, 1e-6),
+            line_segment3d_point3d_intersection(
+                &segment,
+                &outside_segment,
+                standard_distance_tol()
+            ),
             None
         );
     }
@@ -593,11 +605,11 @@ mod tests {
         let off_line = Point3D::new(0.0, 1.0, 0.0);
 
         assert_eq!(
-            infinite_line3d_point3d_intersection(&line, &on_line, 1e-6),
+            infinite_line3d_point3d_intersection(&line, &on_line, standard_distance_tol()),
             Some(on_line)
         );
         assert_eq!(
-            infinite_line3d_point3d_intersection(&line, &off_line, 1e-6),
+            infinite_line3d_point3d_intersection(&line, &off_line, standard_distance_tol()),
             None
         );
     }
@@ -614,11 +626,11 @@ mod tests {
         let off_triangle = Point3D::new(0.2, 0.2, 0.5);
 
         assert_eq!(
-            triangle3d_point3d_intersection(&triangle, &on_triangle, 1e-6),
+            triangle3d_point3d_intersection(&triangle, &on_triangle, standard_distance_tol()),
             Some(on_triangle)
         );
         assert_eq!(
-            triangle3d_point3d_intersection(&triangle, &off_triangle, 1e-6),
+            triangle3d_point3d_intersection(&triangle, &off_triangle, standard_distance_tol()),
             None
         );
     }
@@ -635,11 +647,11 @@ mod tests {
         let inside_disk = Point3D::new(1.0, 0.0, 0.0);
 
         assert_eq!(
-            circle3d_point3d_intersection(&circle, &on_circle, 1e-6),
+            circle3d_point3d_intersection(&circle, &on_circle, standard_distance_tol()),
             Some(on_circle)
         );
         assert_eq!(
-            circle3d_point3d_intersection(&circle, &inside_disk, 1e-6),
+            circle3d_point3d_intersection(&circle, &inside_disk, standard_distance_tol()),
             None
         );
     }
@@ -660,10 +672,13 @@ mod tests {
         let out_of_angle = Point3D::new(-2.0, 0.0, 0.0);
 
         assert_eq!(
-            arc3d_point3d_intersection(&arc, &on_arc, 1e-6),
+            arc3d_point3d_intersection(&arc, &on_arc, standard_distance_tol()),
             Some(on_arc)
         );
-        assert_eq!(arc3d_point3d_intersection(&arc, &out_of_angle, 1e-6), None);
+        assert_eq!(
+            arc3d_point3d_intersection(&arc, &out_of_angle, standard_distance_tol()),
+            None
+        );
     }
 
     #[test]
@@ -682,15 +697,15 @@ mod tests {
         let outside_plane = Point3D::new(0.0, 0.0, 0.5);
 
         assert_eq!(
-            ellipse3d_point3d_intersection(&ellipse, &on_ellipse, 1e-6),
+            ellipse3d_point3d_intersection(&ellipse, &on_ellipse, standard_distance_tol()),
             Some(on_ellipse)
         );
         assert_eq!(
-            ellipse3d_point3d_intersection(&ellipse, &inside_ellipse, 1e-6),
+            ellipse3d_point3d_intersection(&ellipse, &inside_ellipse, standard_distance_tol()),
             Some(inside_ellipse)
         );
         assert_eq!(
-            ellipse3d_point3d_intersection(&ellipse, &outside_plane, 1e-6),
+            ellipse3d_point3d_intersection(&ellipse, &outside_plane, standard_distance_tol()),
             None
         );
     }
@@ -710,11 +725,11 @@ mod tests {
         let inside_tube = Point3D::new(3.0, 0.0, 0.0);
 
         assert_eq!(
-            torus_surface3d_point3d_intersection(&torus, &on_surface, 1e-6),
+            torus_surface3d_point3d_intersection(&torus, &on_surface, standard_distance_tol()),
             Some(on_surface)
         );
         assert_eq!(
-            torus_surface3d_point3d_intersection(&torus, &inside_tube, 1e-6),
+            torus_surface3d_point3d_intersection(&torus, &inside_tube, standard_distance_tol()),
             None
         );
     }
@@ -727,11 +742,11 @@ mod tests {
         let off_surface = Point3D::new(2.0, 0.0, 0.5);
 
         assert_eq!(
-            cylindrical_surface3d_point3d_intersection(&cyl, &on_surface, 1e-6),
+            cylindrical_surface3d_point3d_intersection(&cyl, &on_surface, standard_distance_tol()),
             Some(on_surface)
         );
         assert_eq!(
-            cylindrical_surface3d_point3d_intersection(&cyl, &off_surface, 1e-6),
+            cylindrical_surface3d_point3d_intersection(&cyl, &off_surface, standard_distance_tol()),
             None
         );
     }
@@ -752,11 +767,11 @@ mod tests {
         let off_triangle = Point3D::new(0.2, 0.2, 0.3);
 
         assert_eq!(
-            triangle_mesh3d_point3d_intersection(&mesh, &on_triangle, 1e-6),
+            triangle_mesh3d_point3d_intersection(&mesh, &on_triangle, standard_distance_tol()),
             Some(on_triangle)
         );
         assert_eq!(
-            triangle_mesh3d_point3d_intersection(&mesh, &off_triangle, 1e-6),
+            triangle_mesh3d_point3d_intersection(&mesh, &off_triangle, standard_distance_tol()),
             None
         );
     }
@@ -773,7 +788,7 @@ mod tests {
             LineSegment3D::new(Point3D::new(0.2, 0.2, -1.0), Point3D::new(0.2, 0.2, 1.0)).unwrap();
         let ray = Ray3D::new(Point3D::new(0.2, 0.2, 1.0), Vector3D::new(0.0, 0.0, -1.0)).unwrap();
 
-        let tol = 1e-6;
+        let tol = standard_distance_tol();
         assert_eq!(
             line_segment3d_triangle3d_intersection(&seg, &tri, tol),
             triangle3d_line_segment3d_intersection(&tri, &seg, tol)


### PR DESCRIPTION
## 概要
Issue #348（3D collision/intersection 移管）の次優先タスクとして、
- 実施準備ドキュメント整備
- 初回の小さな実装スライス（対称 entry point 補完）
を実施しました。

## 変更内容
### 1. 実施準備ドキュメント追加
- `dev/architecture/ISSUE_348_IMPLEMENTATION_PREP.md`
- 3D の現状棚卸し、制約（orphan rules / 依存方向）、段階実施方針、最初の実装単位を明記

### 2. 3D 対称 entry point 追加（triangle 系）
- `model/geo_algorithms/src/collision/primitive_3d.rs`
  - `line_segment3d_triangle3d_collides`
  - `ray3d_triangle3d_collides`
- `model/geo_algorithms/src/intersection/primitive_3d.rs`
  - `line_segment3d_triangle3d_intersection`
  - `ray3d_triangle3d_intersection`
- 既存 triangle 側関数へ委譲するラッパーとして追加
- 対称ラッパー一致性テストを追加

## コミット
- `dc51bb4` docs(#348): add execution prep checklist
- `64bf47b` feat(#348): add symmetric 3d triangle entry points

## 検証
- `cargo fmt`
- `cargo test -p geo_algorithms`
- `cargo clippy -p geo_algorithms -- -D warnings`

## 関連
- #348
- #347
- #356
- #357