### PR TITLE
docs(tolerance): #361 正本/互換層の利用ルールと廃止ロードマップを明文化

### DIFF
--- a/dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md
+++ b/dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md
@@ -1,0 +1,64 @@
+# Geometric Tolerance Usage Rules
+
+## 目的
+
+幾何演算におけるトレランスの責務を明確化し、正本と互換層の混在を段階的に解消するための運用ルールを定義する。
+
+## 設計原則
+
+- 正本は `geo_contracts::ToleranceSettings` とする。
+- API入力トレランスは呼び出し元が `ToleranceSettings` から取得し、明示的に渡す。
+- スケーリング責務は呼び出し元に置く。
+- 互換層は暫定運用とし、新規実装での依存追加を禁止する。
+
+## 現状の3層構造
+
+### 層1: 正本（維持）
+
+- `model/geo_contracts/src/tolerance.rs`
+- 提供: `ToleranceSettings<T>`
+- 役割: 幾何演算で使用する標準トレランスの単一の情報源
+
+### 層2: 過渡期互換層（段階的廃止）
+
+- `model/geo_contracts/src/tolerance_migration.rs`
+- 提供: `DefaultTolerances`, `ScalarToleranceExt`
+- 役割: 旧呼び出し経路の暫定サポート
+- 方針: 新規利用禁止、`ToleranceSettings` へ順次移行後に削除
+
+### 層3: geo_algorithms レガシー互換層（段階的廃止）
+
+- `model/geo_algorithms/src/tolerance.rs`
+- 提供: `ToleranceContext`
+- 役割: 旧実装互換の最小定義
+- 方針: `ToleranceSettings` ベースへ順次移行後に削除
+
+## 廃止ロードマップ
+
+### フェーズ1（Issue #361）
+
+- 本ドキュメントを整備する。
+- 互換層ファイルに廃止予定コメントと参照Issueを明記する。
+
+### フェーズ2（別Issue）
+
+- `geo_primitives` の `DefaultTolerances` 依存を `ToleranceSettings` へ移行する。
+- 移行完了後に `model/geo_contracts/src/tolerance_migration.rs` を削除する。
+
+### フェーズ3（別Issue）
+
+- `geo_algorithms` 内で `ToleranceContext` 依存箇所を `ToleranceSettings` ベースへ移行する。
+- 移行完了後に `model/geo_algorithms/src/tolerance.rs` を削除する。
+
+## 運用ルール
+
+- 新規コードでは `ToleranceSettings` を使用し、互換層APIを増やさない。
+- 互換層に変更を入れる場合は、削除に向けた移行目的を明記する。
+- 既存コード移行時は、呼び出し境界でトレランス取得元を統一する。
+
+## 関連Issue
+
+- #361
+- #318
+- #320
+- #360

--- a/model/geo_algorithms/src/tolerance.rs
+++ b/model/geo_algorithms/src/tolerance.rs
@@ -2,6 +2,7 @@
 ///
 /// 旧アルゴリズム実装が参照していた `ToleranceContext` を
 /// 外部基盤クレート非依存で維持するための最小定義。
+/// 廃止予定: #361（フェーズ3で `ToleranceSettings` ベース移行後に削除）。
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ToleranceContext {
     pub linear: f64,

--- a/model/geo_contracts/src/tolerance_migration.rs
+++ b/model/geo_contracts/src/tolerance_migration.rs
@@ -1,6 +1,7 @@
 //! 段階的移行のための許容誤差デフォルト値提供
 //!
 //! Scalar から許容誤差を分離するための過渡期的な仕組み。
+//! 廃止予定: #361（フェーズ2で `ToleranceSettings` 移行完了後に削除）
 
 use crate::{Scalar, ToleranceSettings};
 


### PR DESCRIPTION
## 概要
Issue #361 のフェーズ1として、トレランス責務整理の方針を文書化し、互換層に廃止予定コメントを追加しました。

## 変更内容
- 追加: `dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md`
  - 設計原則
  - 現状の3層構造（正本/過渡期/レガシー互換）
  - フェーズ1〜3の廃止ロードマップ
  - 運用ルール
- 更新: `model/geo_contracts/src/tolerance_migration.rs`
  - 先頭に #361 参照の廃止予定コメントを追加
- 更新: `model/geo_algorithms/src/tolerance.rs`
  - 先頭に #361 参照の廃止予定コメントを追加

## 受け入れ条件との対応
- [x] `GEOMETRIC_TOLERANCE_USAGE_RULES.md` に設計原則・3層構造・廃止ロードマップを追記
- [x] `tolerance_migration.rs` 先頭に廃止予定 Issue 参照コメント追記
- [x] `geo_algorithms/src/tolerance.rs` 先頭に廃止予定 Issue 参照コメント追記

## 検証
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all`
- `cargo test --workspace`

Closes #361