### PR TITLE
PR-5 feat(cam_core): add TwoAxis/TwoPointFiveAxis kinematic meta variants (#257)

### DIFF
--- a/model/cam_core/src/toolpath.rs
+++ b/model/cam_core/src/toolpath.rs
@@ -287,6 +287,8 @@ impl<T: Scalar> PoseAnnotatedSegment<T> {
 /// 機械構成の大分類
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MachineConfigurationClass {
+    /// 2軸（XY平面など）
+    TwoAxis,
     /// 3軸
     ThreeAxis,
     /// 4軸
@@ -298,6 +300,10 @@ pub enum MachineConfigurationClass {
 /// 加工時の運動モード分類
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KinematicMode {
+    /// 純2軸（1平面内の輪郭加工）
+    PureTwoAxis,
+    /// 2.5軸（Z段付き2軸）
+    TwoPointFiveAxis,
     /// 純3軸
     PureThreeAxis,
     /// 3+2 のような indexed 多軸
@@ -349,6 +355,24 @@ impl ToolPathKinematicMeta {
         Self {
             configuration_class: MachineConfigurationClass::ThreeAxis,
             kinematic_mode: KinematicMode::PureThreeAxis,
+            pose_data_policy: PoseDataPolicy::PositionOnlyCompatible,
+        }
+    }
+
+    /// 2軸（平面輪郭加工）向けの既定メタ
+    pub const fn two_axis_position_only() -> Self {
+        Self {
+            configuration_class: MachineConfigurationClass::TwoAxis,
+            kinematic_mode: KinematicMode::PureTwoAxis,
+            pose_data_policy: PoseDataPolicy::PositionOnlyCompatible,
+        }
+    }
+
+    /// 2.5軸（Z段付き輪郭加工）向けの既定メタ
+    pub const fn two_point_five_axis_position_only() -> Self {
+        Self {
+            configuration_class: MachineConfigurationClass::TwoAxis,
+            kinematic_mode: KinematicMode::TwoPointFiveAxis,
             pose_data_policy: PoseDataPolicy::PositionOnlyCompatible,
         }
     }

--- a/model/cam_core/src/toolpath_tests.rs
+++ b/model/cam_core/src/toolpath_tests.rs
@@ -186,8 +186,56 @@ fn test_three_axis_position_only_policy_behavior() {
 }
 
 #[test]
+fn test_two_axis_convenience_fns() {
+    let two_axis = ToolPathKinematicMeta::two_axis_position_only();
+    assert_eq!(
+        two_axis.configuration_class,
+        MachineConfigurationClass::TwoAxis
+    );
+    assert_eq!(two_axis.kinematic_mode, KinematicMode::PureTwoAxis);
+    assert!(two_axis.is_position_only_compatible());
+    assert!(two_axis.allows_optional_pose_layer());
+    assert!(!two_axis.requires_pose_layer());
+
+    let two_point_five = ToolPathKinematicMeta::two_point_five_axis_position_only();
+    assert_eq!(
+        two_point_five.configuration_class,
+        MachineConfigurationClass::TwoAxis
+    );
+    assert_eq!(
+        two_point_five.kinematic_mode,
+        KinematicMode::TwoPointFiveAxis
+    );
+    assert!(two_point_five.is_position_only_compatible());
+    assert!(two_point_five.allows_optional_pose_layer());
+    assert!(!two_point_five.requires_pose_layer());
+}
+
+#[test]
 fn test_toolpath_kinematic_meta_matrix() {
     let cases = [
+        (
+            "2-axis",
+            ToolPathKinematicMeta::new(
+                MachineConfigurationClass::TwoAxis,
+                KinematicMode::PureTwoAxis,
+                PoseDataPolicy::PositionOnlyCompatible,
+            ),
+            true,
+            true,
+            false,
+        ),
+        (
+            "2.5-axis",
+            ToolPathKinematicMeta::new(
+                MachineConfigurationClass::TwoAxis,
+                KinematicMode::TwoPointFiveAxis,
+                PoseDataPolicy::PositionOnlyCompatible,
+            ),
+            true,
+            true,
+            false,
+        ),
         (
             "3-axis",
             ToolPathKinematicMeta::new(


### PR DESCRIPTION
## 概要

Issue #257 PR-5: `MachineConfigurationClass` と `KinematicMode` に2軸・2.5軸のバリアントを追加し、ToolPathのメタ情報で2軸系加工を明示的に区別できるようにします。

Refs #257

## 変更内容

### `model/cam_core/src/toolpath.rs`

#### `MachineConfigurationClass` に追加
- `TwoAxis` — 2軸（XY平面などの平面加工）

#### `KinematicMode` に追加
- `PureTwoAxis` — 純2軸（1平面内の輪郭加工）
- `TwoPointFiveAxis` — 2.5軸（Z段付き2軸）

#### `ToolPathKinematicMeta` convenience fn に追加
- `two_axis_position_only()` — 純2軸の既定メタ
- `two_point_five_axis_position_only()` — 2.5軸の既定メタ

### `model/cam_core/src/toolpath_tests.rs`

- `test_two_axis_convenience_fns` — convenience fn の動作検証
- `test_toolpath_kinematic_meta_matrix` に2軸・2.5軸ケースを追加

## 品質確認

- `cargo clippy -p cam_core -- -D warnings`: ✅ 警告なし
- `cargo test -p cam_core --lib`: ✅ **64 passed**（前回63→+1）
- `cargo fmt`: ✅ 適用済み

## 後方互換性

- 新規バリアント追加のみ。既存の `ThreeAxis`, `PureThreeAxis` 等は変更なし
- `ToolPath::new()` の既定は引き続き `three_axis_position_only()`
- artifact v0.1 wire format 変更なし