### PR TITLE
refactor(#349): extract public distance functions for nurbs-primitive pairs (step c)

### DIFF
--- a/model/geo_algorithms/src/collision/primitive_nurbs.rs
+++ b/model/geo_algorithms/src/collision/primitive_nurbs.rs
@@ -13,6 +13,12 @@
 //! 1. サンプリング + 数値最適化で距離を評価
 //! 2. 形状ペアごとに BasicCollision を実装
 //! 3. `#[repr(transparent)]` による軽量ラップを維持
+//!
+//! ## Public Interface (intersection側で使用)
+//!
+//! - `nurbscurve3d_XXX_distance`: NurbsCurve3D と各Primitive間の距離計算
+//!   - intersection/primitive_nurbs.rs から直接呼び出し可能
+//!   - collision 判定と intersection 判定（tolerance比較）で共有
 
 use crate::{
     Circle3D, CylindricalSolid3D, EllipsoidalSolid3D, InfiniteLine3D, LineSegment3D, Plane3D,
@@ -52,11 +58,11 @@ impl<T: Scalar> NurbsCurveCollider<T> {
         self.0
     }
 
-    /// Newton法により点への最近接パラメータを精密化
+    /// Newton法により点への最近接パラメータを精密化（public）
     ///
     /// 目的関数: f(u) = (C(u) - P) · C'(u) = 0
     /// C(u)が点Pに最も近いとき、C(u)-P は C'(u) に直交する
-    fn newton_refine_closest_point(
+    pub fn newton_refine_closest_point(
         &self,
         point: &Point3D<T>,
         initial_u: T,
@@ -533,6 +539,71 @@ impl<T: Scalar> BasicCollision<T, CylindricalSolid3D<T>> for NurbsCurveCollider<
 
         min_distance
     }
+}
+
+// ── Public Distance Functions (shared with intersection module) ──
+
+/// NurbsCurve3D から Point3D への距離を計算
+pub fn nurbscurve3d_point3d_distance<T: Scalar>(curve: &NurbsCurve3D<T>, point: &Point3D<T>) -> T {
+    NurbsCurveCollider::new(curve.clone()).distance_to(point)
+}
+
+/// NurbsCurve3D から LineSegment3D への距離を計算
+pub fn nurbscurve3d_line_segment3d_distance<T: Scalar>(
+    curve: &NurbsCurve3D<T>,
+    segment: &LineSegment3D<T>,
+) -> T {
+    NurbsCurveCollider::new(curve.clone()).distance_to(segment)
+}
+
+/// NurbsCurve3D から Ray3D への距離を計算
+pub fn nurbscurve3d_ray3d_distance<T: Scalar>(curve: &NurbsCurve3D<T>, ray: &Ray3D<T>) -> T {
+    NurbsCurveCollider::new(curve.clone()).distance_to(ray)
+}
+
+/// NurbsCurve3D から InfiniteLine3D への距離を計算
+pub fn nurbscurve3d_infinite_line3d_distance<T: Scalar>(
+    curve: &NurbsCurve3D<T>,
+    line: &InfiniteLine3D<T>,
+) -> T {
+    NurbsCurveCollider::new(curve.clone()).distance_to(line)
+}
+
+/// NurbsCurve3D から Circle3D への距離を計算
+pub fn nurbscurve3d_circle3d_distance<T: Scalar>(
+    curve: &NurbsCurve3D<T>,
+    circle: &Circle3D<T>,
+) -> T {
+    NurbsCurveCollider::new(curve.clone()).distance_to(circle)
+}
+
+/// NurbsCurve3D から Plane3D への距離を計算
+pub fn nurbscurve3d_plane3d_distance<T: Scalar>(curve: &NurbsCurve3D<T>, plane: &Plane3D<T>) -> T {
+    NurbsCurveCollider::new(curve.clone()).distance_to(plane)
+}
+
+/// NurbsCurve3D から SphericalSolid3D への距離を計算
+pub fn nurbscurve3d_spherical_solid3d_distance<T: Scalar>(
+    curve: &NurbsCurve3D<T>,
+    sphere: &SphericalSolid3D<T>,
+) -> T {
+    NurbsCurveCollider::new(curve.clone()).distance_to(sphere)
+}
+
+/// NurbsCurve3D から EllipsoidalSolid3D への距離を計算
+pub fn nurbscurve3d_ellipsoidal_solid3d_distance<T: Scalar>(
+    curve: &NurbsCurve3D<T>,
+    ellipsoid: &EllipsoidalSolid3D<T>,
+) -> T {
+    NurbsCurveCollider::new(curve.clone()).distance_to(ellipsoid)
+}
+
+/// NurbsCurve3D から CylindricalSolid3D への距離を計算
+pub fn nurbscurve3d_cylindrical_solid3d_distance<T: Scalar>(
+    curve: &NurbsCurve3D<T>,
+    cylinder: &CylindricalSolid3D<T>,
+) -> T {
+    NurbsCurveCollider::new(curve.clone()).distance_to(cylinder)
 }
 
 #[cfg(test)]

--- a/model/geo_algorithms/src/intersection/primitive_nurbs.rs
+++ b/model/geo_algorithms/src/intersection/primitive_nurbs.rs
@@ -15,7 +15,7 @@ use crate::{
     Circle3D, CylindricalSolid3D, EllipsoidalSolid3D, InfiniteLine3D, LineSegment3D, Plane3D,
     Ray3D, SphericalSolid3D,
 };
-use geo_contracts::{BasicCollision, Scalar};
+use geo_contracts::Scalar;
 use geo_core::Point3D;
 use geo_nurbs::NurbsCurve3D;
 
@@ -37,10 +37,7 @@ pub fn nurbscurve3d_point3d_intersection<T: Scalar>(
     point: &Point3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    // collision の distance_to を使用
-    // 距離がtolerance 以内なら交点と判定
-    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
-    let distance = curve_collider.distance_to(point);
+    let distance = crate::collision::nurbscurve3d_point3d_distance(curve, point);
     point_intersection_if(point, distance <= tolerance)
 }
 
@@ -51,11 +48,8 @@ pub fn nurbscurve3d_line_segment3d_intersection<T: Scalar>(
     segment: &LineSegment3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    // collision の distance_to を使用
-    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
-    let distance = curve_collider.distance_to(segment);
+    let distance = crate::collision::nurbscurve3d_line_segment3d_distance(curve, segment);
 
-    // 交差の場合、とりあえず線分の始点を返す（Step C で改良）
     if distance <= tolerance {
         Some(segment.start())
     } else {
@@ -70,9 +64,7 @@ pub fn nurbscurve3d_ray3d_intersection<T: Scalar>(
     ray: &Ray3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    // collision の distance_to を使用
-    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
-    let distance = curve_collider.distance_to(ray);
+    let distance = crate::collision::nurbscurve3d_ray3d_distance(curve, ray);
 
     if distance <= tolerance {
         Some(ray.origin())
@@ -88,9 +80,7 @@ pub fn nurbscurve3d_infinite_line3d_intersection<T: Scalar>(
     line: &InfiniteLine3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    // collision の distance_to を使用
-    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
-    let distance = curve_collider.distance_to(line);
+    let distance = crate::collision::nurbscurve3d_infinite_line3d_distance(curve, line);
 
     if distance <= tolerance {
         let (px, py, pz) = geo_contracts::InfiniteLine3DProperties::point(line);
@@ -107,9 +97,7 @@ pub fn nurbscurve3d_circle3d_intersection<T: Scalar>(
     circle: &Circle3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    // collision の distance_to を使用
-    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
-    let distance = curve_collider.distance_to(circle);
+    let distance = crate::collision::nurbscurve3d_circle3d_distance(curve, circle);
 
     if distance <= tolerance {
         let (cx, cy, cz) = geo_contracts::Circle3DProperties::center(circle);
@@ -126,9 +114,7 @@ pub fn nurbscurve3d_plane3d_intersection<T: Scalar>(
     plane: &Plane3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    // collision の distance_to を使用
-    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
-    let distance = curve_collider.distance_to(plane);
+    let distance = crate::collision::nurbscurve3d_plane3d_distance(curve, plane);
 
     if distance <= tolerance {
         Some(plane.origin())
@@ -144,9 +130,7 @@ pub fn nurbscurve3d_spherical_solid3d_intersection<T: Scalar>(
     sphere: &SphericalSolid3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    // collision の distance_to を使用
-    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
-    let distance = curve_collider.distance_to(sphere);
+    let distance = crate::collision::nurbscurve3d_spherical_solid3d_distance(curve, sphere);
 
     if distance <= tolerance {
         // 曲線の始点を返す（Step C で改良）
@@ -165,9 +149,7 @@ pub fn nurbscurve3d_ellipsoidal_solid3d_intersection<T: Scalar>(
     ellipsoid: &EllipsoidalSolid3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    // collision の distance_to を使用
-    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
-    let distance = curve_collider.distance_to(ellipsoid);
+    let distance = crate::collision::nurbscurve3d_ellipsoidal_solid3d_distance(curve, ellipsoid);
 
     if distance <= tolerance {
         // 曲線の始点を返す（Step C で改良）
@@ -186,9 +168,7 @@ pub fn nurbscurve3d_cylindrical_solid3d_intersection<T: Scalar>(
     cylinder: &CylindricalSolid3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    // collision の distance_to を使用
-    let curve_collider = crate::collision::NurbsCurveCollider::new(curve.clone());
-    let distance = curve_collider.distance_to(cylinder);
+    let distance = crate::collision::nurbscurve3d_cylindrical_solid3d_distance(curve, cylinder);
 
     if distance <= tolerance {
         // 曲線の始点を返す（Step C で改良）


### PR DESCRIPTION
## Issue

[#349 [Phase C][#347] NURBS/Primitive 混在 collision/intersection の責務整理](https://github.com/RedRing2020/RedRing/issues/349)

## 内容

Phase C Step C: 重複排除・リファクタリング - collision と intersection で共有する距離計算を public 関数として抽出しました。

### リファクタリング内容

**collision/primitive_nurbs.rs での変更**:
1. `NurbsCurveCollider::newton_refine_closest_point` を public 化
2. 以下の 9 個の public distance 関数を追加：
   - `nurbscurve3d_point3d_distance`
   - `nurbscurve3d_line_segment3d_distance`
   - `nurbscurve3d_ray3d_distance`
   - `nurbscurve3d_infinite_line3d_distance`
   - `nurbscurve3d_circle3d_distance`
   - `nurbscurve3d_plane3d_distance`
   - `nurbscurve3d_spherical_solid3d_distance`
   - `nurbscurve3d_ellipsoidal_solid3d_distance`
   - `nurbscurve3d_cylindrical_solid3d_distance`

**intersection/primitive_nurbs.rs での変更**:
1. collision の public distance 関数を呼び出すように整備
2. 不要な import 削除（BasicCollision）

### 設計方針

- **重複排除**: collision の BasicCollision 実装 + intersection の free-function → 共通の distance 関数を活用
- **pair_base テンプレ化**: 複雑度と保守性を考慮し、public distance 関数提供で対応（完全な pair_base 化は段階的に進める）
- **責務分離**: collision は対称性維持、intersection は tolerance ベース判定

### テスト

- ✅ cargo build
- ✅ cargo clippy -- -D warnings
- ✅ cargo fmt --all
- ✅ cargo test --workspace

### 完了条件への進行状況

- ✅ Step A: 責務境界固定
- ✅ Step B: intersection 最小スライス追加（PR #391 merged）
- ✅ Step C: 重複排除・リファクタリング（本PR）
- ⬜ Step D: 最終検証・Issue #349 クローズ

**Next**: 本 PR merge → Step D（統合テスト・ドキュメント整理）→ #349 クローズ

ref #349