### PR TITLE
[Phase C][#350] 2D collision/intersection entry points補完と完了条件達成

### DIFF
--- a/dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md
@@ -68,7 +68,7 @@
 - [x] `primitive_2d.rs` で既に扱っている形状ペアと未移管ペアを一覧化
 - [x] `geo_primitives/src/*_collision.rs` / `*_intersection.rs` 側で 2D trait実装の所在を確認
 - [x] orphan rules と依存方向の制約に照らして「直接移管不可」な点を明文化
-- [ ] テスト所在を確認し、移設が必要か参照維持で足りるか判断
+- [x] テスト所在を確認し、移設が必要か参照維持で足りるか判断（`geo_algorithms` 側単体テストを拡充し、`geo_primitives` 側既存テストは #351 で段階縮退）
 
 ### Phase B: geo_algorithms 側実装補完
 
@@ -80,17 +80,17 @@
 
 ### Phase C: 呼び出し整合
 
-- [ ] `geo_primitives` 側に残すべき trait実装ラッパーと shape-local helper を切り分け
-- [ ] `geo_algorithms` を正本ロジックとみなせる形状ペアを確定
-- [ ] #351 に回す削除候補を明文化
+- [x] `geo_primitives` 側に残すべき trait実装ラッパーと shape-local helper を切り分け
+- [x] `geo_algorithms` を正本ロジックとみなせる形状ペアを確定
+- [x] #351 に回す削除候補を明文化
 
 ### Phase D: 検証
 
 - [x] `cargo fmt --all -- --check`（`cargo fmt --all` 実行で整形済み）
-- [ ] `cargo check --workspace`
-- [ ] `cargo test --workspace`
+- [x] `cargo check --workspace`
+- [x] `cargo test --workspace`
 - [x] `cargo clippy -p geo_algorithms -- -D warnings`
-- [ ] `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check_architecture_dependencies.ps1 -ExitOnError`
+- [x] `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check_architecture_dependencies.ps1 -ExitOnError`
 
 ## 6. リスクと対策
 
@@ -108,10 +108,10 @@
 
 ## 7. 完了条件
 
-- [ ] 2D collision/intersection trait実装の主要責務が `geo_algorithms` に寄る
-- [ ] `geo_algorithms` の 2D 実装で必要な型・import 経路が安定する
-- [ ] #351 に送る削除対象が明確化される
-- [ ] `fmt/check/test/clippy` と依存チェックスクリプトが通る
+- [x] 2D collision/intersection trait実装の主要責務が `geo_algorithms` に寄る（対象7形状の代表ペアで free-function / pair-base 正本化を優先）
+- [x] `geo_algorithms` の 2D 実装で必要な型・import 経路が安定する
+- [x] #351 に送る削除対象が明確化される
+- [x] `fmt/check/test/clippy` と依存チェックスクリプトが通る
 
 ## 8. 準備完了時点の判断
 
@@ -216,3 +216,37 @@
   - `cargo test -p geo_algorithms`: pass
 - 次アクション:
   - #351 へ 2D削減候補の詳細マッピング（関数対応表）を更新
+
+## 12. #351 連携用 2D 削減候補対応表（一次）
+
+### 12.1 残置ポリシー
+
+- 残置対象: shape-local な補助計算や Core API 経由の判定（幾何プリミティブ固有実装）
+- 縮退対象: 多形状ペアの trait実装本体（`BasicCollision` / `BasicIntersection` / `MultipleIntersection`）
+- 実施単位: #351 で「wrapper化（`geo_algorithms` 呼び出し）」→ 回帰確認 → 段階削減
+
+### 12.2 マッピング（代表ペア）
+
+| geo_primitives 側（候補） | geo_algorithms 正本エントリ | #351 での扱い |
+|---|---|---|
+| `circle_2d_collision.rs` (`Circle2D-Point/Circle/LineSegment`) | `circle2d_point2d_collides`, `circle2d_circle2d_collides`, `line_segment2d_circle2d_collides` | wrapper化候補 |
+| `circle_2d_intersection.rs` (`Circle2D-Point/Circle/LineSegment`) | `circle2d_point2d_intersection`, `circle2d_circle2d_intersections_algo`, `circle2d_line_segment2d_intersections_algo` | wrapper化候補 |
+| `arc_2d_collision.rs` (`Arc2D-Point/Circle`) | `arc2d_point2d_collides`, `arc2d_circle2d_collides`, `circle2d_arc2d_collides` | wrapper化候補 |
+| `arc_2d_intersection.rs` (`Arc2D-Point/Circle`) | `arc2d_point2d_intersection`, `arc2d_circle2d_intersections_algo`, `circle2d_arc2d_intersections_algo` | wrapper化候補 |
+| `line_segment_2d_collision.rs` (`LineSegment2D-Circle/Arc/LineSegment`) | `line_segment2d_circle2d_collides`, `line_segment2d_arc2d_collides`, `arc2d_line_segment2d_collides` | wrapper化候補 |
+| `line_segment_2d_intersection.rs` (`LineSegment2D-Circle/Arc/LineSegment`) | `line_segment2d_circle2d_intersections_algo`, `line_segment2d_arc2d_intersections_algo`, `line_segment2d_line_segment2d_intersection_algo` | wrapper化候補 |
+| `ray_2d_collision.rs` (`Ray2D-Point/Circle/LineSegment`) | `ray2d_point2d_collides`, `ray2d_circle2d_collides`, `ray2d_line_segment2d_collides` | wrapper化候補 |
+| `ray_2d_intersection.rs` (`Ray2D-Circle/LineSegment`) | `ray2d_circle2d_intersections`, `ray2d_line_segment2d_intersection` | wrapper化候補 |
+| `triangle_2d_collision.rs` (`Triangle2D-Circle/LineSegment/Triangle`) | `triangle2d_circle2d_collides`, `triangle2d_line_segment2d_collides`, `triangle2d_triangle2d_collides` | wrapper化候補 |
+| `triangle_2d_intersection.rs` (`Triangle2D-LineSegment`) | `triangle2d_line_segment2d_intersections` | wrapper化候補 |
+| `infinite_line_2d_collision.rs` (`InfiniteLine2D-Point/Circle/LineSegment/Ray`) | `infinite_line2d_point2d_collides`, `infinite_line2d_circle2d_collides`, `infinite_line2d_line_segment2d_collides`, `infinite_line2d_ray2d_collides` | wrapper化候補 |
+| `infinite_line_2d_intersection.rs` (`InfiniteLine2D-Point/Circle/LineSegment/Ray`) | `infinite_line2d_point2d_intersection`, `infinite_line2d_circle2d_intersection`, `infinite_line2d_circle2d_intersections`, `infinite_line2d_line_segment2d_intersection`, `infinite_line2d_ray2d_intersection` | wrapper化候補 |
+| `ellipse_2d_collision.rs` (`Ellipse2D-Point/Circle`) | `ellipse2d_point2d_collides`, `ellipse2d_circle2d_collides`, `circle2d_ellipse2d_collides` | wrapper化候補 |
+| `ellipse_2d_intersection.rs` (`Ellipse2D-Point/Circle`) | `ellipse2d_point2d_intersection`, `ellipse2d_circle2d_intersection`, `ellipse2d_circle2d_intersections` | wrapper化候補 |
+| `ellipse_arc_2d_collision.rs` (`EllipseArc2D-Point/Circle`) | `ellipse_arc2d_point2d_collides`, `ellipse_arc2d_circle2d_collides`, `circle2d_ellipse_arc2d_collides` | wrapper化候補（未公開モジュール依存なしの現行実装に合わせる） |
+| `ellipse_arc_2d_intersection.rs` (`EllipseArc2D-Point`) | `ellipse_arc2d_point2d_intersection` | wrapper化候補（Point判定のみ先行） |
+
+### 12.3 #351 引き渡しメモ
+
+- `geo_primitives/src/ellipse_arc_2d_collision.rs` / `geo_primitives/src/ellipse_arc_2d_intersection.rs` は `lib.rs` 未公開設定との整合を確認してから削減。
+- `Arc2D` / `Triangle2D` / `Ellipse2D` の複数交点系で `pair_base` 抽出余地あり（#351 実施時に再確認）。

--- a/dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md
@@ -18,6 +18,12 @@
 - `model/geo_algorithms/src/intersection/primitive_2d.rs`: 既存あり
 - 親Issue #347 の分割Issueは #350（2D）, #348（3D）, #349（混在）, #351（削除・回帰）
 
+### 2.2 進捗更新（2026-03-22）
+
+- 実装ブランチ `issue-350-next` を作成し初回スライスを投入済み
+- `geo_algorithms` 2D に対称 entry point を追加し、対称ラッパー一致性テストを追加
+- 検証結果: `cargo clippy -p geo_algorithms -- -D warnings` / `cargo fmt --all` / `cargo test -p geo_algorithms` 通過
+
 ### 2.1 実装制約の確認
 
 - `BasicCollision` / `BasicIntersection` / `MultipleIntersection` は `geo_contracts` 側trait定義
@@ -57,9 +63,9 @@
 
 ### Phase A: 棚卸し
 
-- [ ] `primitive_2d.rs` で既に扱っている形状ペアと未移管ペアを一覧化
-- [ ] `geo_primitives/src/*_collision.rs` / `*_intersection.rs` 側で 2D trait実装の所在を確認
-- [ ] orphan rules と依存方向の制約に照らして「直接移管不可」な点を明文化
+- [x] `primitive_2d.rs` で既に扱っている形状ペアと未移管ペアを一覧化
+- [x] `geo_primitives/src/*_collision.rs` / `*_intersection.rs` 側で 2D trait実装の所在を確認
+- [x] orphan rules と依存方向の制約に照らして「直接移管不可」な点を明文化
 - [ ] テスト所在を確認し、移設が必要か参照維持で足りるか判断
 
 ### Phase B: geo_algorithms 側実装補完
@@ -68,7 +74,7 @@
 - [ ] `model/geo_algorithms/src/intersection/primitive_2d.rs` を補完
 - [ ] `pair_base.rs` に寄せられる共通ロジックを抽出
 - [ ] 必要な型再エクスポートがあれば `model/geo_algorithms/src/lib.rs` を更新
-- [ ] `geo_algorithms` 実装ファイル内の import は `use crate::...` に統一
+- [x] `geo_algorithms` 実装ファイル内の import は `use crate::...` に統一
 
 ### Phase C: 呼び出し整合
 
@@ -78,10 +84,10 @@
 
 ### Phase D: 検証
 
-- [ ] `cargo fmt --all -- --check`
+- [x] `cargo fmt --all -- --check`（`cargo fmt --all` 実行で整形済み）
 - [ ] `cargo check --workspace`
 - [ ] `cargo test --workspace`
-- [ ] `cargo clippy -p geo_algorithms -- -D warnings`
+- [x] `cargo clippy -p geo_algorithms -- -D warnings`
 - [ ] `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check_architecture_dependencies.ps1 -ExitOnError`
 
 ## 6. リスクと対策
@@ -126,6 +132,11 @@
 - `ray2d_line_segment2d_collides`
 - `triangle2d_circle2d_collides`
 - `triangle2d_triangle2d_collides`
+- `arc2d_line_segment2d_collides`（2026-03-22 追加）
+- `circle2d_ray2d_collides`（2026-03-22 追加）
+- `line_segment2d_ray2d_collides`（2026-03-22 追加）
+- `circle2d_triangle2d_collides`（2026-03-22 追加）
+- `line_segment2d_triangle2d_collides`（2026-03-22 追加）
 
 ### 9.2 `geo_algorithms` 側で既にある 2D intersection 関数
 
@@ -141,6 +152,8 @@
 - `triangle2d_line_segment2d_intersections`
 - `ray2d_ellipse2d_intersection`
 - `arc2d_point2d_intersection`
+- `line_segment2d_ray2d_intersection`（2026-03-22 追加）
+- `circle2d_ray2d_intersections`（2026-03-22 追加）
 
 ### 9.3 `geo_primitives` 側に依然として残っている代表的な 2D trait実装
 
@@ -153,3 +166,16 @@
 - `Ellipse2D`, `EllipseArc2D`: 2D複数形状ペア
 
 この差から、#350 の最初の実装差分は `Circle2D` / `Arc2D` / `LineSegment2D` / `Ray2D` / `Triangle2D` 周辺を優先すると小さく始めやすい。
+
+## 10. 実装スライス記録（2026-03-22）
+
+- コミット: `c5cf280`
+- 変更ファイル:
+  - `model/geo_algorithms/src/collision/primitive_2d.rs`
+  - `model/geo_algorithms/src/intersection/primitive_2d.rs`
+- 概要:
+  - 2D collision/intersection の対称 entry point 追加
+  - 対称ラッパー一致性テスト追加
+- 次アクション:
+  - `geo_primitives` 2D の削減候補を #351 へ一次連携
+  - 代表ペア以外（InfiniteLine2D / Ellipse2D / EllipseArc2D）の補完方針を確定

--- a/dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md
@@ -22,6 +22,8 @@
 
 - 実装ブランチ `issue-350-next` を作成し初回スライスを投入済み
 - `geo_algorithms` 2D に対称 entry point を追加し、対称ラッパー一致性テストを追加
+- `InfiniteLine2D` / `Ellipse2D` / `EllipseArc2D` について、2D entry point を追加し対称性を補完
+- `geo_algorithms/src/lib.rs` の再エクスポートに `InfiniteLine2D` / `EllipseArc2D` を追加
 - 検証結果: `cargo clippy -p geo_algorithms -- -D warnings` / `cargo fmt --all` / `cargo test -p geo_algorithms` 通過
 
 ### 2.1 実装制約の確認
@@ -70,10 +72,10 @@
 
 ### Phase B: geo_algorithms 側実装補完
 
-- [ ] `model/geo_algorithms/src/collision/primitive_2d.rs` を補完
-- [ ] `model/geo_algorithms/src/intersection/primitive_2d.rs` を補完
+- [x] `model/geo_algorithms/src/collision/primitive_2d.rs` を補完（対称entry + InfiniteLine2D/Ellipse2D/EllipseArc2D）
+- [x] `model/geo_algorithms/src/intersection/primitive_2d.rs` を補完（対称entry + InfiniteLine2D/Ellipse2D/EllipseArc2D）
 - [ ] `pair_base.rs` に寄せられる共通ロジックを抽出
-- [ ] 必要な型再エクスポートがあれば `model/geo_algorithms/src/lib.rs` を更新
+- [x] 必要な型再エクスポートがあれば `model/geo_algorithms/src/lib.rs` を更新
 - [x] `geo_algorithms` 実装ファイル内の import は `use crate::...` に統一
 
 ### Phase C: 呼び出し整合
@@ -137,6 +139,14 @@
 - `line_segment2d_ray2d_collides`（2026-03-22 追加）
 - `circle2d_triangle2d_collides`（2026-03-22 追加）
 - `line_segment2d_triangle2d_collides`（2026-03-22 追加）
+- `infinite_line2d_point2d_collides`（2026-03-22 追加）
+- `infinite_line2d_circle2d_collides` / `circle2d_infinite_line2d_collides`（2026-03-22 追加）
+- `infinite_line2d_line_segment2d_collides` / `line_segment2d_infinite_line2d_collides`（2026-03-22 追加）
+- `infinite_line2d_ray2d_collides` / `ray2d_infinite_line2d_collides`（2026-03-22 追加）
+- `ellipse2d_point2d_collides`（2026-03-22 追加）
+- `ellipse2d_circle2d_collides` / `circle2d_ellipse2d_collides`（2026-03-22 追加）
+- `ellipse_arc2d_point2d_collides`（2026-03-22 追加）
+- `ellipse_arc2d_circle2d_collides` / `circle2d_ellipse_arc2d_collides`（2026-03-22 追加）
 
 ### 9.2 `geo_algorithms` 側で既にある 2D intersection 関数
 
@@ -154,6 +164,15 @@
 - `arc2d_point2d_intersection`
 - `line_segment2d_ray2d_intersection`（2026-03-22 追加）
 - `circle2d_ray2d_intersections`（2026-03-22 追加）
+- `infinite_line2d_point2d_intersection`（2026-03-22 追加）
+- `infinite_line2d_circle2d_intersection` / `circle2d_infinite_line2d_intersection`（2026-03-22 追加）
+- `infinite_line2d_circle2d_intersections` / `circle2d_infinite_line2d_intersections`（2026-03-22 追加）
+- `infinite_line2d_line_segment2d_intersection` / `line_segment2d_infinite_line2d_intersection`（2026-03-22 追加）
+- `infinite_line2d_ray2d_intersection` / `ray2d_infinite_line2d_intersection`（2026-03-22 追加）
+- `ellipse2d_point2d_intersection`（2026-03-22 追加）
+- `ellipse2d_circle2d_intersection` / `circle2d_ellipse2d_intersection`（2026-03-22 追加）
+- `ellipse2d_circle2d_intersections` / `circle2d_ellipse2d_intersections`（2026-03-22 追加）
+- `ellipse_arc2d_point2d_intersection`（2026-03-22 追加）
 
 ### 9.3 `geo_primitives` 側に依然として残っている代表的な 2D trait実装
 
@@ -179,3 +198,21 @@
 - 次アクション:
   - `geo_primitives` 2D の削減候補を #351 へ一次連携
   - 代表ペア以外（InfiniteLine2D / Ellipse2D / EllipseArc2D）の補完方針を確定
+
+## 11. 実装スライス記録（2026-03-22 追補）
+
+- 変更ファイル:
+  - `model/geo_algorithms/src/collision/primitive_2d.rs`
+  - `model/geo_algorithms/src/intersection/primitive_2d.rs`
+  - `model/geo_algorithms/src/lib.rs`
+- 概要:
+  - `InfiniteLine2D` / `Ellipse2D` / `EllipseArc2D` の 2D collision/intersection entry point を追加
+  - `EllipseArc2D` については `geo_primitives` 側の未公開 collision/intersection モジュールに依存せず、
+    Core API（`contains_point`, `ellipse()`, `point_in_angle_range`, 端点判定）で判定を構成
+  - 対称ラッパーとエントリポイントのテストを追加
+- 検証:
+  - `cargo clippy -p geo_algorithms -- -D warnings`: pass
+  - `cargo fmt --all`: pass
+  - `cargo test -p geo_algorithms`: pass
+- 次アクション:
+  - #351 へ 2D削減候補の詳細マッピング（関数対応表）を更新

--- a/model/geo_algorithms/src/collision/primitive_2d.rs
+++ b/model/geo_algorithms/src/collision/primitive_2d.rs
@@ -121,6 +121,13 @@ pub fn line_segment2d_arc2d_collides<T: Scalar>(
     !line_segment2d_arc2d_intersections(segment, arc).is_empty()
 }
 
+pub fn arc2d_line_segment2d_collides<T: Scalar>(
+    arc: &Arc2D<T>,
+    segment: &LineSegment2D<T>,
+) -> bool {
+    line_segment2d_arc2d_collides(segment, arc)
+}
+
 pub fn ray2d_point2d_collides<T: Scalar>(ray: &Ray2D<T>, point: &Point2D<T>, tolerance: T) -> bool {
     ray.contains_point(point, tolerance)
 }
@@ -132,6 +139,14 @@ pub fn ray2d_circle2d_collides<T: Scalar>(
 ) -> bool {
     let center = Point2D::new(circle.center().0, circle.center().1);
     ray.distance_to_point(&center) <= circle.radius() + tolerance
+}
+
+pub fn circle2d_ray2d_collides<T: Scalar>(
+    circle: &Circle2D<T>,
+    ray: &Ray2D<T>,
+    tolerance: T,
+) -> bool {
+    ray2d_circle2d_collides(ray, circle, tolerance)
 }
 
 pub fn ray2d_line_segment2d_collides<T: Scalar>(
@@ -148,6 +163,14 @@ pub fn ray2d_line_segment2d_collides<T: Scalar>(
     dist_start <= tolerance || dist_end <= tolerance
 }
 
+pub fn line_segment2d_ray2d_collides<T: Scalar>(
+    segment: &LineSegment2D<T>,
+    ray: &Ray2D<T>,
+    tolerance: T,
+) -> bool {
+    ray2d_line_segment2d_collides(ray, segment, tolerance)
+}
+
 pub fn triangle2d_circle2d_collides<T: Scalar>(
     triangle: &Triangle2D<T>,
     circle: &Circle2D<T>,
@@ -159,6 +182,14 @@ pub fn triangle2d_circle2d_collides<T: Scalar>(
     }
 
     triangle.distance_to_point(&center) <= circle.radius() + tolerance
+}
+
+pub fn circle2d_triangle2d_collides<T: Scalar>(
+    circle: &Circle2D<T>,
+    triangle: &Triangle2D<T>,
+    tolerance: T,
+) -> bool {
+    triangle2d_circle2d_collides(triangle, circle, tolerance)
 }
 
 pub fn triangle2d_triangle2d_collides<T: Scalar>(
@@ -216,6 +247,14 @@ pub fn triangle2d_line_segment2d_collides<T: Scalar>(
     !triangle2d_line_segment2d_intersections(triangle, segment, tolerance).is_empty()
 }
 
+pub fn line_segment2d_triangle2d_collides<T: Scalar>(
+    segment: &LineSegment2D<T>,
+    triangle: &Triangle2D<T>,
+    tolerance: T,
+) -> bool {
+    triangle2d_line_segment2d_collides(triangle, segment, tolerance)
+}
+
 fn edges_intersect<T: Scalar>(
     p1: Point2D<T>,
     p2: Point2D<T>,
@@ -242,11 +281,14 @@ fn edges_intersect<T: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::{
-        circle2d_arc2d_collides, circle2d_circle2d_collides, circle2d_point2d_collides,
+        arc2d_line_segment2d_collides, circle2d_arc2d_collides, circle2d_circle2d_collides,
+        circle2d_point2d_collides, circle2d_ray2d_collides, circle2d_triangle2d_collides,
         line_segment2d_arc2d_collides, line_segment2d_circle2d_collides,
+        line_segment2d_ray2d_collides, line_segment2d_triangle2d_collides, ray2d_circle2d_collides,
+        ray2d_line_segment2d_collides, triangle2d_circle2d_collides,
         triangle2d_line_segment2d_collides, triangle2d_triangle2d_collides,
     };
-    use crate::{Arc2D, Circle2D, LineSegment2D, Point2D, Triangle2D};
+    use crate::{Arc2D, Circle2D, LineSegment2D, Point2D, Ray2D, Triangle2D, Vector2D};
 
     #[test]
     fn circle_point_collision_detects_boundary_point() {
@@ -321,5 +363,46 @@ mod tests {
         assert!(triangle2d_line_segment2d_collides(
             &triangle, &segment, 1e-9
         ));
+    }
+
+    #[test]
+    fn symmetric_collision_wrappers_match_base_functions() {
+        let circle = Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap();
+        let ray = Ray2D::new(Point2D::new(-2.0, 0.0), Vector2D::new(1.0, 0.0)).unwrap();
+        let segment = LineSegment2D::new(Point2D::new(-2.0, 0.0), Point2D::new(2.0, 0.0)).unwrap();
+        let triangle = Triangle2D::new(
+            Point2D::new(0.0, 0.0),
+            Point2D::new(2.0, 0.0),
+            Point2D::new(1.0, 2.0),
+        )
+        .unwrap();
+        let arc = Arc2D::new(
+            Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap(),
+            crate::Angle::from_degrees(0.0),
+            crate::Angle::from_degrees(180.0),
+        )
+        .unwrap();
+
+        let tol = 1e-9;
+        assert_eq!(
+            circle2d_ray2d_collides(&circle, &ray, tol),
+            ray2d_circle2d_collides(&ray, &circle, tol)
+        );
+        assert_eq!(
+            line_segment2d_ray2d_collides(&segment, &ray, tol),
+            ray2d_line_segment2d_collides(&ray, &segment, tol)
+        );
+        assert_eq!(
+            circle2d_triangle2d_collides(&circle, &triangle, tol),
+            triangle2d_circle2d_collides(&triangle, &circle, tol)
+        );
+        assert_eq!(
+            line_segment2d_triangle2d_collides(&segment, &triangle, tol),
+            triangle2d_line_segment2d_collides(&triangle, &segment, tol)
+        );
+        assert_eq!(
+            arc2d_line_segment2d_collides(&arc, &segment),
+            line_segment2d_arc2d_collides(&segment, &arc)
+        );
     }
 }

--- a/model/geo_algorithms/src/collision/primitive_2d.rs
+++ b/model/geo_algorithms/src/collision/primitive_2d.rs
@@ -8,9 +8,13 @@
 
 use crate::intersection::pair_base::line_segment2d_arc2d_intersections;
 use crate::intersection::primitive_2d::triangle2d_line_segment2d_intersections;
-use crate::{Arc2D, Circle2D, LineSegment2D, Point2D, Ray2D, Triangle2D, Vector2D};
+use crate::{
+    Arc2D, Circle2D, Ellipse2D, EllipseArc2D, InfiniteLine2D, LineSegment2D, Point2D, Ray2D,
+    Triangle2D, Vector2D,
+};
 use geo_contracts::{
-    Arc2DProperties, Circle2DProperties, LineSegment2DProperties, Scalar, Triangle2DProperties,
+    Arc2DProperties, BasicCollision, Circle2DProperties, LineSegment2DProperties, Scalar,
+    Triangle2DProperties,
 };
 
 pub fn circle2d_point2d_collides<T: Scalar>(
@@ -255,6 +259,122 @@ pub fn line_segment2d_triangle2d_collides<T: Scalar>(
     triangle2d_line_segment2d_collides(triangle, segment, tolerance)
 }
 
+pub fn infinite_line2d_point2d_collides<T: Scalar>(
+    line: &InfiniteLine2D<T>,
+    point: &Point2D<T>,
+    tolerance: T,
+) -> bool {
+    line.intersects(point, tolerance)
+}
+
+pub fn infinite_line2d_circle2d_collides<T: Scalar>(
+    line: &InfiniteLine2D<T>,
+    circle: &Circle2D<T>,
+    tolerance: T,
+) -> bool {
+    line.intersects(circle, tolerance)
+}
+
+pub fn circle2d_infinite_line2d_collides<T: Scalar>(
+    circle: &Circle2D<T>,
+    line: &InfiniteLine2D<T>,
+    tolerance: T,
+) -> bool {
+    infinite_line2d_circle2d_collides(line, circle, tolerance)
+}
+
+pub fn infinite_line2d_line_segment2d_collides<T: Scalar>(
+    line: &InfiniteLine2D<T>,
+    segment: &LineSegment2D<T>,
+    tolerance: T,
+) -> bool {
+    line.intersects(segment, tolerance)
+}
+
+pub fn line_segment2d_infinite_line2d_collides<T: Scalar>(
+    segment: &LineSegment2D<T>,
+    line: &InfiniteLine2D<T>,
+    tolerance: T,
+) -> bool {
+    infinite_line2d_line_segment2d_collides(line, segment, tolerance)
+}
+
+pub fn infinite_line2d_ray2d_collides<T: Scalar>(
+    line: &InfiniteLine2D<T>,
+    ray: &Ray2D<T>,
+    tolerance: T,
+) -> bool {
+    line.intersects(ray, tolerance)
+}
+
+pub fn ray2d_infinite_line2d_collides<T: Scalar>(
+    ray: &Ray2D<T>,
+    line: &InfiniteLine2D<T>,
+    tolerance: T,
+) -> bool {
+    infinite_line2d_ray2d_collides(line, ray, tolerance)
+}
+
+pub fn ellipse2d_point2d_collides<T: Scalar>(
+    ellipse: &Ellipse2D<T>,
+    point: &Point2D<T>,
+    tolerance: T,
+) -> bool {
+    ellipse.intersects(point, tolerance)
+}
+
+pub fn ellipse2d_circle2d_collides<T: Scalar>(
+    ellipse: &Ellipse2D<T>,
+    circle: &Circle2D<T>,
+    tolerance: T,
+) -> bool {
+    ellipse.intersects(circle, tolerance)
+}
+
+pub fn circle2d_ellipse2d_collides<T: Scalar>(
+    circle: &Circle2D<T>,
+    ellipse: &Ellipse2D<T>,
+    tolerance: T,
+) -> bool {
+    ellipse2d_circle2d_collides(ellipse, circle, tolerance)
+}
+
+pub fn ellipse_arc2d_point2d_collides<T: Scalar>(
+    arc: &EllipseArc2D<T>,
+    point: &Point2D<T>,
+    tolerance: T,
+) -> bool {
+    arc.contains_point(point, tolerance)
+}
+
+pub fn ellipse_arc2d_circle2d_collides<T: Scalar>(
+    arc: &EllipseArc2D<T>,
+    circle: &Circle2D<T>,
+    tolerance: T,
+) -> bool {
+    if !arc.ellipse().intersects(circle, tolerance) {
+        return false;
+    }
+
+    let center = Point2D::new(circle.center().0, circle.center().1);
+    if arc.point_in_angle_range(&center, tolerance) {
+        return true;
+    }
+
+    let start = arc.start_point();
+    let end = arc.end_point();
+    circle2d_point2d_collides(circle, &start, tolerance)
+        || circle2d_point2d_collides(circle, &end, tolerance)
+}
+
+pub fn circle2d_ellipse_arc2d_collides<T: Scalar>(
+    circle: &Circle2D<T>,
+    arc: &EllipseArc2D<T>,
+    tolerance: T,
+) -> bool {
+    ellipse_arc2d_circle2d_collides(arc, circle, tolerance)
+}
+
 fn edges_intersect<T: Scalar>(
     p1: Point2D<T>,
     p2: Point2D<T>,
@@ -282,13 +402,22 @@ fn edges_intersect<T: Scalar>(
 mod tests {
     use super::{
         arc2d_line_segment2d_collides, circle2d_arc2d_collides, circle2d_circle2d_collides,
-        circle2d_point2d_collides, circle2d_ray2d_collides, circle2d_triangle2d_collides,
-        line_segment2d_arc2d_collides, line_segment2d_circle2d_collides,
+        circle2d_ellipse2d_collides, circle2d_ellipse_arc2d_collides,
+        circle2d_infinite_line2d_collides, circle2d_point2d_collides, circle2d_ray2d_collides,
+        circle2d_triangle2d_collides, ellipse2d_circle2d_collides, ellipse2d_point2d_collides,
+        ellipse_arc2d_circle2d_collides, ellipse_arc2d_point2d_collides,
+        infinite_line2d_circle2d_collides, infinite_line2d_line_segment2d_collides,
+        infinite_line2d_ray2d_collides, line_segment2d_arc2d_collides,
+        line_segment2d_circle2d_collides, line_segment2d_infinite_line2d_collides,
         line_segment2d_ray2d_collides, line_segment2d_triangle2d_collides, ray2d_circle2d_collides,
-        ray2d_line_segment2d_collides, triangle2d_circle2d_collides,
-        triangle2d_line_segment2d_collides, triangle2d_triangle2d_collides,
+        ray2d_infinite_line2d_collides, ray2d_line_segment2d_collides,
+        triangle2d_circle2d_collides, triangle2d_line_segment2d_collides,
+        triangle2d_triangle2d_collides,
     };
-    use crate::{Arc2D, Circle2D, LineSegment2D, Point2D, Ray2D, Triangle2D, Vector2D};
+    use crate::{
+        Angle, Arc2D, Circle2D, Ellipse2D, EllipseArc2D, InfiniteLine2D, LineSegment2D, Point2D,
+        Ray2D, Triangle2D, Vector2D,
+    };
 
     #[test]
     fn circle_point_collision_detects_boundary_point() {
@@ -403,6 +532,43 @@ mod tests {
         assert_eq!(
             arc2d_line_segment2d_collides(&arc, &segment),
             line_segment2d_arc2d_collides(&segment, &arc)
+        );
+
+        let line = InfiniteLine2D::new(Point2D::new(0.0, 0.0), Vector2D::new(1.0, 0.0)).unwrap();
+        assert_eq!(
+            circle2d_infinite_line2d_collides(&circle, &line, tol),
+            infinite_line2d_circle2d_collides(&line, &circle, tol)
+        );
+        assert_eq!(
+            line_segment2d_infinite_line2d_collides(&segment, &line, tol),
+            infinite_line2d_line_segment2d_collides(&line, &segment, tol)
+        );
+        assert_eq!(
+            ray2d_infinite_line2d_collides(&ray, &line, tol),
+            infinite_line2d_ray2d_collides(&line, &ray, tol)
+        );
+    }
+
+    #[test]
+    fn ellipse_and_ellipse_arc_collision_entry_points_work() {
+        let ellipse = Ellipse2D::new(Point2D::new(0.0, 0.0), 3.0, 2.0, 0.0).unwrap();
+        let ellipse_arc = EllipseArc2D::new(
+            ellipse,
+            Angle::from_degrees(0.0),
+            Angle::from_degrees(180.0),
+        );
+        let point = Point2D::new(3.0, 0.0);
+        let circle = Circle2D::new(Point2D::new(2.5, 0.0), 0.75).unwrap();
+
+        assert!(ellipse2d_point2d_collides(&ellipse, &point, 1e-6));
+        assert!(ellipse_arc2d_point2d_collides(&ellipse_arc, &point, 1e-6));
+        assert_eq!(
+            circle2d_ellipse2d_collides(&circle, &ellipse, 1e-6),
+            ellipse2d_circle2d_collides(&ellipse, &circle, 1e-6)
+        );
+        assert_eq!(
+            circle2d_ellipse_arc2d_collides(&circle, &ellipse_arc, 1e-6),
+            ellipse_arc2d_circle2d_collides(&ellipse_arc, &circle, 1e-6)
         );
     }
 }

--- a/model/geo_algorithms/src/intersection/primitive_2d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_2d.rs
@@ -120,6 +120,14 @@ pub fn ray2d_line_segment2d_intersection<T: Scalar>(
     }
 }
 
+pub fn line_segment2d_ray2d_intersection<T: Scalar>(
+    segment: &LineSegment2D<T>,
+    ray: &Ray2D<T>,
+    tolerance: T,
+) -> Option<Point2D<T>> {
+    ray2d_line_segment2d_intersection(ray, segment, tolerance)
+}
+
 pub fn ray2d_circle2d_intersections<T: Scalar>(
     ray: &Ray2D<T>,
     circle: &Circle2D<T>,
@@ -166,6 +174,14 @@ pub fn ray2d_circle2d_intersections<T: Scalar>(
     }
 
     intersections
+}
+
+pub fn circle2d_ray2d_intersections<T: Scalar>(
+    circle: &Circle2D<T>,
+    ray: &Ray2D<T>,
+    tolerance: T,
+) -> Vec<Point2D<T>> {
+    ray2d_circle2d_intersections(ray, circle, tolerance)
 }
 
 pub fn triangle2d_line_segment2d_intersections<T: Scalar>(
@@ -262,7 +278,9 @@ mod tests {
     use super::{
         arc2d_line_segment2d_intersections_algo, circle2d_arc2d_intersections_algo,
         circle2d_circle2d_intersections_algo, circle2d_point2d_intersection,
-        line_segment2d_line_segment2d_intersection_algo, ray2d_circle2d_intersections,
+        circle2d_ray2d_intersections, line_segment2d_line_segment2d_intersection_algo,
+        line_segment2d_ray2d_intersection, ray2d_circle2d_intersections,
+        ray2d_line_segment2d_intersection,
     };
     use crate::{Arc2D, Circle2D, LineSegment2D, Point2D, Ray2D, Vector2D};
 
@@ -329,5 +347,22 @@ mod tests {
 
         let intersections = arc2d_line_segment2d_intersections_algo(&arc, &segment);
         assert!(!intersections.is_empty());
+    }
+
+    #[test]
+    fn symmetric_intersection_wrappers_match_base_functions() {
+        let ray = Ray2D::new(Point2D::new(-2.0, 0.0), Vector2D::new(1.0, 0.0)).unwrap();
+        let circle = Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap();
+        let segment = LineSegment2D::new(Point2D::new(-2.0, 0.0), Point2D::new(2.0, 0.0)).unwrap();
+
+        let tol = 1e-9;
+        assert_eq!(
+            circle2d_ray2d_intersections(&circle, &ray, tol),
+            ray2d_circle2d_intersections(&ray, &circle, tol)
+        );
+        assert_eq!(
+            line_segment2d_ray2d_intersection(&segment, &ray, tol),
+            ray2d_line_segment2d_intersection(&ray, &segment, tol)
+        );
     }
 }

--- a/model/geo_algorithms/src/intersection/primitive_2d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_2d.rs
@@ -8,10 +8,13 @@ use crate::intersection::pair_base::{
     circle2d_line_segment2d_intersections, line_segment2d_arc2d_intersections,
     line_segment2d_circle2d_intersections, line_segment2d_line_segment2d_intersection,
 };
-use crate::{Arc2D, Circle2D, Ellipse2D, LineSegment2D, Point2D, Ray2D, Triangle2D, Vector2D};
+use crate::{
+    Arc2D, Circle2D, Ellipse2D, EllipseArc2D, InfiniteLine2D, LineSegment2D, Point2D, Ray2D,
+    Triangle2D, Vector2D,
+};
 use geo_contracts::{
-    Arc2DProperties, Circle2DProperties, Ellipse2DProperties, LineSegment2DProperties,
-    Ray2DProperties, Scalar, Triangle2DProperties,
+    Arc2DProperties, BasicIntersection, Circle2DProperties, Ellipse2DProperties,
+    LineSegment2DProperties, MultipleIntersection, Ray2DProperties, Scalar, Triangle2DProperties,
 };
 
 pub fn circle2d_point2d_intersection<T: Scalar>(
@@ -246,6 +249,130 @@ pub fn arc2d_point2d_intersection<T: Scalar>(
     Some(*point)
 }
 
+pub fn infinite_line2d_point2d_intersection<T: Scalar>(
+    line: &InfiniteLine2D<T>,
+    point: &Point2D<T>,
+    tolerance: T,
+) -> Option<Point2D<T>> {
+    line.intersection_with(point, tolerance)
+}
+
+pub fn infinite_line2d_circle2d_intersection<T: Scalar>(
+    line: &InfiniteLine2D<T>,
+    circle: &Circle2D<T>,
+    tolerance: T,
+) -> Option<Point2D<T>> {
+    line.intersection_with(circle, tolerance)
+}
+
+pub fn infinite_line2d_circle2d_intersections<T: Scalar>(
+    line: &InfiniteLine2D<T>,
+    circle: &Circle2D<T>,
+    tolerance: T,
+) -> Vec<Point2D<T>> {
+    line.intersections_with(circle, tolerance)
+}
+
+pub fn circle2d_infinite_line2d_intersection<T: Scalar>(
+    circle: &Circle2D<T>,
+    line: &InfiniteLine2D<T>,
+    tolerance: T,
+) -> Option<Point2D<T>> {
+    infinite_line2d_circle2d_intersection(line, circle, tolerance)
+}
+
+pub fn circle2d_infinite_line2d_intersections<T: Scalar>(
+    circle: &Circle2D<T>,
+    line: &InfiniteLine2D<T>,
+    tolerance: T,
+) -> Vec<Point2D<T>> {
+    infinite_line2d_circle2d_intersections(line, circle, tolerance)
+}
+
+pub fn infinite_line2d_line_segment2d_intersection<T: Scalar>(
+    line: &InfiniteLine2D<T>,
+    segment: &LineSegment2D<T>,
+    tolerance: T,
+) -> Option<Point2D<T>> {
+    line.intersection_with(segment, tolerance)
+}
+
+pub fn line_segment2d_infinite_line2d_intersection<T: Scalar>(
+    segment: &LineSegment2D<T>,
+    line: &InfiniteLine2D<T>,
+    tolerance: T,
+) -> Option<Point2D<T>> {
+    infinite_line2d_line_segment2d_intersection(line, segment, tolerance)
+}
+
+pub fn infinite_line2d_ray2d_intersection<T: Scalar>(
+    line: &InfiniteLine2D<T>,
+    ray: &Ray2D<T>,
+    tolerance: T,
+) -> Option<Point2D<T>> {
+    line.intersection_with(ray, tolerance)
+}
+
+pub fn ray2d_infinite_line2d_intersection<T: Scalar>(
+    ray: &Ray2D<T>,
+    line: &InfiniteLine2D<T>,
+    tolerance: T,
+) -> Option<Point2D<T>> {
+    infinite_line2d_ray2d_intersection(line, ray, tolerance)
+}
+
+pub fn ellipse2d_point2d_intersection<T: Scalar>(
+    ellipse: &Ellipse2D<T>,
+    point: &Point2D<T>,
+    tolerance: T,
+) -> Option<Point2D<T>> {
+    ellipse.intersection_with(point, tolerance)
+}
+
+pub fn ellipse2d_circle2d_intersection<T: Scalar>(
+    ellipse: &Ellipse2D<T>,
+    circle: &Circle2D<T>,
+    tolerance: T,
+) -> Option<Point2D<T>> {
+    ellipse.intersection_with(circle, tolerance)
+}
+
+pub fn ellipse2d_circle2d_intersections<T: Scalar>(
+    ellipse: &Ellipse2D<T>,
+    circle: &Circle2D<T>,
+    tolerance: T,
+) -> Vec<Point2D<T>> {
+    ellipse.intersections_with(circle, tolerance)
+}
+
+pub fn circle2d_ellipse2d_intersection<T: Scalar>(
+    circle: &Circle2D<T>,
+    ellipse: &Ellipse2D<T>,
+    tolerance: T,
+) -> Option<Point2D<T>> {
+    ellipse2d_circle2d_intersection(ellipse, circle, tolerance)
+}
+
+pub fn circle2d_ellipse2d_intersections<T: Scalar>(
+    circle: &Circle2D<T>,
+    ellipse: &Ellipse2D<T>,
+    tolerance: T,
+) -> Vec<Point2D<T>> {
+    ellipse2d_circle2d_intersections(ellipse, circle, tolerance)
+}
+
+pub fn ellipse_arc2d_point2d_intersection<T: Scalar>(
+    arc: &EllipseArc2D<T>,
+    point: &Point2D<T>,
+    tolerance: T,
+) -> Option<Point2D<T>> {
+    if arc.contains_point(point, tolerance) {
+        Some(*point)
+    } else {
+        None
+    }
+}
+
 fn edge_segment_intersection<T: Scalar>(
     edge_p1: Point2D<T>,
     edge_p2: Point2D<T>,
@@ -277,12 +404,22 @@ fn edge_segment_intersection<T: Scalar>(
 mod tests {
     use super::{
         arc2d_line_segment2d_intersections_algo, circle2d_arc2d_intersections_algo,
-        circle2d_circle2d_intersections_algo, circle2d_point2d_intersection,
-        circle2d_ray2d_intersections, line_segment2d_line_segment2d_intersection_algo,
-        line_segment2d_ray2d_intersection, ray2d_circle2d_intersections,
+        circle2d_circle2d_intersections_algo, circle2d_ellipse2d_intersection,
+        circle2d_ellipse2d_intersections, circle2d_infinite_line2d_intersection,
+        circle2d_infinite_line2d_intersections, circle2d_point2d_intersection,
+        circle2d_ray2d_intersections, ellipse2d_circle2d_intersection,
+        ellipse2d_circle2d_intersections, ellipse2d_point2d_intersection,
+        ellipse_arc2d_point2d_intersection, infinite_line2d_circle2d_intersection,
+        infinite_line2d_circle2d_intersections, infinite_line2d_line_segment2d_intersection,
+        infinite_line2d_ray2d_intersection, line_segment2d_infinite_line2d_intersection,
+        line_segment2d_line_segment2d_intersection_algo, line_segment2d_ray2d_intersection,
+        ray2d_circle2d_intersections, ray2d_infinite_line2d_intersection,
         ray2d_line_segment2d_intersection,
     };
-    use crate::{Arc2D, Circle2D, LineSegment2D, Point2D, Ray2D, Vector2D};
+    use crate::{
+        Angle, Arc2D, Circle2D, Ellipse2D, EllipseArc2D, InfiniteLine2D, LineSegment2D, Point2D,
+        Ray2D, Vector2D,
+    };
 
     #[test]
     fn circle_point_intersection_returns_same_point() {
@@ -354,6 +491,7 @@ mod tests {
         let ray = Ray2D::new(Point2D::new(-2.0, 0.0), Vector2D::new(1.0, 0.0)).unwrap();
         let circle = Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap();
         let segment = LineSegment2D::new(Point2D::new(-2.0, 0.0), Point2D::new(2.0, 0.0)).unwrap();
+        let line = InfiniteLine2D::new(Point2D::new(0.0, 0.0), Vector2D::new(1.0, 0.0)).unwrap();
 
         let tol = 1e-9;
         assert_eq!(
@@ -363,6 +501,51 @@ mod tests {
         assert_eq!(
             line_segment2d_ray2d_intersection(&segment, &ray, tol),
             ray2d_line_segment2d_intersection(&ray, &segment, tol)
+        );
+        assert_eq!(
+            circle2d_infinite_line2d_intersection(&circle, &line, tol),
+            infinite_line2d_circle2d_intersection(&line, &circle, tol)
+        );
+        assert_eq!(
+            circle2d_infinite_line2d_intersections(&circle, &line, tol),
+            infinite_line2d_circle2d_intersections(&line, &circle, tol)
+        );
+        assert_eq!(
+            line_segment2d_infinite_line2d_intersection(&segment, &line, tol),
+            infinite_line2d_line_segment2d_intersection(&line, &segment, tol)
+        );
+        assert_eq!(
+            ray2d_infinite_line2d_intersection(&ray, &line, tol),
+            infinite_line2d_ray2d_intersection(&line, &ray, tol)
+        );
+    }
+
+    #[test]
+    fn ellipse_and_ellipse_arc_intersection_entry_points_work() {
+        let ellipse = Ellipse2D::new(Point2D::new(0.0, 0.0), 3.0, 2.0, 0.0).unwrap();
+        let ellipse_arc = EllipseArc2D::new(
+            ellipse,
+            Angle::from_degrees(0.0),
+            Angle::from_degrees(180.0),
+        );
+        let point = Point2D::new(3.0, 0.0);
+        let circle = Circle2D::new(Point2D::new(2.5, 0.0), 0.75).unwrap();
+
+        assert_eq!(
+            ellipse2d_circle2d_intersection(&ellipse, &circle, 1e-6),
+            circle2d_ellipse2d_intersection(&circle, &ellipse, 1e-6)
+        );
+        assert_eq!(
+            ellipse2d_circle2d_intersections(&ellipse, &circle, 1e-6),
+            circle2d_ellipse2d_intersections(&circle, &ellipse, 1e-6)
+        );
+        assert_eq!(
+            ellipse_arc2d_point2d_intersection(&ellipse_arc, &point, 1e-6),
+            Some(point)
+        );
+        assert_eq!(
+            ellipse2d_point2d_intersection(&ellipse, &point, 1e-6),
+            Some(point)
         );
     }
 }

--- a/model/geo_algorithms/src/lib.rs
+++ b/model/geo_algorithms/src/lib.rs
@@ -25,8 +25,8 @@ pub use geo_primitives::{Angle, Direction3D};
 // 基本形状
 pub use geo_primitives::{
     Arc2D, Arc3D, Circle2D, Circle3D, ConicalSolid3D, ConicalSurface3D, CylindricalSolid3D,
-    CylindricalSurface3D, Ellipse2D, Ellipse3D, EllipseArc3D, EllipsoidalSolid3D,
-    EllipsoidalSurface3D, InfiniteLine3D, LineSegment2D, LineSegment3D, Plane3D, Ray2D, Ray3D,
-    SphericalSolid3D, SphericalSurface3D, TorusSolid3D, TorusSurface3D, Triangle2D, Triangle3D,
-    TriangleMesh3D,
+    CylindricalSurface3D, Ellipse2D, Ellipse3D, EllipseArc2D, EllipseArc3D, EllipsoidalSolid3D,
+    EllipsoidalSurface3D, InfiniteLine2D, InfiniteLine3D, LineSegment2D, LineSegment3D, Plane3D,
+    Ray2D, Ray3D, SphericalSolid3D, SphericalSurface3D, TorusSolid3D, TorusSurface3D, Triangle2D,
+    Triangle3D, TriangleMesh3D,
 };


### PR DESCRIPTION
## 概要
Issue #350 の読み替え方針（#356）に沿って、2D collision/intersection の正本ロジック集約を進め、完了条件を満たす状態まで整理しました。

## 変更内容
- `geo_algorithms` 2D entry points を補完
  - 対称 entry point を追加
  - `InfiniteLine2D` / `Ellipse2D` / `EllipseArc2D` 系を追加
- `geo_algorithms/src/lib.rs` に必要な再エクスポートを追加
  - `InfiniteLine2D` / `EllipseArc2D`
- 2Dテストを補完
  - 対称ラッパー一致性テスト
  - 楕円系 entry point の動作確認
- 実施記録を更新
  - `dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md`
  - Phase C/Phase D/完了条件を更新
  - #351 連携用の 2D 削減候補対応表を追記

## 補足（EllipseArc2D）
`geo_primitives` 側の未公開 collision/intersection モジュールに依存せず、Core API（`contains_point`, `ellipse()`, `point_in_angle_range`, 端点判定）で判定を構成しています。

## 検証
- `cargo clippy -p geo_algorithms -- -D warnings`
- `cargo fmt --all`
- `cargo test -p geo_algorithms`
- `cargo check --workspace`
- `cargo test --workspace`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check_architecture_dependencies.ps1 -ExitOnError`

## 関連Issue
- #350
- #351
- #356
- #362