### PR TITLE
[Phase3] i18n: debug toolpath の ValidationError ログ経路を新方式へ移行

### DIFF
--- a/view/app/src/app_state/debug_scene/toolpath.rs
+++ b/view/app/src/app_state/debug_scene/toolpath.rs
@@ -18,12 +18,22 @@ struct ToolPathDebugData {
 
 impl AppState {
     fn build_toolpath_debug_data(&self) -> Result<ToolPathDebugData, String> {
-        use viewmodel::cam_sim_visualization_converter::create_sample_cam_simulation_visualization_bundle_with_settings;
+        use viewmodel::cam_sim_visualization_converter::{
+            create_sample_cam_simulation_visualization_bundle_with_settings,
+            CamSimulationVisualizationError,
+        };
+        use viewmodel::message_catalog::UiLocale;
+        use viewmodel::validation_message_catalog::resolve_validation_error;
 
         let bundle = create_sample_cam_simulation_visualization_bundle_with_settings(
             &self.octree_visualization_settings,
         )
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| match error {
+            CamSimulationVisualizationError::Validation(validation_error) => {
+                resolve_validation_error(UiLocale::Ja, &validation_error)
+            }
+            CamSimulationVisualizationError::Simulation(sim_error) => sim_error.to_string(),
+        })?;
 
         if bundle.snapshot_wireframes.is_empty() {
             return Err("CAMシミュレーション可視化フレームが空です".to_string());

--- a/viewmodel/converter/src/cam_sim_visualization_converter.rs
+++ b/viewmodel/converter/src/cam_sim_visualization_converter.rs
@@ -3,7 +3,10 @@
 //! CAMシミュレーション（toolpath + tool + work octree）の実行と、
 //! 可視化に必要な ViewModel データ（wireframe + snapshot）の結合を担当します。
 
-use cam_core::{PathGeometry, Tool, ToolPath};
+use cam_core::{
+    validate_toolpath_machine_constraints, CamTolerance, MachineConstraint, PathGeometry, Tool,
+    ToolPath, ValidationError,
+};
 use cam_sim::{CuttingSimulator, SimulationError, SnapshotInterval};
 use geo_algorithms::{
     octree::{VoxelOctree, VoxelState},
@@ -24,6 +27,35 @@ use crate::snapshot_converter::{
 use crate::toolpath_converter::{
     create_sample_toolpath, toolpath_to_vertices, ToolPathVisualizationSettings,
 };
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CamSimulationVisualizationError {
+    Validation(ValidationError),
+    Simulation(SimulationError),
+}
+
+impl std::fmt::Display for CamSimulationVisualizationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Validation(error) => write!(f, "{}", error),
+            Self::Simulation(error) => write!(f, "{}", error),
+        }
+    }
+}
+
+impl std::error::Error for CamSimulationVisualizationError {}
+
+impl From<ValidationError> for CamSimulationVisualizationError {
+    fn from(value: ValidationError) -> Self {
+        Self::Validation(value)
+    }
+}
+
+impl From<SimulationError> for CamSimulationVisualizationError {
+    fn from(value: SimulationError) -> Self {
+        Self::Simulation(value)
+    }
+}
 
 /// CAMシミュレーション可視化用の結合データ。
 ///
@@ -504,9 +536,13 @@ fn apply_cutting_progress(
 /// 可視化に必要な深さ別ワイヤーフレームとスナップショット系列を返す。
 pub fn create_sample_cam_simulation_visualization_bundle_with_settings(
     settings: &OctreeVisualizationSettings,
-) -> Result<CamSimulationVisualizationBundle, SimulationError> {
+) -> Result<CamSimulationVisualizationBundle, CamSimulationVisualizationError> {
     let toolpath = create_sample_toolpath();
     let tool = Tool::flat_end_mill("endmill_3mm".to_string(), 10.0, 50.0);
+    let tolerance = CamTolerance::default();
+    let machine_constraint = MachineConstraint::empty();
+    validate_toolpath_machine_constraints(&toolpath, &machine_constraint, &tolerance)?;
+
     let segments = collect_line_segments_with_flags(&toolpath)?;
 
     let work_bounds = compute_work_bounds_from_toolpath(&segments, tool.radius());


### PR DESCRIPTION
Refs #441
Refs #447

## 概要
Debug toolpath 表示経路で発生する ValidationError を、旧来の `to_string()` 直接利用から新しい i18n 経路へ移行しました。

## 変更内容
- `viewmodel/converter`:
  - `CamSimulationVisualizationError` を追加し、ValidationError/SimulationError を型で分離
  - `create_sample_cam_simulation_visualization_bundle_with_settings` の戻り値を型付きエラーへ変更
  - 生成時に `validate_toolpath_machine_constraints` を通して ValidationError を伝播
- `view/app`:
  - debug toolpath のエラー変換で ValidationError を `validation_message_catalog` 経由で解決
  - SimulationError は従来どおり文字列化

## 背景
- UI/ログの ValidationError 経路移行（#441）の一部として、debug toolpath の実表示経路を先行で移行
- ログ方針の拡張（key+EN、出力分離）は #447 で別途設計・実装

## テスト
- cargo clippy
- cargo fmt
- cargo test --workspace