### PR TITLE
[Design] docs: #415 artifact API命名運用ルールを正規化

### DIFF
--- a/dev/architecture/ARCHITECTURE.md
+++ b/dev/architecture/ARCHITECTURE.md
@@ -91,6 +91,25 @@ foundation/analysis（将来改名候補）
     - `job_runtime` は `geo_*` / `cam_*` / View系へ依存しない
     - `cam_*` / 将来のCAE側は `job_runtime` をアダプタ経由で利用する
 
+### Artifact API 命名運用ルール（2026年3月更新, #415）
+
+- 運用原則: `*_v1` は wire format v1.0 を意味せず、API 世代識別子を表す
+- wire format 判定原則: `version_major` / `version_minor` の実値で判定する（現行 v0.1）
+- 改名方針: 現時点では公開 API 互換を優先し、実コード改名は行わない
+
+#### 標準注記テンプレート
+
+```text
+注記: `*_v1` は API 世代識別子を表す。wire format の実バージョンは
+`version_major` / `version_minor` の実値で判定する（現行は v0.1）。
+```
+
+#### 改名再評価トリガー
+
+- `version_minor` 増加（例: v0.2）で API 名と wire format 名の混同が顕著化した場合
+- `cam_sim` / 将来 `cam_algorithms` で命名誤解による障害が発生した場合
+- 破壊的変更を許容できるリリース計画が確保された場合
+
 ### 依存チェック運用
 
 - 実行コマンド: `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check_architecture_dependencies.ps1 -ExitOnError`
@@ -171,4 +190,5 @@ redring ← stage ← render
 - [`GITHUB_PAGES_SETUP.md`](GITHUB_PAGES_SETUP.md) - GitHub Pages 設定ガイド
 - [`dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md`](dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md) - 夜間バッチ計算基盤（Dockerヘッドレス + Kubernetes）
 - [`dev/architecture/GEO_ALGORITHMS_MODULE_STRUCTURE_RULES.md`](dev/architecture/GEO_ALGORITHMS_MODULE_STRUCTURE_RULES.md) - geo_algorithms の分割ルール（primitive_2d/3d/NURBS/pair_base の統一規約）
+- [`dev/archive/issues/ISSUE_412_IMPLEMENTATION_PREP.md`](dev/archive/issues/ISSUE_412_IMPLEMENTATION_PREP.md) - artifact API命名整理の判断記録
 

--- a/dev/architecture/ISSUE_300_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_300_IMPLEMENTATION_PREP.md
@@ -195,6 +195,7 @@ Issue本文の可読性を維持しつつ、実施機能の埋没を防ぐため
 
 - `read_artifact_v1` / `ArtifactHeaderV1` の `V1` は API 世代識別子を表す
 - wire format の判定は `version_major` / `version_minor` の実値で行う（現行 v0.1）
+- 正規参照先: `dev/architecture/ARCHITECTURE.md` の「Artifact API 命名運用ルール（#415）」
 - 標準注記テンプレート:
 
 ```text

--- a/dev/archive/issues/ISSUE_411_IMPLEMENTATION_PREP.md
+++ b/dev/archive/issues/ISSUE_411_IMPLEMENTATION_PREP.md
@@ -33,6 +33,7 @@
 
 - `*_v1` は API 世代識別子を表す
 - wire format の判定は `version_major` / `version_minor` の実値で行う（現行 v0.1）
+- 正規参照先: `dev/architecture/ARCHITECTURE.md` の「Artifact API 命名運用ルール（#415）」
 
 関連ドキュメント:
 - `dev/architecture/ISSUE_300_IMPLEMENTATION_PREP.md`

--- a/dev/archive/issues/ISSUE_412_IMPLEMENTATION_PREP.md
+++ b/dev/archive/issues/ISSUE_412_IMPLEMENTATION_PREP.md
@@ -154,7 +154,8 @@
 
 正規参照ドキュメント:
 
-- 本書（`dev/architecture/ISSUE_412_IMPLEMENTATION_PREP.md`）
+- `dev/architecture/ARCHITECTURE.md` の「Artifact API 命名運用ルール（#415）」
+- 本書（判断経緯）
 - 運用ルール固定 Issue（#415）
 
 ## 7. #412 の完了条件


### PR DESCRIPTION
## 概要

Issue #415 のタスクに沿って、artifact API 命名運用ルールの正規参照先を `ARCHITECTURE.md` へ固定し、関連ドキュメントの参照を統一しました。

## 変更内容

- `dev/architecture/ARCHITECTURE.md`
  - 「Artifact API 命名運用ルール（#415）」を追加
  - 標準注記テンプレートを追加
  - 改名再評価トリガーを明記
  - 関連ドキュメントリンクを更新
- `dev/architecture/ISSUE_300_IMPLEMENTATION_PREP.md`
  - 命名運用注記の正規参照先を `ARCHITECTURE.md` へ統一
- `dev/archive/issues/ISSUE_411_IMPLEMENTATION_PREP.md`
  - 命名注記の正規参照先を `ARCHITECTURE.md` へ統一
- `dev/archive/issues/ISSUE_412_IMPLEMENTATION_PREP.md`
  - クローズ済み Issue 文書として archive へ移動

## 検証

- `./scripts/check_issue_doc_archive.ps1 -Repository "RedRing2020/RedRing" -ExitOnError`
  - SUCCESS（配置違反なし）

## 関連

- #300
- #411
- #412

Closes #415