### PR TITLE
[Phase 3] feature: 角度正規化/Rewind型と制約検証ロジック実装 (#434)

### DIFF
--- a/model/cam_core/src/lib.rs
+++ b/model/cam_core/src/lib.rs
@@ -59,11 +59,15 @@ pub use tool::{Tool, ToolType};
 pub use toolpath::{
     ArcDirection, ContourLevelPath, CuttingDirection, KinematicMode, MachineAxisKind,
     MachineAxisValue, MachineConfigurationClass, PathGeometry, PathSegment, PoseAnnotatedSegment,
-    PoseDataPolicy, PoseInterpolationPolicy, SegmentType, TOOLPATH_SCHEMA_VERSION_V0_1, ToolPath,
+    PoseDataPolicy, PoseInterpolationPolicy, SEGMENT_EXT_TAG_LINEAR_ACCEL_MM_PER_SEC2,
+    SEGMENT_EXT_TAG_ROTARY_ACCEL_DEG_PER_SEC2, SegmentType, TOOLPATH_SCHEMA_VERSION_V0_1, ToolPath,
     ToolPathKinematicMeta, ToolPose, ToolPoseSpan,
 };
 pub use toolset::{
     Holder, HolderInterferenceOffset, HolderSegment, HolderSegmentKind, ToolSet,
     ToolSetReferencePoint,
 };
-pub use validation::{ValidationError, validate_2d_contour};
+pub use validation::{
+    ValidationError, validate_2d_contour, validate_pose_segments_machine_constraints,
+    validate_toolpath_machine_constraints,
+};

--- a/model/cam_core/src/tolerance.rs
+++ b/model/cam_core/src/tolerance.rs
@@ -9,6 +9,7 @@
 //! - **閉曲線判定トレランス**: 始点と終点の距離がこの値以内なら閉じていると判定
 //! - **工具クリアランス比率**: 工具径に対する最小クリアランス（干渉回避）
 //! - **機械精度**: NC機械の位置決め精度
+//! - **角度トレランス**: 回転軸角度の制約判定に用いる許容誤差
 //!
 //! # 例
 //!
@@ -24,6 +25,7 @@
 //!     closure_tolerance: 0.0001,  // 高精度機械
 //!     tool_clearance_ratio: 0.05,  // タイトなクリアランス
 //!     machine_accuracy: 0.001,
+//!     angle_tolerance_deg: 0.001,
 //! };
 //! ```
 
@@ -32,14 +34,17 @@ use analysis::Scalar;
 pub const CAM_DEFAULT_CLOSURE_TOLERANCE_F64: f64 = 0.001;
 pub const CAM_DEFAULT_TOOL_CLEARANCE_RATIO_F64: f64 = 0.1;
 pub const CAM_DEFAULT_MACHINE_ACCURACY_F64: f64 = 0.01;
+pub const CAM_DEFAULT_ANGLE_TOLERANCE_DEG_F64: f64 = 0.01;
 
 pub const CAM_HIGH_PRECISION_CLOSURE_TOLERANCE_F64: f64 = 0.0001;
 pub const CAM_HIGH_PRECISION_TOOL_CLEARANCE_RATIO_F64: f64 = 0.05;
 pub const CAM_HIGH_PRECISION_MACHINE_ACCURACY_F64: f64 = 0.001;
+pub const CAM_HIGH_PRECISION_ANGLE_TOLERANCE_DEG_F64: f64 = 0.001;
 
 pub const CAM_LOW_PRECISION_CLOSURE_TOLERANCE_F64: f64 = 0.01;
 pub const CAM_LOW_PRECISION_TOOL_CLEARANCE_RATIO_F64: f64 = 0.2;
 pub const CAM_LOW_PRECISION_MACHINE_ACCURACY_F64: f64 = 0.1;
+pub const CAM_LOW_PRECISION_ANGLE_TOLERANCE_DEG_F64: f64 = 0.1;
 
 /// CAM用トレランス設定
 ///
@@ -71,6 +76,15 @@ pub struct CamTolerance<T: Scalar = f64> {
     /// - 一般的なNCフライス: `0.01` mm
     /// - 高精度機: `0.001` mm
     pub machine_accuracy: T,
+
+    /// 角度トレランス（deg）
+    ///
+    /// 回転軸角度の制約判定で使用する許容誤差です。
+    ///
+    /// **推奨値**:
+    /// - 一般的なNCフライス: `0.01` deg
+    /// - 高精度機: `0.001` deg
+    pub angle_tolerance_deg: T,
 }
 
 impl<T: Scalar> Default for CamTolerance<T> {
@@ -79,11 +93,13 @@ impl<T: Scalar> Default for CamTolerance<T> {
     /// - `closure_tolerance`: 0.001 mm
     /// - `tool_clearance_ratio`: 0.1（10%）
     /// - `machine_accuracy`: 0.01 mm（一般的なNCフライス）
+    /// - `angle_tolerance_deg`: 0.01 deg
     fn default() -> Self {
         Self {
             closure_tolerance: T::from_f64(CAM_DEFAULT_CLOSURE_TOLERANCE_F64),
             tool_clearance_ratio: T::from_f64(CAM_DEFAULT_TOOL_CLEARANCE_RATIO_F64),
             machine_accuracy: T::from_f64(CAM_DEFAULT_MACHINE_ACCURACY_F64),
+            angle_tolerance_deg: T::from_f64(CAM_DEFAULT_ANGLE_TOLERANCE_DEG_F64),
         }
     }
 }
@@ -96,19 +112,26 @@ impl<T: Scalar> CamTolerance<T> {
     /// - `closure_tolerance`: 閉曲線判定トレランス（mm）
     /// - `tool_clearance_ratio`: 工具クリアランス比率
     /// - `machine_accuracy`: 機械精度（mm）
+    /// - `angle_tolerance_deg`: 角度トレランス（deg）
     ///
     /// # 例
     ///
     /// ```
     /// use cam_core::CamTolerance;
     ///
-    /// let tolerance = CamTolerance::new(0.001, 0.1, 0.01);
+    /// let tolerance = CamTolerance::new(0.001, 0.1, 0.01, 0.01);
     /// ```
-    pub fn new(closure_tolerance: T, tool_clearance_ratio: T, machine_accuracy: T) -> Self {
+    pub fn new(
+        closure_tolerance: T,
+        tool_clearance_ratio: T,
+        machine_accuracy: T,
+        angle_tolerance_deg: T,
+    ) -> Self {
         Self {
             closure_tolerance,
             tool_clearance_ratio,
             machine_accuracy,
+            angle_tolerance_deg,
         }
     }
 
@@ -117,11 +140,13 @@ impl<T: Scalar> CamTolerance<T> {
     /// - `closure_tolerance`: 0.0001 mm
     /// - `tool_clearance_ratio`: 0.05（5%）
     /// - `machine_accuracy`: 0.001 mm
+    /// - `angle_tolerance_deg`: 0.001 deg
     pub fn high_precision() -> Self {
         Self {
             closure_tolerance: T::from_f64(CAM_HIGH_PRECISION_CLOSURE_TOLERANCE_F64),
             tool_clearance_ratio: T::from_f64(CAM_HIGH_PRECISION_TOOL_CLEARANCE_RATIO_F64),
             machine_accuracy: T::from_f64(CAM_HIGH_PRECISION_MACHINE_ACCURACY_F64),
+            angle_tolerance_deg: T::from_f64(CAM_HIGH_PRECISION_ANGLE_TOLERANCE_DEG_F64),
         }
     }
 
@@ -130,11 +155,13 @@ impl<T: Scalar> CamTolerance<T> {
     /// - `closure_tolerance`: 0.01 mm
     /// - `tool_clearance_ratio`: 0.2（20%）
     /// - `machine_accuracy`: 0.1 mm
+    /// - `angle_tolerance_deg`: 0.1 deg
     pub fn low_precision() -> Self {
         Self {
             closure_tolerance: T::from_f64(CAM_LOW_PRECISION_CLOSURE_TOLERANCE_F64),
             tool_clearance_ratio: T::from_f64(CAM_LOW_PRECISION_TOOL_CLEARANCE_RATIO_F64),
             machine_accuracy: T::from_f64(CAM_LOW_PRECISION_MACHINE_ACCURACY_F64),
+            angle_tolerance_deg: T::from_f64(CAM_LOW_PRECISION_ANGLE_TOLERANCE_DEG_F64),
         }
     }
 
@@ -201,6 +228,10 @@ mod tests {
             CAM_DEFAULT_TOOL_CLEARANCE_RATIO_F64
         );
         assert_eq!(tolerance.machine_accuracy, CAM_DEFAULT_MACHINE_ACCURACY_F64);
+        assert_eq!(
+            tolerance.angle_tolerance_deg,
+            CAM_DEFAULT_ANGLE_TOLERANCE_DEG_F64
+        );
     }
 
     #[test]
@@ -217,6 +248,10 @@ mod tests {
         assert_eq!(
             tolerance.machine_accuracy,
             CAM_HIGH_PRECISION_MACHINE_ACCURACY_F64
+        );
+        assert_eq!(
+            tolerance.angle_tolerance_deg,
+            CAM_HIGH_PRECISION_ANGLE_TOLERANCE_DEG_F64
         );
     }
 

--- a/model/cam_core/src/toolpath.rs
+++ b/model/cam_core/src/toolpath.rs
@@ -49,6 +49,11 @@ use geo_algorithms::{Point3D, Vector3D};
 /// ToolPath wire schema version used by artifact binary v0.1.
 pub const TOOLPATH_SCHEMA_VERSION_V0_1: (u16, u16) = (0, 1);
 
+/// セグメント拡張属性タグ: 線形加速度ヒント [mm/s^2]
+pub const SEGMENT_EXT_TAG_LINEAR_ACCEL_MM_PER_SEC2: i16 = -101;
+/// セグメント拡張属性タグ: 回転加速度ヒント [deg/s^2]
+pub const SEGMENT_EXT_TAG_ROTARY_ACCEL_DEG_PER_SEC2: i16 = -102;
+
 /// 円弧方向
 ///
 /// Gコードの円弧補間（G02/G03）に対応します。
@@ -549,6 +554,68 @@ impl<T: Scalar> PathSegment<T> {
             }
         }
     }
+
+    /// 線形加速度ヒントを拡張属性として設定する。
+    pub fn with_linear_acceleration_hint_mm_per_sec2(
+        mut self,
+        acceleration_mm_per_sec2: f64,
+    ) -> Self {
+        upsert_ext_attr_f64(
+            &mut self.ext_attributes,
+            SEGMENT_EXT_TAG_LINEAR_ACCEL_MM_PER_SEC2,
+            acceleration_mm_per_sec2,
+        );
+        self
+    }
+
+    /// 回転加速度ヒントを拡張属性として設定する。
+    pub fn with_rotary_acceleration_hint_deg_per_sec2(
+        mut self,
+        acceleration_deg_per_sec2: f64,
+    ) -> Self {
+        upsert_ext_attr_f64(
+            &mut self.ext_attributes,
+            SEGMENT_EXT_TAG_ROTARY_ACCEL_DEG_PER_SEC2,
+            acceleration_deg_per_sec2,
+        );
+        self
+    }
+
+    /// 線形加速度ヒント [mm/s^2] を取得する。
+    pub fn linear_acceleration_hint_mm_per_sec2(&self) -> Option<f64> {
+        read_ext_attr_f64(
+            &self.ext_attributes,
+            SEGMENT_EXT_TAG_LINEAR_ACCEL_MM_PER_SEC2,
+        )
+    }
+
+    /// 回転加速度ヒント [deg/s^2] を取得する。
+    pub fn rotary_acceleration_hint_deg_per_sec2(&self) -> Option<f64> {
+        read_ext_attr_f64(
+            &self.ext_attributes,
+            SEGMENT_EXT_TAG_ROTARY_ACCEL_DEG_PER_SEC2,
+        )
+    }
+}
+
+fn upsert_ext_attr_f64(ext_attributes: &mut Vec<ExtAttribute>, tag: i16, value: f64) {
+    let encoded = value.to_le_bytes().to_vec();
+    if let Some(existing) = ext_attributes.iter_mut().find(|attr| attr.tag == tag) {
+        existing.data = encoded;
+    } else {
+        ext_attributes.push(ExtAttribute::new(tag, encoded));
+    }
+}
+
+fn read_ext_attr_f64(ext_attributes: &[ExtAttribute], tag: i16) -> Option<f64> {
+    let attr = ext_attributes.iter().find(|attr| attr.tag == tag)?;
+    if attr.data.len() != 8 {
+        return None;
+    }
+
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(&attr.data);
+    Some(f64::from_le_bytes(bytes))
 }
 
 /// 等高線レベル経路

--- a/model/cam_core/src/toolpath_tests.rs
+++ b/model/cam_core/src/toolpath_tests.rs
@@ -334,3 +334,40 @@ fn test_pose_annotated_segment_creation() {
     assert_eq!(annotated.pose_span.start_pose, start_pose);
     assert_eq!(annotated.pose_span.end_pose, end_pose);
 }
+
+#[test]
+fn test_path_segment_acceleration_hints_round_trip() {
+    let segment = PathSegment::new_line(
+        Point3D::new(0.0, 0.0, 0.0),
+        Point3D::new(1.0, 0.0, 0.0),
+        SegmentType::Rapid,
+    )
+    .with_linear_acceleration_hint_mm_per_sec2(25.5)
+    .with_rotary_acceleration_hint_deg_per_sec2(120.25);
+
+    assert_eq!(segment.linear_acceleration_hint_mm_per_sec2(), Some(25.5));
+    assert_eq!(
+        segment.rotary_acceleration_hint_deg_per_sec2(),
+        Some(120.25)
+    );
+}
+
+#[test]
+fn test_path_segment_acceleration_hint_overwrite() {
+    let segment = PathSegment::new_line(
+        Point3D::new(0.0, 0.0, 0.0),
+        Point3D::new(1.0, 0.0, 0.0),
+        SegmentType::Rapid,
+    )
+    .with_linear_acceleration_hint_mm_per_sec2(10.0)
+    .with_linear_acceleration_hint_mm_per_sec2(30.0);
+
+    assert_eq!(segment.linear_acceleration_hint_mm_per_sec2(), Some(30.0));
+
+    let linear_tag_count = segment
+        .ext_attributes
+        .iter()
+        .filter(|attr| attr.tag == SEGMENT_EXT_TAG_LINEAR_ACCEL_MM_PER_SEC2)
+        .count();
+    assert_eq!(linear_tag_count, 1);
+}

--- a/model/cam_core/src/validation.rs
+++ b/model/cam_core/src/validation.rs
@@ -7,6 +7,7 @@
 //! Phase 1では以下の検証機能を実装します：
 //!
 //! - **2D輪郭の閉曲線判定**: 始点と終点の距離がトレランス以内か検証
+//! - **機械制約チェック**: 送り速度と機械軸値が制約内か検証
 //!
 //! # 例
 //!
@@ -28,8 +29,15 @@
 //! ```
 
 use crate::tolerance::CamTolerance;
+use crate::{
+    LinearAxisLabel, MachineAxisKind, MachineAxisValue, MachineConstraint, PathSegment,
+    PoseAnnotatedSegment, RotaryAxisLabel, SegmentType, ToolPath,
+};
 use analysis::Scalar;
-use geo_algorithms::Point2D;
+use geo_algorithms::{
+    Point2D, validate_linear_acceleration_mm_per_s2, validate_linear_speed_mm_per_min,
+    validate_linear_travel_mm, validate_rotary_acceleration_deg_per_s2, validate_rotary_angle_deg,
+};
 
 /// 検証エラー
 ///
@@ -56,6 +64,80 @@ pub enum ValidationError {
 
     /// 2D輪郭が空
     EmptyContour,
+
+    /// セグメント送り速度が機械制約を超過
+    FeedRateLimitExceeded {
+        /// ToolPath内のセグメントインデックス
+        segment_index: usize,
+        /// 要求送り速度 [mm/min]
+        feed_rate: f64,
+        /// 上限 [mm/min]
+        max_feed_rate: f64,
+    },
+
+    /// 線形加速度が機械制約を超過
+    LinearAccelerationLimitExceeded {
+        /// ToolPath内のセグメントインデックス
+        segment_index: usize,
+        /// 要求加速度 [mm/s^2]
+        acceleration_mm_per_sec2: f64,
+        /// 上限 [mm/s^2]
+        max_acceleration_mm_per_sec2: f64,
+    },
+
+    /// 回転加速度が機械制約を超過
+    RotaryAccelerationLimitExceeded {
+        /// ToolPath内のセグメントインデックス
+        segment_index: usize,
+        /// 要求加速度 [deg/s^2]
+        acceleration_deg_per_sec2: f64,
+        /// 上限 [deg/s^2]
+        max_acceleration_deg_per_sec2: f64,
+    },
+
+    /// 直動軸値が移動範囲を超過
+    LinearAxisLimitExceeded {
+        /// 姿勢セグメント配列内のインデックス
+        segment_index: usize,
+        /// どちらの姿勢か（start / end）
+        pose_endpoint: &'static str,
+        /// 軸名
+        axis_name: String,
+        /// 現在値 [mm]
+        value_mm: f64,
+        /// 最小値 [mm]
+        min_mm: f64,
+        /// 最大値 [mm]
+        max_mm: f64,
+    },
+
+    /// 回転軸値が旋回範囲を超過
+    RotaryAxisLimitExceeded {
+        /// 姿勢セグメント配列内のインデックス
+        segment_index: usize,
+        /// どちらの姿勢か（start / end）
+        pose_endpoint: &'static str,
+        /// 軸名
+        axis_name: String,
+        /// 現在値 [deg]
+        value_deg: f64,
+        /// 最小値 [deg]
+        min_deg: f64,
+        /// 最大値 [deg]
+        max_deg: f64,
+    },
+
+    /// サポート外の機械軸名
+    UnsupportedMachineAxis {
+        /// 姿勢セグメント配列内のインデックス
+        segment_index: usize,
+        /// どちらの姿勢か（start / end）
+        pose_endpoint: &'static str,
+        /// 軸名
+        axis_name: String,
+        /// 軸種別
+        axis_kind: MachineAxisKind,
+    },
 }
 
 impl std::fmt::Display for ValidationError {
@@ -75,6 +157,67 @@ impl std::fmt::Display for ValidationError {
                 point_count
             ),
             ValidationError::EmptyContour => write!(f, "Contour is empty"),
+            ValidationError::FeedRateLimitExceeded {
+                segment_index,
+                feed_rate,
+                max_feed_rate,
+            } => write!(
+                f,
+                "Feed rate exceeds machine limit at segment {}: feed_rate={:.6}, max_feed_rate={:.6}",
+                segment_index, feed_rate, max_feed_rate
+            ),
+            ValidationError::LinearAccelerationLimitExceeded {
+                segment_index,
+                acceleration_mm_per_sec2,
+                max_acceleration_mm_per_sec2,
+            } => write!(
+                f,
+                "Linear acceleration exceeds machine limit at segment {}: acceleration_mm_per_sec2={:.6}, max_acceleration_mm_per_sec2={:.6}",
+                segment_index, acceleration_mm_per_sec2, max_acceleration_mm_per_sec2
+            ),
+            ValidationError::RotaryAccelerationLimitExceeded {
+                segment_index,
+                acceleration_deg_per_sec2,
+                max_acceleration_deg_per_sec2,
+            } => write!(
+                f,
+                "Rotary acceleration exceeds machine limit at segment {}: acceleration_deg_per_sec2={:.6}, max_acceleration_deg_per_sec2={:.6}",
+                segment_index, acceleration_deg_per_sec2, max_acceleration_deg_per_sec2
+            ),
+            ValidationError::LinearAxisLimitExceeded {
+                segment_index,
+                pose_endpoint,
+                axis_name,
+                value_mm,
+                min_mm,
+                max_mm,
+            } => write!(
+                f,
+                "Linear axis out of range at segment {} ({}) axis {}: value_mm={:.6}, range=[{:.6}, {:.6}]",
+                segment_index, pose_endpoint, axis_name, value_mm, min_mm, max_mm
+            ),
+            ValidationError::RotaryAxisLimitExceeded {
+                segment_index,
+                pose_endpoint,
+                axis_name,
+                value_deg,
+                min_deg,
+                max_deg,
+            } => write!(
+                f,
+                "Rotary axis out of range at segment {} ({}) axis {}: value_deg={:.6}, range=[{:.6}, {:.6}]",
+                segment_index, pose_endpoint, axis_name, value_deg, min_deg, max_deg
+            ),
+            ValidationError::UnsupportedMachineAxis {
+                segment_index,
+                pose_endpoint,
+                axis_name,
+                axis_kind,
+            } => write!(
+                f,
+                "Unsupported machine axis at segment {} ({}) axis {} ({:?})",
+                segment_index, pose_endpoint, axis_name, axis_kind
+            ),
         }
     }
 }
