### PR TITLE
[PR-2] feat: SpeedLimit/AccelerationLimit を MachineConstraint に追加

### DIFF
--- a/model/cam_core/src/lib.rs
+++ b/model/cam_core/src/lib.rs
@@ -51,8 +51,8 @@ pub use artifact_binary::{
     read_toolpath_payload_v1, write_interference_payload_v1, write_toolpath_payload_v1,
 };
 pub use machine_constraint::{
-    LinearAxisLabel, LinearAxisLimit, MachineAxisLabel, MachineConstraint, RotaryAxisLabel,
-    RotaryAxisLimit,
+    LinearAccelerationLimit, LinearAxisLabel, LinearAxisLimit, LinearSpeedLimit, MachineAxisLabel,
+    MachineConstraint, RotaryAccelerationLimit, RotaryAxisLabel, RotaryAxisLimit, RotarySpeedLimit,
 };
 pub use tolerance::CamTolerance;
 pub use tool::{Tool, ToolType};

--- a/model/cam_core/src/machine_constraint.rs
+++ b/model/cam_core/src/machine_constraint.rs
@@ -82,9 +82,85 @@ impl<T: Scalar> LinearAxisLimit<T> {
         }
     }
 
-    /// 指定座標がトラベル範囲に含まれるか
+    /// 指定座標が移動範囲に含まれるか
     pub fn contains_mm(&self, mm: T) -> bool {
         self.min_mm <= mm && mm <= self.max_mm
+    }
+}
+
+/// 直動軸の速度上限（mm/min）
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LinearSpeedLimit<T: Scalar = f64> {
+    /// 速度上限 [mm/min]
+    pub limit_mm_per_min: T,
+}
+
+impl<T: Scalar> LinearSpeedLimit<T> {
+    /// 直動軸の速度上限を作成
+    pub fn new(limit_mm_per_min: T) -> Self {
+        Self { limit_mm_per_min }
+    }
+
+    /// 指定速度が上限以下か
+    pub fn allows_mm_per_min(&self, requested_mm_per_min: T) -> bool {
+        requested_mm_per_min <= self.limit_mm_per_min
+    }
+}
+
+/// 回転軸の速度上限（deg/s）
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RotarySpeedLimit<T: Scalar = f64> {
+    /// 速度上限 [deg/s]
+    pub limit_deg_per_sec: T,
+}
+
+impl<T: Scalar> RotarySpeedLimit<T> {
+    /// 回転軸の速度上限を作成
+    pub fn new(limit_deg_per_sec: T) -> Self {
+        Self { limit_deg_per_sec }
+    }
+
+    /// 指定速度が上限以下か
+    pub fn allows_deg_per_sec(&self, requested_deg_per_sec: T) -> bool {
+        requested_deg_per_sec <= self.limit_deg_per_sec
+    }
+}
+
+/// 直動軸の加速度上限（mm/s^2）
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LinearAccelerationLimit<T: Scalar = f64> {
+    /// 加速度上限 [mm/s^2]
+    pub limit_mm_per_sec2: T,
+}
+
+impl<T: Scalar> LinearAccelerationLimit<T> {
+    /// 直動軸の加速度上限を作成
+    pub fn new(limit_mm_per_sec2: T) -> Self {
+        Self { limit_mm_per_sec2 }
+    }
+
+    /// 指定加速度が上限以下か
+    pub fn allows_mm_per_sec2(&self, requested_mm_per_sec2: T) -> bool {
+        requested_mm_per_sec2 <= self.limit_mm_per_sec2
+    }
+}
+
+/// 回転軸の加速度上限（deg/s^2）
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RotaryAccelerationLimit<T: Scalar = f64> {
+    /// 加速度上限 [deg/s^2]
+    pub limit_deg_per_sec2: T,
+}
+
+impl<T: Scalar> RotaryAccelerationLimit<T> {
+    /// 回転軸の加速度上限を作成
+    pub fn new(limit_deg_per_sec2: T) -> Self {
+        Self { limit_deg_per_sec2 }
+    }
+
+    /// 指定加速度が上限以下か
+    pub fn allows_deg_per_sec2(&self, requested_deg_per_sec2: T) -> bool {
+        requested_deg_per_sec2 <= self.limit_deg_per_sec2
     }
 }
 
