### PR TITLE
[Phase2] i18n: ValidationError message catalog 解決層を実装

### DIFF
--- a/dev/architecture/ISSUE_435_VALIDATION_ERROR_I18N_DESIGN.md
+++ b/dev/architecture/ISSUE_435_VALIDATION_ERROR_I18N_DESIGN.md
@@ -132,6 +132,11 @@ ValidationError のロケール非依存表現:
 - ValidationError 用 message catalog（JA/EN）を追加
 - フォールバック規約を実装
 
+2026-03-26 追記（#442 残タスク）:
+- `validation_message_mapper` で `ValidationError -> UiMessage` を一元化する
+- `validation_message_catalog` で JA/EN テーブルを提供する
+- フォールバックは `指定ロケール -> En -> key文字列` をテストで担保する
+
 ### Phase 3
 
 - UI/ログの呼び出し経路を新経路へ段階移行

--- a/foundation/i18n_foundation/src/lib.rs
+++ b/foundation/i18n_foundation/src/lib.rs
@@ -52,6 +52,13 @@ impl TableMessageCatalog {
             .find(|(candidate, _)| *candidate == key)
             .map(|(_, template)| *template)
     }
+
+    pub fn template_or_none(&self, locale: UiLocale, key: &str) -> Option<&'static str> {
+        match locale {
+            UiLocale::Ja => Self::lookup(self.ja, key),
+            UiLocale::En => Self::lookup(self.en, key),
+        }
+    }
 }
 
 impl MessageCatalog for TableMessageCatalog {
@@ -70,8 +77,12 @@ pub fn resolve_message<C: MessageCatalog>(
 ) -> String {
     let template = catalog.template(locale, &message.key);
 
+    render_template(template, &message.args)
+}
+
+pub fn render_template(template: &str, args: &[UiMessageArg]) -> String {
     let mut resolved = template.to_string();
-    for arg in &message.args {
+    for arg in args {
         resolved = resolved.replace(&format!("{{{}}}", arg.name), &arg.value);
     }
     resolved

--- a/viewmodel/converter/src/lib.rs
+++ b/viewmodel/converter/src/lib.rs
@@ -28,6 +28,8 @@ pub mod snapshot_converter;
 pub mod stl_loader;
 pub mod svg_loader;
 pub mod toolpath_converter;
+pub mod validation_message_catalog;
+pub mod validation_message_mapper;
 
 /// テスト用の関数（削除予定）
 pub fn add(left: u64, right: u64) -> u64 {

--- a/viewmodel/converter/src/validation_message_catalog.rs
+++ b/viewmodel/converter/src/validation_message_catalog.rs
@@ -1,0 +1,203 @@
+use cam_core::ValidationError;
+use i18n_foundation::{render_template, TableMessageCatalog, UiLocale, UiMessage};
+
+use crate::validation_message_mapper::validation_error_to_ui_message;
+
+const VALIDATION_TEMPLATE_JA: &[(&str, &str)] = &[
+    (
+        "validation.contour.not_closed",
+        "輪郭が閉じていません: distance={distance}, tolerance={tolerance}",
+    ),
+    (
+        "validation.contour.insufficient_points",
+        "閉曲線に必要な点数が不足しています: point_count={point_count}",
+    ),
+    ("validation.contour.empty", "輪郭が空です"),
+    (
+        "validation.machine.feed_rate_limit_exceeded",
+        "送り速度が上限を超えています: segment={segment_index}, feed_rate={feed_rate}, max={max_feed_rate}",
+    ),
+    (
+        "validation.machine.linear_acceleration_limit_exceeded",
+        "線形加速度が上限を超えています: segment={segment_index}, acceleration={acceleration_mm_per_sec2}, max={max_acceleration_mm_per_sec2}",
+    ),
+    (
+        "validation.machine.rotary_acceleration_limit_exceeded",
+        "回転加速度が上限を超えています: segment={segment_index}, acceleration={acceleration_deg_per_sec2}, max={max_acceleration_deg_per_sec2}",
+    ),
+    (
+        "validation.machine.linear_axis_limit_exceeded",
+        "直動軸が範囲外です: segment={segment_index}, pose={pose_endpoint}, axis={axis_name}, value={value_mm}, range=[{min_mm}, {max_mm}]",
+    ),
+    (
+        "validation.machine.rotary_axis_limit_exceeded",
+        "回転軸が範囲外です: segment={segment_index}, pose={pose_endpoint}, axis={axis_name}, value={value_deg}, range=[{min_deg}, {max_deg}]",
+    ),
+    (
+        "validation.machine.unsupported_axis",
+        "未対応の機械軸です: segment={segment_index}, pose={pose_endpoint}, axis={axis_name}, kind={axis_kind}",
+    ),
+];
+
+const VALIDATION_TEMPLATE_EN: &[(&str, &str)] = &[
+    (
+        "validation.contour.not_closed",
+        "Contour is not closed: distance={distance}, tolerance={tolerance}",
+    ),
+    (
+        "validation.contour.insufficient_points",
+        "Insufficient points for closed contour: point_count={point_count}",
+    ),
+    ("validation.contour.empty", "Contour is empty"),
+    (
+        "validation.machine.feed_rate_limit_exceeded",
+        "Feed rate exceeds machine limit: segment={segment_index}, feed_rate={feed_rate}, max={max_feed_rate}",
+    ),
+    (
+        "validation.machine.linear_acceleration_limit_exceeded",
+        "Linear acceleration exceeds machine limit: segment={segment_index}, acceleration={acceleration_mm_per_sec2}, max={max_acceleration_mm_per_sec2}",
+    ),
+    (
+        "validation.machine.rotary_acceleration_limit_exceeded",
+        "Rotary acceleration exceeds machine limit: segment={segment_index}, acceleration={acceleration_deg_per_sec2}, max={max_acceleration_deg_per_sec2}",
+    ),
+    (
+        "validation.machine.linear_axis_limit_exceeded",
+        "Linear axis is out of range: segment={segment_index}, pose={pose_endpoint}, axis={axis_name}, value={value_mm}, range=[{min_mm}, {max_mm}]",
+    ),
+    (
+        "validation.machine.rotary_axis_limit_exceeded",
+        "Rotary axis is out of range: segment={segment_index}, pose={pose_endpoint}, axis={axis_name}, value={value_deg}, range=[{min_deg}, {max_deg}]",
+    ),
+    (
+        "validation.machine.unsupported_axis",
+        "Unsupported machine axis: segment={segment_index}, pose={pose_endpoint}, axis={axis_name}, kind={axis_kind}",
+    ),
+];
+
+pub const VALIDATION_MESSAGE_CATALOG: TableMessageCatalog = TableMessageCatalog::new(
+    VALIDATION_TEMPLATE_JA,
+    VALIDATION_TEMPLATE_EN,
+    "__missing__",
+    "__missing__",
+);
+
+pub fn resolve_validation_error(locale: UiLocale, error: &ValidationError) -> String {
+    let message = validation_error_to_ui_message(error);
+    resolve_validation_message(locale, &message)
+}
+
+pub fn resolve_validation_message(locale: UiLocale, message: &UiMessage) -> String {
+    resolve_with_default_locale(&VALIDATION_MESSAGE_CATALOG, locale, UiLocale::En, message)
+}
+
+fn resolve_with_default_locale(
+    catalog: &TableMessageCatalog,
+    locale: UiLocale,
+    default_locale: UiLocale,
+    message: &UiMessage,
+) -> String {
+    if let Some(template) = catalog.template_or_none(locale, &message.key) {
+        return render_template(template, &message.args);
+    }
+
+    if let Some(template) = catalog.template_or_none(default_locale, &message.key) {
+        return render_template(template, &message.args);
+    }
+
+    message.key.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        resolve_validation_message, resolve_with_default_locale, TableMessageCatalog, UiLocale,
+    };
+    use i18n_foundation::{UiMessage, UiMessageArg};
+
+    #[test]
+    fn resolves_validation_message_in_ja_and_en() {
+        let message = UiMessage {
+            key: "validation.contour.not_closed".to_string(),
+            args: vec![
+                UiMessageArg {
+                    name: "distance".to_string(),
+                    value: "1.000000".to_string(),
+                },
+                UiMessageArg {
+                    name: "tolerance".to_string(),
+                    value: "0.010000".to_string(),
+                },
+            ],
+        };
+
+        let ja = resolve_validation_message(UiLocale::Ja, &message);
+        let en = resolve_validation_message(UiLocale::En, &message);
+
+        assert!(ja.contains("輪郭が閉じていません"));
+        assert!(en.contains("Contour is not closed"));
+    }
+
+    #[test]
+    fn fallback_order_is_locale_then_en_then_key() {
+        let ja_only_missing_catalog = TableMessageCatalog::new(
+            &[("validation.only.ja", "JA")],
+            &[("validation.only.en", "EN")],
+            "__missing__",
+            "__missing__",
+        );
+
+        let en_fallback_message = UiMessage {
+            key: "validation.only.en".to_string(),
+            args: Vec::new(),
+        };
+        let key_fallback_message = UiMessage {
+            key: "validation.unknown".to_string(),
+            args: Vec::new(),
+        };
+
+        let resolved_by_en = resolve_with_default_locale(
+            &ja_only_missing_catalog,
+            UiLocale::Ja,
+            UiLocale::En,
+            &en_fallback_message,
+        );
+        let resolved_by_key = resolve_with_default_locale(
+            &ja_only_missing_catalog,
+            UiLocale::Ja,
+            UiLocale::En,
+            &key_fallback_message,
+        );
+
+        assert_eq!(resolved_by_en, "EN");
+        assert_eq!(resolved_by_key, "validation.unknown");
+    }
+
+    #[test]
+    fn all_validation_keys_have_templates_for_ja_and_en() {
+        let required_keys = [
+            "validation.contour.not_closed",
+            "validation.contour.insufficient_points",
+            "validation.contour.empty",
+            "validation.machine.feed_rate_limit_exceeded",
+            "validation.machine.linear_acceleration_limit_exceeded",
+            "validation.machine.rotary_acceleration_limit_exceeded",
+            "validation.machine.linear_axis_limit_exceeded",
+            "validation.machine.rotary_axis_limit_exceeded",
+            "validation.machine.unsupported_axis",
+        ];
+
+        for key in required_keys {
+            let message = UiMessage {
+                key: key.to_string(),
+                args: Vec::new(),
+            };
+
+            let ja = resolve_validation_message(UiLocale::Ja, &message);
+            let en = resolve_validation_message(UiLocale::En, &message);
+
+            assert_ne!(ja, key);
+            assert_ne!(en, key);
+        }
+    }
+}

--- a/viewmodel/converter/src/validation_message_mapper.rs
+++ b/viewmodel/converter/src/validation_message_mapper.rs
@@ -1,0 +1,149 @@
+use cam_core::ValidationError;
+use i18n_foundation::{UiMessage, UiMessageArg};
+
+pub fn validation_error_to_ui_message(error: &ValidationError) -> UiMessage {
+    let args = match error {
+        ValidationError::ContourNotClosed {
+            distance,
+            tolerance,
+        } => vec![
+            arg("distance", format!("{distance:.6}")),
+            arg("tolerance", format!("{tolerance:.6}")),
+        ],
+        ValidationError::InsufficientPoints { point_count } => {
+            vec![arg("point_count", point_count.to_string())]
+        }
+        ValidationError::EmptyContour => Vec::new(),
+        ValidationError::FeedRateLimitExceeded {
+            segment_index,
+            feed_rate,
+            max_feed_rate,
+        } => vec![
+            arg("segment_index", segment_index.to_string()),
+            arg("feed_rate", format!("{feed_rate:.6}")),
+            arg("max_feed_rate", format!("{max_feed_rate:.6}")),
+        ],
+        ValidationError::LinearAccelerationLimitExceeded {
+            segment_index,
+            acceleration_mm_per_sec2,
+            max_acceleration_mm_per_sec2,
+        } => vec![
+            arg("segment_index", segment_index.to_string()),
+            arg(
+                "acceleration_mm_per_sec2",
+                format!("{acceleration_mm_per_sec2:.6}"),
+            ),
+            arg(
+                "max_acceleration_mm_per_sec2",
+                format!("{max_acceleration_mm_per_sec2:.6}"),
+            ),
+        ],
+        ValidationError::RotaryAccelerationLimitExceeded {
+            segment_index,
+            acceleration_deg_per_sec2,
+            max_acceleration_deg_per_sec2,
+        } => vec![
+            arg("segment_index", segment_index.to_string()),
+            arg(
+                "acceleration_deg_per_sec2",
+                format!("{acceleration_deg_per_sec2:.6}"),
+            ),
+            arg(
+                "max_acceleration_deg_per_sec2",
+                format!("{max_acceleration_deg_per_sec2:.6}"),
+            ),
+        ],
+        ValidationError::LinearAxisLimitExceeded {
+            segment_index,
+            pose_endpoint,
+            axis_name,
+            value_mm,
+            min_mm,
+            max_mm,
+        } => vec![
+            arg("segment_index", segment_index.to_string()),
+            arg("pose_endpoint", pose_endpoint.to_string()),
+            arg("axis_name", axis_name.clone()),
+            arg("value_mm", format!("{value_mm:.6}")),
+            arg("min_mm", format!("{min_mm:.6}")),
+            arg("max_mm", format!("{max_mm:.6}")),
+        ],
+        ValidationError::RotaryAxisLimitExceeded {
+            segment_index,
+            pose_endpoint,
+            axis_name,
+            value_deg,
+            min_deg,
+            max_deg,
+        } => vec![
+            arg("segment_index", segment_index.to_string()),
+            arg("pose_endpoint", pose_endpoint.to_string()),
+            arg("axis_name", axis_name.clone()),
+            arg("value_deg", format!("{value_deg:.6}")),
+            arg("min_deg", format!("{min_deg:.6}")),
+            arg("max_deg", format!("{max_deg:.6}")),
+        ],
+        ValidationError::UnsupportedMachineAxis {
+            segment_index,
+            pose_endpoint,
+            axis_name,
+            axis_kind,
+        } => vec![
+            arg("segment_index", segment_index.to_string()),
+            arg("pose_endpoint", pose_endpoint.to_string()),
+            arg("axis_name", axis_name.clone()),
+            arg("axis_kind", format!("{axis_kind:?}")),
+        ],
+    };
+
+    UiMessage {
+        key: error.message_key().to_string(),
+        args,
+    }
+}
+
+fn arg(name: &str, value: String) -> UiMessageArg {
+    UiMessageArg {
+        name: name.to_string(),
+        value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validation_error_to_ui_message;
+    use cam_core::{MachineAxisKind, ValidationError};
+
+    #[test]
+    fn contour_not_closed_maps_to_stable_key_and_args() {
+        let error = ValidationError::ContourNotClosed {
+            distance: 1.0,
+            tolerance: 0.01,
+        };
+
+        let message = validation_error_to_ui_message(&error);
+
+        assert_eq!(message.key, "validation.contour.not_closed");
+        assert_eq!(message.args.len(), 2);
+        assert!(message.args.iter().any(|a| a.name == "distance"));
+        assert!(message.args.iter().any(|a| a.name == "tolerance"));
+    }
+
+    #[test]
+    fn unsupported_axis_maps_all_context_fields() {
+        let error = ValidationError::UnsupportedMachineAxis {
+            segment_index: 3,
+            pose_endpoint: "start",
+            axis_name: "A".to_string(),
+            axis_kind: MachineAxisKind::Rotary,
+        };
+
+        let message = validation_error_to_ui_message(&error);
+
+        assert_eq!(message.key, "validation.machine.unsupported_axis");
+        assert!(message.args.iter().any(|a| a.name == "segment_index"));
+        assert!(message.args.iter().any(|a| a.name == "pose_endpoint"));
+        assert!(message.args.iter().any(|a| a.name == "axis_name"));
+        assert!(message.args.iter().any(|a| a.name == "axis_kind"));
+    }
+}


### PR DESCRIPTION
Refs #435
Closes #442

## 概要
Phase2 の残タスクとして、ValidationError のローカライズ解決層を追加しました。

## 変更内容
- `viewmodel/converter` に ValidationError 向け変換レイヤーを追加
  - `validation_message_mapper.rs`
  - `ValidationError -> UiMessage` 変換を一元化
- `viewmodel/converter` に ValidationError 向け message catalog を追加
  - `validation_message_catalog.rs`
  - JA/EN のテンプレートを追加
  - フォールバック規約（指定ロケール -> En -> key文字列）を実装
- `i18n_foundation` に補助APIを追加
  - `TableMessageCatalog::template_or_none`
  - `render_template`
- 設計ドキュメント更新
  - `ISSUE_435_VALIDATION_ERROR_I18N_DESIGN.md` に #442 残タスク追記

## テスト
- `cargo clippy`
- `cargo fmt`
- `cargo test --workspace`

## 受け入れ条件との対応
- [x] `foundation/i18n_foundation` が workspace で利用可能
- [x] JA/EN の ValidationError キーが解決できる
- [x] Job系の既存 message catalog が共通基盤利用へ移行している
- [x] フォールバック動作テストがある
- [x] `cargo test --workspace` が通る