### PR TITLE
feat(cam_core): #257 PR-4 ToolPath本体へ運動学メタを導入

### DIFF
--- a/dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md
@@ -503,6 +503,7 @@ PR-3 で確定した方針:
 1. PR-1（型追加）
 2. PR-2（テスト固定）
 3. PR-3（artifact 拡張設計）
+4. PR-4（`ToolPath` 本体への運動学メタ搭載）
 
 注記:
 
@@ -514,3 +515,29 @@ PR-3 で確定した方針:
 - [x] PR-1: `cam_core` 型追加（最小）
 - [x] PR-2: 3軸軽量方針のテスト固定
 - [x] PR-3: artifact 連携方針の文書化（実装変更なし）
+- [x] PR-4: `ToolPath` 本体へ `kinematic_meta` を追加（既定は3軸互換）
+
+### 12.6 PR-4 実施内容
+
+目的:
+
+- 未解決論点だった「`ToolPathKinematicMeta` の保持場所」を `ToolPath` 本体に確定する
+
+対象ファイル:
+
+- `model/cam_core/src/toolpath.rs`
+- `model/cam_core/src/toolpath_tests.rs`
+- `model/cam_core/src/artifact_binary.rs`
+
+実装範囲:
+
+- `ToolPath` に `kinematic_meta: ToolPathKinematicMeta` を追加
+- 既存 `ToolPath::new` は `three_axis_position_only()` を既定設定し、既存呼び出し互換を維持
+- `ToolPath::new_with_kinematic_meta` を追加し、multi-axis メタの明示指定を可能にする
+- `read_toolpath_payload_v1` で `v0.1` 読み取り時に3軸既定メタを設定する
+
+受け入れ条件:
+
+- 既存 `ToolPath::new` 呼び出しは修正なしで利用できる
+- 明示メタ指定の `ToolPath` をテストで検証できる
+- `v0.1` 読み取りが3軸互換メタで初期化される

--- a/model/cam_core/src/artifact_binary.rs
+++ b/model/cam_core/src/artifact_binary.rs
@@ -19,7 +19,7 @@ use geo_algorithms::Point3D;
 
 use crate::toolpath::{
     ArcDirection, ContourLevelPath, CuttingDirection, PathGeometry, PathSegment, SegmentType,
-    ToolPath,
+    ToolPath, ToolPathKinematicMeta,
 };
 
 /// toolpath artifact magic: `RRTP`
@@ -417,6 +417,7 @@ pub fn read_toolpath_payload_v1<R: Read>(
         contour_levels,
         retract_segments,
         ext_attributes,
+        kinematic_meta: ToolPathKinematicMeta::three_axis_position_only(),
     })
 }
 

--- a/model/cam_core/src/toolpath.rs
+++ b/model/cam_core/src/toolpath.rs
@@ -638,6 +638,9 @@ pub struct ToolPath<T: Scalar = f64> {
 
     /// ToolPath全体の拡張属性（ユーザーが付与可能）
     pub ext_attributes: Vec<ExtAttribute>,
+
+    /// ToolPath全体の運動学メタ情報
+    pub kinematic_meta: ToolPathKinematicMeta,
 }
 
 impl<T: Scalar + std::iter::Sum> ToolPath<T> {
@@ -657,6 +660,25 @@ impl<T: Scalar + std::iter::Sum> ToolPath<T> {
         contour_levels: Vec<ContourLevelPath<T>>,
         retract_segments: Vec<PathSegment<T>>,
     ) -> Self {
+        Self::new_with_kinematic_meta(
+            tool_id,
+            cutting_direction,
+            approach_segments,
+            contour_levels,
+            retract_segments,
+            ToolPathKinematicMeta::three_axis_position_only(),
+        )
+    }
+
+    /// 運動学メタを明示して新しい工具経路を作成
+    pub fn new_with_kinematic_meta(
+        tool_id: String,
+        cutting_direction: CuttingDirection,
+        approach_segments: Vec<PathSegment<T>>,
+        contour_levels: Vec<ContourLevelPath<T>>,
+        retract_segments: Vec<PathSegment<T>>,
+        kinematic_meta: ToolPathKinematicMeta,
+    ) -> Self {
         Self {
             tool_id,
             cutting_direction,
@@ -664,6 +686,7 @@ impl<T: Scalar + std::iter::Sum> ToolPath<T> {
             contour_levels,
             retract_segments,
             ext_attributes: Vec::new(),
+            kinematic_meta,
         }
     }
 

--- a/model/cam_core/src/toolpath_tests.rs
+++ b/model/cam_core/src/toolpath_tests.rs
@@ -105,6 +105,31 @@ fn test_tool_path() {
     assert_eq!(toolpath.tool_id, "tool1");
     assert_eq!(toolpath.cutting_direction, CuttingDirection::Down);
     assert_eq!(toolpath.level_count(), 2);
+    assert_eq!(
+        toolpath.kinematic_meta,
+        ToolPathKinematicMeta::three_axis_position_only()
+    );
+}
+
+#[test]
+fn test_tool_path_with_kinematic_meta() {
+    let custom_meta = ToolPathKinematicMeta::new(
+        MachineConfigurationClass::FourAxis,
+        KinematicMode::ContinuousFourAxis,
+        PoseDataPolicy::PoseLayerOptional,
+    );
+
+    let toolpath = ToolPath::<f64>::new_with_kinematic_meta(
+        "tool2".to_string(),
+        CuttingDirection::Up,
+        vec![],
+        vec![],
+        vec![],
+        custom_meta,
+    );
+
+    assert_eq!(toolpath.kinematic_meta, custom_meta);
+    assert_eq!(toolpath.cutting_direction, CuttingDirection::Up);
 }
 
 #[test]


### PR DESCRIPTION
## 概要
Issue #257 の PR-4 として、`ToolPathKinematicMeta` の保持場所を `ToolPath` 本体に確定しました。
既存3軸API互換を維持しつつ、multi-axis 向けメタを明示保持できるようにしています。

## 変更内容
- `model/cam_core/src/toolpath.rs`
  - `ToolPath` に `kinematic_meta: ToolPathKinematicMeta` を追加
  - 既存 `ToolPath::new` は互換維持のため
    - `ToolPathKinematicMeta::three_axis_position_only()` を既定設定
  - `ToolPath::new_with_kinematic_meta(...)` を追加
    - multi-axis メタを明示指定して生成可能
- `model/cam_core/src/artifact_binary.rs`
  - `read_toolpath_payload_v1` で `v0.1` 読み取り時に3軸既定メタを設定
- `model/cam_core/src/toolpath_tests.rs`
  - `ToolPath::new` の既定メタ検証を追加
  - `ToolPath::new_with_kinematic_meta` の明示メタ検証を追加
- `dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md`
  - PR-4の実施内容と受け入れ条件を追記

## 互換性
- 既存 `ToolPath::new` 呼び出しはそのまま利用可能
- `v0.1` payload は3軸互換メタで初期化されるため、既存ワークフローを維持

## 検証
- `cargo clippy -p cam_core -- -D warnings`
- `cargo fmt --all`
- `cargo test -p cam_core`

Refs #257