@@ -122,6 +198,14 @@ pub struct MachineConstraint<T: Scalar = f64> {
     pub linear_axis_limits: Vec<LinearAxisLimit<T>>,
     /// 回転軸の旋回範囲定義
     pub rotary_axis_limits: Vec<RotaryAxisLimit<T>>,
+    /// 直動軸の速度上限 [mm/min]
+    pub linear_speed_limit: Option<LinearSpeedLimit<T>>,
+    /// 回転軸の速度上限 [deg/s]
+    pub rotary_speed_limit: Option<RotarySpeedLimit<T>>,
+    /// 直動軸の加速度上限 [mm/s^2]
+    pub linear_acceleration_limit: Option<LinearAccelerationLimit<T>>,
+    /// 回転軸の加速度上限 [deg/s^2]
+    pub rotary_acceleration_limit: Option<RotaryAccelerationLimit<T>>,
 }
 
 impl<T: Scalar> MachineConstraint<T> {
@@ -130,6 +214,10 @@ impl<T: Scalar> MachineConstraint<T> {
         Self {
             linear_axis_limits: Vec::new(),
             rotary_axis_limits,
+            linear_speed_limit: None,
+            rotary_speed_limit: None,
+            linear_acceleration_limit: None,
+            rotary_acceleration_limit: None,
         }
     }
 
@@ -138,6 +226,10 @@ impl<T: Scalar> MachineConstraint<T> {
         Self {
             linear_axis_limits: Vec::new(),
             rotary_axis_limits: Vec::new(),
+            linear_speed_limit: None,
+            rotary_speed_limit: None,
+            linear_acceleration_limit: None,
+            rotary_acceleration_limit: None,
         }
     }
 

--- a/model/cam_core/src/machine_constraint_tests.rs
+++ b/model/cam_core/src/machine_constraint_tests.rs
@@ -19,6 +19,10 @@ fn test_machine_constraint_linear_limit_for_axis() {
             LinearAxisLimit::new(LinearAxisLabel::Z, -100.0, 0.0),
         ],
         rotary_axis_limits: vec![RotaryAxisLimit::new(RotaryAxisLabel::B, -30.0, 120.0)],
+        linear_speed_limit: None,
+        rotary_speed_limit: None,
+        linear_acceleration_limit: None,
+        rotary_acceleration_limit: None,
     };
 
     let x_limit = constraint.linear_limit_for_axis(LinearAxisLabel::X);
@@ -65,6 +69,10 @@ fn test_machine_constraint_empty() {
 
     assert!(constraint.linear_axis_limits.is_empty());
     assert!(constraint.rotary_axis_limits.is_empty());
+    assert_eq!(constraint.linear_speed_limit, None);
+    assert_eq!(constraint.rotary_speed_limit, None);
+    assert_eq!(constraint.linear_acceleration_limit, None);
+    assert_eq!(constraint.rotary_acceleration_limit, None);
     assert_eq!(constraint.linear_limit_for_axis(LinearAxisLabel::X), None);
     assert_eq!(constraint.rotary_limit_for_axis(RotaryAxisLabel::B), None);
 }
@@ -80,6 +88,10 @@ fn test_machine_constraint_new_with_rotary_only() {
 
     assert_eq!(constraint.rotary_axis_limits, rotary_limits);
     assert!(constraint.linear_axis_limits.is_empty());
+    assert_eq!(constraint.linear_speed_limit, None);
+    assert_eq!(constraint.rotary_speed_limit, None);
+    assert_eq!(constraint.linear_acceleration_limit, None);
+    assert_eq!(constraint.rotary_acceleration_limit, None);
 }
 
 #[test]
@@ -94,6 +106,10 @@ fn test_machine_constraint_mixed_axes() {
             RotaryAxisLimit::new(RotaryAxisLabel::A, 0.0, 360.0),
             RotaryAxisLimit::new(RotaryAxisLabel::B, -30.0, 120.0),
         ],
