### PR TITLE
[Phase 3][PR-B] test: ToolSetサンプルをFlat/Ballに拡張 (#260)

### DIFF
--- a/tests/fixtures/toolset_samples.rs
+++ b/tests/fixtures/toolset_samples.rs
@@ -8,7 +8,7 @@ use cam_core::{
 };
 
 /// 2段ホルダー + フラットエンドミルのサンプルツールセット
-pub fn sample_toolset() -> ToolSet<f64> {
+pub fn sample_flat_toolset() -> ToolSet<f64> {
     let tool = Tool::new("EM10".to_string(), ToolType::FlatEndMill, 10.0, 0.0, 30.0);
 
     let holder = Holder::new(
@@ -31,4 +31,54 @@ pub fn sample_toolset() -> ToolSet<f64> {
     .with_shank_diameter(10.0)
     .with_shank_length(25.0)
     .with_reference_point(ToolSetReferencePoint::Tip)
+}
+
+/// 2段ホルダー + ボールエンドミルのサンプルツールセット
+pub fn sample_ball_toolset() -> ToolSet<f64> {
+    let tool = Tool::new("BEM6".to_string(), ToolType::BallEndMill, 6.0, 3.0, 24.0);
+
+    let holder = Holder::new(
+        "HOLDER-SAMPLE-BALL".to_string(),
+        vec![
+            HolderSegment::cylinder(18.0, 26.0, 0.5, 0.5),
+            HolderSegment::taper(12.0, 26.0, 16.0, 0.5, 0.25),
+        ],
+    )
+    .with_interference_offset(HolderInterferenceOffset::new(8.0, 0.0));
+
+    ToolSet::new(
+        "TS-SAMPLE-02".to_string(),
+        "Ball 6 Sample".to_string(),
+        tool,
+        holder,
+        62.0,
+        30.0,
+    )
+    .with_shank_diameter(6.0)
+    .with_shank_length(18.0)
+    .with_reference_point(ToolSetReferencePoint::Tip)
+}
+
+/// 後方互換のため、既存名はフラットサンプルを返す。
+pub fn sample_toolset() -> ToolSet<f64> {
+    sample_flat_toolset()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sample_flat_toolset_is_valid() {
+        let toolset = sample_flat_toolset();
+        assert!(toolset.validate_parameters());
+        assert_eq!(toolset.tool.tool_type, ToolType::FlatEndMill);
+    }
+
+    #[test]
+    fn sample_ball_toolset_is_valid() {
+        let toolset = sample_ball_toolset();
+        assert!(toolset.validate_parameters());
+        assert_eq!(toolset.tool.tool_type, ToolType::BallEndMill);
+    }
 }


### PR DESCRIPTION
## 概要

Issue #260 の PR-B として、ToolSet フィクスチャを最小スコープで更新しました。

- Flat/Ball の代表サンプルを追加
- 既存 `sample_toolset()` 呼び出しは維持（`sample_flat_toolset()` を返す）
- サンプル妥当性テストを追加

## 変更内容

- `tests/fixtures/toolset_samples.rs`
  - `sample_flat_toolset()` を追加（既存フラットサンプルを明示化）
  - `sample_ball_toolset()` を追加
  - 互換のため `sample_toolset()` は `sample_flat_toolset()` を返す
  - テスト2件追加
    - `sample_flat_toolset_is_valid`
    - `sample_ball_toolset_is_valid`

## スコープ判断

Issue #260 に記載の「永続化・I/O経路」については、現行コードベースに ToolSet のシリアライズ境界が存在しないため、本PRでは対象外としました。
本PRは「サンプル更新 + テスト」に限定しています。

## 検証

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all`
- `cargo test --workspace`

すべて成功しています。

Closes #260