### PR TITLE
test(cam_core): #257 PR-2 3軸軽量方針と分類マトリクスをテスト固定

### DIFF
--- a/model/cam_core/src/toolpath.rs
+++ b/model/cam_core/src/toolpath.rs
@@ -352,6 +352,24 @@ impl ToolPathKinematicMeta {
             pose_data_policy: PoseDataPolicy::PositionOnlyCompatible,
         }
     }
+
+    /// 位置中心データのみで互換運用可能か
+    pub const fn is_position_only_compatible(&self) -> bool {
+        matches!(
+            self.pose_data_policy,
+            PoseDataPolicy::PositionOnlyCompatible
+        )
+    }
+
+    /// 姿勢レイヤーを省略可能か
+    pub const fn allows_optional_pose_layer(&self) -> bool {
+        !self.requires_pose_layer()
+    }
+
+    /// 姿勢レイヤーが必須か
+    pub const fn requires_pose_layer(&self) -> bool {
+        matches!(self.pose_data_policy, PoseDataPolicy::PoseLayerRequired)
+    }
 }
 
 /// 工具経路セグメント

--- a/model/cam_core/src/toolpath_tests.rs
+++ b/model/cam_core/src/toolpath_tests.rs
@@ -152,6 +152,83 @@ fn test_toolpath_kinematic_meta_classification() {
 }
 
 #[test]
+fn test_three_axis_position_only_policy_behavior() {
+    let three_axis = ToolPathKinematicMeta::three_axis_position_only();
+
+    assert!(three_axis.is_position_only_compatible());
+    assert!(three_axis.allows_optional_pose_layer());
+    assert!(!three_axis.requires_pose_layer());
+}
+
+#[test]
+fn test_toolpath_kinematic_meta_matrix() {
+    let cases = [
+        (
+            "3-axis",
+            ToolPathKinematicMeta::new(
+                MachineConfigurationClass::ThreeAxis,
+                KinematicMode::PureThreeAxis,
+                PoseDataPolicy::PositionOnlyCompatible,
+            ),
+            true,
+            true,
+            false,
+        ),
+        (
+            "4-axis continuous",
+            ToolPathKinematicMeta::new(
+                MachineConfigurationClass::FourAxis,
+                KinematicMode::ContinuousFourAxis,
+                PoseDataPolicy::PoseLayerOptional,
+            ),
+            false,
+            true,
+            false,
+        ),
+        (
+            "3+2 indexed",
+            ToolPathKinematicMeta::new(
+                MachineConfigurationClass::FiveAxisOrMore,
+                KinematicMode::IndexedMultiAxis,
+                PoseDataPolicy::PoseLayerOptional,
+            ),
+            false,
+            true,
+            false,
+        ),
+        (
+            "5-axis continuous",
+            ToolPathKinematicMeta::new(
+                MachineConfigurationClass::FiveAxisOrMore,
+                KinematicMode::ContinuousFiveAxis,
+                PoseDataPolicy::PoseLayerRequired,
+            ),
+            false,
+            false,
+            true,
+        ),
+    ];
+
+    for (name, meta, expected_position_only, expected_optional, expected_required) in cases {
+        assert_eq!(
+            meta.is_position_only_compatible(),
+            expected_position_only,
+            "unexpected position_only result for {name}"
+        );
+        assert_eq!(
+            meta.allows_optional_pose_layer(),
+            expected_optional,
+            "unexpected optional_pose result for {name}"
+        );
+        assert_eq!(
+            meta.requires_pose_layer(),
+            expected_required,
+            "unexpected required_pose result for {name}"
+        );
+    }
+}
+
+#[test]
 fn test_pose_annotated_segment_creation() {
     let segment = PathSegment::new_line(
         Point3D::new(0.0, 0.0, 0.0),


### PR DESCRIPTION
## 概要
Issue #257 の PR-2 として、3軸軽量方針と multi-axis 分類をテストで固定しました。

## 変更内容
- `model/cam_core/src/toolpath.rs`
  - `ToolPathKinematicMeta` に方針判定ヘルパーを追加
    - `is_position_only_compatible()`
    - `allows_optional_pose_layer()`
    - `requires_pose_layer()`
- `model/cam_core/src/toolpath_tests.rs`
  - 追加テスト
    - `test_three_axis_position_only_policy_behavior`
      - 3軸の `PositionOnlyCompatible` が軽量運用（pose optional）として判定されることを固定
    - `test_toolpath_kinematic_meta_matrix`
      - 3軸 / 4軸 / 3+2 / 同時5軸を表すメタ構成を表形式で検証

## 検証
- `cargo clippy -p cam_core -- -D warnings`
- `cargo fmt --all`
- `cargo test -p cam_core`

Refs #257