### PR TITLE
refactor(geo_contracts): core cross-shape distance 契約を deprecated 化 (#344 step4)

### DIFF
--- a/dev/architecture/ISSUE_344_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_344_IMPLEMENTATION_PREP.md
@@ -40,11 +40,23 @@
 
 ## #344 実装ステップ
 
-1. `operations` に distance 契約モジュールを追加
-2. `operations/mod.rs` で distance 契約を再エクスポート
-3. `lib.rs` で distance 契約の再エクスポートを統一
-4. `core` 側 cross-shape distance を `#[deprecated]` で段階縮退開始
-5. `cargo check -p geo_contracts` で契約整合を確認
+1. [x] `operations` に distance 契約モジュールを追加
+2. [x] `operations/mod.rs` で distance 契約を再エクスポート
+3. [x] `lib.rs` で distance 契約の再エクスポートを統一
+4. [x] `core` 側 cross-shape distance を `#[deprecated]` で段階縮退開始
+5. [x] `cargo check -p geo_contracts` で契約整合を確認
+
+## 進捗メモ（2026-03-23）
+
+- `core` の以下メソッドへ `#[deprecated]` を追加し、移行先を
+  `geometry::operations::CrossDistance` に統一:
+  - `Circle2DMeasure::distance_to_circle`
+  - `Circle3DMeasure::distance_to_circle`
+  - `InfiniteLine3DMeasure::distance_to_line`
+  - `LineSegment2DMeasure::distance_to_segment`
+  - `LineSegment3DMeasure::distance_to_segment`
+  - `LineSegment3DCollisionDetection::distance_to_aabb`
+  - `Ray3DMeasure::distance_to_ray`
 
 ## 互換方針
 

--- a/model/geo_algorithms/src/octree/voxel/node_impl.rs
+++ b/model/geo_algorithms/src/octree/voxel/node_impl.rs
@@ -1,5 +1,5 @@
 use super::*;
-use geo_contracts::LineSegment3DCollisionDetection;
+use geo_contracts::CrossDistance;
 
 impl<T: Scalar> VoxelNode<T> {
     /// 新しいソリッドノードを作成
@@ -177,7 +177,7 @@ impl<T: Scalar> VoxelNode<T> {
                 let min = self.bounds.min();
                 let max = self.bounds.max();
                 let distance = segment
-                    .distance_to_aabb((min.x(), min.y(), min.z()), (max.x(), max.y(), max.z()));
+                    .distance_to(&((min.x(), min.y(), min.z()), (max.x(), max.y(), max.z())));
 
                 if distance > radius {
                     return;
@@ -234,7 +234,7 @@ impl<T: Scalar> VoxelNode<T> {
                 let min = self.bounds.min();
                 let max = self.bounds.max();
                 let distance = segment
-                    .distance_to_aabb((min.x(), min.y(), min.z()), (max.x(), max.y(), max.z()));
+                    .distance_to(&((min.x(), min.y(), min.z()), (max.x(), max.y(), max.z())));
 
                 // 軸方向へ射影可能でも半径外なら非交差。
                 if distance > radius {

--- a/model/geo_contracts/src/geometry/core/circle_traits.rs
+++ b/model/geo_contracts/src/geometry/core/circle_traits.rs
@@ -98,6 +98,10 @@ pub trait Circle2DMeasure<T: Scalar> {
     fn point_on_circumference(&self, point: (T, T)) -> bool;
     fn closest_point_to(&self, point: (T, T)) -> (T, T);
     fn point_at_parameter(&self, t: T) -> (T, T);
+    #[deprecated(
+        since = "0.1.0",
+        note = "cross-shape distance contracts are migrating to geometry::operations::CrossDistance"
+    )]
     fn distance_to_circle(&self, other: &Self) -> T;
 }
 
@@ -109,6 +113,10 @@ pub trait Circle3DMeasure<T: Scalar> {
     fn point_on_circumference(&self, point: (T, T, T)) -> bool;
     fn closest_point_to(&self, point: (T, T, T)) -> (T, T, T);
     fn point_at_parameter(&self, t: T) -> (T, T, T);
+    #[deprecated(
+        since = "0.1.0",
+        note = "cross-shape distance contracts are migrating to geometry::operations::CrossDistance"
+    )]
     fn distance_to_circle(&self, other: &Self) -> T;
 }
 

--- a/model/geo_contracts/src/geometry/core/infinite_line_traits.rs
+++ b/model/geo_contracts/src/geometry/core/infinite_line_traits.rs
@@ -166,6 +166,10 @@ pub trait InfiniteLine3DMeasure<T: Scalar> {
     fn contains_point(&self, point: (T, T, T)) -> bool;
     fn project_point(&self, point: (T, T, T)) -> (T, T, T);
     fn parameter_for_point(&self, point: (T, T, T)) -> T;
+    #[deprecated(
+        since = "0.1.0",
+        note = "cross-shape distance contracts are migrating to geometry::operations::CrossDistance"
+    )]
     fn distance_to_line(&self, other: &Self) -> T;
     fn closest_points(&self, other: &Self) -> Option<TwoPoints3D<T>>;
     fn is_parallel_to(&self, other: &Self) -> bool;

--- a/model/geo_contracts/src/geometry/core/linesegment_traits.rs
+++ b/model/geo_contracts/src/geometry/core/linesegment_traits.rs
@@ -147,6 +147,10 @@ pub trait LineSegment2DMeasure<T: Scalar> {
     fn closest_point_to(&self, point: (T, T)) -> (T, T);
 
     /// 2つの線分間の最短距離
+    #[deprecated(
+        since = "0.1.0",
+        note = "cross-shape distance contracts are migrating to geometry::operations::CrossDistance"
+    )]
     fn distance_to_segment(&self, other: &Self) -> T;
 
     /// 方向ベクトルを取得
