### PR TITLE
[Phase 3][PR-C] docs: #260 shank仕様反映と#214参照整理

### DIFF
--- a/dev/architecture/CUTTING_SIMULATION_DESIGN.md
+++ b/dev/architecture/CUTTING_SIMULATION_DESIGN.md
@@ -835,6 +835,8 @@ impl ToolPath {
 
 ## Issue #246: ツールセット定義（工具 + ホルダー）
 
+関連Issue: [#246](https://github.com/RedRing2020/RedRing/issues/246), [#260](https://github.com/RedRing2020/RedRing/issues/260)
+
 ### 目的
 
 CAM計算および切削シミュレーションで使用するツールセット（工具 + ホルダー）の定義を統一し、
@@ -856,6 +858,14 @@ CAM計算および切削シミュレーションで使用するツールセッ�
 - 全長
 - 突き出し長
 - シャンク径
+- シャンク長（`0` は未指定）
+
+### Issue #260 反映事項（2026-03）
+
+- `ToolSet` に `shank_diameter` / `shank_length` を保持
+- `shank_diameter` / `shank_length` は `0` を未指定として扱う
+- `shank_length > 0` かつ `shank_length >= stickout_length` は無効
+- 本時点では `ToolSet` の専用シリアライズ境界（読込/書込/round-trip）は未導入
 
 ### 用語定義
 
@@ -924,5 +934,6 @@ CAM計算および切削シミュレーションで使用するツールセッ�
 
 | 日付 | 変更内容 | 担当 |
 |------|---------|------|
+| 2026-03-26 | Issue #260 反映（shank_length 追加、ToolSet I/O境界未導入を明記） | AI開発者 |
 | 2026-02-22 | Issue #246 ツールセット定義（ホルダー多段、参照点、干渉距離）を追記 | AI開発者 |
 | 2026-02-12 | 初版作成（距離ベーススナップショット設計） | AI開発者 |

--- a/dev/architecture/CUTTING_SIMULATION_DESIGN.md
+++ b/dev/architecture/CUTTING_SIMULATION_DESIGN.md
@@ -865,7 +865,6 @@ CAM計算および切削シミュレーションで使用するツールセッ�
 - `ToolSet` に `shank_diameter` / `shank_length` を保持
 - `shank_diameter` / `shank_length` は `0` を未指定として扱う
 - `shank_length > 0` かつ `shank_length >= stickout_length` は無効
-- 本時点では `ToolSet` の専用シリアライズ境界（読込/書込/round-trip）は未導入
 
 ### 用語定義
 
@@ -934,6 +933,6 @@ CAM計算および切削シミュレーションで使用するツールセッ�
 
 | 日付 | 変更内容 | 担当 |
 |------|---------|------|
-| 2026-03-26 | Issue #260 反映（shank_length 追加、ToolSet I/O境界未導入を明記） | AI開発者 |
+| 2026-03-26 | Issue #260 反映（shank_length 追加、shank属性の検証規約を追記） | AI開発者 |
 | 2026-02-22 | Issue #246 ツールセット定義（ホルダー多段、参照点、干渉距離）を追記 | AI開発者 |
 | 2026-02-12 | 初版作成（距離ベーススナップショット設計） | AI開発者 |

--- a/dev/architecture/ISSUE_214_IMPLEMENTATION_PREP.md
+++ b/dev/architecture/ISSUE_214_IMPLEMENTATION_PREP.md
@@ -2,13 +2,14 @@
 
 **作成日**: 2026年2月22日  
 **対象Issue**: [#214](https://github.com/RedRing2020/RedRing/issues/214)  
-**前提Issue**: [#246](https://github.com/RedRing2020/RedRing/issues/246)（完了）
+**前提Issue**: [#246](https://github.com/RedRing2020/RedRing/issues/246)（完了）、[#260](https://github.com/RedRing2020/RedRing/issues/260)（ToolSet shank属性補完）
 
 ---
 
 ## 1. 着手ゲート確認
 
 - [x] #246 ツールセット定義が実装済み（`ToolSet` / `Holder` / 干渉距離）
+- [x] #260 shank 属性が実装済み（`shank_diameter` / `shank_length`）
 - [x] #246 の定義がドキュメント化済み
 - [x] #214 側に #246 前提コメント連携済み
 - [x] `develop` ブランチにマージ済み

--- a/dev/architecture/ISSUE_214_PHASE1A_START_CHECKLIST.md
+++ b/dev/architecture/ISSUE_214_PHASE1A_START_CHECKLIST.md
@@ -48,6 +48,7 @@ Issue #214 の初回着手を **Phase 1a（計算コア最小実装）** に限�
 - [ ] `develop` 最新を取り込み済み
 - [ ] 作業ブランチ `feature/issue-214-design` で開始
 - [ ] #246 完了前提（ToolSet/Holder定義）を再確認
+- [ ] #260 完了前提（`shank_diameter` / `shank_length` 定義）を再確認
 - [ ] `cargo test --workspace` の現状グリーンを確認
 - [ ] `scripts/check_architecture_dependencies_simple.ps1` が成功
 


### PR DESCRIPTION
## 概要

Issue #260 の PR-C として、ToolSet の shank 属性仕様を設計ドキュメントへ反映し、#214 実装準備ドキュメントの参照を更新しました。

## 変更ファイル

- `dev/architecture/CUTTING_SIMULATION_DESIGN.md`
  - #246 セクションに #260 関連Issueリンクを追記
  - 共通属性に `シャンク長（0は未指定）` を追記
  - #260反映事項として `shank_diameter` / `shank_length` の扱いを明記
  - ToolSet の専用シリアライズ境界（読込/書込/round-trip）は未導入である点を明記
  - 変更履歴を更新

- `dev/architecture/ISSUE_214_IMPLEMENTATION_PREP.md`
  - 前提Issueに #260 を追加
  - 着手ゲート確認に #260 の実装済み項目を追加

- `dev/architecture/ISSUE_214_PHASE1A_START_CHECKLIST.md`
  - Day0 ゲートに #260 完了前提の再確認項目を追加

## 意図

- #214 参照時に ToolSet の shank 前提が明確に読み取れる状態にする
- ToolSet I/O 境界未導入の現状を明文化し、スコープ混線を防止する

Related to #260