@@ -150,10 +293,243 @@ pub fn validate_2d_contour<T: Scalar>(
     Ok(())
 }
 
+/// ToolPathの送り速度が機械制約内かを検証
+pub fn validate_toolpath_machine_constraints<T: Scalar + std::iter::Sum>(
+    toolpath: &ToolPath<T>,
+    machine_constraint: &MachineConstraint<T>,
+    tolerance: &CamTolerance<T>,
+) -> Result<(), ValidationError> {
+    let Some(linear_speed_limit) = machine_constraint.linear_speed_limit else {
+        return Ok(());
+    };
+
+    let max_feed = linear_speed_limit.limit_mm_per_min.to_f64();
+    let tol = tolerance.machine_accuracy.to_f64();
+    let linear_accel_limit = machine_constraint
+        .linear_acceleration_limit
+        .map(|limit| limit.limit_mm_per_sec2.to_f64());
+    let rotary_accel_limit = machine_constraint
+        .rotary_acceleration_limit
+        .map(|limit| limit.limit_deg_per_sec2.to_f64());
+
+    for (segment_index, segment) in collect_toolpath_segments(toolpath).into_iter().enumerate() {
+        let Some(feed_rate) = segment_feed_rate(segment) else {
+            continue;
+        };
+
+        let feed = feed_rate.to_f64();
+        let result = validate_linear_speed_mm_per_min(feed, 0.0, max_feed, tol);
+        if !result.is_valid() {
+            return Err(ValidationError::FeedRateLimitExceeded {
+                segment_index,
+                feed_rate: feed,
+                max_feed_rate: max_feed,
+            });
+        }
+
+        if let (Some(max_linear_accel), Some(requested_linear_accel)) = (
+            linear_accel_limit,
+            segment.linear_acceleration_hint_mm_per_sec2(),
+        ) {
+            let result = validate_linear_acceleration_mm_per_s2(
+                requested_linear_accel,
+                0.0,
+                max_linear_accel,
+                tol,
+            );
+            if !result.is_valid() {
+                return Err(ValidationError::LinearAccelerationLimitExceeded {
+                    segment_index,
+                    acceleration_mm_per_sec2: requested_linear_accel,
+                    max_acceleration_mm_per_sec2: max_linear_accel,
+                });
+            }
+        }
+
+        if let (Some(max_rotary_accel), Some(requested_rotary_accel)) = (
+            rotary_accel_limit,
+            segment.rotary_acceleration_hint_deg_per_sec2(),
+        ) {
+            let result = validate_rotary_acceleration_deg_per_s2(
+                requested_rotary_accel,
+                0.0,
+                max_rotary_accel,
+                tol,
+            );
+            if !result.is_valid() {
+                return Err(ValidationError::RotaryAccelerationLimitExceeded {
+                    segment_index,
+                    acceleration_deg_per_sec2: requested_rotary_accel,
+                    max_acceleration_deg_per_sec2: max_rotary_accel,
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// 姿勢付きセグメント列の機械軸値が制約内かを検証
+pub fn validate_pose_segments_machine_constraints<T: Scalar>(
+    segments: &[PoseAnnotatedSegment<T>],
+    machine_constraint: &MachineConstraint<T>,
+    tolerance: &CamTolerance<T>,
+) -> Result<(), ValidationError> {
+    let linear_tol_mm = tolerance.machine_accuracy.to_f64();
+    let rotary_tol_deg = tolerance.angle_tolerance_deg.to_f64();
+
+    for (segment_index, segment) in segments.iter().enumerate() {
+        validate_axis_values(
+            segment.pose_span.start_pose.machine_axes.as_deref(),
+            segment_index,
+            "start",
+            machine_constraint,
+            linear_tol_mm,
+            rotary_tol_deg,
+        )?;
+        validate_axis_values(
+            segment.pose_span.end_pose.machine_axes.as_deref(),
+            segment_index,
+            "end",
+            machine_constraint,
+            linear_tol_mm,
+            rotary_tol_deg,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn collect_toolpath_segments<T: Scalar + std::iter::Sum>(
+    toolpath: &ToolPath<T>,
+) -> Vec<&PathSegment<T>> {
+    let mut segments = Vec::new();
+    segments.extend(toolpath.approach_segments.iter());
+    for contour in &toolpath.contour_levels {
+        segments.extend(contour.segments.iter());
+    }
+    segments.extend(toolpath.retract_segments.iter());
+    segments
+}
+
+fn segment_feed_rate<T: Scalar>(segment: &PathSegment<T>) -> Option<T> {
+    match segment.segment_type {
+        SegmentType::Cutting { feed_rate }
+        | SegmentType::Approach { feed_rate }
+        | SegmentType::Retract { feed_rate }
+        | SegmentType::PassRetract { feed_rate } => Some(feed_rate),
+        SegmentType::Rapid => None,
+    }
+}
+
+fn validate_axis_values<T: Scalar>(
+    machine_axes: Option<&[MachineAxisValue<T>]>,
+    segment_index: usize,
+    pose_endpoint: &'static str,
+    machine_constraint: &MachineConstraint<T>,
+    linear_tol_mm: f64,
+    rotary_tol_deg: f64,
+) -> Result<(), ValidationError> {
+    let Some(machine_axes) = machine_axes else {
+        return Ok(());
+    };
+
+    for axis in machine_axes {
+        match axis.axis_kind {
+            MachineAxisKind::Linear => {
+                let Some(axis_label) = parse_linear_axis_label(&axis.axis_name) else {
+                    return Err(ValidationError::UnsupportedMachineAxis {
+                        segment_index,
+                        pose_endpoint,
+                        axis_name: axis.axis_name.clone(),
+                        axis_kind: axis.axis_kind,
+                    });
+                };
+
+                let Some(limit) = machine_constraint.linear_limit_for_axis(axis_label) else {
+                    continue;
+                };
+
+                let value_mm = axis.value.to_f64();
+                let min_mm = limit.min_mm.to_f64();
+                let max_mm = limit.max_mm.to_f64();
+                let result = validate_linear_travel_mm(value_mm, min_mm, max_mm, linear_tol_mm);
+                if !result.is_valid() {
+                    return Err(ValidationError::LinearAxisLimitExceeded {
+                        segment_index,
+                        pose_endpoint,
+                        axis_name: axis.axis_name.clone(),
+                        value_mm,
+                        min_mm,
+                        max_mm,
+                    });
+                }
+            }
+            MachineAxisKind::Rotary => {
+                let Some(axis_label) = parse_rotary_axis_label(&axis.axis_name) else {
+                    return Err(ValidationError::UnsupportedMachineAxis {
+                        segment_index,
+                        pose_endpoint,
+                        axis_name: axis.axis_name.clone(),
+                        axis_kind: axis.axis_kind,
+                    });
+                };
+
+                let Some(limit) = machine_constraint.rotary_limit_for_axis(axis_label) else {
+                    continue;
+                };
+
+                let value_deg = axis.value.to_f64();
+                let min_deg = limit.min_deg.to_f64();
+                let max_deg = limit.max_deg.to_f64();
+                let result = validate_rotary_angle_deg(value_deg, min_deg, max_deg, rotary_tol_deg);
+                if !result.is_valid() {
+                    return Err(ValidationError::RotaryAxisLimitExceeded {
+                        segment_index,
+                        pose_endpoint,
+                        axis_name: axis.axis_name.clone(),
+                        value_deg,
+                        min_deg,
+                        max_deg,
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_linear_axis_label(axis_name: &str) -> Option<LinearAxisLabel> {
+    match axis_name.trim().to_ascii_uppercase().as_str() {
+        "X" => Some(LinearAxisLabel::X),
+        "Y" => Some(LinearAxisLabel::Y),
+        "Z" => Some(LinearAxisLabel::Z),
+        "U" => Some(LinearAxisLabel::U),
+        "V" => Some(LinearAxisLabel::V),
+        "W" => Some(LinearAxisLabel::W),
+        _ => None,
+    }
+}
+
+fn parse_rotary_axis_label(axis_name: &str) -> Option<RotaryAxisLabel> {
+    match axis_name.trim().to_ascii_uppercase().as_str() {
+        "A" => Some(RotaryAxisLabel::A),
+        "B" => Some(RotaryAxisLabel::B),
+        "C" => Some(RotaryAxisLabel::C),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::tolerance::CAM_DEFAULT_CLOSURE_TOLERANCE_F64;
+    use crate::{
+        ArcDirection, ContourLevelPath, CuttingDirection, LinearAxisLimit, PathSegment,
+        PoseInterpolationPolicy, RotaryAxisLimit, ToolPose, ToolPoseSpan,
+    };
+    use geo_algorithms::{Point3D, Vector3D};
 
     #[test]
     fn test_validate_closed_contour() {
@@ -232,5 +608,234 @@ mod tests {
         } else {
             panic!("Expected InsufficientPoints error");
         }
+    }
+
+    #[test]
+    fn test_validate_toolpath_machine_constraints_ok() {
+        let segment = PathSegment::new_line(
+            Point3D::new(0.0, 0.0, 0.0),
+            Point3D::new(10.0, 0.0, 0.0),
+            SegmentType::Cutting { feed_rate: 500.0 },
+        );
+        let toolpath = ToolPath::new(
+            "tool1".to_string(),
+            CuttingDirection::Down,
+            vec![],
+            vec![ContourLevelPath::new(0, -1.0, vec![segment])],
+            vec![],
+        );
+
+        let mut constraint = MachineConstraint::empty();
+        constraint.linear_speed_limit = Some(crate::LinearSpeedLimit::new(1000.0));
+
+        let tolerance = CamTolerance::default();
+        assert!(validate_toolpath_machine_constraints(&toolpath, &constraint, &tolerance).is_ok());
+    }
+
+    #[test]
+    fn test_validate_toolpath_machine_constraints_feed_rate_exceeded() {
+        let segment = PathSegment::new_arc(
+            Point3D::new(1.0, 0.0, 0.0),
+            Point3D::new(0.0, 1.0, 0.0),
+            Point3D::new(0.0, 0.0, 0.0),
+            ArcDirection::CounterClockwise,
+            SegmentType::Approach { feed_rate: 1500.0 },
+        );
+        let toolpath = ToolPath::new(
+            "tool2".to_string(),
+            CuttingDirection::Up,
+            vec![segment],
+            vec![],
+            vec![],
+        );
+
+        let mut constraint = MachineConstraint::empty();
+        constraint.linear_speed_limit = Some(crate::LinearSpeedLimit::new(1000.0));
+
+        let tolerance = CamTolerance::default();
+        let result = validate_toolpath_machine_constraints(&toolpath, &constraint, &tolerance);
+        assert!(matches!(
+            result,
+            Err(ValidationError::FeedRateLimitExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn test_validate_toolpath_machine_constraints_linear_acceleration_exceeded() {
+        let segment = PathSegment::new_line(
+            Point3D::new(0.0, 0.0, 0.0),
+            Point3D::new(5.0, 0.0, 0.0),
+            SegmentType::Cutting { feed_rate: 500.0 },
+        )
+        .with_linear_acceleration_hint_mm_per_sec2(80.0);
+
+        let toolpath = ToolPath::new(
+            "tool3".to_string(),
+            CuttingDirection::Down,
+            vec![],
+            vec![ContourLevelPath::new(0, -1.0, vec![segment])],
+            vec![],
+        );
+
+        let mut constraint = MachineConstraint::empty();
+        constraint.linear_speed_limit = Some(crate::LinearSpeedLimit::new(1000.0));
+        constraint.linear_acceleration_limit = Some(crate::LinearAccelerationLimit::new(50.0));
+
+        let tolerance = CamTolerance::default();
+        let result = validate_toolpath_machine_constraints(&toolpath, &constraint, &tolerance);
+        assert!(matches!(
+            result,
+            Err(ValidationError::LinearAccelerationLimitExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn test_validate_toolpath_machine_constraints_rotary_acceleration_exceeded() {
+        let segment = PathSegment::new_line(
+            Point3D::new(0.0, 0.0, 0.0),
+            Point3D::new(5.0, 0.0, 0.0),
+            SegmentType::Cutting { feed_rate: 500.0 },
+        )
+        .with_rotary_acceleration_hint_deg_per_sec2(180.0);
+
+        let toolpath = ToolPath::new(
+            "tool4".to_string(),
+            CuttingDirection::Down,
+            vec![],
+            vec![ContourLevelPath::new(0, -1.0, vec![segment])],
+            vec![],
+        );
+
+        let mut constraint = MachineConstraint::empty();
+        constraint.linear_speed_limit = Some(crate::LinearSpeedLimit::new(1000.0));
+        constraint.rotary_acceleration_limit = Some(crate::RotaryAccelerationLimit::new(120.0));
+
+        let tolerance = CamTolerance::default();
+        let result = validate_toolpath_machine_constraints(&toolpath, &constraint, &tolerance);
+        assert!(matches!(
+            result,
+            Err(ValidationError::RotaryAccelerationLimitExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn test_validate_pose_segments_machine_constraints_ok_with_wrapped_rotary_range() {
+        let segment = PathSegment::new_line(
+            Point3D::new(0.0, 0.0, 0.0),
+            Point3D::new(1.0, 0.0, 0.0),
+            SegmentType::Rapid,
+        );
+        let start_pose = ToolPose::new(
+            Point3D::new(0.0, 0.0, 0.0),
+            Vector3D::new(0.0, 0.0, -1.0),
+            Some(vec![
+                MachineAxisValue::new("X".to_string(), MachineAxisKind::Linear, 10.0),
+                MachineAxisValue::new("A".to_string(), MachineAxisKind::Rotary, 350.0),
+            ]),
+        );
+        let end_pose = ToolPose::new(
+            Point3D::new(1.0, 0.0, 0.0),
+            Vector3D::new(0.0, 0.0, -1.0),
+            Some(vec![
+                MachineAxisValue::new("X".to_string(), MachineAxisKind::Linear, 15.0),
+                MachineAxisValue::new("A".to_string(), MachineAxisKind::Rotary, 5.0),
+            ]),
+        );
+        let pose_span = ToolPoseSpan::new(
+            start_pose,
+            end_pose,
+            PoseInterpolationPolicy::MachineConstrained,
+        );
+        let pose_segments = vec![PoseAnnotatedSegment::new(segment, pose_span)];
+
+        let constraint = MachineConstraint {
+            linear_axis_limits: vec![LinearAxisLimit::new(LinearAxisLabel::X, 0.0, 100.0)],
+            rotary_axis_limits: vec![RotaryAxisLimit::new(RotaryAxisLabel::A, 300.0, 30.0)],
+            linear_speed_limit: None,
+            rotary_speed_limit: None,
+            linear_acceleration_limit: None,
+            rotary_acceleration_limit: None,
+        };
+
+        let tolerance = CamTolerance::default();
+        assert!(
+            validate_pose_segments_machine_constraints(&pose_segments, &constraint, &tolerance)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_validate_pose_segments_machine_constraints_axis_range_error() {
+        let segment = PathSegment::new_line(
+            Point3D::new(0.0, 0.0, 0.0),
+            Point3D::new(1.0, 0.0, 0.0),
+            SegmentType::Rapid,
+        );
+        let pose = ToolPose::new(
+            Point3D::new(0.0, 0.0, 0.0),
+            Vector3D::new(0.0, 0.0, -1.0),
+            Some(vec![MachineAxisValue::new(
+                "X".to_string(),
+                MachineAxisKind::Linear,
+                120.0,
+            )]),
+        );
+        let pose_span = ToolPoseSpan::new(
+            pose.clone(),
+            pose,
+            PoseInterpolationPolicy::MachineConstrained,
+        );
+        let pose_segments = vec![PoseAnnotatedSegment::new(segment, pose_span)];
+
+        let constraint = MachineConstraint {
+            linear_axis_limits: vec![LinearAxisLimit::new(LinearAxisLabel::X, 0.0, 100.0)],
+            rotary_axis_limits: vec![],
+            linear_speed_limit: None,
+            rotary_speed_limit: None,
+            linear_acceleration_limit: None,
+            rotary_acceleration_limit: None,
+        };
+
+        let tolerance = CamTolerance::default();
+        let result =
+            validate_pose_segments_machine_constraints(&pose_segments, &constraint, &tolerance);
+        assert!(matches!(
+            result,
+            Err(ValidationError::LinearAxisLimitExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn test_validate_pose_segments_machine_constraints_unsupported_axis_name() {
+        let segment = PathSegment::new_line(
+            Point3D::new(0.0, 0.0, 0.0),
+            Point3D::new(1.0, 0.0, 0.0),
+            SegmentType::Rapid,
+        );
+        let pose = ToolPose::new(
+            Point3D::new(0.0, 0.0, 0.0),
+            Vector3D::new(0.0, 0.0, -1.0),
+            Some(vec![MachineAxisValue::new(
+                "Q".to_string(),
+                MachineAxisKind::Linear,
+                10.0,
+            )]),
+        );
+        let pose_span = ToolPoseSpan::new(
+            pose.clone(),
+            pose,
+            PoseInterpolationPolicy::MachineConstrained,
+        );
+        let pose_segments = vec![PoseAnnotatedSegment::new(segment, pose_span)];
+
+        let constraint = MachineConstraint::empty();
+        let tolerance = CamTolerance::default();
+
+        let result =
+            validate_pose_segments_machine_constraints(&pose_segments, &constraint, &tolerance);
+        assert!(matches!(
+            result,
+            Err(ValidationError::UnsupportedMachineAxis { .. })
+        ));
     }
 }

--- a/model/geo_algorithms/src/angle_utils.rs
+++ b/model/geo_algorithms/src/angle_utils.rs
@@ -1,0 +1,132 @@
+//! 角度処理ユーティリティ
+//!
+//! すべて度数法（deg）で扱う。
+
+pub const FULL_TURN_DEG: f64 = 360.0;
+pub const HALF_TURN_DEG: f64 = 180.0;
+
+/// [0, 360) に正規化する。
+pub fn normalize_angle_deg(angle_deg: f64) -> f64 {
+    let normalized = angle_deg.rem_euclid(FULL_TURN_DEG);
+    if normalized == FULL_TURN_DEG {
+        0.0
+    } else {
+        normalized
+    }
+}
+
+/// (-180, 180] に正規化する。
+pub fn normalize_angle_signed_deg(angle_deg: f64) -> f64 {
+    let mut normalized = normalize_angle_deg(angle_deg);
+    if normalized > HALF_TURN_DEG {
+        normalized -= FULL_TURN_DEG;
+    }
+    normalized
+}
+
+/// `from_deg` から `to_deg` への最短角差を返す。
+///
+/// 戻り値は [-180, 180]。
+pub fn shortest_angular_delta_deg(from_deg: f64, to_deg: f64) -> f64 {
+    normalize_angle_signed_deg(to_deg - from_deg)
+}
+
+/// 許容誤差付きで角度同値を判定する。
+pub fn are_angles_equivalent_deg(a_deg: f64, b_deg: f64, tolerance_deg: f64) -> bool {
+    shortest_angular_delta_deg(a_deg, b_deg).abs() <= tolerance_deg.abs()
+}
+
+/// 巻き戻し（rewind）方針。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RewindPolicy {
+    /// 現在角度から最短経路で到達する。
+    Shortest,
+    /// 正方向（CCW）のみで到達する。
+    PositiveOnly,
+    /// 負方向（CW）のみで到達する。
+    NegativeOnly,
+}
+
+/// 方針に従い、連続角度系での目標角を返す。
+///
+/// 例: current=350, target=10, Shortest -> 370
+pub fn rewound_target_deg(current_deg: f64, target_deg: f64, policy: RewindPolicy) -> f64 {
+    let current_norm = normalize_angle_deg(current_deg);
+    let target_norm = normalize_angle_deg(target_deg);
+
+    match policy {
+        RewindPolicy::Shortest => {
+            current_deg + shortest_angular_delta_deg(current_norm, target_norm)
+        }
+        RewindPolicy::PositiveOnly => {
+            let delta = (target_norm - current_norm).rem_euclid(FULL_TURN_DEG);
+            current_deg + delta
+        }
+        RewindPolicy::NegativeOnly => {
+            let delta = -((current_norm - target_norm).rem_euclid(FULL_TURN_DEG));
+            current_deg + delta
+        }
+    }
+}
+
+/// 離散角列を連続角列へ変換する。
+pub fn unwind_angles_deg(angles_deg: &[f64]) -> Vec<f64> {
+    if angles_deg.is_empty() {
+        return Vec::new();
+    }
+
+    let mut unwound = Vec::with_capacity(angles_deg.len());
+    unwound.push(angles_deg[0]);
+
+    for &angle in &angles_deg[1..] {
+        let prev = *unwound.last().expect("unwound is never empty");
+        unwound.push(rewound_target_deg(prev, angle, RewindPolicy::Shortest));
+    }
+
+    unwound
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_angle_deg_wraps_correctly() {
+        assert!((normalize_angle_deg(370.0) - 10.0).abs() < 1e-12);
+        assert!((normalize_angle_deg(-10.0) - 350.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn shortest_angular_delta_prefers_short_path() {
+        assert!((shortest_angular_delta_deg(350.0, 10.0) - 20.0).abs() < 1e-12);
+        assert!((shortest_angular_delta_deg(10.0, 350.0) + 20.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn angle_equivalence_works_across_wrap() {
+        assert!(are_angles_equivalent_deg(0.0, 360.0, 1e-9));
+        assert!(are_angles_equivalent_deg(-180.0, 180.0, 1e-9));
+        assert!(!are_angles_equivalent_deg(0.0, 1.0, 0.1));
+    }
+
+    #[test]
+    fn rewound_target_supports_policies() {
+        assert!((rewound_target_deg(350.0, 10.0, RewindPolicy::Shortest) - 370.0).abs() < 1e-12);
+        assert!(
+            (rewound_target_deg(350.0, 10.0, RewindPolicy::PositiveOnly) - 370.0).abs() < 1e-12
+        );
+        assert!((rewound_target_deg(350.0, 10.0, RewindPolicy::NegativeOnly) - 10.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn unwind_angles_creates_continuous_series() {
+        let src = [350.0, 355.0, 2.0, 8.0, 355.0];
+        let unwound = unwind_angles_deg(&src);
+
+        assert_eq!(unwound.len(), 5);
+        assert!((unwound[0] - 350.0).abs() < 1e-12);
+        assert!((unwound[2] - 362.0).abs() < 1e-12);
+        assert!((unwound[3] - 368.0).abs() < 1e-12);
+        assert!((unwound[4] - 355.0).abs() < 1e-12);
+    }
+}

--- a/model/geo_algorithms/src/constraint_validation.rs
+++ b/model/geo_algorithms/src/constraint_validation.rs
@@ -1,0 +1,193 @@
+use crate::angle_utils::normalize_angle_deg;
+
+/// 制約検証結果。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConstraintViolation {
+    None,
+    NotFinite,
+    InvalidRange,
+    BelowMinimum,
+    AboveMaximum,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ValidationResult {
+    pub violation: ConstraintViolation,
+}
+
+impl ValidationResult {
+    pub fn ok() -> Self {
+        Self {
+            violation: ConstraintViolation::None,
+        }
+    }
+
+    pub fn is_valid(self) -> bool {
+        self.violation == ConstraintViolation::None
+    }
+}
+
+/// 線形軸の移動範囲（mm）を検証する。
+pub fn validate_linear_travel_mm(
+    requested_mm: f64,
+    min_mm: f64,
+    max_mm: f64,
+    tolerance_mm: f64,
+) -> ValidationResult {
+    validate_closed_range(requested_mm, min_mm, max_mm, tolerance_mm)
+}
+
+/// 線形速度（mm/min）を検証する。
+pub fn validate_linear_speed_mm_per_min(
+    requested: f64,
+    min_limit: f64,
+    max_limit: f64,
+    tolerance: f64,
+) -> ValidationResult {
+    validate_closed_range(requested, min_limit, max_limit, tolerance)
+}
+
+/// 回転速度（deg/min）を検証する。
+pub fn validate_rotary_speed_deg_per_min(
+    requested: f64,
+    min_limit: f64,
+    max_limit: f64,
+    tolerance: f64,
+) -> ValidationResult {
+    validate_closed_range(requested, min_limit, max_limit, tolerance)
+}
+
+/// 線形加速度（mm/s^2）を検証する。
+pub fn validate_linear_acceleration_mm_per_s2(
+    requested: f64,
+    min_limit: f64,
+    max_limit: f64,
+    tolerance: f64,
+) -> ValidationResult {
+    validate_closed_range(requested, min_limit, max_limit, tolerance)
+}
+
+/// 回転加速度（deg/s^2）を検証する。
+pub fn validate_rotary_acceleration_deg_per_s2(
+    requested: f64,
+    min_limit: f64,
+    max_limit: f64,
+    tolerance: f64,
+) -> ValidationResult {
+    validate_closed_range(requested, min_limit, max_limit, tolerance)
+}
+
+/// 回転軸角度（deg）の範囲検証。
+///
+/// `min_deg > max_deg` の場合は 0 度跨ぎの範囲として扱う。
+pub fn validate_rotary_angle_deg(
+    requested_deg: f64,
+    min_deg: f64,
+    max_deg: f64,
+    tolerance_deg: f64,
+) -> ValidationResult {
+    if !requested_deg.is_finite() || !min_deg.is_finite() || !max_deg.is_finite() {
+        return ValidationResult {
+            violation: ConstraintViolation::NotFinite,
+        };
+    }
+
+    let tol = tolerance_deg.abs();
+    let requested = normalize_angle_deg(requested_deg);
+    let min_norm = normalize_angle_deg(min_deg);
+    let max_norm = normalize_angle_deg(max_deg);
+
+    if (min_norm - max_norm).abs() <= tol {
+        return ValidationResult::ok();
+    }
+
+    let in_range = if min_norm < max_norm {
+        requested >= min_norm - tol && requested <= max_norm + tol
+    } else {
+        requested >= min_norm - tol || requested <= max_norm + tol
+    };
+
+    if in_range {
+        ValidationResult::ok()
+    } else {
+        ValidationResult {
+            violation: ConstraintViolation::InvalidRange,
+        }
+    }
+}
+
+fn validate_closed_range(value: f64, min: f64, max: f64, tolerance: f64) -> ValidationResult {
+    if !value.is_finite() || !min.is_finite() || !max.is_finite() {
+        return ValidationResult {
+            violation: ConstraintViolation::NotFinite,
+        };
+    }
+
+    if min > max {
+        return ValidationResult {
+            violation: ConstraintViolation::InvalidRange,
+        };
+    }
+
+    let tol = tolerance.abs();
+
+    if value < min - tol {
+        return ValidationResult {
+            violation: ConstraintViolation::BelowMinimum,
+        };
+    }
+
+    if value > max + tol {
+        return ValidationResult {
+            violation: ConstraintViolation::AboveMaximum,
+        };
+    }
+
+    ValidationResult::ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linear_travel_accepts_within_tolerance() {
+        let result = validate_linear_travel_mm(10.0001, 0.0, 10.0, 0.001);
+        assert!(result.is_valid());
+    }
+
+    #[test]
+    fn linear_travel_detects_violations() {
+        let low = validate_linear_travel_mm(-0.1, 0.0, 100.0, 0.0);
+        let high = validate_linear_travel_mm(100.1, 0.0, 100.0, 0.0);
+
+        assert_eq!(low.violation, ConstraintViolation::BelowMinimum);
+        assert_eq!(high.violation, ConstraintViolation::AboveMaximum);
+    }
+
+    #[test]
+    fn linear_speed_and_acceleration_validate_like_ranges() {
+        assert!(validate_linear_speed_mm_per_min(1200.0, 0.0, 2000.0, 0.0).is_valid());
+        assert!(validate_rotary_speed_deg_per_min(360.0, 0.0, 720.0, 0.0).is_valid());
+        assert!(validate_linear_acceleration_mm_per_s2(30.0, 0.0, 50.0, 0.0).is_valid());
+        assert!(validate_rotary_acceleration_deg_per_s2(100.0, 0.0, 200.0, 0.0).is_valid());
+    }
+
+    #[test]
+    fn rotary_angle_supports_wrapped_ranges() {
+        let ok = validate_rotary_angle_deg(350.0, 300.0, 30.0, 0.0);
+        let ng = validate_rotary_angle_deg(120.0, 300.0, 30.0, 0.0);
+
+        assert!(ok.is_valid());
+        assert_eq!(ng.violation, ConstraintViolation::InvalidRange);
+    }
+
+    #[test]
+    fn invalid_ranges_and_non_finite_are_rejected() {
+        let invalid = validate_linear_travel_mm(10.0, 20.0, 0.0, 0.0);
+        let non_finite = validate_linear_travel_mm(f64::NAN, 0.0, 1.0, 0.0);
+
+        assert_eq!(invalid.violation, ConstraintViolation::InvalidRange);
+        assert_eq!(non_finite.violation, ConstraintViolation::NotFinite);
+    }
+}

--- a/model/geo_algorithms/src/lib.rs
+++ b/model/geo_algorithms/src/lib.rs
@@ -3,13 +3,25 @@
 //! このクレートは、衝突判定・交点計算・空間分割などの幾何アルゴリズムを提供する
 //! 設計方針と全体構成は `dev/architecture/ARCHITECTURE.md` を参照
 
+pub mod angle_utils;
 pub mod collision;
+pub mod constraint_validation;
 pub mod distance;
 pub mod intersection;
 pub mod octree;
 
 // Octree関連の公開API
 pub use octree::{Octree, OctreeNode, OctreeTolerance};
+
+pub use angle_utils::{
+    are_angles_equivalent_deg, normalize_angle_deg, normalize_angle_signed_deg, rewound_target_deg,
+    shortest_angular_delta_deg, unwind_angles_deg, RewindPolicy,
+};
+pub use constraint_validation::{
+    validate_linear_acceleration_mm_per_s2, validate_linear_speed_mm_per_min,
+    validate_linear_travel_mm, validate_rotary_acceleration_deg_per_s2, validate_rotary_angle_deg,
+    validate_rotary_speed_deg_per_min, ConstraintViolation, ValidationResult,
+};
 
 // NURBS型の再エクスポート（ViewModel層からのアクセス用）
 pub use geo_contracts::Scalar;


### PR DESCRIPTION
## 概要
Issue #434 の実装完了です。

## 実装内容
- **角度処理ユーティリティ** (`model/geo_algorithms/src/angle_utils.rs`)
  - `normalize_angle_deg()`: [0, 360) 正規化
  - `normalize_angle_signed_deg()`: (-180, 180] 正規化
  - `shortest_angular_delta_deg()`: 最短角差計算
  - `are_angles_equivalent_deg()`: 許容誤差付き同値判定
  - `rewound_target_deg()`: Rewind 方針適用
  - `unwind_angles_deg()`: 連続角列への変換
  - `RewindPolicy` enum: Shortest/PositiveOnly/NegativeOnly

- **制約検証ロジック** (`model/geo_algorithms/src/constraint_validation.rs`)
  - `ConstraintViolation` enum: 違反分類
  - `ValidationResult` struct: 検証結果
  - `validate_linear_travel_mm()`: 線形移動範囲検証
  - `validate_linear_speed_mm_per_min()`: 線形速度検証
  - `validate_rotary_speed_deg_per_min()`: 回転速度検証
  - `validate_linear_acceleration_mm_per_s2()`: 線形加速度検証
  - `validate_rotary_acceleration_deg_per_s2()`: 回転加速度検証
  - `validate_rotary_angle_deg()`: 回転角度範囲検証

- **加速度制約データパス** (`model/cam_core/src/toolpath.rs`)
  - セグメント拡張属性タグ: `SEGMENT_EXT_TAG_LINEAR_ACCEL_MM_PER_SEC2` (-101)
  - セグメント拡張属性タグ: `SEGMENT_EXT_TAG_ROTARY_ACCEL_DEG_PER_SEC2` (-102)
  - Builder メソッド: `with_linear_acceleration_hint_mm_per_sec2()`, `with_rotary_acceleration_hint_deg_per_sec2()`
  - Getter メソッド: `linear_acceleration_hint_mm_per_sec2()`, `rotary_acceleration_hint_deg_per_sec2()`
  - ヘルパー関数: `upsert_ext_attr_f64()`, `read_ext_attr_f64()`

- **加速度制約検証フロー** (`model/cam_core/src/validation.rs`)
  - `ValidationError` に新規バリアント追加:
    - `LinearAccelerationLimitExceeded`
    - `RotaryAccelerationLimitExceeded`
  - `validate_toolpath_machine_constraints()` に加速度検証ロジック統合

- **テスト群**
  - `angle_utils` テスト: 正規化、最短角差、同値判定、Rewind 方針、角列展開
  - `toolpath_tests` テスト: 加速度ヒント丸め、上書き時タグ重複排除
  - `validation_tests` テスト: 加速度制約超過ケース

## 検証
✅ `cargo fmt --all -- --check` 成功
✅ `cargo clippy --workspace --all-targets -- -D warnings` 成功
✅ `cargo test --workspace` 全テスト成功

## 関連
Refs #434
Refs #426
Refs #435