@@ -174,6 +178,10 @@ pub trait LineSegment3DMeasure<T: Scalar> {
     fn closest_point_to(&self, point: (T, T, T)) -> (T, T, T);
 
     /// 2つの線分間の最短距離
+    #[deprecated(
+        since = "0.1.0",
+        note = "cross-shape distance contracts are migrating to geometry::operations::CrossDistance"
+    )]
     fn distance_to_segment(&self, other: &Self) -> T;
 
     /// 方向ベクトルを取得
@@ -186,6 +194,10 @@ pub trait LineSegment3DMeasure<T: Scalar> {
 /// LineSegment3DとAxisAlignedBoundingBox（AABB）の衝突検出トレイト
 pub trait LineSegment3DCollisionDetection<T: Scalar> {
     /// 線分と軸並行境界ボックス（AABB）の最短距離を計算
+    #[deprecated(
+        since = "0.1.0",
+        note = "cross-shape distance contracts are migrating to geometry::operations::CrossDistance"
+    )]
     fn distance_to_aabb(&self, aabb_min: (T, T, T), aabb_max: (T, T, T)) -> T;
 }
 

--- a/model/geo_contracts/src/geometry/core/ray_traits.rs
+++ b/model/geo_contracts/src/geometry/core/ray_traits.rs
@@ -183,6 +183,10 @@ pub trait Ray3DMeasure<T: Scalar> {
     fn translate(&self, offset: (T, T, T)) -> Self
     where
         Self: Sized;
+    #[deprecated(
+        since = "0.1.0",
+        note = "cross-shape distance contracts are migrating to geometry::operations::CrossDistance"
+    )]
     fn distance_to_ray(&self, other: &Self) -> T;
     fn point_at_distance(&self, distance: T) -> (T, T, T);
     fn angle_between(&self, other: &Self) -> T;

--- a/model/geo_primitives/src/line_segment_3d.rs
+++ b/model/geo_primitives/src/line_segment_3d.rs
@@ -5,7 +5,7 @@
 
 use crate::{InfiniteLine3D, Point3D, Vector3D};
 use geo_contracts::{
-    LineSegment3DCollisionDetection, LineSegment3DConstructor, LineSegment3DMeasure,
+    CrossDistance, LineSegment3DCollisionDetection, LineSegment3DConstructor, LineSegment3DMeasure,
     LineSegment3DProperties, Scalar,
 };
 
@@ -320,5 +320,18 @@ impl<T: Scalar> LineSegment3DCollisionDetection<T> for LineSegment3D<T> {
         let start = (start_point.x(), start_point.y(), start_point.z());
         let end = (end_point.x(), end_point.y(), end_point.z());
         line_segment_to_aabb_distance(start, end, aabb_min, aabb_max)
+    }
+}
+
+impl<T: Scalar> CrossDistance<T, ((T, T, T), (T, T, T))> for LineSegment3D<T> {
+    fn distance_to(&self, other: &((T, T, T), (T, T, T))) -> T {
+        use geo_commons::line_segment_to_aabb_distance;
+
+        let start_point = self.start();
+        let end_point = self.end();
+        let start = (start_point.x(), start_point.y(), start_point.z());
+        let end = (end_point.x(), end_point.y(), end_point.z());
+
+        line_segment_to_aabb_distance(start, end, other.0, other.1)
     }
 }


### PR DESCRIPTION
## 概要
#344 の継続として、`geometry::core` に残っていた cross-shape distance 契約を段階縮退（`#[deprecated]`）しました。

設計方針（#343）に沿って、cross-shape distance の一次参照先を `geometry::operations::CrossDistance` に寄せるための移行ステップです。

## 変更内容
- `Circle2DMeasure::distance_to_circle` を deprecated 化
- `Circle3DMeasure::distance_to_circle` を deprecated 化
- `InfiniteLine3DMeasure::distance_to_line` を deprecated 化
- `LineSegment2DMeasure::distance_to_segment` を deprecated 化
- `LineSegment3DMeasure::distance_to_segment` を deprecated 化
- `LineSegment3DCollisionDetection::distance_to_aabb` を deprecated 化
- `Ray3DMeasure::distance_to_ray` を deprecated 化
- `dev/architecture/ISSUE_344_IMPLEMENTATION_PREP.md` の実装ステップ進捗を更新

## 検証
- `cargo clippy -p geo_contracts -- -D warnings`
- `cargo fmt --all`
- `cargo check -p geo_contracts`
- `cargo test -p geo_contracts`

## 関連
- Refs #344