### PR TITLE
[Design] architecture: cam_algorithms クレート新設とCAM責務境界の定義

### DIFF
--- a/dev/architecture/ARCHITECTURE.md
+++ b/dev/architecture/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # RedRing アーキテクチャ構成
 
-**最終更新日**: 2026年3月15日
+**最終更新日**: 2026年3月25日
 
 RedRing の幾何計算層とレンダリング層の構成、および現在の課題と解決策について説明します。
 
@@ -34,6 +34,18 @@ foundation/analysis（将来改名候補）
                     ↓
          application層クレート群
     （tessellation / simulation / job manager）
+
+        CAM側の責務分離（設計更新）
+
+            geo_*（汎用幾何演算）
+                ↓
+            cam_core（中立データ基盤）
+               ↙          ↘
+        cam_algorithms      cam_entity
+        （CAM固有計算）     （表示/統合）
+               ↓
+              cam_sim
+        （CAM特化ユースケース実行）
 ```
 
 #### クレート責務定義
@@ -45,6 +57,10 @@ foundation/analysis（将来改名候補）
 - **`geo_algorithms`**: `geo_primitives` / `geo_nurbs` を利用した高レベル幾何アルゴリズム（intersect, collision 等）
 - **`application::*`（新設方針）**: テセレーション、シミュレーション、ジョブ管理など業務ユースケース
 - **`geo_io`**: ファイル I/O（STL/OBJ/PLY 等）
+- **`cam_core`**: CAM の中立データ基盤（ToolPath / Tool / artifact I/O / 最小機械制約）
+- **`cam_algorithms`（新設方針）**: CAM 固有アルゴリズム（経路生成、順序最適化、干渉回避、機械制約検証）
+- **`cam_sim`**: CAM 特化の実行・ユースケース層（ToolPath 実行、除去量更新、結果キャッシュ）
+- **`cam_entity`**: CAM 向け表示/属性統合層
 
 #### レイヤー設計の重要ポイント
 
@@ -53,6 +69,8 @@ foundation/analysis（将来改名候補）
 - **`geo_foundation`廃止（完了）**: 形状trait定義は`geo_contracts`へ統一済み
 - **依存と import の区別**: `geo_algorithms -> geo_primitives/geo_nurbs` 依存は許可だが、`geo_algorithms` 実装ファイルでの `use geo_primitives::...` 直接 import は禁止（`use crate::...` 再エクスポート経由を使用）
 - **上位責務分離**: tessellation/simulation/job managerは`geo_algorithms`より上位のapplication層へ集約
+- **CAM責務分離**: `cam_core` は中立データ、`cam_algorithms` は計算ロジック、`cam_sim` はCAM特化ユースケース実行として分離する
+- **`cam_sim` の位置づけ**: 物理配置は `model/` 配下だが、責務としては純粋データ層ではなく CAM ドメイン専用の application 層に近い
 - **循環依存回避**: `geo_primitives` ↔ `geo_nurbs` の直接依存は禁止（交差処理は`geo_algorithms`に集約）
 
 ### 段階移行計画（提案）
@@ -73,13 +91,22 @@ foundation/analysis（将来改名候補）
 - `foundation/analysis` の名称変更を検討
 - 内部実装を純粋数値解析（線形代数等）に整理し、ドメイン責務を排除
 
-### CAD/CAM 境界ルール（2026年2月更新）
+### CAD/CAM 境界ルール（2026年3月更新）
 
 - **原則**: `model/geo_*` から `model/cam_*` への依存は禁止
-- **許可**: `cam_core -> cam_entity`
+- **CAM内部の基準依存**: `cam_algorithms -> cam_core` は許可、`cam_core -> cam_algorithms` は禁止
+- **CAM内部の実行依存**: `cam_sim -> cam_core` は許可、`cam_sim -> cam_algorithms` は限定的に許可
+- **CAM内部の表示依存**: `cam_entity -> cam_core` は許可、`cam_entity -> cam_algorithms` は禁止
 - **禁止**: `cam_core -> geo_entity`
 - **禁止**: `geo_core -> cam_entity`
 - **許可**: `geo_core -> geo_entity`
+
+#### CAMクレート責務の補足
+
+- **`cam_core`**: 他CAMクレートから参照される中立データのみを保持する
+- **`cam_algorithms`**: 生成・最適化・検証・干渉回避などの CAM 計算を集約する
+- **`cam_sim`**: シミュレーション実行を担う。`cam_algorithms` への依存は実行前後の問い合わせに限定する
+- **`cam_entity`**: UI/可視化向け属性統合を担い、計算ロジックは保持しない
 
 ### 共通ジョブマネージャー方針（2026年3月更新）
 
@@ -114,6 +141,7 @@ foundation/analysis（将来改名候補）
 
 - 実行コマンド: `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check_architecture_dependencies.ps1 -ExitOnError`
 - CI/ローカルともに上記スクリプトで依存境界違反を検出する
+- `cam_algorithms` 新設時は、workspace 参加、`scripts/_arch_rules_data.ps1` の依存ルール更新、関連ドキュメント更新を同一変更セットで行う
 
 ## 🔧 修正方針
 

--- a/dev/architecture/CAM_ALGORITHMS_DESIGN.md
+++ b/dev/architecture/CAM_ALGORITHMS_DESIGN.md
@@ -1,0 +1,354 @@
+# CAM クレート責務設計と cam_algorithms 新設案
+
+**作成日**: 2026年3月25日  
+**最終更新**: 2026年3月25日  
+**ステータス**: 設計案更新中 - 依存例の具体化とPoC選定反映済み  
+**関連Issue**: #413（親）、#426（分離）、#411、#412
+
+---
+
+## 📋 概要
+
+現状の CAM 関連クレートは `cam_core`（データ/契約）・`cam_sim`（切削シミュレーション）・`cam_entity`（表示/属性統合）に分かれており、**経路生成・最適化・干渉回避などのアルゴリズム層の受け皿が明確でない**。
+
+本設計では、`geo_algorithms` と対称的な責務分離を実現するため、`cam_algorithms` 新設を提案し、CAM クレート間の依存方向を確定する。
+
+---
+
+## 🎯 目的
+
+1. **責務分離の明確化**: 各 CAM クレートが持つべき責務を一覧化
+2. **依存方向の固定**: 許可/禁止される依存を定義し、将来実装の迷いを削減
+3. **サーキュラー依存の回避**: `geo_*` 層との境界ルール確認
+4. **段階導入の基盤**: 後続 Issue（アルゴリズム実装）の立案基盤
+
+---
+
+## 1️⃣ CAMクレート責務表（確定案）
+
+### 1.1 cam_core（データ基盤層）
+
+**責務**:
+- ToolPath / Tool セット定義（構造体・trait）
+- Artifact バイナリ I/O 契約（read/write）
+- ToolPathKinematicMeta / MachineConstraint（最小型）
+- ToolPose / 補間ポリシー定義
+
+**許可される依存**:
+- ✅ `geo_contracts`, `geo_primitives`, `geo_nurbs`（形状参照）
+- ✅ `geo_core`（基本型）
+- ✅ `geo_commons`（共通定数）
+
+**禁止される依存**:
+- ❌ `cam_algorithms`（単向依存、逆はOK）
+- ❌ `cam_sim`（消費側への依存は不可）
+- ❌ `cam_entity`（表示層への依存は不可）
+
+**現行実装**:
+- `model/cam_core/src/toolpath.rs`
+- `model/cam_core/src/tool.rs`
+- `model/cam_core/src/artifact_binary.rs`
+
+---
+
+### 1.2 cam_algorithms（アルゴリズム層）✨ **新設候補**
+
+**責務**:
+- ToolPath 生成・最適化アルゴリズム
+- 干渉回避・衝突チェック
+- 経路順序最適化
+- 工具軌跡ビジュアライゼーション補助
+- 機械制約の適用・検証
+
+**許可される依存**:
+- ✅ `cam_core`（データ モデル利用）
+- ✅ `geo_algorithms`（交差/衝突判定）
+- ✅ `geo_primitives`, `geo_nurbs`（形状演算）
+- ✅ `geo_contracts`, `geo_core`, `geo_commons`
+
+**禁止される依存**:
+- ❌ `cam_sim`（シミュレーション側への依存禁止）
+- ❌ `cam_entity`（表示層への依存禁止）
+
+**位置づけ**:
+- `geo_algorithms` との対称性を確保
+- 形状演算よりも上位（CAM固有ロジック）
+
+**想定実装例**:
+- `cam_algorithms/src/path_optimization/` - 経路順序最適化
+- `cam_algorithms/src/collision_avoidance/` - 干渉回避
+- `cam_algorithms/src/machine_validation/` - 機械制約検証
+
+---
+
+### 1.3 cam_sim（CAM特化ユースケース実行層）
+
+**責務**:
+- ToolPath の実行シミュレーション
+- フレーム進行・時刻管理
+- 切削体積計算（離散幾何ベース）
+- シミュレーション結果のキャッシング
+
+**位置づけ**:
+- 物理配置は `model/` 配下だが、責務としては純粋データ層というより CAM ドメイン専用の実行・ユースケース層に近い
+- `geo_algorithms` より上位で、`cam_core` が持つ中立データを消費してシミュレーションという業務処理を実行する
+- そのため `cam_sim` は「Model内のCAM特化アプリケーション層」と捉えるのが実態に近い
+
+**許可される依存**:
+- ✅ `cam_core`（ToolPath 読み取り）
+- 🔶 `cam_algorithms`（段階的・必要時のみ）
+  - 理由: アルゴリズム関数の呼び出しが必要になる場合がある
+  - ただし常時依存は避ける。インターフェッシングは最小化
+- ✅ `geo_primitives`, `geo_algorithms`（幾何演算）
+
+**禁止される依存**:
+- ❌ `cam_entity`（表示層への直接依存は避ける）
+
+**現行実装**:
+- `model/cam_sim/src/`
+
+**`cam_algorithms` を参照する具体例**:
+- シミュレーション開始前の ToolPath 正規化
+  - 例: `cam_algorithms::path_optimization` が近接セグメント統合や順序調整を行い、`cam_sim` は最適化後の経路だけを実行する
+- ステップ実行中の機械制約再検証
+  - 例: ロータリ軸角度や姿勢補間結果が `MachineConstraint` を満たすかを `cam_algorithms::machine_validation` に問い合わせる
+- 再生品質向上のための事前干渉チェック
+  - 例: シミュレーション本体は切削除去量を担当し、ホルダ干渉や退避不足の判定だけを `cam_algorithms::collision_avoidance` に委譲する
+
+**設計上の整理**:
+- `cam_sim` が直接持つべきなのは時間進行、除去量更新、結果キャッシュ
+- 経路の改善、実行前検証、干渉判定ロジックは `cam_algorithms` に集約する
+- そのため `cam_sim -> cam_algorithms` は「実行前後の問い合わせ」に限定し、シミュレーション状態そのものは渡さない
+
+---
+
+### 1.4 cam_entity（表示/統合層）
+
+**責務**:
+- UI エンティティ（ToolPanel、PathPanel 等）
+- Tool/ToolPath の属性統合
+- ビューバインディング
+- 表示不要な内部状態に関する ID・メタデータ
+
+**許可される依存**:
+- ✅ `cam_core`, `cam_sim`（データ読み取り）
+- ✅ `geo_entity`（表示用形状エンティティ）
+
+**禁止される依存**:
+- ❌ `cam_algorithms`（消費側はアルゴリズムに直依存する設計は避ける）
+
+**現行実装**:
+- `model/cam_entity/src/`
+
+---
+
+## 2️⃣ 依存方針（確定案）
+
+### 依存グラフ（許可関係）
+
+```
+┌─────────────────────────────────────────────────────┐
+│  geo_* 層（CADベース幾何演算）                      │
+│  ├─ geo_core                                        │
+│  ├─ geo_primitives / geo_nurbs                      │
+│  └─ geo_algorithms（交差/衝突等）                   │
+└───────────────┬─────────────────────────────────────┘
+                │（依存許可）
+                ↓
+┌─────────────────────────────────────────────────────┐
+│  CAM層（CAMアルゴリズム・実行）                     │
+│                                                     │
+│  ┌─────────────────────────────────────────┐       │
+│  │ cam_core（データ基盤）                  │       │
+│  │ - ToolPath/Tool 定義                    │       │
+│  │ - Artifact I/O 契約                     │       │
+│  └─────────────────────────────────────────┘       │
+│              ↑        ↑         ↑                   │
+│              │        │         │(依存)             │
+│         (逆依存禁止) (逆依存禁止) (逆依存禁止)      │
+│              │        │         │                   │
+│  ┌───────────┴──┐  ┌──┴─────┐  ┌──┴──────┐        │
+│  │cam_algorithms│  │cam_sim  │  │cam_entity│       │
+│  │(新設)        │  │         │  │（UI層）  │       │
+│  └───────────┬──┘  └──┬─────┘  └──┬──────┘        │
+│              │(依存OK) │(段階的)    │(許可)        │
+│              └────┬────┘         ┌─┘              │
+│                   ↓              ↓                │
+│              [アルゴリズム]    [表示]            │
+└─────────────────────────────────────────────────────┘
+```
+
+### 依存方向の規則表
+
+| From | To | 許可 | 備考 |
+|------|-----|-----|------|
+| `cam_core` | `cam_algorithms` | ❌ | データ基盤は逆依存のみ |
+| `cam_core` | `cam_sim` | ❌ | シミュレーション層への依存不可 |
+| `cam_core` | `cam_entity` | ❌ | 表示層への依存不可 |
+| `cam_algorithms` | `cam_core` | ✅ | **正向依存OK** |
+| `cam_algorithms` | `geo_algorithms` | ✅ | 幾何アルゴリズムへの依存OK |
+| `cam_algorithms` | `cam_sim` | ❌ | シミュレーション層への依存不可 |
+| `cam_algorithms` | `cam_entity` | ❌ | 表示層への依存不可 |
+| `cam_sim` | `cam_core` | ✅ | データ読み取りOK |
+| `cam_sim` | `cam_algorithms` | 🔶 | **限定的 OK**（*1） |
+| `cam_sim` | `cam_entity` | ❌ | 直接依存は避ける |
+| `cam_entity` | `cam_core` | ✅ | データ読み取りOK |
+| `cam_entity` | `cam_algorithms` | ❌ | 存在しない関数呼び出し |
+| `cam_entity` | `cam_sim` | ✅ | シミュレーション読み取りOK |
+
+*1: `cam_sim -> cam_algorithms` について
+- **許可理由**: ツールパス再検証、干渉チェック再実行など、シミュレ中にアルゴリズムが必要な場合がある
+- **制約**: 逆依存（`cam_algorithms -> cam_sim`）は厳禁
+- **運用**: インターフェイスは最小化。FAT ファンクション は避ける
+
+---
+
+## 3️⃣ CAM層と geo_* 層の境界ルール
+
+### 原則
+
+```
+┌──────────────────────────────────┐
+│  geo_* 層                        │
+│  （汎用幾何演算・アルゴリズム）  │
+└──────────────────────────────────┘
+         ↑ 依存 (OK)
+         │
+┌──────────────────────────────────┐
+│  cam_* 層                        │
+│  （CAM固有ロジック）            │
+└──────────────────────────────────┘
+         │ 依存 OK
+         ↓
+[アプリケーション層：viewmodel etc] 
+```
+
+### 具体規則
+
+| 事項 | ルール |
+|------|--------|
+| **Shape 型参照** | CAM層は `geo_primitives` / `geo_nurbs` の形状を自由に使用可 |
+| **アルゴリズム呼び出し** | `geo_algorithms` の関数を `cam_algorithms` から呼び出し可。`cam_core` からは呼び出し不可 |
+| **Trait 実装** | CAM固有のtrait（例: `CamSpecificProperty`）は `cam_core` / `cam_algorithms` 側で定義。geo側は拡張不可 |
+| **逆依存** | **厳禁**: `geo_*` 層から `cam_*` への依存は一切不可 |
+
+---
+
+## 4️⃣ アーキテクチャスクリプト対応
+
+### 現状の制約スクリプト
+
+ファイル: `scripts/check_architecture_dependencies_simple.ps1`
+
+**拡張対象**:
+- `cam_algorithms` を新しいレイヤーとして追加
+- 上記「依存方向の規則表」をスクリプトで検証可能な形に記述
+
+**単なる許可表追加以外に必要な作業**:
+- `Cargo.toml` の workspace members に `model/cam_algorithms` を追加する
+- `scripts/_arch_rules_data.ps1` の `ARCH_LAYER_MAPPING` に `cam_algorithms` を追加する
+- `scripts/_arch_rules_data.ps1` の `ARCH_LAYERS` に `cam_algorithms` を Model 層として追加する
+- `scripts/_arch_rules_data.ps1` の `ARCH_ALLOWED_DEPS` に `cam_algorithms` 自身の許可依存と、既存クレート側の `cam_algorithms` 許可有無を反映する
+- `scripts/_arch_rules_data.ps1` の `ARCH_FORBIDDEN_DEPS` に `cam_algorithms` を含む禁止方向を反映する
+- 必要なら `ARCH_REQUIRED_MODEL_CRATES` に `cam_algorithms` を追加し、新設後は存在必須クレートとして扱う
+- `dev/architecture/ARCHITECTURE.md` 側の層構成説明も同時更新する
+
+**重要な整理**:
+- `check_architecture_dependencies_simple.ps1` 本体は共有ルールデータを読むだけなので、主変更点は `scripts/_arch_rules_data.ps1`
+- つまり「cam_algorithms 追加時はスクリプト反映が必須でセット実施」という認識で正しい
+- さらに実運用では、workspace 参加、設計ドキュメント更新、依存ルール更新を同一変更セットに含める必要がある
+
+**実装例** (pseudo-code):
+
+```ps1
+$allowed = @(
+    "cam_algorithms -> cam_core",
+    "cam_algorithms -> geo_algorithms",
+    "cam_sim -> cam_core",
+    "cam_sim -> cam_algorithms",  # 限定的（注記）
+    "cam_entity -> cam_core",
+    "cam_entity -> cam_sim",
+)
+
+$forbidden = @(
+    "cam_core -> cam_algorithms",
+    "cam_core -> cam_sim",
+    "cam_core -> cam_entity",
+)
+```
+
+---
+
+## 5️⃣ 最小 PoC（実装候補）
+
+新規 `cam_algorithms` 初版での最初の実装候補：
+
+### PoC-1: ToolPath 順序最適化（選定済み）
+
+**目的**: リコンフィグ移動時間を最小化  
+**スコープ**: 等高線レベル / Segment の順序入替え最適化  
+**難易度**: 中（組み合わせ最適化基盤実装）  
+**期間**: 1〜1.5週間  
+**関連Issue**: 後続の Issue #2XX として起票
+
+**選定理由**:
+- `cam_core` の既存 ToolPath 表現をそのまま入力に使える
+- `cam_sim` や UI に依存せず、`cam_algorithms` 単体の責務を検証しやすい
+- #426 の機械制約拡張より前でも着手でき、後続の制約検証とも競合しにくい
+
+### PoC-2: 機械制約検証
+
+**目的**: ToolPath の実行可能性を事前判定  
+**スコープ**: 回転軸範囲チェック（#426 に関連）  
+**難易度**: 低（単純な値チェック）  
+**期間**: 3〜5日  
+
+### PoC-3: 干渉回避（Pre）
+
+**目的**: 工具干渉チェック（全形状ペア）  
+**スコープ**: #338 / #350 等の collision 実装完了後  
+**難易度**: 高（Phase C に依存）  
+**期間**: TBD（後続スケジュール次第）
+
+---
+
+## 6️⃣ 後続実装 Issue への分割
+
+本設計確定後、以下の Issue を起票予定：
+
+| # | Title | 内容 | 依存 | 工数 |
+|---|-------|------|------|------|
+| TBD | [Phase X] cam_algorithms新設と最小実装 | クレート作成、カーゴ化、PoC-1 | #413 | 1-1.5w |
+| #426 | MachineConstraint拡張 | 直動軸・速度/加速度 | #413 | 1.5-2w |
+| TBD | [Phase X] ToolPath順序最適化アルゴリズム | 組み合わせ最適化実装 | 上記 | 1-1.5w |
+| TBD | [Phase X] 機械制約検証API | constraint check インターフェース | #426 | 0.5-1w |
+
+---
+
+## ✅ 受け入れ条件（本Issue #413 の完了条件）
+
+- [x] `cam_algorithms` 新設の採否が明文化される（✅ 採択）
+- [x] CAM クレート責務表（core/algorithms/sim/entity）が確定する（本文 Section 1）
+- [x] 依存方向の許可/禁止が文書化される（本文 Section 2）
+- [x] `scripts/check_architecture_dependencies_simple.ps1` の既存方針に反しない導入手順が定義される（本文 Section 4）
+- [x] 最小 PoC の対象が1件以上選定される（本文 Section 5 - PoC-1を選定）
+- [ ] 後続実装 Issue を起票できる粒度でスコープ分割される（本文 Section 6）
+
+---
+
+## 📎 関連ドキュメント
+
+- `dev/architecture/ARCHITECTURE.md` - 全体レイヤー構成
+- `dev/architecture/CAM_CRATE_DESIGN_PROPOSAL.md` - 旧設計（参考）
+- `dev/archive/issues/ISSUE_257_IMPLEMENTATION_PREP.md` - 5軸表現設計（完了）
+- Issue #411 - `read_artifact_v1` 導線統一
+- Issue #412 - artifact API 命名整理
+- Issue #426 - MachineConstraint拡張（本設計に依存）
+
+---
+
+## 📝 ステータス
+
+- **作成日**: 2026年3月25日
+- **設計段階**: 🔶 主要方針は承認済み、依存例を具体化して継続整理中
+- **実装開始**: ⏳ #413 完了 → 後続 Issue で実施

--- a/dev/architecture/ISSUE_413_DESIGN_SUMMARY.md
+++ b/dev/architecture/ISSUE_413_DESIGN_SUMMARY.md
@@ -1,0 +1,139 @@
+# Issue #413 設計差分サマリ
+
+**対象Issue**: #413  
+**目的**: `cam_algorithms` 新設判断と CAM クレート責務境界の固定  
+**更新日**: 2026年3月25日
+
+---
+
+## 1. 今回確定した判断
+
+### 1.1 `cam_algorithms` は新設する
+
+- 位置づけ: CAM 固有アルゴリズム層
+- 主責務: 経路生成、順序最適化、干渉回避、機械制約検証
+- 非責務: シミュレーション実行、UI 属性統合、中立データ保持
+
+### 1.2 `cam_sim` は CAM 特化ユースケース実行層として扱う
+
+- 物理配置は `model/` 配下
+- ただし責務は純粋データ層ではなく、CAM ドメイン専用の application 層に近い
+- 主責務: ToolPath 実行、時間進行、除去量更新、結果キャッシュ
+
+### 1.3 `cam_core` は中立データ基盤に限定する
+
+- ToolPath / Tool / artifact I/O / 最小機械制約を保持
+- `cam_algorithms` や `cam_sim` への逆依存は禁止
+
+---
+
+## 2. 依存方向の確定点
+
+### 許可
+
+- `cam_algorithms -> cam_core`
+- `cam_algorithms -> geo_algorithms`
+- `cam_sim -> cam_core`
+- `cam_sim -> cam_algorithms`（限定的）
+- `cam_entity -> cam_core`
+
+### 禁止
+
+- `cam_core -> cam_algorithms`
+- `cam_algorithms -> cam_sim`
+- `cam_entity -> cam_algorithms`
+- `geo_* -> cam_*`
+
+### 限定許可の意味
+
+- `cam_sim -> cam_algorithms` は、実行前後の問い合わせに限定する
+- `cam_sim` から `cam_algorithms` へ渡すのは ToolPath や制約検証用入力などの中立データに留める
+- シミュレーション内部状態を `cam_algorithms` に渡して密結合化しない
+
+---
+
+## 3. `cam_sim -> cam_algorithms` を許可する理由
+
+代表例は次の3点。
+
+1. ToolPath 実行前の順序最適化
+2. 姿勢補間後の機械制約再検証
+3. 再生前の干渉チェック委譲
+
+この整理により、`cam_sim` は実行器、`cam_algorithms` は計算器として責務が分離される。
+
+---
+
+## 4. PoC の選定結果
+
+### 選定対象
+
+- PoC-1: ToolPath 順序最適化
+
+### 選定理由
+
+- `cam_core` の既存 ToolPath 表現をそのまま入力に使える
+- `cam_algorithms` 単体責務を検証しやすい
+- `cam_sim` 実装や UI 実装へ依存しない
+- #426 の詳細拡張前でも先行できる
+
+---
+
+## 5. スクリプト反映で必要なこと
+
+`cam_algorithms` 導入時は、依存許可の追記だけでは不十分で、以下を同一変更セットで実施する。
+
+1. `Cargo.toml` の workspace members 更新
+2. `scripts/_arch_rules_data.ps1` の layer mapping 更新
+3. `scripts/_arch_rules_data.ps1` の layer group 更新
+4. `scripts/_arch_rules_data.ps1` の allowed deps 更新
+5. `scripts/_arch_rules_data.ps1` の forbidden deps 更新
+6. クレート作成後に required model crates 更新
+7. `ARCHITECTURE.md` と設計文書の同期更新
+
+注意:
+
+- 現時点では `model/cam_algorithms` が未作成のため、必須クレート一覧への追加は保留
+- 先に追加すると依存チェックが常時失敗する
+
+---
+
+## 6. 今回更新した文書
+
+- `dev/architecture/CAM_ALGORITHMS_DESIGN.md`
+- `dev/architecture/ARCHITECTURE.md`
+- `scripts/_arch_rules_data.ps1`
+
+---
+
+## 7. レビュー観点
+
+レビューでは特に次を確認する。
+
+1. `cam_sim` を application 層相当として扱う整理に違和感がないか
+2. `cam_sim -> cam_algorithms` の限定許可が広すぎないか
+3. `cam_entity` を計算非保持に固定して問題ないか
+4. `cam_core` に将来ロジックが逆流しない定義になっているか
+5. 後続 Issue 分割粒度が実装計画として十分か
+
+---
+
+## 8. 残課題
+
+- `cam_algorithms` クレートの実体は未作成
+- `scripts/_arch_rules_data.ps1` は設計メモ追記のみで、依存ルール自体は未有効化
+- 後続実装 Issue の起票番号は未確定
+
+---
+
+## 9. 設計完了の判定
+
+Issue #413 については、少なくとも以下は設計完了とみなせる。
+
+- `cam_algorithms` 新設採否
+- CAM クレート責務表
+- 許可/禁止依存の固定
+- PoC-1 の選定
+- スクリプト反映時の作業範囲整理
+
+未完了なのは、後続 Issue 起票と実クレート導入作業のみ。

--- a/scripts/_arch_rules_data.ps1
+++ b/scripts/_arch_rules_data.ps1
@@ -33,11 +33,30 @@ $ARCH_LAYERS = @{
     View      = @("render", "stage", "app")
 }
 
+# Issue #413 design note:
+# `cam_algorithms` 新設時は以下を同一変更セットで反映する。
+# 1. ARCH_LAYER_MAPPING に `cam_algorithms = "model/cam_algorithms"` を追加
+# 2. ARCH_LAYERS.Model に `cam_algorithms` を追加
+# 3. ARCH_ALLOWED_DEPS に以下を追加
+#    cam_algorithms = @("analysis", "cam_core", "geo_contracts", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs")
+# 4. 既存クレート側の許可依存を更新
+#    - cam_sim: `cam_algorithms` を限定的に許可
+#    - converter: 必要になるまで `cam_algorithms` は許可しない
+#    - cam_entity: `cam_algorithms` は許可しない
+# 5. ARCH_FORBIDDEN_DEPS に以下を反映
+#    - cam_core -> cam_algorithms を禁止
+#    - cam_entity -> cam_algorithms を禁止
+#    - cam_algorithms -> cam_sim を禁止
+#    - geo_* -> cam_algorithms を禁止
+# 6. クレート作成後に ARCH_REQUIRED_MODEL_CRATES へ追加する
+# 注意: クレート未作成の段階で ARCH_REQUIRED_MODEL_CRATES へ追加すると、依存チェックが必須クレート不足で失敗する。
+
 # Required model crates
 $ARCH_REQUIRED_MODEL_CRATES = @("geo_contracts", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity")
 
 # Allowed dependency rules
 # Last updated: 2026-03-20 (#318 Phase C: contracts-first dependency alignment)
+# Pending update: Issue #413 で `cam_algorithms` 新設時に CAM 依存ルールを追加する。
 $ARCH_ALLOWED_DEPS = @{
     analysis       = @()
     geo_contracts  = @("analysis", "geo_commons")
@@ -61,6 +80,7 @@ $ARCH_ALLOWED_DEPS = @{
 }
 
 # Forbidden dependency rules
+# Pending update: `cam_algorithms` 新設時は CAM 内の逆依存禁止をここへ追加する。
 $ARCH_FORBIDDEN_DEPS = @{
     geo_foundation = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
     geo_contracts  = @("geo_foundation", "geo_core", "geo_primitives", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "job_runtime", "graphics", "render", "stage", "app")


### PR DESCRIPTION
Closes #413

## 概要
CAM 関連クレートの責務境界を整理し、`cam_algorithms` 新設方針を設計として明文化しました。

今回の変更は実装追加ではなく、以下の判断を固定するためのドキュメント更新です。
- `cam_core` は中立データ基盤に限定
- `cam_algorithms` を CAM 固有アルゴリズム層として新設
- `cam_sim` を CAM 特化ユースケース実行層として位置づけ
- CAM 内部の許可/禁止依存を明文化
- `cam_algorithms` 導入時のスクリプト反映範囲を整理

## 変更内容
- `dev/architecture/CAM_ALGORITHMS_DESIGN.md` を追加
- `dev/architecture/ISSUE_413_DESIGN_SUMMARY.md` を追加
- `dev/architecture/ARCHITECTURE.md` を更新
- `scripts/_arch_rules_data.ps1` に `cam_algorithms` 導入時の更新ポイントを追記

## 主な判断
### cam_sim の位置づけ
`cam_sim` は `model/` 配下にあるが、責務としては純粋データ層ではなく CAM ドメイン専用のユースケース実行層とみなす。

### cam_sim -> cam_algorithms
限定的に許可。用途は以下を想定。
1. ToolPath 実行前の順序最適化
2. 姿勢補間後の機械制約再検証
3. 再生前の干渉チェック委譲

ただし、シミュレーション内部状態を渡す密結合は避け、実行前後の問い合わせに限定。

### 最小 PoC
PoC-1 として ToolPath 順序最適化を選定。

## テスト
ドキュメント更新とスクリプトコメント追加のみのため未実施。

## レビューポイント
1. `cam_sim` を CAM 特化 application 層相当とみなす整理に違和感がないか
2. `cam_sim -> cam_algorithms` の限定許可が妥当か
3. `cam_entity` を計算非保持に固定する整理で問題ないか
4. `cam_core` にロジックが逆流しないルールになっているか

## 備考
- `model/cam_algorithms` クレート自体は未作成
- 実装着手時は workspace 参加、依存ルール有効化、文書更新を同一変更セットで実施予定