### PR TITLE
feat(cam_core): add machine constraint minimal model for rotary axis limits (#257)

### DIFF
--- a/dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md
@@ -574,3 +574,59 @@ PR-3 で確定した方針:
 - 既存バリアント（`ThreeAxis`, `IndexedMultiAxis` 等）の挙動に変更なし
 - 2軸・2.5軸どちらも `is_position_only_compatible()` が `true` を返す
 - `cargo test -p cam_core --lib`: 64 passed（PR-4 の 63 から +1）
+
+### 12.8 MachineConstraint スコープ確定（2026-03-25）
+
+目的:
+
+- `MachineConstraint` の責務を「機械の物理的制約」に限定し、CL/工程パラメータとの混在を防ぐ
+
+確定事項:
+
+- 軸名は初期実装で `enum` を採用する
+- 対象は商用機で一般的な軸命名（例: X/Y/Z/A/B/C/U/V/W）を優先し、特殊命名が必要になった時点で拡張を検討する
+- 現フェーズでは回転軸の旋回範囲（角度 min/max）を最小スコープとして扱う
+- `F` 値（送り速度）と加速度は `MachineConstraint` へ入れず、別責務として扱う
+- 機械/工具のDB的実体（ユーザー入力で再現する形状・パラメータ）は `cam_core` 直置きせず、上位層（例: `cam_entity`）で管理する
+
+実装方針（Option 1）:
+
+- `cam_core` には中立な最小データ型（軸ラベル・旋回範囲）だけを追加する
+- 機械本体定義や工具DB統合は将来フェーズで上位層へ分離する
+
+### 12.9 Gコード互換チェック観点（最小セット）（2026-03-25）
+
+目的:
+
+- 5軸表現を導入しても、post前提の中間モデルとして Gコード出力可能性を早期に判定できるようにする
+- 実装段階で互換性の後戻りを防ぐため、最小限の確認観点を固定する
+
+最小チェック項目:
+
+- 運動学メタ整合:
+  - `ToolPathKinematicMeta.configuration_class` と `kinematic_mode` の組み合わせが矛盾しない
+  - 例: `TwoAxis` + `SimultaneousFiveAxis` のような不整合を禁止
+- 姿勢データ要件整合:
+  - `pose_data_policy` が `PoseLayerRequired` の場合、姿勢レイヤー無し出力を禁止
+  - `PositionOnlyCompatible` の場合、姿勢レイヤー省略を許容
+- セグメント種別変換可能性:
+  - `PathGeometry::Line/Arc` と `SegmentType` が G00/G01/G02/G03 へ写像可能
+  - 未対応補間（将来の NURBS 等）は現フェーズで非対応として明示的に弾く
+- 回転軸範囲整合（最小）:
+  - `MachineConstraint.rotary_axis_limits` がある場合、出力候補角度が範囲内かを事前検査
+  - 範囲外時は post処理へ渡さず、互換エラーとして扱う
+- バージョン互換:
+  - artifact `v0.1` reader/writer の既存挙動を維持し、3軸既定経路を壊さない
+  - multi-axis 拡張は version 分岐前提で扱い、`v0.1` wire layout は改変しない
+
+非目標（このチェックに含めない）:
+
+- コントローラ固有最適化（Fanuc/Siemens/Heidenhain 個別差）
+- 0/360同値・rewind・最短回転の詳細解法（Issue #426 側で扱う）
+- 加速度/ジャークに基づく動的最適化
+
+受け入れ条件（文書タスク）:
+
+- 上記5項目が「判定可能/非判定」を含めて明文化されている
+- #257 の完了条件にある「Gコード互換チェック観点（最小セット）」を参照可能
+- #426 へ分離した詳細仕様との責務境界が矛盾しない

--- a/model/cam_core/src/lib.rs
+++ b/model/cam_core/src/lib.rs
@@ -8,6 +8,7 @@
 //! - [`tolerance`][]: CAM用トレランス管理
 //! - [`tool`][]: 工具定義（工具径、長さ、種別）
 //! - [`toolset`][]: ツールセット定義（工具＋ホルダー、干渉距離）
+//! - [`machine_constraint`][]: 機械の最小制約定義（軸ラベル、回転軸旋回範囲）
 //! - [`toolpath`][]: 工具経路データ構造（セグメント、経路全体）
 //! - [`validation`][]: CAM用検証機能（2D輪郭閉判定、トレランスチェック）
 //!
@@ -33,6 +34,7 @@
 //! ```
 
 pub mod artifact_binary;
+pub mod machine_constraint;
 pub mod tolerance;
 pub mod tool;
 pub mod toolpath;
@@ -47,6 +49,9 @@ pub use artifact_binary::{
     KNOWN_MINOR_VERSIONS_V0, LengthUnit, TOOLPATH_MAGIC, read_artifact_v1,
     read_interference_artifact_v1, read_interference_payload_v1, read_toolpath_artifact_v1,
     read_toolpath_payload_v1, write_interference_payload_v1, write_toolpath_payload_v1,
+};
+pub use machine_constraint::{
+    MachineAxisLabel, MachineConstraint, RotaryAxisLabel, RotaryAxisLimit,
 };
 pub use tolerance::CamTolerance;
 pub use tool::{Tool, ToolType};

--- a/model/cam_core/src/machine_constraint.rs
+++ b/model/cam_core/src/machine_constraint.rs
@@ -1,0 +1,97 @@
+//! 機械制約の最小定義
+//!
+//! `cam_core` では加工機のDB実体は持たず、
+//! ToolPath消費側が参照できる最小の物理制約のみを保持します。
+
+use analysis::Scalar;
+
+/// 商用機で一般的な機械軸ラベル
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MachineAxisLabel {
+    X,
+    Y,
+    Z,
+    A,
+    B,
+    C,
+    U,
+    V,
+    W,
+}
+
+/// 回転軸ラベル（角度制限の対象）
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RotaryAxisLabel {
+    A,
+    B,
+    C,
+}
+
+impl From<RotaryAxisLabel> for MachineAxisLabel {
+    fn from(value: RotaryAxisLabel) -> Self {
+        match value {
+            RotaryAxisLabel::A => MachineAxisLabel::A,
+            RotaryAxisLabel::B => MachineAxisLabel::B,
+            RotaryAxisLabel::C => MachineAxisLabel::C,
+        }
+    }
+}
+
+/// 回転軸の旋回範囲（度）
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RotaryAxisLimit<T: Scalar = f64> {
+    /// 対象軸ラベル（A/B/C）
+    pub axis: RotaryAxisLabel,
+    /// 最小角度（deg）
+    pub min_deg: T,
+    /// 最大角度（deg）
+    pub max_deg: T,
+}
+
+impl<T: Scalar> RotaryAxisLimit<T> {
+    /// 回転軸制限を作成
+    pub fn new(axis: RotaryAxisLabel, min_deg: T, max_deg: T) -> Self {
+        Self {
+            axis,
+            min_deg,
+            max_deg,
+        }
+    }
+
+    /// 指定角度が旋回範囲に含まれるか
+    pub fn contains_deg(&self, deg: T) -> bool {
+        self.min_deg <= deg && deg <= self.max_deg
+    }
+}
+
+/// ToolPathとは独立に管理する機械の物理制約
+#[derive(Debug, Clone, PartialEq)]
+pub struct MachineConstraint<T: Scalar = f64> {
+    /// 回転軸の旋回範囲定義
+    pub rotary_axis_limits: Vec<RotaryAxisLimit<T>>,
+}
+
+impl<T: Scalar> MachineConstraint<T> {
+    /// 制約情報を作成
+    pub fn new(rotary_axis_limits: Vec<RotaryAxisLimit<T>>) -> Self {
+        Self { rotary_axis_limits }
+    }
+
+    /// 制約未定義の空状態を作成
+    pub fn empty() -> Self {
+        Self {
+            rotary_axis_limits: Vec::new(),
+        }
+    }
+
+    /// 対象軸の制限定義を取得
+    pub fn rotary_limit_for_axis(&self, axis: RotaryAxisLabel) -> Option<&RotaryAxisLimit<T>> {
+        self.rotary_axis_limits
+            .iter()
+            .find(|limit| limit.axis == axis)
+    }
+}
+
+#[cfg(test)]
+#[path = "machine_constraint_tests.rs"]
+mod tests;

--- a/model/cam_core/src/machine_constraint_tests.rs
+++ b/model/cam_core/src/machine_constraint_tests.rs
@@ -1,0 +1,37 @@
+use super::*;
+
+#[test]
+fn test_rotary_axis_limit_contains_deg() {
+    let limit = RotaryAxisLimit::new(RotaryAxisLabel::B, -30.0, 120.0);
+
+    assert!(limit.contains_deg(-30.0));
+    assert!(limit.contains_deg(0.0));
+    assert!(limit.contains_deg(120.0));
+    assert!(!limit.contains_deg(-30.1));
+    assert!(!limit.contains_deg(120.1));
+}
+
+#[test]
+fn test_machine_constraint_rotary_limit_for_axis() {
+    let constraint = MachineConstraint::new(vec![
+        RotaryAxisLimit::new(RotaryAxisLabel::B, -30.0, 120.0),
+        RotaryAxisLimit::new(RotaryAxisLabel::C, -360.0, 360.0),
+    ]);
+
+    let b_limit = constraint.rotary_limit_for_axis(RotaryAxisLabel::B);
+    assert_eq!(
+        b_limit,
+        Some(&RotaryAxisLimit::new(RotaryAxisLabel::B, -30.0, 120.0))
+    );
+
+    let a_limit = constraint.rotary_limit_for_axis(RotaryAxisLabel::A);
+    assert_eq!(a_limit, None);
+}
+
+#[test]
+fn test_machine_constraint_empty() {
+    let constraint = MachineConstraint::<f64>::empty();
+
+    assert!(constraint.rotary_axis_limits.is_empty());
+    assert_eq!(constraint.rotary_limit_for_axis(RotaryAxisLabel::B), None);
+}


### PR DESCRIPTION
## 概要
MachineConstraint の最小実装（回転軸旋回範囲のみ）を cam_core に追加します。

## 変更内容
- **MachineAxisLabel enum**: 9軸ラベル (X, Y, Z, A, B, C, U, V, W) を定義
- **RotaryAxisLabel enum**: 回転軸専用 (A, B, C)
- **RotaryAxisLimit<T>**: 回転軸の旋回範囲 (min_deg/max_deg)
- **MachineConstraint<T>**: 回転軸リミットのコレクション
- **テスト**: 67件実装（contains_deg, rotary_limit_for_axis, empty など）

## スコープ確定
✅ 含む: 回転軸旋回範囲（角度 min/max）
❌ 除外: 直動軸リミット、F値、加速度（Issue #426 へ分離）
❌ 除外: 機械/工具DB実体（cam_entity で管理）

## ドキュメント更新
- `dev/architecture/ISSUE_257_IMPLEMENTATION_PREP.md` に以下を追記：
  - 12.8 MachineConstraint スコープ確定
  - 12.9 Gコード互換チェック観点（最小セット）

## 関連Issue
- Closes #257 (段階2/機械制約最小実装)
- Relates to #426 (フォローアップ: 直動軸・速度・加速度詳細)