### PR TITLE
[Phase C][#350] 2D line/ray collision を pair-base 経由へ集約

### DIFF
--- a/dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md
@@ -250,3 +250,24 @@
 
 - `geo_primitives/src/ellipse_arc_2d_collision.rs` / `geo_primitives/src/ellipse_arc_2d_intersection.rs` は `lib.rs` 未公開設定との整合を確認してから削減。
 - `Arc2D` / `Triangle2D` / `Ellipse2D` の複数交点系で `pair_base` 抽出余地あり（#351 実施時に再確認）。
+
+## 13. 実装スライス記録（2026-03-22 追補2）
+
+- 変更ファイル:
+  - `model/geo_algorithms/src/collision/pair_base.rs`
+  - `model/geo_algorithms/src/collision/primitive_2d.rs`
+- 概要:
+  - 2D の `Ray2D-LineSegment2D` / `InfiniteLine2D-LineSegment2D` / `InfiniteLine2D-Ray2D` について、
+    collision 判定を intersection 正本（`intersection::primitive_2d`）へ委譲する pair-base 関数を追加。
+  - `primitive_2d` 側の該当 collision entry point を pair-base 呼び出しへ切り替え、
+    endpoint 偏重の判定経路を削減。
+  - 中点交差や ray-origin 以外での交差を検出する回帰テストを追加。
+- 検証:
+  - `cargo clippy -- -D warnings`: pass
+  - `cargo fmt --all`: pass
+  - `cargo check --workspace`: pass
+  - `cargo test --workspace`: pass
+  - `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\check_architecture_dependencies_simple.ps1`: pass
+- #350 観点の更新:
+  - `pair_base.rs` への 2D 共通ロジック抽出を一部実施（線分・直線・半直線系）。
+  - 残る抽出余地は曲線ペア系（Arc/Ellipse/EllipseArc）中心で、#351 側で段階整理可能。

--- a/model/geo_algorithms/src/collision/pair_base.rs
+++ b/model/geo_algorithms/src/collision/pair_base.rs
@@ -11,8 +11,64 @@ use crate::intersection::pair_base::{
     ray3d_line_segment3d_intersection, ray3d_ray3d_intersection,
     ray3d_spherical_surface3d_intersections,
 };
-use crate::{InfiniteLine3D, LineSegment3D, Plane3D, Ray3D, SphericalSurface3D};
+use crate::intersection::primitive_2d::{
+    infinite_line2d_line_segment2d_intersection as infinite_line2d_line_segment2d_intersection_2d,
+    infinite_line2d_ray2d_intersection as infinite_line2d_ray2d_intersection_2d,
+    ray2d_line_segment2d_intersection as ray2d_line_segment2d_intersection_2d,
+};
+use crate::{
+    InfiniteLine2D, InfiniteLine3D, LineSegment2D, LineSegment3D, Plane3D, Ray2D, Ray3D,
+    SphericalSurface3D,
+};
 use geo_contracts::Scalar;
+
+pub fn ray2d_line_segment2d_collides<T: Scalar>(
+    ray: &Ray2D<T>,
+    segment: &LineSegment2D<T>,
+    tolerance: T,
+) -> bool {
+    ray2d_line_segment2d_intersection_2d(ray, segment, tolerance).is_some()
+}
+
+pub fn line_segment2d_ray2d_collides<T: Scalar>(
+    segment: &LineSegment2D<T>,
+    ray: &Ray2D<T>,
+    tolerance: T,
+) -> bool {
+    ray2d_line_segment2d_collides(ray, segment, tolerance)
+}
+
+pub fn infinite_line2d_line_segment2d_collides<T: Scalar>(
+    line: &InfiniteLine2D<T>,
+    segment: &LineSegment2D<T>,
+    tolerance: T,
+) -> bool {
+    infinite_line2d_line_segment2d_intersection_2d(line, segment, tolerance).is_some()
+}
+
+pub fn line_segment2d_infinite_line2d_collides<T: Scalar>(
+    segment: &LineSegment2D<T>,
+    line: &InfiniteLine2D<T>,
+    tolerance: T,
+) -> bool {
+    infinite_line2d_line_segment2d_collides(line, segment, tolerance)
+}
+
+pub fn infinite_line2d_ray2d_collides<T: Scalar>(
+    line: &InfiniteLine2D<T>,
+    ray: &Ray2D<T>,
+    tolerance: T,
+) -> bool {
+    infinite_line2d_ray2d_intersection_2d(line, ray, tolerance).is_some()
+}
+
+pub fn ray2d_infinite_line2d_collides<T: Scalar>(
+    ray: &Ray2D<T>,
+    line: &InfiniteLine2D<T>,
+    tolerance: T,
+) -> bool {
+    infinite_line2d_ray2d_collides(line, ray, tolerance)
+}
 
 // collision 判定は intersection 側の判定ロジックを正本として再利用し、
 // 幾何条件の二重実装を避ける。

--- a/model/geo_algorithms/src/collision/primitive_2d.rs
+++ b/model/geo_algorithms/src/collision/primitive_2d.rs
@@ -6,6 +6,11 @@
 //! 注意: orphan rules により、ここでは trait 実装ではなく
 //! 形状ペア関数を提供する。
 
+use crate::collision::pair_base::{
+    infinite_line2d_line_segment2d_collides as pair_base_infinite_line2d_line_segment2d_collides,
+    infinite_line2d_ray2d_collides as pair_base_infinite_line2d_ray2d_collides,
+    ray2d_line_segment2d_collides as pair_base_ray2d_line_segment2d_collides,
+};
 use crate::intersection::pair_base::line_segment2d_arc2d_intersections;
 use crate::intersection::primitive_2d::triangle2d_line_segment2d_intersections;
 use crate::{
@@ -13,8 +18,7 @@ use crate::{
     Triangle2D, Vector2D,
 };
 use geo_contracts::{
-    Arc2DProperties, Circle2DProperties, LineSegment2DProperties, Ray2DProperties, Scalar,
-    Triangle2DProperties,
+    Arc2DProperties, Circle2DProperties, LineSegment2DProperties, Scalar, Triangle2DProperties,
 };
 
 pub fn circle2d_point2d_collides<T: Scalar>(
@@ -158,13 +162,7 @@ pub fn ray2d_line_segment2d_collides<T: Scalar>(
     segment: &LineSegment2D<T>,
     tolerance: T,
 ) -> bool {
-    let start = Point2D::new(segment.start().0, segment.start().1);
-    let end = Point2D::new(segment.end().0, segment.end().1);
-
-    let dist_start = ray.distance_to_point(&start);
-    let dist_end = ray.distance_to_point(&end);
-
-    dist_start <= tolerance || dist_end <= tolerance
+    pair_base_ray2d_line_segment2d_collides(ray, segment, tolerance)
 }
 
 pub fn line_segment2d_ray2d_collides<T: Scalar>(
@@ -289,9 +287,7 @@ pub fn infinite_line2d_line_segment2d_collides<T: Scalar>(
     segment: &LineSegment2D<T>,
     tolerance: T,
 ) -> bool {
-    let start = Point2D::new(segment.start().0, segment.start().1);
-    let end = Point2D::new(segment.end().0, segment.end().1);
-    line.distance_to_point(&start) <= tolerance || line.distance_to_point(&end) <= tolerance
+    pair_base_infinite_line2d_line_segment2d_collides(line, segment, tolerance)
 }
 
 pub fn line_segment2d_infinite_line2d_collides<T: Scalar>(
@@ -307,9 +303,7 @@ pub fn infinite_line2d_ray2d_collides<T: Scalar>(
     ray: &Ray2D<T>,
     tolerance: T,
 ) -> bool {
-    let (ox, oy) = ray.origin();
-    let origin = Point2D::new(ox, oy);
-    line.contains_point(&origin, tolerance)
+    pair_base_infinite_line2d_ray2d_collides(line, ray, tolerance)
 }
 
 pub fn ray2d_infinite_line2d_collides<T: Scalar>(
@@ -501,6 +495,37 @@ mod tests {
         assert!(triangle2d_line_segment2d_collides(
             &triangle, &segment, 1e-9
         ));
+    }
+
+    #[test]
+    fn ray_line_segment_collision_detects_midpoint_intersection() {
+        let ray = Ray2D::new(Point2D::new(-2.0, 0.0), Vector2D::new(1.0, 0.0)).unwrap();
+        let segment = LineSegment2D::new(Point2D::new(0.0, -1.0), Point2D::new(0.0, 1.0)).unwrap();
+
+        assert!(ray2d_line_segment2d_collides(&ray, &segment, 1e-9));
+        assert!(line_segment2d_ray2d_collides(&segment, &ray, 1e-9));
+    }
+
+    #[test]
+    fn infinite_line_line_segment_collision_detects_midpoint_intersection() {
+        let line = InfiniteLine2D::new(Point2D::new(0.0, 0.0), Vector2D::new(1.0, 0.0)).unwrap();
+        let segment = LineSegment2D::new(Point2D::new(-1.0, -1.0), Point2D::new(1.0, 1.0)).unwrap();
+
+        assert!(infinite_line2d_line_segment2d_collides(
+            &line, &segment, 1e-9
+        ));
+        assert!(line_segment2d_infinite_line2d_collides(
+            &segment, &line, 1e-9
+        ));
+    }
+
+    #[test]
+    fn infinite_line_ray_collision_detects_off_origin_intersection() {
+        let line = InfiniteLine2D::new(Point2D::new(0.0, 0.0), Vector2D::new(1.0, 0.0)).unwrap();
+        let ray = Ray2D::new(Point2D::new(1.0, 1.0), Vector2D::new(0.0, -1.0)).unwrap();
+
+        assert!(infinite_line2d_ray2d_collides(&line, &ray, 1e-9));
+        assert!(ray2d_infinite_line2d_collides(&ray, &line, 1e-9));
     }
 
     #[test]


### PR DESCRIPTION
## 概要
- 2D collision のうち、`Ray2D-LineSegment2D` / `InfiniteLine2D-LineSegment2D` / `InfiniteLine2D-Ray2D` を `collision::pair_base` に抽出
- `collision::primitive_2d` の該当 entrypoint を pair-base 呼び出しへ切り替え
- collision 判定の正本ロジックを `intersection::primitive_2d` に寄せ、endpoint 依存の経路を削減
- #350 実装スライスを `dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md` に追記

## 主な変更
- `model/geo_algorithms/src/collision/pair_base.rs`
  - 2D pair-base 関数を追加
    - `ray2d_line_segment2d_collides`
    - `line_segment2d_ray2d_collides`
    - `infinite_line2d_line_segment2d_collides`
    - `line_segment2d_infinite_line2d_collides`
    - `infinite_line2d_ray2d_collides`
    - `ray2d_infinite_line2d_collides`
- `model/geo_algorithms/src/collision/primitive_2d.rs`
  - 上記 pair-base 関数への委譲に変更
  - 中点交差・ray origin 外交差の回帰テストを追加
- `dev/architecture/ISSUE_350_IMPLEMENTATION_PREP.md`
  - 実装スライス記録（2026-03-22 追補2）を追加

## 検証
- `cargo clippy -- -D warnings`
- `cargo fmt --all`
- `cargo check --workspace`
- `cargo test --workspace`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check_architecture_dependencies_simple.ps1`

すべて pass。

Closes #350