### PR TITLE
test(#366): add matrix-driven coverage validation engine

### DIFF
--- a/dev/architecture/CROSS_OPERATION_COVERAGE_MATRIX_SPEC.md
+++ b/dev/architecture/CROSS_OPERATION_COVERAGE_MATRIX_SPEC.md
@@ -158,3 +158,20 @@ notes: string | null
 1. #364 で本仕様へのレビューコメントを反映して v1.0 確定
 2. #366 で「未登録/非対称/重複」検出テストを実装
 3. #367/#365/#363 で演算ごとに登録範囲を拡張
+
+## 11. #366 検証契約
+
+matrix-driven テストエンジンは、最低限以下を fail として検出する。
+
+- 必須未登録:
+	- 条件: `required=true` かつ `entrypoint_a_to_b=null`
+	- 出力: `missing required entrypoints` セクションに `id` 一覧を列挙
+- 非対称:
+	- 条件: `symmetric=true` で逆向きレコード `(shape_b, shape_a)` が存在しない
+	- 条件: `symmetric=true` で逆向きの `cardinality` が不一致
+	- 出力: `symmetry mismatch` セクションに mismatch 内容を列挙
+- 重複登録:
+	- 条件: 同一主キー `(dimension, operation, shape_a, shape_b)` が複数存在
+	- 出力: `duplicate matrix keys` セクションに重複キーを列挙
+
+失敗メッセージは、最初の1件のみではなく不足/不整合の一覧をまとめて表示する。

--- a/model/geo_algorithms/tests/coverage_matrix_engine.rs
+++ b/model/geo_algorithms/tests/coverage_matrix_engine.rs
@@ -1,0 +1,289 @@
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Dimension {
+    D2,
+    D3,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Operation {
+    Collision,
+    Intersection,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Cardinality {
+    Single,
+    Multiple,
+    Optional,
+}
+
+#[derive(Debug, Clone)]
+struct MatrixEntry {
+    id: &'static str,
+    dimension: Dimension,
+    operation: Operation,
+    shape_a: &'static str,
+    shape_b: &'static str,
+    required: bool,
+    symmetric: bool,
+    cardinality: Option<Cardinality>,
+    entrypoint_a_to_b: Option<&'static str>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct MatrixKey {
+    dimension: Dimension,
+    operation: Operation,
+    shape_a: &'static str,
+    shape_b: &'static str,
+}
+
+impl MatrixEntry {
+    fn key(&self) -> MatrixKey {
+        MatrixKey {
+            dimension: self.dimension,
+            operation: self.operation,
+            shape_a: self.shape_a,
+            shape_b: self.shape_b,
+        }
+    }
+
+    fn reverse_key(&self) -> MatrixKey {
+        MatrixKey {
+            dimension: self.dimension,
+            operation: self.operation,
+            shape_a: self.shape_b,
+            shape_b: self.shape_a,
+        }
+    }
+}
+
+fn detect_duplicate_keys(entries: &[MatrixEntry]) -> Result<(), String> {
+    let mut seen = HashSet::new();
+    let mut duplicates = Vec::new();
+
+    for entry in entries {
+        let key = entry.key();
+        if !seen.insert(key) {
+            duplicates.push(format!(
+                "{:?}:{:?}:{}:{}",
+                key.dimension, key.operation, key.shape_a, key.shape_b
+            ));
+        }
+    }
+
+    if duplicates.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "duplicate matrix keys:\n- {}",
+            duplicates.join("\n- ")
+        ))
+    }
+}
+
+fn detect_missing_required(entries: &[MatrixEntry]) -> Result<(), String> {
+    let missing: Vec<&str> = entries
+        .iter()
+        .filter(|e| e.required && e.entrypoint_a_to_b.is_none())
+        .map(|e| e.id)
+        .collect();
+
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "missing required entrypoints:\n- {}",
+            missing.join("\n- ")
+        ))
+    }
+}
+
+fn detect_symmetry_mismatch(entries: &[MatrixEntry]) -> Result<(), String> {
+    let by_key: HashMap<MatrixKey, &MatrixEntry> = entries.iter().map(|e| (e.key(), e)).collect();
+    let mut mismatches = Vec::new();
+
+    for entry in entries {
+        if !entry.symmetric {
+            continue;
+        }
+
+        match by_key.get(&entry.reverse_key()) {
+            None => mismatches.push(format!(
+                "missing reverse pair for {} ({} -> {})",
+                entry.id, entry.shape_a, entry.shape_b
+            )),
+            Some(reverse) => {
+                if reverse.cardinality != entry.cardinality {
+                    mismatches.push(format!(
+                        "cardinality mismatch {} <-> {} ({:?} vs {:?})",
+                        entry.id, reverse.id, entry.cardinality, reverse.cardinality
+                    ));
+                }
+            }
+        }
+    }
+
+    if mismatches.is_empty() {
+        Ok(())
+    } else {
+        Err(format!("symmetry mismatch:\n- {}", mismatches.join("\n- ")))
+    }
+}
+
+fn validate_matrix(entries: &[MatrixEntry]) -> Result<(), String> {
+    let mut errors = Vec::new();
+
+    if let Err(err) = detect_duplicate_keys(entries) {
+        errors.push(err);
+    }
+    if let Err(err) = detect_missing_required(entries) {
+        errors.push(err);
+    }
+    if let Err(err) = detect_symmetry_mismatch(entries) {
+        errors.push(err);
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("\n\n"))
+    }
+}
+
+fn valid_seed_entries() -> Vec<MatrixEntry> {
+    vec![
+        MatrixEntry {
+            id: "2d:circle-ray:collision",
+            dimension: Dimension::D2,
+            operation: Operation::Collision,
+            shape_a: "Circle2D",
+            shape_b: "Ray2D",
+            required: true,
+            symmetric: true,
+            cardinality: None,
+            entrypoint_a_to_b: Some("circle2d_ray2d_collides"),
+        },
+        MatrixEntry {
+            id: "2d:ray-circle:collision",
+            dimension: Dimension::D2,
+            operation: Operation::Collision,
+            shape_a: "Ray2D",
+            shape_b: "Circle2D",
+            required: true,
+            symmetric: true,
+            cardinality: None,
+            entrypoint_a_to_b: Some("ray2d_circle2d_collides"),
+        },
+        MatrixEntry {
+            id: "3d:line-segment:intersection",
+            dimension: Dimension::D3,
+            operation: Operation::Intersection,
+            shape_a: "InfiniteLine3D",
+            shape_b: "LineSegment3D",
+            required: true,
+            symmetric: false,
+            cardinality: Some(Cardinality::Optional),
+            entrypoint_a_to_b: Some("infinite_line3d_line_segment3d_intersection"),
+        },
+    ]
+}
+
+#[test]
+fn matrix_engine_passes_for_valid_seed() {
+    let entries = valid_seed_entries();
+    assert!(validate_matrix(&entries).is_ok());
+}
+
+#[test]
+fn matrix_engine_fails_for_missing_required_entrypoint() {
+    let mut entries = valid_seed_entries();
+    entries.push(MatrixEntry {
+        id: "2d:segment-ray:intersection",
+        dimension: Dimension::D2,
+        operation: Operation::Intersection,
+        shape_a: "LineSegment2D",
+        shape_b: "Ray2D",
+        required: true,
+        symmetric: false,
+        cardinality: Some(Cardinality::Single),
+        entrypoint_a_to_b: None,
+    });
+
+    let err = validate_matrix(&entries).unwrap_err();
+    assert!(err.contains("missing required entrypoints"));
+    assert!(err.contains("2d:segment-ray:intersection"));
+}
+
+#[test]
+fn matrix_engine_fails_for_symmetry_mismatch() {
+    let entries = vec![
+        MatrixEntry {
+            id: "2d:circle-ray:intersection",
+            dimension: Dimension::D2,
+            operation: Operation::Intersection,
+            shape_a: "Circle2D",
+            shape_b: "Ray2D",
+            required: true,
+            symmetric: true,
+            cardinality: Some(Cardinality::Multiple),
+            entrypoint_a_to_b: Some("circle2d_ray2d_intersections"),
+        },
+        MatrixEntry {
+            id: "2d:ray-circle:intersection",
+            dimension: Dimension::D2,
+            operation: Operation::Intersection,
+            shape_a: "Ray2D",
+            shape_b: "Circle2D",
+            required: true,
+            symmetric: true,
+            cardinality: Some(Cardinality::Single),
+            entrypoint_a_to_b: Some("ray2d_circle2d_intersections"),
+        },
+    ];
+
+    let err = validate_matrix(&entries).unwrap_err();
+    assert!(err.contains("symmetry mismatch"));
+    assert!(err.contains("cardinality mismatch"));
+}
+
+#[test]
+fn matrix_engine_fails_for_duplicate_registration() {
+    let mut entries = valid_seed_entries();
+    entries.push(MatrixEntry {
+        id: "2d:circle-ray:collision:dup",
+        dimension: Dimension::D2,
+        operation: Operation::Collision,
+        shape_a: "Circle2D",
+        shape_b: "Ray2D",
+        required: false,
+        symmetric: false,
+        cardinality: None,
+        entrypoint_a_to_b: Some("circle2d_ray2d_collides"),
+    });
+
+    let err = validate_matrix(&entries).unwrap_err();
+    assert!(err.contains("duplicate matrix keys"));
+    assert!(err.contains("Circle2D:Ray2D"));
+}
+
+#[test]
+fn matrix_engine_fails_for_missing_reverse_pair() {
+    let entries = vec![MatrixEntry {
+        id: "2d:segment-ray:collision",
+        dimension: Dimension::D2,
+        operation: Operation::Collision,
+        shape_a: "LineSegment2D",
+        shape_b: "Ray2D",
+        required: true,
+        symmetric: true,
+        cardinality: None,
+        entrypoint_a_to_b: Some("line_segment2d_ray2d_collides"),
+    }];
+
+    let err = validate_matrix(&entries).unwrap_err();
+    assert!(err.contains("symmetry mismatch"));
+    assert!(err.contains("missing reverse pair"));
+}