+        linear_speed_limit: Some(LinearSpeedLimit::new(12000.0)),
+        rotary_speed_limit: Some(RotarySpeedLimit::new(100.0)),
+        linear_acceleration_limit: Some(LinearAccelerationLimit::new(10000.0)),
+        rotary_acceleration_limit: Some(RotaryAccelerationLimit::new(500.0)),
     };
 
     // 直動軸確認
@@ -119,4 +135,40 @@ fn test_machine_constraint_mixed_axes() {
             .rotary_limit_for_axis(RotaryAxisLabel::C)
             .is_none()
     );
+
+    assert_eq!(
+        constraint.linear_speed_limit,
+        Some(LinearSpeedLimit::new(12000.0))
+    );
+    assert_eq!(
+        constraint.rotary_speed_limit,
+        Some(RotarySpeedLimit::new(100.0))
+    );
+    assert_eq!(
+        constraint.linear_acceleration_limit,
+        Some(LinearAccelerationLimit::new(10000.0))
+    );
+    assert_eq!(
+        constraint.rotary_acceleration_limit,
+        Some(RotaryAccelerationLimit::new(500.0))
+    );
+}
+
+#[test]
+fn test_speed_and_acceleration_limits_allow_values() {
+    let linear_speed = LinearSpeedLimit::new(12000.0);
+    assert!(linear_speed.allows_mm_per_min(12000.0));
+    assert!(!linear_speed.allows_mm_per_min(12000.1));
+
+    let rotary_speed = RotarySpeedLimit::new(100.0);
+    assert!(rotary_speed.allows_deg_per_sec(99.9));
+    assert!(!rotary_speed.allows_deg_per_sec(100.1));
+
+    let linear_acceleration = LinearAccelerationLimit::new(10000.0);
+    assert!(linear_acceleration.allows_mm_per_sec2(10000.0));
+    assert!(!linear_acceleration.allows_mm_per_sec2(10000.1));
+
+    let rotary_acceleration = RotaryAccelerationLimit::new(500.0);
+    assert!(rotary_acceleration.allows_deg_per_sec2(500.0));
+    assert!(!rotary_acceleration.allows_deg_per_sec2(500.1));
 }


### PR DESCRIPTION
## 概要
Issue #432 (Phase 2) に対応し、`cam_core::machine_constraint` に速度・加速度リミット型を追加しました。既存API互換を維持しつつ `MachineConstraint` を非破壊拡張しています。

## 変更内容
- 新規型を追加
  - `LinearSpeedLimit<T>` (`limit_mm_per_min`)
  - `RotarySpeedLimit<T>` (`limit_deg_per_sec`)
  - `LinearAccelerationLimit<T>` (`limit_mm_per_sec2`)
  - `RotaryAccelerationLimit<T>` (`limit_deg_per_sec2`)
- 各型に基本メソッドを追加
  - `new(...)`
  - `allows_*` 系ヘルパー
- `MachineConstraint<T>` を拡張
  - `linear_speed_limit: Option<LinearSpeedLimit<T>>`
  - `rotary_speed_limit: Option<RotarySpeedLimit<T>>`
  - `linear_acceleration_limit: Option<LinearAccelerationLimit<T>>`
  - `rotary_acceleration_limit: Option<RotaryAccelerationLimit<T>>`
- 既存コンストラクタ互換維持
  - `MachineConstraint::new(rotary_axis_limits)` のシグネチャ不変
  - 新規4フィールドは `None` 初期化
- `cam_core` 再エクスポートを更新

## テスト
- `cargo fmt --all`
- `cargo clippy --lib -p cam_core -- -D warnings`
- `cargo test -p cam_core machine_constraint --lib`
- `cargo test --workspace`

## 互換性
- 既存の `LinearAxisLimit` / `RotaryAxisLimit` と検索メソッド挙動は不変
- 既存コードは新規フィールド未指定 (`None`) のまま継続利用可能

## 関連
- Refs #426
- Refs #432