### PR TITLE
feat(#392): add Stage1 NurbsSurface3D mixed collision/intersection

### DIFF
--- a/dev/architecture/ISSUE_392_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_392_IMPLEMENTATION_PREP.md
@@ -1,0 +1,54 @@
+# Issue #392 実装準備メモ
+
+対象Issue: [#392 [Phase C][#347] NurbsSurface3D × Primitive 混在 collision/intersection の責務整理](https://github.com/RedRing2020/RedRing/issues/392)
+
+関連:
+- 親Issue: #347
+- 完了Issue: #349（NurbsCurve3D × Primitive）
+- Design Freeze: #356
+
+## 1. 方針（段階導入）
+
+NurbsSurface3D は計算負荷と数値探索の難易度が高いため、最小セットから段階導入する。
+
+### Stage 1（最小）
+- 対象ペア: Point3D / Plane3D / Ray3D
+- collision: `primitive_nurbs_surface.rs` に最小距離判定を実装
+- intersection: tolerance ベースの最小 entry point を実装
+
+### Stage 2（拡張）
+- 対象ペア: LineSegment3D / InfiniteLine3D / Circle3D
+- Stage 1 で抽出した共通ロジックを再利用
+
+### Stage 3（残り）
+- 対象ペア: SphericalSolid3D / EllipsoidalSolid3D / CylindricalSolid3D
+- 必要に応じて pair_base 化を段階適用
+
+## 2. 現状棚卸（要点）
+
+- `geo_algorithms` 側に NurbsSurface3D 専用の collision/intersection 実装は未存在
+- `geo_contracts` には NurbsSurface3D の Core trait定義は存在
+- #349 で確立した `primitive_nurbs.rs` 構成（collision + intersection 対称）を流用可能
+
+## 3. 実装対象ファイル（Stage 1）
+
+- 追加:
+  - `model/geo_algorithms/src/collision/primitive_nurbs_surface.rs`
+  - `model/geo_algorithms/src/intersection/primitive_nurbs_surface.rs`
+- 更新:
+  - `model/geo_algorithms/src/collision/mod.rs`
+  - `model/geo_algorithms/src/intersection/mod.rs`
+
+## 4. 実装順序（Stage 1）
+
+1. `collision/primitive_nurbs_surface.rs` 追加（Point3D / Plane3D / Ray3D）
+2. `intersection/primitive_nurbs_surface.rs` 追加（同3ペア）
+3. `mod.rs` 2箇所にモジュール追加・再エクスポート
+4. テスト追加（最小対称ケース）
+5. 検証: `cargo clippy` -> `cargo fmt` -> `cargo test --workspace`
+
+## 5. 完了条件（Stage 1）
+
+- NurbsSurface3D × (Point3D/Plane3D/Ray3D) の collision/intersection が `geo_algorithms` に実装される
+- 対称 entry point と最小テストが存在する
+- 上記検証が通過する

--- a/model/geo_algorithms/src/collision/mod.rs
+++ b/model/geo_algorithms/src/collision/mod.rs
@@ -8,7 +8,9 @@ pub mod pair_base;
 pub mod primitive_2d;
 pub mod primitive_3d;
 pub mod primitive_nurbs;
+pub mod primitive_nurbs_surface;
 
 pub use primitive_2d::*;
 pub use primitive_3d::*;
 pub use primitive_nurbs::*;
+pub use primitive_nurbs_surface::*;

--- a/model/geo_algorithms/src/collision/primitive_nurbs_surface.rs
+++ b/model/geo_algorithms/src/collision/primitive_nurbs_surface.rs
@@ -1,0 +1,222 @@
+//! NurbsSurface3D × Primitives 衝突判定実装（Stage 1）
+//!
+//! Stage 1 では Point3D / Plane3D / Ray3D の最小セットを提供する。
+
+use crate::{Plane3D, Point3D, Ray3D};
+use geo_contracts::{BasicCollision, Plane3DProperties, Scalar};
+use geo_nurbs::NurbsSurface3D;
+
+#[repr(transparent)]
+#[derive(Debug, Clone)]
+pub struct NurbsSurfaceCollider<T: Scalar>(pub NurbsSurface3D<T>);
+
+impl<T: Scalar> NurbsSurfaceCollider<T> {
+    pub fn new(surface: NurbsSurface3D<T>) -> Self {
+        Self(surface)
+    }
+
+    fn nearest_sample_to_point(&self, point: &Point3D<T>) -> (Point3D<T>, T) {
+        let samples_u = 24;
+        let samples_v = 24;
+        let ((u_min, u_max), (v_min, v_max)) = self.0.parameter_domain();
+        let du = (u_max - u_min) / T::from_usize(samples_u);
+        let dv = (v_max - v_min) / T::from_usize(samples_v);
+
+        let mut best_point = Point3D::new(T::ZERO, T::ZERO, T::ZERO);
+        let mut min_dist = T::INFINITY;
+
+        for i in 0..=samples_u {
+            for j in 0..=samples_v {
+                let u = u_min + du * T::from_usize(i);
+                let v = v_min + dv * T::from_usize(j);
+                let p = self.0.evaluate_at(u, v);
+                let surface_point = Point3D::new(p.x(), p.y(), p.z());
+
+                let dx = surface_point.x() - point.x();
+                let dy = surface_point.y() - point.y();
+                let dz = surface_point.z() - point.z();
+                let d = (dx * dx + dy * dy + dz * dz).sqrt();
+
+                if d < min_dist {
+                    min_dist = d;
+                    best_point = surface_point;
+                }
+            }
+        }
+
+        (best_point, min_dist)
+    }
+
+    fn min_distance_to_plane(&self, plane: &Plane3D<T>) -> T {
+        let samples_u = 24;
+        let samples_v = 24;
+        let ((u_min, u_max), (v_min, v_max)) = self.0.parameter_domain();
+        let du = (u_max - u_min) / T::from_usize(samples_u);
+        let dv = (v_max - v_min) / T::from_usize(samples_v);
+
+        let origin = plane.origin();
+        let (nx, ny, nz) = <Plane3D<T> as Plane3DProperties<T>>::normal(plane);
+
+        let mut min_dist = T::INFINITY;
+
+        for i in 0..=samples_u {
+            for j in 0..=samples_v {
+                let u = u_min + du * T::from_usize(i);
+                let v = v_min + dv * T::from_usize(j);
+                let p = self.0.evaluate_at(u, v);
+
+                let dx = p.x() - origin.x();
+                let dy = p.y() - origin.y();
+                let dz = p.z() - origin.z();
+                let d = (dx * nx + dy * ny + dz * nz).abs();
+                min_dist = min_dist.min(d);
+            }
+        }
+
+        min_dist
+    }
+
+    fn min_distance_to_ray(&self, ray: &Ray3D<T>) -> T {
+        let samples_u = 24;
+        let samples_v = 24;
+        let ((u_min, u_max), (v_min, v_max)) = self.0.parameter_domain();
+        let du = (u_max - u_min) / T::from_usize(samples_u);
+        let dv = (v_max - v_min) / T::from_usize(samples_v);
+
+        let origin = ray.origin();
+        let direction = ray.direction_vector();
+
+        let mut min_dist = T::INFINITY;
+
+        for i in 0..=samples_u {
+            for j in 0..=samples_v {
+                let u = u_min + du * T::from_usize(i);
+                let v = v_min + dv * T::from_usize(j);
+                let p = self.0.evaluate_at(u, v);
+
+                let to_px = p.x() - origin.x();
+                let to_py = p.y() - origin.y();
+                let to_pz = p.z() - origin.z();
+
+                let t = (to_px * direction.x() + to_py * direction.y() + to_pz * direction.z())
+                    .max(T::ZERO);
+
+                let closest_x = origin.x() + t * direction.x();
+                let closest_y = origin.y() + t * direction.y();
+                let closest_z = origin.z() + t * direction.z();
+
+                let dx = p.x() - closest_x;
+                let dy = p.y() - closest_y;
+                let dz = p.z() - closest_z;
+                let d = (dx * dx + dy * dy + dz * dz).sqrt();
+
+                min_dist = min_dist.min(d);
+            }
+        }
+
+        min_dist
+    }
+}
+
+impl<T: Scalar> BasicCollision<T, Point3D<T>> for NurbsSurfaceCollider<T> {
+    type Point2D = Point3D<T>;
+
+    fn intersects(&self, point: &Point3D<T>, tolerance: T) -> bool {
+        self.distance_to(point) <= tolerance
+    }
+
+    fn overlaps(&self, point: &Point3D<T>, tolerance: T) -> bool {
+        self.intersects(point, tolerance)
+    }
+
+    fn distance_to(&self, point: &Point3D<T>) -> T {
+        self.nearest_sample_to_point(point).1
+    }
+}
+
+impl<T: Scalar> BasicCollision<T, Plane3D<T>> for NurbsSurfaceCollider<T> {
+    type Point2D = Point3D<T>;
+
+    fn intersects(&self, plane: &Plane3D<T>, tolerance: T) -> bool {
+        self.distance_to(plane) <= tolerance
+    }
+
+    fn overlaps(&self, plane: &Plane3D<T>, tolerance: T) -> bool {
+        self.intersects(plane, tolerance)
+    }
+
+    fn distance_to(&self, plane: &Plane3D<T>) -> T {
+        self.min_distance_to_plane(plane)
+    }
+}
+
+impl<T: Scalar> BasicCollision<T, Ray3D<T>> for NurbsSurfaceCollider<T> {
+    type Point2D = Point3D<T>;
+
+    fn intersects(&self, ray: &Ray3D<T>, tolerance: T) -> bool {
+        self.distance_to(ray) <= tolerance
+    }
+
+    fn overlaps(&self, ray: &Ray3D<T>, tolerance: T) -> bool {
+        self.intersects(ray, tolerance)
+    }
+
+    fn distance_to(&self, ray: &Ray3D<T>) -> T {
+        self.min_distance_to_ray(ray)
+    }
+}
+
+// Public distance functions shared by intersection module.
+
+pub fn nurbssurface3d_point3d_distance<T: Scalar>(
+    surface: &NurbsSurface3D<T>,
+    point: &Point3D<T>,
+) -> T {
+    NurbsSurfaceCollider::new(surface.clone()).distance_to(point)
+}
+
+pub fn nurbssurface3d_plane3d_distance<T: Scalar>(
+    surface: &NurbsSurface3D<T>,
+    plane: &Plane3D<T>,
+) -> T {
+    NurbsSurfaceCollider::new(surface.clone()).distance_to(plane)
+}
+
+pub fn nurbssurface3d_ray3d_distance<T: Scalar>(surface: &NurbsSurface3D<T>, ray: &Ray3D<T>) -> T {
+    NurbsSurfaceCollider::new(surface.clone()).distance_to(ray)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Vector3D;
+    use geo_contracts::NurbsSurface3DConstructor;
+
+    fn create_test_surface<T: Scalar>() -> NurbsSurface3D<T> {
+        <NurbsSurface3D<T> as NurbsSurface3DConstructor<T>>::unit_plane()
+    }
+
+    #[test]
+    fn test_nurbssurface3d_point3d_distance_zero_on_surface() {
+        let surface = create_test_surface::<f64>();
+        let point = Point3D::new(0.5, 0.5, 0.0);
+        let d = nurbssurface3d_point3d_distance(&surface, &point);
+        assert!(d <= 1e-6);
+    }
+
+    #[test]
+    fn test_nurbssurface3d_plane3d_distance_zero_for_xy_plane() {
+        let surface = create_test_surface::<f64>();
+        let plane = Plane3D::xy_plane(0.0);
+        let d = nurbssurface3d_plane3d_distance(&surface, &plane);
+        assert!(d <= 1e-6);
+    }
+
+    #[test]
+    fn test_nurbssurface3d_ray3d_distance_zero_for_vertical_hit() {
+        let surface = create_test_surface::<f64>();
+        let ray = Ray3D::new(Point3D::new(0.5, 0.5, -1.0), Vector3D::new(0.0, 0.0, 1.0)).unwrap();
+        let d = nurbssurface3d_ray3d_distance(&surface, &ray);
+        assert!(d <= 1e-6);
+    }
+}

--- a/model/geo_algorithms/src/intersection/mod.rs
+++ b/model/geo_algorithms/src/intersection/mod.rs
@@ -9,7 +9,9 @@ pub mod pair_base;
 pub mod primitive_2d;
 pub mod primitive_3d;
 pub mod primitive_nurbs;
+pub mod primitive_nurbs_surface;
 
 pub use primitive_2d::*;
 pub use primitive_3d::*;
 pub use primitive_nurbs::*;
+pub use primitive_nurbs_surface::*;

--- a/model/geo_algorithms/src/intersection/primitive_nurbs_surface.rs
+++ b/model/geo_algorithms/src/intersection/primitive_nurbs_surface.rs
@@ -1,0 +1,87 @@
+//! NurbsSurface3D × Primitives 交点計算実装（Stage 1）
+//!
+//! Stage 1 では Point3D / Plane3D / Ray3D の最小セットを提供する。
+
+use crate::{Plane3D, Point3D, Ray3D};
+use geo_contracts::Scalar;
+use geo_nurbs::NurbsSurface3D;
+
+fn point_intersection_if<T: Scalar>(point: &Point3D<T>, condition: bool) -> Option<Point3D<T>> {
+    if condition {
+        Some(Point3D::new(point.x(), point.y(), point.z()))
+    } else {
+        None
+    }
+}
+
+pub fn nurbssurface3d_point3d_intersection<T: Scalar>(
+    surface: &NurbsSurface3D<T>,
+    point: &Point3D<T>,
+    tolerance: T,
+) -> Option<Point3D<T>> {
+    let distance = crate::collision::nurbssurface3d_point3d_distance(surface, point);
+    point_intersection_if(point, distance <= tolerance)
+}
+
+pub fn nurbssurface3d_plane3d_intersection<T: Scalar>(
+    surface: &NurbsSurface3D<T>,
+    plane: &Plane3D<T>,
+    tolerance: T,
+) -> Option<Point3D<T>> {
+    let distance = crate::collision::nurbssurface3d_plane3d_distance(surface, plane);
+
+    if distance <= tolerance {
+        Some(plane.origin())
+    } else {
+        None
+    }
+}
+
+pub fn nurbssurface3d_ray3d_intersection<T: Scalar>(
+    surface: &NurbsSurface3D<T>,
+    ray: &Ray3D<T>,
+    tolerance: T,
+) -> Option<Point3D<T>> {
+    let distance = crate::collision::nurbssurface3d_ray3d_distance(surface, ray);
+
+    if distance <= tolerance {
+        Some(ray.origin())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Vector3D;
+    use geo_contracts::NurbsSurface3DConstructor;
+
+    fn create_test_surface<T: Scalar>() -> NurbsSurface3D<T> {
+        <NurbsSurface3D<T> as NurbsSurface3DConstructor<T>>::unit_plane()
+    }
+
+    #[test]
+    fn test_nurbssurface3d_point3d_intersection_on_surface() {
+        let surface = create_test_surface::<f64>();
+        let point = Point3D::new(0.5, 0.5, 0.0);
+        let result = nurbssurface3d_point3d_intersection(&surface, &point, 1e-6);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_nurbssurface3d_plane3d_intersection_on_same_plane() {
+        let surface = create_test_surface::<f64>();
+        let plane = Plane3D::xy_plane(0.0);
+        let result = nurbssurface3d_plane3d_intersection(&surface, &plane, 1e-6);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_nurbssurface3d_ray3d_intersection_vertical_hit() {
+        let surface = create_test_surface::<f64>();
+        let ray = Ray3D::new(Point3D::new(0.5, 0.5, -1.0), Vector3D::new(0.0, 0.0, 1.0)).unwrap();
+        let result = nurbssurface3d_ray3d_intersection(&surface, &ray, 1e-6);
+        assert!(result.is_some());
+    }
+}


### PR DESCRIPTION
## Issue
- #392

## Scope (Stage 1)
NurbsSurface3D × Primitive の段階導入（最小3ペア）
- Point3D
- Plane3D
- Ray3D

## Changes
- 追加: `model/geo_algorithms/src/collision/primitive_nurbs_surface.rs`
  - `NurbsSurfaceCollider`（Newtype）
  - `BasicCollision` 実装（Point3D / Plane3D / Ray3D）
  - 公開距離関数
    - `nurbssurface3d_point3d_distance`
    - `nurbssurface3d_plane3d_distance`
    - `nurbssurface3d_ray3d_distance`

- 追加: `model/geo_algorithms/src/intersection/primitive_nurbs_surface.rs`
  - tolerance ベース entry point
    - `nurbssurface3d_point3d_intersection`
    - `nurbssurface3d_plane3d_intersection`
    - `nurbssurface3d_ray3d_intersection`

- 更新:
  - `model/geo_algorithms/src/collision/mod.rs`
  - `model/geo_algorithms/src/intersection/mod.rs`

## Validation
- ✅ cargo clippy -- -D warnings
- ✅ cargo fmt
- ✅ cargo test --workspace

## Next
- Stage 2: LineSegment3D / InfiniteLine3D / Circle3D

ref #392