### PR DESCRIPTION
親Issue: #366
関連: #362, #364

## 概要
matrix-driven 汎用テストエンジンを `geo_algorithms` に追加し、coverage matrix の基本検証を自動化しました。

## 実装内容
- 追加: `model/geo_algorithms/tests/coverage_matrix_engine.rs`
  - マトリクスエントリ型（dimension/operation/required/symmetric/cardinality/entrypoint）
  - 検証関数:
    - 必須未登録検出（required=true かつ entrypoint未設定）
    - 非対称検出（A-B/B-A 逆向き欠落、cardinality不一致）
    - 重複登録検出（同一主キー重複）
  - 可読性のある失敗メッセージ（不足・不整合一覧をまとめて出力）
  - 正常系/異常系テスト（5件）
- 更新: `dev/architecture/CROSS_OPERATION_COVERAGE_MATRIX_SPEC.md`
  - #366 検証契約を追記（fail条件と出力方針）

## 受け入れ条件との対応
- [x] 必須未登録で fail する
- [x] A-B/B-A 不一致で fail する
- [x] 重複登録を fail できる
- [x] CI 実行時間が許容範囲に収まる（`geo_algorithms` テスト実行で問題なし）

## 検証
- `cargo clippy -p geo_algorithms --tests -- -D warnings`: pass
- `cargo fmt`: pass
- `cargo test -p geo_algorithms`: pass