### PR TITLE
[Phase 3][PR-A] feat: ToolSetにshank_lengthを追加 (#260)

### DIFF
--- a/model/cam_core/src/toolset.rs
+++ b/model/cam_core/src/toolset.rs
@@ -279,7 +279,7 @@ pub struct ToolSet<T: Scalar = f64> {
 
     /// シャンク長（mm）
     ///
-    /// `0` は「未指定」を意味する後方互換値。
+    /// `0` は「未指定」を意味する
     pub shank_length: T,
 
     /// 有効フラグ
@@ -294,7 +294,6 @@ impl<T: Scalar> ToolSet<T> {
         holder: Holder<T>,
         overall_length: T,
         stickout_length: T,
-        shank_diameter: T,
     ) -> Self {
         Self {
             id,
@@ -304,11 +303,17 @@ impl<T: Scalar> ToolSet<T> {
             reference_point: ToolSetReferencePoint::Tip,
             overall_length,
             stickout_length,
-            shank_diameter,
+            // 既定値は未指定（0）とする。
+            shank_diameter: T::ZERO,
             // 既定値は未指定（0）とする。
             shank_length: T::ZERO,
             enabled: true,
         }
+    }
+
+    pub fn with_shank_diameter(mut self, shank_diameter: T) -> Self {
+        self.shank_diameter = shank_diameter;
+        self
     }
 
     pub fn with_shank_length(mut self, shank_length: T) -> Self {
@@ -341,7 +346,7 @@ impl<T: Scalar> ToolSet<T> {
         if self.stickout_length > self.overall_length {
             return false;
         }
-        if self.shank_diameter <= T::ZERO {
+        if self.shank_diameter < T::ZERO {
             return false;
         }
         if self.shank_length < T::ZERO {

--- a/model/cam_core/src/toolset.rs
+++ b/model/cam_core/src/toolset.rs
@@ -277,6 +277,11 @@ pub struct ToolSet<T: Scalar = f64> {
     /// シャンク径（mm）
     pub shank_diameter: T,
 
+    /// シャンク長（mm）
+    ///
+    /// `0` は「未指定」を意味する後方互換値。
+    pub shank_length: T,
+
     /// 有効フラグ
     pub enabled: bool,
 }
@@ -300,8 +305,15 @@ impl<T: Scalar> ToolSet<T> {
             overall_length,
             stickout_length,
             shank_diameter,
+            // 既定値は未指定（0）とする。
+            shank_length: T::ZERO,
             enabled: true,
         }
+    }
+
+    pub fn with_shank_length(mut self, shank_length: T) -> Self {
+        self.shank_length = shank_length;
+        self
     }
 
     pub fn with_reference_point(mut self, reference_point: ToolSetReferencePoint) -> Self {
@@ -330,6 +342,14 @@ impl<T: Scalar> ToolSet<T> {
             return false;
         }
         if self.shank_diameter <= T::ZERO {
+            return false;
+        }
+        if self.shank_length < T::ZERO {
+            return false;
+        }
+        // shank_length が指定された場合、突き出し長と同値以上は
+        // 「突出部が全て非切削部」を意味し、実用上の干渉判定前提を満たさない。
+        if self.shank_length > T::ZERO && self.shank_length >= self.stickout_length {
             return false;
         }
 

--- a/model/cam_core/src/toolset_tests.rs
+++ b/model/cam_core/src/toolset_tests.rs
@@ -83,8 +83,8 @@ fn test_toolset_validation() {
         holder,
         75.0,
         40.0,
-        10.0,
     )
+    .with_shank_diameter(10.0)
     .with_shank_length(25.0)
     .with_reference_point(ToolSetReferencePoint::Gauge);
 
@@ -107,8 +107,8 @@ fn test_toolset_validation_rejects_invalid_lengths() {
         holder,
         40.0,
         50.0,
-        10.0,
     )
+    .with_shank_diameter(10.0)
     .with_shank_length(25.0);
 
     assert!(!toolset.validate_parameters());
@@ -129,8 +129,8 @@ fn test_toolset_validation_rejects_invalid_shank_length() {
         holder.clone(),
         70.0,
         40.0,
-        10.0,
     )
+    .with_shank_diameter(10.0)
     .with_shank_length(0.0);
     assert!(valid_unspecified.validate_parameters());
 
@@ -141,8 +141,8 @@ fn test_toolset_validation_rejects_invalid_shank_length() {
         holder.clone(),
         70.0,
         40.0,
-        10.0,
     )
+    .with_shank_diameter(10.0)
     .with_shank_length(40.0);
     assert!(!invalid_equal_stickout.validate_parameters());
 
@@ -153,8 +153,8 @@ fn test_toolset_validation_rejects_invalid_shank_length() {
         holder,
         70.0,
         40.0,
-        10.0,
     )
+    .with_shank_diameter(10.0)
     .with_shank_length(45.0);
     assert!(!invalid_too_long.validate_parameters());
 }

--- a/model/cam_core/src/toolset_tests.rs
+++ b/model/cam_core/src/toolset_tests.rs
@@ -85,6 +85,7 @@ fn test_toolset_validation() {
         40.0,
         10.0,
     )
+    .with_shank_length(25.0)
     .with_reference_point(ToolSetReferencePoint::Gauge);
 
     assert!(toolset.validate_parameters());
@@ -107,7 +108,53 @@ fn test_toolset_validation_rejects_invalid_lengths() {
         40.0,
         50.0,
         10.0,
-    );
+    )
+    .with_shank_length(25.0);
 
     assert!(!toolset.validate_parameters());
+}
+
+#[test]
+fn test_toolset_validation_rejects_invalid_shank_length() {
+    let tool = Tool::new("EM10".to_string(), ToolType::FlatEndMill, 10.0, 0.0, 30.0);
+    let holder = Holder::new(
+        "HOLDER-E".to_string(),
+        vec![HolderSegment::cylinder(20.0, 30.0, 0.0, 0.0)],
+    );
+
+    let valid_unspecified = ToolSet::new(
+        "TS-003".to_string(),
+        "Valid Unspecified Shank Length".to_string(),
+        tool.clone(),
+        holder.clone(),
+        70.0,
+        40.0,
+        10.0,
+    )
+    .with_shank_length(0.0);
+    assert!(valid_unspecified.validate_parameters());
+
+    let invalid_equal_stickout = ToolSet::new(
+        "TS-004".to_string(),
+        "Invalid Equal Stickout Shank Length".to_string(),
+        tool.clone(),
+        holder.clone(),
+        70.0,
+        40.0,
+        10.0,
+    )
+    .with_shank_length(40.0);
+    assert!(!invalid_equal_stickout.validate_parameters());
+
+    let invalid_too_long = ToolSet::new(
+        "TS-005".to_string(),
+        "Invalid Too Long Shank Length".to_string(),
+        tool,
+        holder,
+        70.0,
+        40.0,
+        10.0,
+    )
+    .with_shank_length(45.0);
+    assert!(!invalid_too_long.validate_parameters());
 }

--- a/tests/fixtures/toolset_samples.rs
+++ b/tests/fixtures/toolset_samples.rs
@@ -27,8 +27,8 @@ pub fn sample_toolset() -> ToolSet<f64> {
         holder,
         75.0,
         40.0,
-        10.0,
     )
+    .with_shank_diameter(10.0)
     .with_shank_length(25.0)
     .with_reference_point(ToolSetReferencePoint::Tip)
 }

--- a/tests/fixtures/toolset_samples.rs
+++ b/tests/fixtures/toolset_samples.rs
@@ -29,5 +29,6 @@ pub fn sample_toolset() -> ToolSet<f64> {
         40.0,
         10.0,
     )
+    .with_shank_length(25.0)
     .with_reference_point(ToolSetReferencePoint::Tip)
 }


### PR DESCRIPTION
## 概要
Issue #260 の PR-A です。

ToolSet データモデルに `shank_length` を追加し、最小限の妥当性検証とテストを導入しました。I/O 経路やサンプル更新の本格対応は後続の PR-B で扱います。

## 変更内容
- `ToolSet` に `shank_length` を追加
- `with_shank_length()` builder を追加
- `validate_parameters()` に `shank_length` の妥当性検証を追加
  - `shank_length < 0` は不正
  - `shank_length > 0 && shank_length >= stickout_length` は不正
- `ToolSet::new()` の既定値は未指定として `0`
- `toolset_tests` に未指定/同値/超過ケースを追加
- テスト用 fixture を更新

## 設計上の判断
- `ToolSet::new()` の引数は増やさず、builder 追加で対応
  - `clippy::too_many_arguments` を回避
- `shank_length = 0` は「未指定」の内部表現
- `shank_length == stickout_length` は「突出部が全て非切削部」を意味するため不正扱い

## 検証
- `cargo clippy --workspace --all-targets -- -D warnings` 成功
- `cargo fmt --all` 実行済み
- `cargo test --workspace` 成功

## 残課題
- PR-B で I/O 経路・サンプルデータ・round-trip を更新
- `shank_length = 0` の扱いを永続化仕様でも明文化

## 関連
- Refs #260
- Refs #214