### PR TITLE
test(geo_algorithms): #363 distance coverage と tolerance/整合ルールを適用

### DIFF
--- a/model/geo_algorithms/src/distance/primitive_2d.rs
+++ b/model/geo_algorithms/src/distance/primitive_2d.rs
@@ -5,8 +5,24 @@
 //!
 //! 命名規則: `{shape_a}_{shape_b}_distance`
 
-use crate::{Circle2D, InfiniteLine2D, Point2D, Ray2D};
+use crate::{Circle2D, InfiniteLine2D, LineSegment2D, Point2D, Ray2D};
 use geo_contracts::Scalar;
+
+/// LineSegment2D-点 間の最短距離（端点クランプあり）
+pub fn line_segment2d_point2d_distance<T: Scalar>(
+    segment: &LineSegment2D<T>,
+    point: &Point2D<T>,
+) -> T {
+    segment.distance_to_point(point)
+}
+
+/// 逆向きラッパー: point-segment
+pub fn point2d_line_segment2d_distance<T: Scalar>(
+    point: &Point2D<T>,
+    segment: &LineSegment2D<T>,
+) -> T {
+    segment.distance_to_point(point)
+}
 
 /// 無限直線-点 間の最短距離（垂直距離）
 pub fn infinite_line2d_point2d_distance<T: Scalar>(

--- a/model/geo_algorithms/tests/coverage_matrix_engine.rs
+++ b/model/geo_algorithms/tests/coverage_matrix_engine.rs
@@ -708,10 +708,22 @@ fn valid_seed_entries() -> Vec<MatrixEntry> {
             shape_a: "LineSegment2D",
             shape_b: "Point2D",
             required: true,
-            symmetric: false,
+            symmetric: true,
             cardinality: None,
             entrypoint_a_to_b: Some("line_segment2d_point2d_distance"),
-            entrypoint_b_to_a: None,
+            entrypoint_b_to_a: Some("point2d_line_segment2d_distance"),
+        },
+        MatrixEntry {
+            id: "2d:point-segment:distance",
+            dimension: Dimension::D2,
+            operation: Operation::Distance,
+            shape_a: "Point2D",
+            shape_b: "LineSegment2D",
+            required: true,
+            symmetric: true,
+            cardinality: None,
+            entrypoint_a_to_b: Some("point2d_line_segment2d_distance"),
+            entrypoint_b_to_a: Some("line_segment2d_point2d_distance"),
         },
         MatrixEntry {
             id: "3d:line-segment:intersection",
@@ -1419,4 +1431,68 @@ fn matrix_engine_fails_for_unknown_entrypoint_symbol() {
     let err = validate_matrix(&entries).unwrap_err();
     assert!(err.contains("unknown entrypoints"));
     assert!(err.contains("does_not_exist_entrypoint"));
+}
+
+#[test]
+fn distance_tolerance_guard_circle2d_point2d() {
+    let circle =
+        geo_algorithms::Circle2D::new(geo_algorithms::Point2D::new(0.0, 0.0), 1.0).unwrap();
+    let on = geo_algorithms::Point2D::new(1.0, 0.0);
+    let near = geo_algorithms::Point2D::new(1.0 + 5e-7, 0.0);
+    let far = geo_algorithms::Point2D::new(1.0 + 1e-3, 0.0);
+    let tol = 1e-6;
+
+    let d_on = geo_algorithms::distance::circle2d_point2d_distance(&circle, &on);
+    let d_near = geo_algorithms::distance::circle2d_point2d_distance(&circle, &near);
+    let d_far = geo_algorithms::distance::circle2d_point2d_distance(&circle, &far);
+
+    assert!(
+        d_on <= tol,
+        "on-boundary distance should be within tolerance"
+    );
+    assert!(
+        d_near <= tol,
+        "near point distance should be within tolerance"
+    );
+    assert!(d_far > tol, "far point distance should exceed tolerance");
+}
+
+#[test]
+fn distance_collision_consistency_for_point_pairs() {
+    let tol: f64 = 1e-6;
+
+    let circle =
+        geo_algorithms::Circle2D::new(geo_algorithms::Point2D::new(0.0, 0.0), 1.0).unwrap();
+    let candidates_2d = [
+        geo_algorithms::Point2D::new(1.0, 0.0),
+        geo_algorithms::Point2D::new(1.0 + 5e-7, 0.0),
+        geo_algorithms::Point2D::new(1.2, 0.0),
+    ];
+
+    for point in candidates_2d {
+        let dist = geo_algorithms::distance::circle2d_point2d_distance(&circle, &point);
+        let collides = geo_algorithms::collision::circle2d_point2d_collides(&circle, &point, tol);
+        assert_eq!(
+            dist <= tol,
+            collides,
+            "2D circle-point consistency violated"
+        );
+    }
+
+    let plane = geo_algorithms::Plane3D::xy_plane(0.0);
+    let candidates_3d = [
+        geo_algorithms::Point3D::new(0.0, 0.0, 0.0),
+        geo_algorithms::Point3D::new(0.0, 0.0, 5e-7),
+        geo_algorithms::Point3D::new(0.0, 0.0, 1e-2),
+    ];
+
+    for point in candidates_3d {
+        let signed_dist: f64 = geo_algorithms::distance::plane3d_point3d_distance(&plane, &point);
+        let collides = geo_algorithms::collision::plane3d_point3d_collides(&plane, &point, tol);
+        assert_eq!(
+            signed_dist.abs() <= tol,
+            collides,
+            "3D plane-point consistency violated"
+        );
+    }
 }


### PR DESCRIPTION
## 概要

Issue #363 対応として、distance カバレッジの matrix 適用を補強し、
`tolerance` 逸脱検知と `distance ↔ collision` の整合チェックを追加しました。

## 変更内容

### 1) distance entrypoint 補強（2D）

- `model/geo_algorithms/src/distance/primitive_2d.rs`
  - `line_segment2d_point2d_distance` を distance モジュール側にも公開
  - `point2d_line_segment2d_distance` を追加（逆向き）

### 2) matrix distance シード拡張

- `model/geo_algorithms/tests/coverage_matrix_engine.rs`
  - 既存 `2d:segment-point:distance` を対称ペア化
  - `2d:point-segment:distance` を追加

これにより 2D/3D distance 必須ペアの登録を補強。

### 3) tolerance-based 検証ルール（実テスト）

- `distance_tolerance_guard_circle2d_point2d` を追加
  - `distance <= tolerance` / `distance > tolerance` を境界近傍で検証

### 4) 他演算との整合チェック（実テスト）

- `distance_collision_consistency_for_point_pairs` を追加
  - 2D: `circle2d_point2d_distance` と `circle2d_point2d_collides`
  - 3D: `plane3d_point3d_distance`（符号付き）と `plane3d_point3d_collides`
  - `distance ≈ 0`（許容誤差内）と collision 判定の一致を検証

## 検証

- `cargo clippy -p geo_algorithms --tests -- -D warnings` ✅
- `cargo fmt --all` ✅
- `cargo test -p geo_algorithms --test coverage_matrix_engine` ✅ (14 passed)
- `cargo test -p geo_algorithms` ✅

## 関連

- Closes #363
- Related: #366, #362