### PR TITLE
feat(#349): add nurbs-primitive intersection entry points (step b)

### DIFF
--- a/dev/architecture/ISSUE_349_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_349_IMPLEMENTATION_PREP.md
@@ -1,0 +1,87 @@
+# Issue #349 実装準備メモ
+
+対象Issue: [#349 [Phase C][#347] NURBS/Primitive 混在 collision/intersection の責務整理](https://github.com/RedRing2020/RedRing/issues/349)
+
+関連:
+- Design Freeze: #356
+- 親Issue: #347
+- 既存準備メモ: ISSUE_350_IMPLEMENTATION_PREP, ISSUE_348_IMPLEMENTATION_PREP
+
+## 1. 目的
+
+- NURBS/Primitive 混在演算の責務境界を #356 fixed-policy に沿って明確化する
+- geo_algorithms を混在演算ロジックの正本とする
+- 重複経路と未整備領域（特に intersection 側）を段階的に整理する
+
+## 2. 現状整理（2026-03-22）
+
+### 2.1 実装の所在
+
+- 既存実装は主に model/geo_algorithms/src/collision/primitive_nurbs.rs に集約されている
+- 同ファイルは NurbsCurveCollider Newtype を定義し、BasicCollision を複数 Primitive へ実装
+- 現時点で geo_algorithms 側に nurbs 専用の intersection モジュールは見当たらない
+
+### 2.2 既存で対応済みの主な衝突ペア
+
+NurbsCurveCollider ->
+- Point3D
+- LineSegment3D
+- Ray3D
+- InfiniteLine3D
+- Plane3D
+- Circle3D
+- SphericalSolid3D
+- EllipsoidalSolid3D
+- CylindricalSolid3D
+
+### 2.3 未整備・要判断
+
+- NURBS/Primitive の intersection 責務の実装単位
+- NurbsSurface3D 混在ペアの扱い（対象に含めるか）
+- 実装粒度: pair-base 抽出を先に行うか、entry point を先に揃えるか
+
+## 3. #356 fixed-policy 準拠の実装方針
+
+- collision/intersection は Foundation パターン対象外として扱う
+- 正本ロジックは geo_algorithms 側に置く
+- orphan rules 前提のため、必要に応じて Newtype/adapter を継続採用する
+- 完了条件は trait 実装の物理移管ではなく、ロジック正本化で評価する
+
+## 4. 実装対象ファイル（初期）
+
+- model/geo_algorithms/src/collision/primitive_nurbs.rs
+- model/geo_algorithms/src/collision/mod.rs
+- model/geo_algorithms/src/intersection/mod.rs
+- model/geo_algorithms/src/intersection/primitive_nurbs.rs（新規候補）
+- model/geo_algorithms/src/lib.rs（再エクスポート調整が必要な場合のみ）
+
+## 5. 推奨実装順
+
+### Step A: 責務境界の固定
+
+- [ ] collision と intersection の対象ペア一覧を issue body に明記
+- [ ] NurbsCurve と NurbsSurface の対象範囲を確定
+
+### Step B: intersection 側の最小スライス追加
+
+- [ ] primitive_nurbs の intersection entry point を最小セットで追加
+- [ ] 既存 collision 実装との対称性ルールをテストで固定
+
+### Step C: 重複整理
+
+- [ ] primitive 系との重複判定ロジックを抽出（必要なら pair_base 化）
+- [ ] NURBS専用実装に残す責務を限定
+
+### Step D: 検証
+
+- [ ] cargo clippy -p geo_algorithms --all-targets -- -D warnings
+- [ ] cargo fmt --all
+- [ ] cargo test -p geo_algorithms
+- [ ] scripts/check_architecture_dependencies_simple.ps1
+
+## 6. 完了条件（#349 向け読み替え）
+
+- [ ] NURBS/Primitive 混在演算の責務境界が文書化されている
+- [ ] geo_algorithms 側に混在演算ロジック正本が集約されている
+- [ ] 追加した対称 entry point の整合テストがある
+- [ ] 上記検証が通過する

--- a/model/geo_algorithms/src/intersection/mod.rs
+++ b/model/geo_algorithms/src/intersection/mod.rs
@@ -8,6 +8,8 @@
 pub mod pair_base;
 pub mod primitive_2d;
 pub mod primitive_3d;
+pub mod primitive_nurbs;
 
 pub use primitive_2d::*;
 pub use primitive_3d::*;
+pub use primitive_nurbs::*;

--- a/model/geo_algorithms/src/intersection/primitive_nurbs.rs
+++ b/model/geo_algorithms/src/intersection/primitive_nurbs.rs
@@ -1,0 +1,288 @@
+//! NURBS × Primitives 交点計算実装（最小スライス）
+//!
+//! geo_nurbs と geo_primitives 間の交点計算を
+//! geo_algorithms で集約して実装するモジュールです。
+//!
+//! ## 設計方針
+//!
+//! - NurbsCurve3D × Primitive（9ペア）の交点計算を提供
+//! - collision 実装と対称性を保つ（同一ペア数・同一形状セット）
+//! - orphan rules への対応は collision 側の NurbsCurveCollider Newtype パターンを参照
+//! - Phase C Step B では最小実装（tolerance ベース交点判定）を提供
+//! - 重複排除・pair_base 抽出は Step C で実施
+
+use crate::{
+    Circle3D, CylindricalSolid3D, EllipsoidalSolid3D, InfiniteLine3D, LineSegment3D, Plane3D,
+    Ray3D, SphericalSolid3D,
+};
+use geo_contracts::{BasicCollision, Scalar};
+use geo_core::Point3D;
+use geo_nurbs::NurbsCurve3D;
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+/// 交点条件の判定に基づき Point3D を返す
+fn point_intersection_if<T: Scalar>(point: &Point3D<T>, condition: bool) -> Option<Point3D<T>> {
+    if condition {
+        Some(Point3D::new(point.x(), point.y(), point.z()))
+    } else {
+        None
+    }
+}
+
+// ── NurbsCurve3D × Point3D ────────────────────────────────────────────────────
+
+pub fn nurbscurve3d_point3d_intersection<T: Scalar>(
+    curve: &NurbsCurve3D<T>,
+    point: &Point3D<T>,
+    tolerance: T,
+) -> Option<Point3D<T>> {
+    // collision の distance_to を使用
+    // 距離がtolerance 以内なら交点と判定
+    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
+    let distance = curve_collider.distance_to(point);
+    point_intersection_if(point, distance <= tolerance)
+}
+
+// ── NurbsCurve3D × LineSegment3D ──────────────────────────────────────────────
+
+pub fn nurbscurve3d_line_segment3d_intersection<T: Scalar>(
+    curve: &NurbsCurve3D<T>,
+    segment: &LineSegment3D<T>,
+    tolerance: T,
+) -> Option<Point3D<T>> {
+    // collision の distance_to を使用
+    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
+    let distance = curve_collider.distance_to(segment);
+
+    // 交差の場合、とりあえず線分の始点を返す（Step C で改良）
+    if distance <= tolerance {
+        Some(segment.start())
+    } else {
+        None
+    }
+}
+
+// ── NurbsCurve3D × Ray3D ──────────────────────────────────────────────────────
+
+pub fn nurbscurve3d_ray3d_intersection<T: Scalar>(
+    curve: &NurbsCurve3D<T>,
+    ray: &Ray3D<T>,
+    tolerance: T,
+) -> Option<Point3D<T>> {
+    // collision の distance_to を使用
+    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
+    let distance = curve_collider.distance_to(ray);
+
+    if distance <= tolerance {
+        Some(ray.origin())
+    } else {
+        None
+    }
+}
+
+// ── NurbsCurve3D × InfiniteLine3D ────────────────────────────────────────────
+
+pub fn nurbscurve3d_infinite_line3d_intersection<T: Scalar>(
+    curve: &NurbsCurve3D<T>,
+    line: &InfiniteLine3D<T>,
+    tolerance: T,
+) -> Option<Point3D<T>> {
+    // collision の distance_to を使用
+    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
+    let distance = curve_collider.distance_to(line);
+
+    if distance <= tolerance {
+        let (px, py, pz) = geo_contracts::InfiniteLine3DProperties::point(line);
+        Some(Point3D::new(px, py, pz))
+    } else {
+        None
+    }
+}
+
+// ── NurbsCurve3D × Circle3D ────────────────────────────────────────────────────
+
+pub fn nurbscurve3d_circle3d_intersection<T: Scalar>(
+    curve: &NurbsCurve3D<T>,
+    circle: &Circle3D<T>,
+    tolerance: T,
+) -> Option<Point3D<T>> {
+    // collision の distance_to を使用
+    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
+    let distance = curve_collider.distance_to(circle);
+
+    if distance <= tolerance {
+        let (cx, cy, cz) = geo_contracts::Circle3DProperties::center(circle);
+        Some(Point3D::new(cx, cy, cz))
+    } else {
+        None
+    }
+}
+
+// ── NurbsCurve3D × Plane3D ────────────────────────────────────────────────────
+
+pub fn nurbscurve3d_plane3d_intersection<T: Scalar>(
+    curve: &NurbsCurve3D<T>,
+    plane: &Plane3D<T>,
+    tolerance: T,
+) -> Option<Point3D<T>> {
+    // collision の distance_to を使用
+    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
+    let distance = curve_collider.distance_to(plane);
+
+    if distance <= tolerance {
+        Some(plane.origin())
+    } else {
+        None
+    }
+}
+
+// ── NurbsCurve3D × SphericalSolid3D ────────────────────────────────────────────
+
+pub fn nurbscurve3d_spherical_solid3d_intersection<T: Scalar>(
+    curve: &NurbsCurve3D<T>,
+    sphere: &SphericalSolid3D<T>,
+    tolerance: T,
+) -> Option<Point3D<T>> {
+    // collision の distance_to を使用
+    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
+    let distance = curve_collider.distance_to(sphere);
+
+    if distance <= tolerance {
+        // 曲線の始点を返す（Step C で改良）
+        let (u_min, _) = curve.parameter_domain();
+        let vec = curve.evaluate_at(u_min);
+        Some(Point3D::new(vec.x(), vec.y(), vec.z()))
+    } else {
+        None
+    }
+}
+
+// ── NurbsCurve3D × EllipsoidalSolid3D ──────────────────────────────────────────
+
+pub fn nurbscurve3d_ellipsoidal_solid3d_intersection<T: Scalar>(
+    curve: &NurbsCurve3D<T>,
+    ellipsoid: &EllipsoidalSolid3D<T>,
+    tolerance: T,
+) -> Option<Point3D<T>> {
+    // collision の distance_to を使用
+    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
+    let distance = curve_collider.distance_to(ellipsoid);
+
+    if distance <= tolerance {
+        // 曲線の始点を返す（Step C で改良）
+        let (u_min, _) = curve.parameter_domain();
+        let vec = curve.evaluate_at(u_min);
+        Some(Point3D::new(vec.x(), vec.y(), vec.z()))
+    } else {
+        None
+    }
+}
+
+// ── NurbsCurve3D × CylindricalSolid3D ──────────────────────────────────────────
+
+pub fn nurbscurve3d_cylindrical_solid3d_intersection<T: Scalar>(
+    curve: &NurbsCurve3D<T>,
+    cylinder: &CylindricalSolid3D<T>,
+    tolerance: T,
+) -> Option<Point3D<T>> {
+    // collision の distance_to を使用
+    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
+    let distance = curve_collider.distance_to(cylinder);
+
+    if distance <= tolerance {
+        // 曲線の始点を返す（Step C で改良）
+        let (u_min, _) = curve.parameter_domain();
+        let vec = curve.evaluate_at(u_min);
+        Some(Point3D::new(vec.x(), vec.y(), vec.z()))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use geo_contracts::NurbsCurve3DConstructor;
+
+    fn create_test_curve<T: Scalar>() -> NurbsCurve3D<T> {
+        use analysis::linalg::vector::vector3::Vector3;
+
+        // 3次 NURBS 曲線
+        let control_points = vec![
+            Vector3::new(T::ZERO, T::ZERO, T::ZERO),
+            Vector3::new(T::ONE, T::ZERO, T::ZERO),
+            Vector3::new(T::ONE, T::ONE, T::ZERO),
+            Vector3::new(T::ZERO, T::ONE, T::ZERO),
+        ];
+
+        let weights = Some(vec![T::ONE, T::ONE, T::ONE, T::ONE]);
+        let knots = vec![
+            T::ZERO,
+            T::ZERO,
+            T::ZERO,
+            T::ZERO,
+            T::ONE,
+            T::ONE,
+            T::ONE,
+            T::ONE,
+        ];
+
+        let control_points_tuples = control_points
+            .into_iter()
+            .map(|v| (v.x(), v.y(), v.z()))
+            .collect();
+        <NurbsCurve3D<T> as NurbsCurve3DConstructor<T>>::new(
+            3,
+            knots,
+            control_points_tuples,
+            weights,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_nurbscurve3d_point3d_intersection_on_curve() {
+        let curve = create_test_curve::<f64>();
+        let point = Point3D::new(0.0, 0.0, 0.0);
+        let tolerance = 1e-6;
+
+        let result = nurbscurve3d_point3d_intersection(&curve, &point, tolerance);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_nurbscurve3d_point3d_no_intersection() {
+        let curve = create_test_curve::<f64>();
+        let point = Point3D::new(10.0, 10.0, 10.0);
+        let tolerance = 1e-6;
+
+        let result = nurbscurve3d_point3d_intersection(&curve, &point, tolerance);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_nurbscurve3d_line_segment3d_intersection() {
+        let curve = create_test_curve::<f64>();
+        let segment =
+            LineSegment3D::new(Point3D::new(-0.1, 0.0, 0.0), Point3D::new(0.1, 0.0, 0.0)).unwrap();
+        let tolerance = 0.1;
+
+        let result = nurbscurve3d_line_segment3d_intersection(&curve, &segment, tolerance);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_nurbscurve3d_ray3d_intersection() {
+        let curve = create_test_curve::<f64>();
+        let ray = Ray3D::new(
+            Point3D::new(0.0, 0.0, 0.0),
+            crate::Vector3D::new(1.0, 0.0, 0.0),
+        )
+        .unwrap();
+        let tolerance = 1e-6;
+
+        let result = nurbscurve3d_ray3d_intersection(&curve, &ray, tolerance);
+        assert!(result.is_some());
+    }
+}


### PR DESCRIPTION
## Issue

[#349 [Phase C][#347] NURBS/Primitive 混在 collision/intersection の責務整理](https://github.com/RedRing2020/RedRing/issues/349)

## 内容

Phase C Step B: 対称性を保つため、intersection 側の entry point を最小実装しました。

### 実装内容

**新規ファイル**: `model/geo_algorithms/src/intersection/primitive_nurbs.rs`
- NurbsCurve3D × Primitive（9ペア）の交点計算 entry point を定義
  - `nurbscurve3d_point3d_intersection`
  - `nurbscurve3d_line_segment3d_intersection`
  - `nurbscurve3d_ray3d_intersection`
  - `nurbscurve3d_infinite_line3d_intersection`
  - `nurbscurve3d_circle3d_intersection`
  - `nurbscurve3d_plane3d_intersection`
  - `nurbscurve3d_spherical_solid3d_intersection`
  - `nurbscurve3d_ellipsoidal_solid3d_intersection`
  - `nurbscurve3d_cylindrical_solid3d_intersection`

**実装方針**:
- collision の `NurbsCurveCollider` と `BasicCollision` trait を活用
- tolerance ベースの最小判定（True Intersection Point の算出は Step C で実装）
- orphan rules への対応は collision 側のパターンを継承

**モジュール統合**:
- `model/geo_algorithms/src/intersection/mod.rs` に `pub mod primitive_nurbs;` を追記
- 再エクスポート: `pub use primitive_nurbs::*;`

### テスト

- ✅ cargo check --workspace
- ✅ cargo build
- ✅ cargo clippy -- -D warnings
- ✅ cargo fmt --all
- ✅ cargo test --workspace

### 完了条件への進行状況

- ✅ Step A: 責務境界の固定（コメント記録済み）
- ✅ Step B: intersection 最小スライス追加（本PR）
- ⬜ Step C: 重複整理・pair_base 抽出
- ⬜ Step D: 最終検証

### 次ステップ

Step C では以下を予定：
1. `primitive.rs` の重複ロジック抽出（共通化）
2. pair_base への移管検討
3. 正確な交点座標の計算実装（現在は simplified)

ref #349