### PR TITLE
refactor(cam_core): align kinematic mode terms with industry naming (#257 follow-up)

### DIFF
--- a/dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md
@@ -192,12 +192,15 @@ MachineAxisValue<T> {
 
 `MachineConfigurationClass` 候補:
 
+- `TwoAxis`（PR-5 追加）
 - `ThreeAxis`
 - `FourAxis`
 - `FiveAxisOrMore`
 
 `KinematicMode` 候補:
 
+- `PureTwoAxis`（PR-5 追加） — 純2軸（1平面内の輪郭加工）
+- `TwoPointFiveAxis`（PR-5 追加） — 2.5軸（Z段付き2軸）
 - `PureThreeAxis`
 - `IndexedMultiAxis`
 - `ContinuousFourAxis`
@@ -215,6 +218,8 @@ MachineAxisValue<T> {
 - `kinematic_mode` は同じ5軸以上でも 3+2 と同時多軸を区別する
 - `pose_data_policy` はデータ量要件の表明であり、3軸では `PositionOnlyCompatible` を基本にする
 - このメタは `ToolPath` 全体、または `ToolPath` に付随する上位コンテキストへ持たせる想定とし、各 pose に重複保持しない
+- `TwoAxis` は XY 平面など1平面内の加工機構成を表し、Z軸を持つ `ThreeAxis` と明示的に区別する
+- `PureTwoAxis` と `TwoPointFiveAxis` の差は「Z軸が固定か段階変化か」であり、両方とも `PositionOnlyCompatible` で運用できる
 
 ### 6.3 MachineAxisValue / MachineAxisKind
 
@@ -516,6 +521,7 @@ PR-3 で確定した方針:
 - [x] PR-2: 3軸軽量方針のテスト固定
 - [x] PR-3: artifact 連携方針の文書化（実装変更なし）
 - [x] PR-4: `ToolPath` 本体へ `kinematic_meta` を追加（既定は3軸互換）
+- [x] PR-5: `MachineConfigurationClass`/`KinematicMode` に2軸・2.5軸バリアントを追加
 
 ### 12.6 PR-4 実施内容
 
@@ -541,3 +547,30 @@ PR-3 で確定した方針:
 - 既存 `ToolPath::new` 呼び出しは修正なしで利用できる
 - 明示メタ指定の `ToolPath` をテストで検証できる
 - `v0.1` 読み取りが3軸互換メタで初期化される
+
+### 12.7 PR-5 実施内容
+
+目的:
+
+- 2軸（XY平面加工）および 2.5軸（Z段付き2軸）を `ToolPathKinematicMeta` で明示区別できるようにする
+- 既存の3軸以上のバリアントとの整合を保つ
+
+対象ファイル:
+
+- `model/cam_core/src/toolpath.rs`
+- `model/cam_core/src/toolpath_tests.rs`
+
+実装範囲:
+
+- `MachineConfigurationClass` に `TwoAxis` バリアントを追加
+- `KinematicMode` に `PureTwoAxis` / `TwoPointFiveAxis` バリアントを追加
+- `ToolPathKinematicMeta::two_axis_position_only()` convenience fn を追加
+- `ToolPathKinematicMeta::two_point_five_axis_position_only()` convenience fn を追加
+- `test_two_axis_convenience_fns` テストを追加
+- `test_toolpath_kinematic_meta_matrix` に 2軸 / 2.5軸ケースを追加
+
+受け入れ条件:
+
+- 既存バリアント（`ThreeAxis`, `PureThreeAxis` 等）の挙動に変更なし
+- 2軸・2.5軸どちらも `is_position_only_compatible()` が `true` を返す
+- `cargo test -p cam_core --lib`: 64 passed（PR-4 の 63 から +1）

--- a/dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md
@@ -199,7 +199,7 @@ MachineAxisValue<T> {
 
 `KinematicMode` 候補:
 
-- `PureTwoAxis`（PR-5 追加） — 純2軸（1平面内の輪郭加工）
+- `PureTwoAxis`（PR-5 追加） — 2軸（1平面内の輪郭加工）
 - `TwoPointFiveAxis`（PR-5 追加） — 2.5軸（Z段付き2軸）
 - `PureThreeAxis`
 - `IndexedMultiAxis`（割り出し多軸 / 3+2）

--- a/dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md
@@ -199,12 +199,12 @@ MachineAxisValue<T> {
 
 `KinematicMode` 候補:
 
-- `PureTwoAxis`（PR-5 追加） — 2軸（1平面内の輪郭加工）
+- `TwoAxis`（PR-5 追加） — 2軸（1平面内の輪郭加工）
 - `TwoPointFiveAxis`（PR-5 追加） — 2.5軸（Z段付き2軸）
-- `PureThreeAxis`
+- `ThreeAxis`
 - `IndexedMultiAxis`（割り出し多軸 / 3+2）
-- `ContinuousFourAxis`（同時4軸）
-- `ContinuousFiveAxis`（同時5軸）
+- `SimultaneousFourAxis`（同時4軸）
+- `SimultaneousFiveAxis`（同時5軸）
 
 `PoseDataPolicy` 候補:
 
@@ -219,7 +219,7 @@ MachineAxisValue<T> {
 - `pose_data_policy` はデータ量要件の表明であり、3軸では `PositionOnlyCompatible` を基本にする
 - このメタは `ToolPath` 全体、または `ToolPath` に付随する上位コンテキストへ持たせる想定とし、各 pose に重複保持しない
 - `TwoAxis` は XY 平面など1平面内の加工機構成を表し、Z軸を持つ `ThreeAxis` と明示的に区別する
-- `PureTwoAxis` と `TwoPointFiveAxis` の差は「Z軸が固定か段階変化か」であり、両方とも `PositionOnlyCompatible` で運用できる
+- `TwoAxis` と `TwoPointFiveAxis` の差は「Z軸が固定か段階変化か」であり、両方とも `PositionOnlyCompatible` で運用できる
 
 ### 6.3 MachineAxisValue / MachineAxisKind
 
@@ -287,7 +287,7 @@ PoseAnnotatedSegment {
 
 - 位置は移動するが姿勢は固定
 - 現行3軸 `ToolPath` とほぼ同義の表現になる
-- `ToolPathKinematicMeta { configuration_class: ThreeAxis, kinematic_mode: PureThreeAxis, pose_data_policy: PositionOnlyCompatible }` を付けることで、binary では pose レイヤー省略可能と判断できる
+- `ToolPathKinematicMeta { configuration_class: ThreeAxis, kinematic_mode: ThreeAxis, pose_data_policy: PositionOnlyCompatible }` を付けることで、binary では pose レイヤー省略可能と判断できる
 
 ### 7.2 4軸ケース
 
@@ -305,7 +305,7 @@ PoseAnnotatedSegment {
 解釈:
 
 - 回転軸が1本だけ連続変化する 4軸ケースを表す
-- `ToolPathKinematicMeta { configuration_class: FourAxis, kinematic_mode: ContinuousFourAxis, pose_data_policy: PoseLayerOptional }` により、3軸との差分を明示できる
+- `ToolPathKinematicMeta { configuration_class: FourAxis, kinematic_mode: SimultaneousFourAxis, pose_data_policy: PoseLayerOptional }` により、3軸との差分を明示できる
 
 ### 7.3 3+2 ケース
 
@@ -343,7 +343,7 @@ PoseAnnotatedSegment {
 
 - セグメント内で位置と姿勢が同時に変化する
 - 最短角だけでなく機械制約を考慮した補間が必要になる
-- `ToolPathKinematicMeta { configuration_class: FiveAxisOrMore, kinematic_mode: ContinuousFiveAxis, pose_data_policy: PoseLayerRequired }`（= 同時5軸）により、姿勢レイヤー必須のケースだと表明できる
+- `ToolPathKinematicMeta { configuration_class: FiveAxisOrMore, kinematic_mode: SimultaneousFiveAxis, pose_data_policy: PoseLayerRequired }`（= 同時5軸）により、姿勢レイヤー必須のケースだと表明できる
 
 ### 7.5 レーザー加工の変則軸ケース
 
@@ -563,7 +563,7 @@ PR-3 で確定した方針:
 実装範囲:
 
 - `MachineConfigurationClass` に `TwoAxis` バリアントを追加
-- `KinematicMode` に `PureTwoAxis` / `TwoPointFiveAxis` バリアントを追加
+- `KinematicMode` に `TwoAxis` / `TwoPointFiveAxis` バリアントを追加
 - `ToolPathKinematicMeta::two_axis_position_only()` convenience fn を追加
 - `ToolPathKinematicMeta::two_point_five_axis_position_only()` convenience fn を追加
 - `test_two_axis_convenience_fns` テストを追加
@@ -571,6 +571,6 @@ PR-3 で確定した方針:
 
 受け入れ条件:
 
-- 既存バリアント（`ThreeAxis`, `PureThreeAxis` 等）の挙動に変更なし
+- 既存バリアント（`ThreeAxis`, `IndexedMultiAxis` 等）の挙動に変更なし
 - 2軸・2.5軸どちらも `is_position_only_compatible()` が `true` を返す
 - `cargo test -p cam_core --lib`: 64 passed（PR-4 の 63 から +1）

--- a/dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md
@@ -202,9 +202,9 @@ MachineAxisValue<T> {
 - `PureTwoAxis`（PR-5 追加） — 純2軸（1平面内の輪郭加工）
 - `TwoPointFiveAxis`（PR-5 追加） — 2.5軸（Z段付き2軸）
 - `PureThreeAxis`
-- `IndexedMultiAxis`
-- `ContinuousFourAxis`
-- `ContinuousFiveAxis`
+- `IndexedMultiAxis`（割り出し多軸 / 3+2）
+- `ContinuousFourAxis`（同時4軸）
+- `ContinuousFiveAxis`（同時5軸）
 
 `PoseDataPolicy` 候補:
 
@@ -343,7 +343,7 @@ PoseAnnotatedSegment {
 
 - セグメント内で位置と姿勢が同時に変化する
 - 最短角だけでなく機械制約を考慮した補間が必要になる
-- `ToolPathKinematicMeta { configuration_class: FiveAxisOrMore, kinematic_mode: ContinuousFiveAxis, pose_data_policy: PoseLayerRequired }` により、姿勢レイヤー必須のケースだと表明できる
+- `ToolPathKinematicMeta { configuration_class: FiveAxisOrMore, kinematic_mode: ContinuousFiveAxis, pose_data_policy: PoseLayerRequired }`（= 同時5軸）により、姿勢レイヤー必須のケースだと表明できる
 
 ### 7.5 レーザー加工の変則軸ケース
 

--- a/model/cam_core/src/toolpath.rs
+++ b/model/cam_core/src/toolpath.rs
@@ -300,11 +300,11 @@ pub enum MachineConfigurationClass {
 /// 加工時の運動モード分類
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KinematicMode {
-    /// 純2軸（1平面内の輪郭加工）
+    /// 2軸（1平面内の輪郭加工）
     PureTwoAxis,
     /// 2.5軸（Z段付き2軸）
     TwoPointFiveAxis,
-    /// 純3軸
+    /// 3軸
     PureThreeAxis,
     /// 割り出し多軸（3+2）
     IndexedMultiAxis,

--- a/model/cam_core/src/toolpath.rs
+++ b/model/cam_core/src/toolpath.rs
@@ -301,17 +301,17 @@ pub enum MachineConfigurationClass {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KinematicMode {
     /// 2軸（1平面内の輪郭加工）
-    PureTwoAxis,
+    TwoAxis,
     /// 2.5軸（Z段付き2軸）
     TwoPointFiveAxis,
     /// 3軸
-    PureThreeAxis,
+    ThreeAxis,
     /// 割り出し多軸（3+2）
     IndexedMultiAxis,
     /// 同時4軸
-    ContinuousFourAxis,
+    SimultaneousFourAxis,
     /// 同時5軸
-    ContinuousFiveAxis,
+    SimultaneousFiveAxis,
 }
 
 /// 姿勢データ保持ポリシー
@@ -354,7 +354,7 @@ impl ToolPathKinematicMeta {
     pub const fn three_axis_position_only() -> Self {
         Self {
             configuration_class: MachineConfigurationClass::ThreeAxis,
-            kinematic_mode: KinematicMode::PureThreeAxis,
+            kinematic_mode: KinematicMode::ThreeAxis,
             pose_data_policy: PoseDataPolicy::PositionOnlyCompatible,
         }
     }
@@ -363,7 +363,7 @@ impl ToolPathKinematicMeta {
     pub const fn two_axis_position_only() -> Self {
         Self {
             configuration_class: MachineConfigurationClass::TwoAxis,
-            kinematic_mode: KinematicMode::PureTwoAxis,
+            kinematic_mode: KinematicMode::TwoAxis,
             pose_data_policy: PoseDataPolicy::PositionOnlyCompatible,
         }
     }

--- a/model/cam_core/src/toolpath.rs
+++ b/model/cam_core/src/toolpath.rs
@@ -306,11 +306,11 @@ pub enum KinematicMode {
     TwoPointFiveAxis,
     /// 純3軸
     PureThreeAxis,
-    /// 3+2 のような indexed 多軸
+    /// 割り出し多軸（3+2）
     IndexedMultiAxis,
-    /// 連続4軸
+    /// 同時4軸
     ContinuousFourAxis,
-    /// 連続5軸
+    /// 同時5軸
     ContinuousFiveAxis,
 }
 

--- a/model/cam_core/src/toolpath_tests.rs
+++ b/model/cam_core/src/toolpath_tests.rs
@@ -115,7 +115,7 @@ fn test_tool_path() {
 fn test_tool_path_with_kinematic_meta() {
     let custom_meta = ToolPathKinematicMeta::new(
         MachineConfigurationClass::FourAxis,
-        KinematicMode::ContinuousFourAxis,
+        KinematicMode::SimultaneousFourAxis,
         PoseDataPolicy::PoseLayerOptional,
     );
 
@@ -156,14 +156,14 @@ fn test_toolpath_kinematic_meta_classification() {
         three_axis,
         ToolPathKinematicMeta::new(
             MachineConfigurationClass::ThreeAxis,
-            KinematicMode::PureThreeAxis,
+            KinematicMode::ThreeAxis,
             PoseDataPolicy::PositionOnlyCompatible,
         )
     );
 
     let continuous_four_axis = ToolPathKinematicMeta::new(
         MachineConfigurationClass::FourAxis,
-        KinematicMode::ContinuousFourAxis,
+        KinematicMode::SimultaneousFourAxis,
         PoseDataPolicy::PoseLayerOptional,
     );
     assert_eq!(
@@ -172,7 +172,7 @@ fn test_toolpath_kinematic_meta_classification() {
     );
     assert_eq!(
         continuous_four_axis.kinematic_mode,
-        KinematicMode::ContinuousFourAxis
+        KinematicMode::SimultaneousFourAxis
     );
 }
 
@@ -192,7 +192,7 @@ fn test_two_axis_convenience_fns() {
         two_axis.configuration_class,
         MachineConfigurationClass::TwoAxis
     );
-    assert_eq!(two_axis.kinematic_mode, KinematicMode::PureTwoAxis);
+    assert_eq!(two_axis.kinematic_mode, KinematicMode::TwoAxis);
     assert!(two_axis.is_position_only_compatible());
     assert!(two_axis.allows_optional_pose_layer());
     assert!(!two_axis.requires_pose_layer());
@@ -218,7 +218,7 @@ fn test_toolpath_kinematic_meta_matrix() {
             "2-axis",
             ToolPathKinematicMeta::new(
                 MachineConfigurationClass::TwoAxis,
-                KinematicMode::PureTwoAxis,
+                KinematicMode::TwoAxis,
                 PoseDataPolicy::PositionOnlyCompatible,
             ),
             true,
@@ -240,7 +240,7 @@ fn test_toolpath_kinematic_meta_matrix() {
             "3-axis",
             ToolPathKinematicMeta::new(
                 MachineConfigurationClass::ThreeAxis,
-                KinematicMode::PureThreeAxis,
+                KinematicMode::ThreeAxis,
                 PoseDataPolicy::PositionOnlyCompatible,
             ),
             true,
@@ -251,7 +251,7 @@ fn test_toolpath_kinematic_meta_matrix() {
             "4-axis simultaneous",
             ToolPathKinematicMeta::new(
                 MachineConfigurationClass::FourAxis,
-                KinematicMode::ContinuousFourAxis,
+                KinematicMode::SimultaneousFourAxis,
                 PoseDataPolicy::PoseLayerOptional,
             ),
             false,
@@ -273,7 +273,7 @@ fn test_toolpath_kinematic_meta_matrix() {
             "5-axis simultaneous",
             ToolPathKinematicMeta::new(
                 MachineConfigurationClass::FiveAxisOrMore,
-                KinematicMode::ContinuousFiveAxis,
+                KinematicMode::SimultaneousFiveAxis,
                 PoseDataPolicy::PoseLayerRequired,
             ),
             false,

--- a/model/cam_core/src/toolpath_tests.rs
+++ b/model/cam_core/src/toolpath_tests.rs
@@ -248,7 +248,7 @@ fn test_toolpath_kinematic_meta_matrix() {
             false,
         ),
         (
-            "4-axis continuous",
+            "4-axis simultaneous",
             ToolPathKinematicMeta::new(
                 MachineConfigurationClass::FourAxis,
                 KinematicMode::ContinuousFourAxis,
@@ -270,7 +270,7 @@ fn test_toolpath_kinematic_meta_matrix() {
             false,
         ),
         (
-            "5-axis continuous",
+            "5-axis simultaneous",
             ToolPathKinematicMeta::new(
                 MachineConfigurationClass::FiveAxisOrMore,
                 KinematicMode::ContinuousFiveAxis,


### PR DESCRIPTION
## 概要

PR #424 マージ後のフォローアップとして、運動モード命名を業界用語に合わせて整理します。

Refs #257

## 変更内容

- KinematicMode バリアント名を更新
  - `PureTwoAxis` -> `TwoAxis`
  - `PureThreeAxis` -> `ThreeAxis`
  - `ContinuousFourAxis` -> `SimultaneousFourAxis`
  - `ContinuousFiveAxis` -> `SimultaneousFiveAxis`
- コメント/テスト/設計ドキュメントの用語を同時更新
- 2軸・3軸/同時5軸/割り出し5軸の表記ゆれを解消

## 変更ファイル

- `model/cam_core/src/toolpath.rs`
- `model/cam_core/src/toolpath_tests.rs`
- `dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md`

## 検証

- `cargo clippy -p cam_core -- -D warnings` : ✅
- `cargo fmt --check -p cam_core` : ✅
- `cargo test -p cam_core --lib` : ✅ (64 passed)

## 補足

- PR #424 は既にマージ済み
- 本PRはマージ後に追加した4コミットを対象とするフォローアップPR