### PR TITLE
[#451] logging: 残存 error/warn へ error_kind 構造化フィールドを一括付与

### DIFF
--- a/view/app/src/app_state/debug_scene/nurbs.rs
+++ b/view/app/src/app_state/debug_scene/nurbs.rs
@@ -22,7 +22,11 @@ impl AppState {
             {
                 Ok(data) => data,
                 Err(error) => {
-                    tracing::error!("NURBS曲線データ生成失敗: {}", error);
+                    tracing::error!(
+                        error_kind = logging_foundation::ERROR_KIND_APP,
+                        "nurbs curve eval data generation failed: {}",
+                        error
+                    );
                     return;
                 }
             };
@@ -61,7 +65,11 @@ impl AppState {
             match viewmodel::nurbs_eval_loader::create_sample_nurbs_surface_eval(tolerance_value) {
                 Ok(data) => data,
                 Err(error) => {
-                    tracing::error!("NURBS曲面データ生成失敗: {}", error);
+                    tracing::error!(
+                        error_kind = logging_foundation::ERROR_KIND_APP,
+                        "nurbs surface eval data generation failed: {}",
+                        error
+                    );
                     return;
                 }
             };

--- a/view/app/src/app_state/debug_scene/shapes.rs
+++ b/view/app/src/app_state/debug_scene/shapes.rs
@@ -15,7 +15,11 @@ impl AppState {
                 Some(vertices)
             }
             Err(error) => {
-                tracing::error!("SVG読み込みエラー: {}", error);
+                tracing::error!(
+                    error_kind = logging_foundation::ERROR_KIND_APP,
+                    "svg load failed: {}",
+                    error
+                );
                 None
             }
         }

--- a/view/app/src/app_state/snapshot_playback.rs
+++ b/view/app/src/app_state/snapshot_playback.rs
@@ -23,7 +23,11 @@ impl AppState {
                 self.log_current_snapshot_frame(true);
             }
             Err(error) => {
-                tracing::error!("シミュレーションスナップショット読込失敗: {}", error);
+                tracing::error!(
+                    error_kind = logging_foundation::ERROR_KIND_SIMULATION,
+                    "cam simulation snapshot load failed: {}",
+                    error
+                );
             }
         }
     }

--- a/view/render/src/surface.rs
+++ b/view/render/src/surface.rs
@@ -6,11 +6,18 @@ pub fn safe_get_current_texture(surface: &Surface) -> Option<SurfaceTexture> {
     match catch_unwind(AssertUnwindSafe(|| surface.get_current_texture())) {
         Ok(Ok(texture)) => Some(texture),
         Ok(Err(e)) => {
-            tracing::warn!("Surface texture acquisition failed: {:?}", e);
+            tracing::warn!(
+                error_kind = logging_foundation::ERROR_KIND_SYSTEM,
+                "surface texture acquisition failed: {:?}",
+                e
+            );
             None
         }
         Err(_) => {
-            tracing::error!("Panic occurred during surface texture acquisition");
+            tracing::error!(
+                error_kind = logging_foundation::ERROR_KIND_SYSTEM,
+                "panic during surface texture acquisition"
+            );
             None
         }
     }

--- a/view/stage/src/nurbs_curve_stage.rs
+++ b/view/stage/src/nurbs_curve_stage.rs
@@ -54,13 +54,19 @@ impl NurbsCurveStage {
         );
 
         if num_evals == 0 {
-            tracing::warn!("⚠️ 評価点が0個 - 曲線描画されません");
+            tracing::warn!(
+                error_kind = logging_foundation::ERROR_KIND_APP,
+                "nurbs curve stage: no eval points, skip draw"
+            );
             self.has_data = false;
             return;
         }
 
         if num_cps == 0 {
-            tracing::warn!("⚠️ 制御点が0個 - 曲線描画されません");
+            tracing::warn!(
+                error_kind = logging_foundation::ERROR_KIND_APP,
+                "nurbs curve stage: no control points, skip draw"
+            );
             self.has_data = false;
             return;
         }
@@ -116,7 +122,10 @@ impl RenderStage for NurbsCurveStage {
         }
 
         let Some(resources) = &self.resources else {
-            tracing::warn!("NurbsCurveStage: リソース未初期化");
+            tracing::warn!(
+                error_kind = logging_foundation::ERROR_KIND_APP,
+                "nurbs curve stage: resources not initialized"
+            );
             return;
         };
 

--- a/view/stage/src/nurbs_surface_stage.rs
+++ b/view/stage/src/nurbs_surface_stage.rs
@@ -59,7 +59,10 @@ impl NurbsSurfaceStage {
         );
 
         if num_vertices == 0 {
-            tracing::warn!("⚠️ 評価点が0個 - 曲面描画されません");
+            tracing::warn!(
+                error_kind = logging_foundation::ERROR_KIND_APP,
+                "nurbs surface stage: no eval points, skip draw"
+            );
             self.has_data = false;
             return;
         }

--- a/viewmodel/converter/src/stl_loader.rs
+++ b/viewmodel/converter/src/stl_loader.rs
@@ -128,7 +128,10 @@ fn calculate_bounds(mesh: &geo_algorithms::TriangleMesh3D<f64>) -> ([f32; 3], [f
         (min_bounds, max_bounds)
     } else {
         // デフォルトの境界ボックス（空のメッシュの場合）
-        tracing::warn!("メッシュが空のため、デフォルト境界ボックスを使用");
+        tracing::warn!(
+            error_kind = logging_foundation::ERROR_KIND_APP,
+            "mesh is empty, falling back to default bounding box"
+        );
         ([-1.0, -1.0, -1.0], [1.0, 1.0, 1.0])
     }
 }


### PR DESCRIPTION
Refs #447
Closes #451

## 概要
#447 の Step 3/4 残タスクを、単一 Issue (#451) に集約して一括実施しました。

## 変更内容

- `viewmodel/converter/src/stl_loader.rs`
  - `tracing::warn!` に `error_kind = ERROR_KIND_APP` 追加

- `view/app/src/app_state/snapshot_playback.rs`
  - `tracing::error!` に `error_kind = ERROR_KIND_SIMULATION` 追加

- `view/app/src/app_state/debug_scene/shapes.rs`
  - `tracing::error!` に `error_kind = ERROR_KIND_APP` 追加

- `view/app/src/app_state/debug_scene/nurbs.rs`
  - `tracing::error!` 2箇所に `error_kind = ERROR_KIND_APP` 追加

- `view/render/src/surface.rs`
  - `tracing::warn!` / `tracing::error!` に `error_kind = ERROR_KIND_SYSTEM` 追加

- `view/stage/src/nurbs_curve_stage.rs`
  - `tracing::warn!` 3箇所に `error_kind = ERROR_KIND_APP` 追加

- `view/stage/src/nurbs_surface_stage.rs`
  - `tracing::warn!` に `error_kind = ERROR_KIND_APP` 追加

## 品質確認
- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo fmt --all`