### PR TITLE
feat(cam_core): #257 PR-1 multi-axis core型を最小追加

### DIFF
--- a/dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md
@@ -403,10 +403,87 @@ PoseAnnotatedSegment {
 - [x] `ToolPose` / 姿勢補間 / 機械制約の API 草案がある
 - [x] 3軸 / 4軸 / 3+2 / 同時5軸のケース表現例が揃う
 - [x] 3軸軽量維持と軸分類メタの方針が整理される
-- [ ] 実装フェーズへ移れる候補ファイルと変更順が整理される
+- [x] 実装フェーズへ移れる候補ファイルと変更順が整理される
 
 ## 11. 次アクション
 
 1. 選択肢Bを採択案として維持できるか、A/C にしか解けない論点が残るか確認する
 2. `ToolPathKinematicMeta` と `MachineConstraint` を `ToolPath` 本体に持つか、別コンテキストで持つか切り分ける
 3. 実装開始前にユーザー承認を得る
+
+## 12. 実装フェーズ分割（PR分離案）
+
+### 12.1 PR-1: `cam_core` 型追加（最小）
+
+目的:
+
+- Option B の中核型を `cam_core` に最小追加し、既存3軸 API を壊さないことを確認する
+
+対象ファイル:
+
+- `model/cam_core/src/toolpath.rs`
+- `model/cam_core/src/lib.rs`
+- `model/cam_core/src/toolpath_tests.rs`
+
+実装範囲:
+
+- `ToolPose<T>` / `ToolPoseSpan<T>` / `PoseAnnotatedSegment<T>` 追加
+- `MachineAxisValue<T>` / `MachineAxisKind` 追加
+- `ToolPathKinematicMeta` / `MachineConfigurationClass` / `KinematicMode` / `PoseDataPolicy` 追加
+- 3軸既存 API への破壊的変更を行わない
+
+受け入れ条件:
+
+- 既存 `ToolPath` 利用コードが修正なしでビルドできる
+- 新規型の基本生成と比較をテストで確認できる
+
+### 12.2 PR-2: 3軸軽量方針のテスト固定
+
+目的:
+
+- 3軸ケースで pose レイヤーが必須でないことをテストで固定し、将来拡張時の肥大化を防ぐ
+
+対象ファイル:
+
+- `model/cam_core/src/toolpath_tests.rs`
+
+実装範囲:
+
+- `PoseDataPolicy::PositionOnlyCompatible` の期待動作テスト追加
+- 3軸 / 4軸 / 3+2 / 同時5軸のメタ分類テーブルテスト追加
+
+受け入れ条件:
+
+- 分類メタの誤設定をテストで検出できる
+- 3軸ケースの軽量運用（pose optional）を明示的に検証できる
+
+### 12.3 PR-3: artifact 連携方針（別フェーズ設計）
+
+目的:
+
+- #300 v0.1 を維持したまま、将来の multi-axis wire format 拡張方針を整理する
+
+対象ファイル:
+
+- `model/cam_core/src/artifact_binary.rs`
+- `dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md`
+
+実装範囲:
+
+- 初回は実装せず、互換ポリシーと version 戦略のみ文書化する
+- `v0.1` 読み書き互換を壊さない前提を固定する
+
+受け入れ条件:
+
+- #300/#411 の既存契約に反しない移行案になっている
+
+### 12.4 推奨実施順
+
+1. PR-1（型追加）
+2. PR-2（テスト固定）
+3. PR-3（artifact 拡張設計）
+
+注記:
+
+- 実装開始時はこの順序で小さく分割し、各PRは `Refs #257` を使用する
+- 最終的に #257 を閉じるPRのみ `Closes #257` を使用する

--- a/model/cam_core/src/lib.rs
+++ b/model/cam_core/src/lib.rs
@@ -51,8 +51,10 @@ pub use artifact_binary::{
 pub use tolerance::CamTolerance;
 pub use tool::{Tool, ToolType};
 pub use toolpath::{
-    ArcDirection, ContourLevelPath, CuttingDirection, PathGeometry, PathSegment, SegmentType,
-    TOOLPATH_SCHEMA_VERSION_V0_1, ToolPath,
+    ArcDirection, ContourLevelPath, CuttingDirection, KinematicMode, MachineAxisKind,
+    MachineAxisValue, MachineConfigurationClass, PathGeometry, PathSegment, PoseAnnotatedSegment,
+    PoseDataPolicy, PoseInterpolationPolicy, SegmentType, TOOLPATH_SCHEMA_VERSION_V0_1, ToolPath,
+    ToolPathKinematicMeta, ToolPose, ToolPoseSpan,
 };
 pub use toolset::{
     Holder, HolderInterferenceOffset, HolderSegment, HolderSegmentKind, ToolSet,

--- a/model/cam_core/src/toolpath.rs
+++ b/model/cam_core/src/toolpath.rs
@@ -44,7 +44,7 @@
 
 use crate::ExtAttribute;
 use analysis::Scalar;
-use geo_algorithms::Point3D;
+use geo_algorithms::{Point3D, Vector3D};
 
 /// ToolPath wire schema version used by artifact binary v0.1.
 pub const TOOLPATH_SCHEMA_VERSION_V0_1: (u16, u16) = (0, 1);
@@ -170,6 +170,188 @@ pub enum CuttingDirection {
     ///
     /// 工具回転方向と送り方向が逆。荒加工向き。
     Up,
+}
+
+/// 機械軸種別
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MachineAxisKind {
+    /// 直動軸（X/Y/Z/U/V/W など）
+    Linear,
+    /// 回転軸（A/B/C など）
+    Rotary,
+}
+
+/// 任意名称の機械軸値
+#[derive(Debug, Clone, PartialEq)]
+pub struct MachineAxisValue<T: Scalar = f64> {
+    /// 軸名（例: A, C, U, W）
+    pub axis_name: String,
+    /// 軸種別（直動/回転）
+    pub axis_kind: MachineAxisKind,
+    /// 軸値
+    pub value: T,
+}
+
+impl<T: Scalar> MachineAxisValue<T> {
+    /// 機械軸値を作成
+    pub fn new(axis_name: String, axis_kind: MachineAxisKind, value: T) -> Self {
+        Self {
+            axis_name,
+            axis_kind,
+            value,
+        }
+    }
+}
+
+/// 姿勢補間ポリシー
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PoseInterpolationPolicy {
+    /// セグメント内で姿勢固定（3+2 相当）
+    FixedOrientation,
+    /// 角度変化の最短経路を優先
+    ShortestAngularPath,
+    /// 連続変化を優先
+    ContinuousPreferred,
+    /// 機械制約を優先
+    MachineConstrained,
+}
+
+/// 工具/プロセス姿勢
+#[derive(Debug, Clone, PartialEq)]
+pub struct ToolPose<T: Scalar = f64> {
+    /// 姿勢評価時の位置
+    pub position: Point3D<T>,
+    /// 工具軸またはプロセス軸方向
+    pub process_axis: Vector3D<T>,
+    /// 任意軸名で管理される機械軸値
+    pub machine_axes: Option<Vec<MachineAxisValue<T>>>,
+}
+
+impl<T: Scalar> ToolPose<T> {
+    /// 姿勢を作成
+    pub fn new(
+        position: Point3D<T>,
+        process_axis: Vector3D<T>,
+        machine_axes: Option<Vec<MachineAxisValue<T>>>,
+    ) -> Self {
+        Self {
+            position,
+            process_axis,
+            machine_axes,
+        }
+    }
+}
+
+/// 姿勢スパン
+#[derive(Debug, Clone, PartialEq)]
+pub struct ToolPoseSpan<T: Scalar = f64> {
+    /// 始点姿勢
+    pub start_pose: ToolPose<T>,
+    /// 終点姿勢
+    pub end_pose: ToolPose<T>,
+    /// 姿勢補間ポリシー
+    pub interpolation_policy: PoseInterpolationPolicy,
+}
+
+impl<T: Scalar> ToolPoseSpan<T> {
+    /// 姿勢スパンを作成
+    pub fn new(
+        start_pose: ToolPose<T>,
+        end_pose: ToolPose<T>,
+        interpolation_policy: PoseInterpolationPolicy,
+    ) -> Self {
+        Self {
+            start_pose,
+            end_pose,
+            interpolation_policy,
+        }
+    }
+}
+
+/// 姿勢付きセグメント
+#[derive(Debug, Clone, PartialEq)]
+pub struct PoseAnnotatedSegment<T: Scalar = f64> {
+    /// 位置幾何セグメント
+    pub segment: PathSegment<T>,
+    /// セグメントに対応する姿勢情報
+    pub pose_span: ToolPoseSpan<T>,
+}
+
+impl<T: Scalar> PoseAnnotatedSegment<T> {
+    /// 姿勢付きセグメントを作成
+    pub fn new(segment: PathSegment<T>, pose_span: ToolPoseSpan<T>) -> Self {
+        Self { segment, pose_span }
+    }
+}
+
+/// 機械構成の大分類
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MachineConfigurationClass {
+    /// 3軸
+    ThreeAxis,
+    /// 4軸
+    FourAxis,
+    /// 5軸以上
+    FiveAxisOrMore,
+}
+
+/// 加工時の運動モード分類
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KinematicMode {
+    /// 純3軸
+    PureThreeAxis,
+    /// 3+2 のような indexed 多軸
+    IndexedMultiAxis,
+    /// 連続4軸
+    ContinuousFourAxis,
+    /// 連続5軸
+    ContinuousFiveAxis,
+}
+
+/// 姿勢データ保持ポリシー
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PoseDataPolicy {
+    /// 位置中心データだけで互換運用可能
+    PositionOnlyCompatible,
+    /// 姿勢レイヤーは任意
+    PoseLayerOptional,
+    /// 姿勢レイヤーが必須
+    PoseLayerRequired,
+}
+
+/// ToolPath の運動学メタ情報
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ToolPathKinematicMeta {
+    /// 機械構成の大分類
+    pub configuration_class: MachineConfigurationClass,
+    /// 加工時の運動モード
+    pub kinematic_mode: KinematicMode,
+    /// 姿勢データ保持ポリシー
+    pub pose_data_policy: PoseDataPolicy,
+}
+
+impl ToolPathKinematicMeta {
+    /// 運動学メタ情報を作成
+    pub const fn new(
+        configuration_class: MachineConfigurationClass,
+        kinematic_mode: KinematicMode,
+        pose_data_policy: PoseDataPolicy,
+    ) -> Self {
+        Self {
+            configuration_class,
+            kinematic_mode,
+            pose_data_policy,
+        }
+    }
+
+    /// 既存3軸互換向けの既定メタ
+    pub const fn three_axis_position_only() -> Self {
+        Self {
+            configuration_class: MachineConfigurationClass::ThreeAxis,
+            kinematic_mode: KinematicMode::PureThreeAxis,
+            pose_data_policy: PoseDataPolicy::PositionOnlyCompatible,
+        }
+    }
 }
 
 /// 工具経路セグメント

--- a/model/cam_core/src/toolpath_tests.rs
+++ b/model/cam_core/src/toolpath_tests.rs
@@ -106,3 +106,81 @@ fn test_tool_path() {
     assert_eq!(toolpath.cutting_direction, CuttingDirection::Down);
     assert_eq!(toolpath.level_count(), 2);
 }
+
+#[test]
+fn test_tool_pose_and_machine_axis_value_creation() {
+    let machine_axes = vec![
+        MachineAxisValue::new("C".to_string(), MachineAxisKind::Rotary, 30.0),
+        MachineAxisValue::new("U".to_string(), MachineAxisKind::Linear, 12.5),
+    ];
+    let pose = ToolPose::new(
+        Point3D::new(1.0, 2.0, 3.0),
+        Vector3D::new(0.0, 0.0, -1.0),
+        Some(machine_axes.clone()),
+    );
+
+    assert_eq!(pose.position, Point3D::new(1.0, 2.0, 3.0));
+    assert_eq!(pose.process_axis, Vector3D::new(0.0, 0.0, -1.0));
+    assert_eq!(pose.machine_axes, Some(machine_axes));
+}
+
+#[test]
+fn test_toolpath_kinematic_meta_classification() {
+    let three_axis = ToolPathKinematicMeta::three_axis_position_only();
+    assert_eq!(
+        three_axis,
+        ToolPathKinematicMeta::new(
+            MachineConfigurationClass::ThreeAxis,
+            KinematicMode::PureThreeAxis,
+            PoseDataPolicy::PositionOnlyCompatible,
+        )
+    );
+
+    let continuous_four_axis = ToolPathKinematicMeta::new(
+        MachineConfigurationClass::FourAxis,
+        KinematicMode::ContinuousFourAxis,
+        PoseDataPolicy::PoseLayerOptional,
+    );
+    assert_eq!(
+        continuous_four_axis.configuration_class,
+        MachineConfigurationClass::FourAxis
+    );
+    assert_eq!(
+        continuous_four_axis.kinematic_mode,
+        KinematicMode::ContinuousFourAxis
+    );
+}
+
+#[test]
+fn test_pose_annotated_segment_creation() {
+    let segment = PathSegment::new_line(
+        Point3D::new(0.0, 0.0, 0.0),
+        Point3D::new(5.0, 0.0, 0.0),
+        SegmentType::Cutting { feed_rate: 400.0 },
+    );
+    let start_pose = ToolPose::new(
+        Point3D::new(0.0, 0.0, 0.0),
+        Vector3D::new(0.0, 0.0, -1.0),
+        None,
+    );
+    let end_pose = ToolPose::new(
+        Point3D::new(5.0, 0.0, 0.0),
+        Vector3D::new(0.1, 0.0, -0.9),
+        Some(vec![MachineAxisValue::new(
+            "A".to_string(),
+            MachineAxisKind::Rotary,
+            12.0,
+        )]),
+    );
+    let pose_span = ToolPoseSpan::new(
+        start_pose.clone(),
+        end_pose.clone(),
+        PoseInterpolationPolicy::MachineConstrained,
+    );
+    let annotated = PoseAnnotatedSegment::new(segment.clone(), pose_span.clone());
+
+    assert_eq!(annotated.segment, segment);
+    assert_eq!(annotated.pose_span, pose_span);
+    assert_eq!(annotated.pose_span.start_pose, start_pose);
+    assert_eq!(annotated.pose_span.end_pose, end_pose);
+}


### PR DESCRIPTION
## 概要
Issue #257 の PR-1 として、`cam_core` に multi-axis 拡張の最小コア型を追加しました。
既存3軸 `ToolPath` API は破壊せず、拡張レイヤーを追加する構成です。

## 変更内容
- `model/cam_core/src/toolpath.rs`
  - 追加:
    - `MachineAxisKind`
    - `MachineAxisValue<T>`
    - `PoseInterpolationPolicy`
    - `ToolPose<T>`
    - `ToolPoseSpan<T>`
    - `PoseAnnotatedSegment<T>`
    - `MachineConfigurationClass`
    - `KinematicMode`
    - `PoseDataPolicy`
    - `ToolPathKinematicMeta`
  - 追加API:
    - 各型の `new` コンストラクタ
    - `ToolPathKinematicMeta::three_axis_position_only()`
- `model/cam_core/src/lib.rs`
  - 追加型の再エクスポート
- `model/cam_core/src/toolpath_tests.rs`
  - 追加テスト:
    - 姿勢・機械軸型の生成
    - 運動学メタの分類検証
    - 姿勢付きセグメント生成検証

## 非対象
- `artifact_binary` の wire format 変更は含みません（PR-3で扱う）
- 既存3軸の `ToolPath` 構造変更は行っていません

## 検証
- `cargo clippy -p cam_core -- -D warnings`
- `cargo fmt --all`
- `cargo test -p cam_core`

Refs #257