### PR TITLE
[#453][1st batch] primitive_3d 高頻度 intersection entrypoint の pair_base 委譲を直接実装へ移行

### DIFF
--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -14,7 +14,7 @@ use crate::{
     TorusSurface3D, Triangle3D, TriangleMesh3D,
 };
 use geo_contracts::{
-    default_orthogonality_dot_error_tolerance, Arc3DMeasure, Arc3DProperties, Circle3DProperties,
+    Arc3DMeasure, Arc3DProperties, Circle3DProperties,
     CylindricalSurface3DMeasure, CylindricalSurface3DProperties, Ellipse3DMeasure,
     EllipsoidalSolid3DProperties, InfiniteLine3DProperties, Scalar, TorusSurface3DMeasure,
     Triangle3DProperties,
@@ -590,7 +590,7 @@ pub fn line_segment3d_triangle3d_intersection<T: Scalar>(
 pub fn triangle3d_ray3d_intersection<T: Scalar>(
     triangle: &Triangle3D<T>,
     ray: &Ray3D<T>,
-    _tolerance: T,
+    tolerance: T,
 ) -> Option<Point3D<T>> {
     let va = triangle.vertex_a();
     let vb = triangle.vertex_b();
@@ -607,8 +607,7 @@ pub fn triangle3d_ray3d_intersection<T: Scalar>(
     let h = ray_dir.cross(&edge2);
     let a = edge1.dot(&h);
 
-    let dot_tolerance = default_orthogonality_dot_error_tolerance::<T>();
-    if a.abs() <= dot_tolerance {
+    if a.abs() <= tolerance {
         return None;
     }
 
@@ -696,9 +695,8 @@ pub fn plane3d_line_segment3d_intersection<T: Scalar>(
 
     let normal = plane.normal().as_vector();
     let denom = direction.dot(&normal);
-    let dot_tolerance = default_orthogonality_dot_error_tolerance::<T>();
 
-    if denom.abs() <= dot_tolerance {
+    if denom.abs() <= tolerance {
         return if plane.contains_point(start, tolerance) {
             Some(start)
         } else {
@@ -729,9 +727,8 @@ pub fn plane3d_ray3d_intersection<T: Scalar>(
     let direction = ray.direction_vector();
     let normal = plane.normal().as_vector();
     let denom = direction.dot(&normal);
-    let dot_tolerance = default_orthogonality_dot_error_tolerance::<T>();
 
-    if denom.abs() <= dot_tolerance {
+    if denom.abs() <= tolerance {
         return if plane.contains_point(origin, tolerance) {
             Some(origin)
         } else {
@@ -764,9 +761,8 @@ pub fn plane3d_infinite_line3d_intersection<T: Scalar>(
     let line_dir_vec = crate::Vector3D::new(ld.0, ld.1, ld.2);
     let normal = plane.normal().as_vector();
     let denom = line_dir_vec.dot(&normal);
-    let dot_tolerance = default_orthogonality_dot_error_tolerance::<T>();
 
-    if denom.abs() <= dot_tolerance {
+    if denom.abs() <= tolerance {
         return if plane.distance_to_point(line_point).abs() <= tolerance {
             Some(line_point)
         } else {
@@ -892,8 +888,7 @@ pub fn line_segment3d_line_segment3d_intersection<T: Scalar>(
     let e = d2.dot(&r);
 
     let denom = a * c - b * b;
-    let dot_tolerance = default_orthogonality_dot_error_tolerance::<T>();
-    if denom.abs() <= dot_tolerance {
+    if denom.abs() <= tolerance {
         return None;
     }
 

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -560,7 +560,22 @@ pub fn triangle3d_line_segment3d_intersection<T: Scalar>(
     segment: &LineSegment3D<T>,
     _tolerance: T,
 ) -> Option<Point3D<T>> {
-    pair_base::triangle3d_line_segment3d_intersection(triangle, segment)
+    let start = segment.start();
+    let end = segment.end();
+    let dir = end - start;
+    let length = dir.length();
+    if length <= T::EPSILON {
+        return None;
+    }
+    let ray = Ray3D::new(start, dir)?;
+    let point = triangle3d_ray3d_intersection(triangle, &ray, _tolerance)?;
+
+    let t = ray.parameter_for_point(&point);
+    if t >= T::ZERO && t <= length {
+        Some(point)
+    } else {
+        None
+    }
 }
 
 pub fn line_segment3d_triangle3d_intersection<T: Scalar>(
@@ -576,7 +591,50 @@ pub fn triangle3d_ray3d_intersection<T: Scalar>(
     ray: &Ray3D<T>,
     _tolerance: T,
 ) -> Option<Point3D<T>> {
-    pair_base::triangle3d_ray3d_intersection(triangle, ray)
+    let va = triangle.vertex_a();
+    let vb = triangle.vertex_b();
+    let vc = triangle.vertex_c();
+
+    let v0 = Point3D::new(va.0, va.1, va.2);
+    let v1 = Point3D::new(vb.0, vb.1, vb.2);
+    let v2 = Point3D::new(vc.0, vc.1, vc.2);
+
+    let edge1 = crate::Vector3D::from_points(&v0, &v1);
+    let edge2 = crate::Vector3D::from_points(&v0, &v2);
+
+    let ray_dir = ray.direction_vector();
+    let h = ray_dir.cross(&edge2);
+    let a = edge1.dot(&h);
+
+    if a.abs() < T::EPSILON {
+        return None;
+    }
+
+    let f = T::ONE / a;
+    let s = crate::Vector3D::from_points(&v0, &ray.origin());
+    let u = f * s.dot(&h);
+
+    if u < T::ZERO || u > T::ONE {
+        return None;
+    }
+
+    let q = s.cross(&edge1);
+    let v = f * ray_dir.dot(&q);
+
+    if v < T::ZERO || u + v > T::ONE {
+        return None;
+    }
+
+    let t = f * edge2.dot(&q);
+    if t < T::ZERO {
+        return None;
+    }
+
+    Some(Point3D::new(
+        ray.origin().x() + t * ray_dir.x(),
+        ray.origin().y() + t * ray_dir.y(),
+        ray.origin().z() + t * ray_dir.z(),
+    ))
 }
 
 pub fn ray3d_triangle3d_intersection<T: Scalar>(
@@ -622,7 +680,41 @@ pub fn plane3d_line_segment3d_intersection<T: Scalar>(
     segment: &LineSegment3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    pair_base::plane3d_line_segment3d_intersection(plane, segment, tolerance)
+    let start = segment.start();
+    let end = segment.end();
+    let direction = crate::Vector3D::from_points(&start, &end);
+
+    if direction.is_zero() {
+        return if plane.contains_point(start, tolerance) {
+            Some(start)
+        } else {
+            None
+        };
+    }
+
+    let normal = plane.normal().as_vector();
+    let denom = direction.dot(&normal);
+
+    if denom.abs() <= T::EPSILON {
+        return if plane.contains_point(start, tolerance) {
+            Some(start)
+        } else {
+            None
+        };
+    }
+
+    let to_plane = crate::Vector3D::from_points(&start, &plane.origin());
+    let t = to_plane.dot(&normal) / denom;
+
+    if t >= T::ZERO && t <= T::ONE {
+        Some(Point3D::new(
+            start.x() + t * direction.x(),
+            start.y() + t * direction.y(),
+            start.z() + t * direction.z(),
+        ))
+    } else {
+        None
+    }
 }
 
 pub fn plane3d_ray3d_intersection<T: Scalar>(
@@ -630,7 +722,31 @@ pub fn plane3d_ray3d_intersection<T: Scalar>(
     ray: &Ray3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    pair_base::plane3d_ray3d_intersection(plane, ray, tolerance)
+    let origin = ray.origin();
+    let direction = ray.direction_vector();
+    let normal = plane.normal().as_vector();
+    let denom = direction.dot(&normal);
+
+    if denom.abs() <= T::EPSILON {
+        return if plane.contains_point(origin, tolerance) {
+            Some(origin)
+        } else {
+            None
+        };
+    }
+
+    let to_plane = crate::Vector3D::from_points(&origin, &plane.origin());
+    let t = to_plane.dot(&normal) / denom;
+
+    if t >= T::ZERO {
+        Some(Point3D::new(
+            origin.x() + t * direction.x(),
+            origin.y() + t * direction.y(),
+            origin.z() + t * direction.z(),
+        ))
+    } else {
+        None
+    }
 }
 
 pub fn plane3d_infinite_line3d_intersection<T: Scalar>(
@@ -638,7 +754,28 @@ pub fn plane3d_infinite_line3d_intersection<T: Scalar>(
     line: &InfiniteLine3D<T>,
     _tolerance: T,
 ) -> Option<Point3D<T>> {
-    pair_base::plane3d_infinite_line3d_intersection(plane, line)
+    let lp = line.point();
+    let ld = line.direction();
+    let line_point = Point3D::new(lp.0, lp.1, lp.2);
+    let line_dir_vec = crate::Vector3D::new(ld.0, ld.1, ld.2);
+    let normal = plane.normal().as_vector();
+    let denom = line_dir_vec.dot(&normal);
+
+    if denom.abs() <= T::EPSILON {
+        return if plane.distance_to_point(line_point).abs() <= T::EPSILON {
+            Some(line_point)
+        } else {
+            None
+        };
+    }
+
+    let to_plane = crate::Vector3D::from_points(&line_point, &plane.origin());
+    let t = to_plane.dot(&normal) / denom;
+    Some(Point3D::new(
+        line_point.x() + t * line_dir_vec.x(),
+        line_point.y() + t * line_dir_vec.y(),
+        line_point.z() + t * line_dir_vec.z(),
+    ))
 }
 
 // ── Ray3D ─────────────────────────────────────────────────────────────────────
@@ -670,7 +807,19 @@ pub fn ray3d_line_segment3d_intersection<T: Scalar>(
     segment: &LineSegment3D<T>,
     _tolerance: T,
 ) -> Option<Point3D<T>> {
-    pair_base::ray3d_line_segment3d_intersection(ray, segment)
+    let ray_line = InfiniteLine3D::new(ray.origin(), ray.direction_vector())?;
+    let segment_line = segment.line();
+
+    if ray_line.is_parallel_to(segment_line) || !ray_line.is_coplanar_with(segment_line) {
+        return None;
+    }
+
+    let point = ray_line.intersection_with_line(segment_line)?;
+    if ray.contains_point(&point, T::EPSILON) && segment.contains_point(&point, T::EPSILON) {
+        Some(point)
+    } else {
+        None
+    }
 }
 
 pub fn ray3d_infinite_line3d_intersection<T: Scalar>(
@@ -678,7 +827,18 @@ pub fn ray3d_infinite_line3d_intersection<T: Scalar>(
     line: &InfiniteLine3D<T>,
     _tolerance: T,
 ) -> Option<Point3D<T>> {
-    pair_base::ray3d_infinite_line3d_intersection(ray, line)
+    let ray_line = InfiniteLine3D::new(ray.origin(), ray.direction_vector())?;
+
+    if ray_line.is_parallel_to(line) || !ray_line.is_coplanar_with(line) {
+        return None;
+    }
+
+    let point = ray_line.intersection_with_line(line)?;
+    if ray.contains_point(&point, T::EPSILON) {
+        Some(point)
+    } else {
+        None
+    }
 }
 
 pub fn ray3d_plane3d_intersection<T: Scalar>(
@@ -711,7 +871,49 @@ pub fn line_segment3d_line_segment3d_intersection<T: Scalar>(
     seg_b: &LineSegment3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    pair_base::line_segment3d_line_segment3d_intersection(seg_a, seg_b, tolerance)
+    let p1 = seg_a.start();
+    let p2 = seg_a.end();
+    let p3 = seg_b.start();
+    let p4 = seg_b.end();
+
+    let d1 = crate::Vector3D::from_points(&p1, &p2);
+    let d2 = crate::Vector3D::from_points(&p3, &p4);
+    let r = crate::Vector3D::from_points(&p3, &p1);
+
+    let a = d1.dot(&d1);
+    let b = d1.dot(&d2);
+    let c = d2.dot(&d2);
+    let d = d1.dot(&r);
+    let e = d2.dot(&r);
+
+    let denom = a * c - b * b;
+    if denom.abs() < T::EPSILON {
+        return None;
+    }
+
+    let s = (b * e - c * d) / denom;
+    let t = (a * e - b * d) / denom;
+
+    if s >= T::ZERO && s <= T::ONE && t >= T::ZERO && t <= T::ONE {
+        let point1 = Point3D::new(
+            p1.x() + s * d1.x(),
+            p1.y() + s * d1.y(),
+            p1.z() + s * d1.z(),
+        );
+        let point2 = Point3D::new(
+            p3.x() + t * d2.x(),
+            p3.y() + t * d2.y(),
+            p3.z() + t * d2.z(),
+        );
+
+        if point1.distance_to(&point2) <= tolerance {
+            Some(point1)
+        } else {
+            None
+        }
+    } else {
+        None
+    }
 }
 
 pub fn line_segment3d_ray3d_intersection<T: Scalar>(
@@ -760,7 +962,12 @@ pub fn infinite_line3d_infinite_line3d_intersection<T: Scalar>(
     line_b: &InfiniteLine3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    pair_base::infinite_line3d_infinite_line3d_intersection(line_a, line_b, tolerance)
+    let point = line_a.intersection_with_line(line_b)?;
+    if line_b.distance_to_point(&point) <= tolerance {
+        Some(point)
+    } else {
+        None
+    }
 }
 
 pub fn infinite_line3d_line_segment3d_intersection<T: Scalar>(
@@ -768,7 +975,13 @@ pub fn infinite_line3d_line_segment3d_intersection<T: Scalar>(
     segment: &LineSegment3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    pair_base::infinite_line3d_line_segment3d_intersection(line, segment, tolerance)
+    let segment_line = segment.line();
+    let point = line.intersection_with_line(segment_line)?;
+    if segment.contains_point(&point, tolerance) {
+        Some(point)
+    } else {
+        None
+    }
 }
 
 pub fn infinite_line3d_ray3d_intersection<T: Scalar>(
@@ -776,7 +989,13 @@ pub fn infinite_line3d_ray3d_intersection<T: Scalar>(
     ray: &Ray3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    pair_base::infinite_line3d_ray3d_intersection(line, ray, tolerance)
+    let ray_line = InfiniteLine3D::new(ray.origin(), ray.direction_vector())?;
+    let point = line.intersection_with_line(&ray_line)?;
+    if ray.contains_point(&point, tolerance) {
+        Some(point)
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -14,9 +14,10 @@ use crate::{
     TorusSurface3D, Triangle3D, TriangleMesh3D,
 };
 use geo_contracts::{
-    Arc3DMeasure, Arc3DProperties, Circle3DProperties, CylindricalSurface3DMeasure,
-    CylindricalSurface3DProperties, Ellipse3DMeasure, EllipsoidalSolid3DProperties,
-    InfiniteLine3DProperties, Scalar, TorusSurface3DMeasure, Triangle3DProperties,
+    default_orthogonality_dot_error_tolerance, Arc3DMeasure, Arc3DProperties, Circle3DProperties,
+    CylindricalSurface3DMeasure, CylindricalSurface3DProperties, Ellipse3DMeasure,
+    EllipsoidalSolid3DProperties, InfiniteLine3DProperties, Scalar, TorusSurface3DMeasure,
+    Triangle3DProperties,
 };
 
 fn point_intersection_if<T: Scalar>(point: &Point3D<T>, condition: bool) -> Option<Point3D<T>> {
@@ -558,17 +559,17 @@ pub fn triangle3d_point3d_intersection<T: Scalar>(
 pub fn triangle3d_line_segment3d_intersection<T: Scalar>(
     triangle: &Triangle3D<T>,
     segment: &LineSegment3D<T>,
-    _tolerance: T,
+    tolerance: T,
 ) -> Option<Point3D<T>> {
     let start = segment.start();
     let end = segment.end();
     let dir = end - start;
     let length = dir.length();
-    if length <= T::EPSILON {
+    if length <= tolerance {
         return None;
     }
     let ray = Ray3D::new(start, dir)?;
-    let point = triangle3d_ray3d_intersection(triangle, &ray, _tolerance)?;
+    let point = triangle3d_ray3d_intersection(triangle, &ray, tolerance)?;
 
     let t = ray.parameter_for_point(&point);
     if t >= T::ZERO && t <= length {
@@ -606,7 +607,8 @@ pub fn triangle3d_ray3d_intersection<T: Scalar>(
     let h = ray_dir.cross(&edge2);
     let a = edge1.dot(&h);
 
-    if a.abs() < T::EPSILON {
+    let dot_tolerance = default_orthogonality_dot_error_tolerance::<T>();
+    if a.abs() <= dot_tolerance {
         return None;
     }
 
@@ -694,8 +696,9 @@ pub fn plane3d_line_segment3d_intersection<T: Scalar>(
 
     let normal = plane.normal().as_vector();
     let denom = direction.dot(&normal);
+    let dot_tolerance = default_orthogonality_dot_error_tolerance::<T>();
 
-    if denom.abs() <= T::EPSILON {
+    if denom.abs() <= dot_tolerance {
         return if plane.contains_point(start, tolerance) {
             Some(start)
         } else {
@@ -726,8 +729,9 @@ pub fn plane3d_ray3d_intersection<T: Scalar>(
     let direction = ray.direction_vector();
     let normal = plane.normal().as_vector();
     let denom = direction.dot(&normal);
+    let dot_tolerance = default_orthogonality_dot_error_tolerance::<T>();
 
-    if denom.abs() <= T::EPSILON {
+    if denom.abs() <= dot_tolerance {
         return if plane.contains_point(origin, tolerance) {
             Some(origin)
         } else {
@@ -752,7 +756,7 @@ pub fn plane3d_ray3d_intersection<T: Scalar>(
 pub fn plane3d_infinite_line3d_intersection<T: Scalar>(
     plane: &Plane3D<T>,
     line: &InfiniteLine3D<T>,
-    _tolerance: T,
+    tolerance: T,
 ) -> Option<Point3D<T>> {
     let lp = line.point();
     let ld = line.direction();
@@ -760,9 +764,10 @@ pub fn plane3d_infinite_line3d_intersection<T: Scalar>(
     let line_dir_vec = crate::Vector3D::new(ld.0, ld.1, ld.2);
     let normal = plane.normal().as_vector();
     let denom = line_dir_vec.dot(&normal);
+    let dot_tolerance = default_orthogonality_dot_error_tolerance::<T>();
 
-    if denom.abs() <= T::EPSILON {
-        return if plane.distance_to_point(line_point).abs() <= T::EPSILON {
+    if denom.abs() <= dot_tolerance {
+        return if plane.distance_to_point(line_point).abs() <= tolerance {
             Some(line_point)
         } else {
             None
@@ -805,7 +810,7 @@ pub fn ray3d_ray3d_intersection<T: Scalar>(
 pub fn ray3d_line_segment3d_intersection<T: Scalar>(
     ray: &Ray3D<T>,
     segment: &LineSegment3D<T>,
-    _tolerance: T,
+    tolerance: T,
 ) -> Option<Point3D<T>> {
     let ray_line = InfiniteLine3D::new(ray.origin(), ray.direction_vector())?;
     let segment_line = segment.line();
@@ -815,7 +820,7 @@ pub fn ray3d_line_segment3d_intersection<T: Scalar>(
     }
 
     let point = ray_line.intersection_with_line(segment_line)?;
-    if ray.contains_point(&point, T::EPSILON) && segment.contains_point(&point, T::EPSILON) {
+    if ray.contains_point(&point, tolerance) && segment.contains_point(&point, tolerance) {
         Some(point)
     } else {
         None
@@ -825,7 +830,7 @@ pub fn ray3d_line_segment3d_intersection<T: Scalar>(
 pub fn ray3d_infinite_line3d_intersection<T: Scalar>(
     ray: &Ray3D<T>,
     line: &InfiniteLine3D<T>,
-    _tolerance: T,
+    tolerance: T,
 ) -> Option<Point3D<T>> {
     let ray_line = InfiniteLine3D::new(ray.origin(), ray.direction_vector())?;
 
@@ -834,7 +839,7 @@ pub fn ray3d_infinite_line3d_intersection<T: Scalar>(
     }
 
     let point = ray_line.intersection_with_line(line)?;
-    if ray.contains_point(&point, T::EPSILON) {
+    if ray.contains_point(&point, tolerance) {
         Some(point)
     } else {
         None
@@ -887,7 +892,8 @@ pub fn line_segment3d_line_segment3d_intersection<T: Scalar>(
     let e = d2.dot(&r);
 
     let denom = a * c - b * b;
-    if denom.abs() < T::EPSILON {
+    let dot_tolerance = default_orthogonality_dot_error_tolerance::<T>();
+    if denom.abs() <= dot_tolerance {
         return None;
     }
 

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -14,10 +14,9 @@ use crate::{
     TorusSurface3D, Triangle3D, TriangleMesh3D,
 };
 use geo_contracts::{
-    Arc3DMeasure, Arc3DProperties, Circle3DProperties,
-    CylindricalSurface3DMeasure, CylindricalSurface3DProperties, Ellipse3DMeasure,
-    EllipsoidalSolid3DProperties, InfiniteLine3DProperties, Scalar, TorusSurface3DMeasure,
-    Triangle3DProperties,
+    Arc3DMeasure, Arc3DProperties, Circle3DProperties, CylindricalSurface3DMeasure,
+    CylindricalSurface3DProperties, Ellipse3DMeasure, EllipsoidalSolid3DProperties,
+    InfiniteLine3DProperties, Scalar, TorusSurface3DMeasure, Triangle3DProperties,
 };
 
 fn point_intersection_if<T: Scalar>(point: &Point3D<T>, condition: bool) -> Option<Point3D<T>> {


### PR DESCRIPTION
Refs #453

## 概要
#453 の 1st バッチとして、`model/geo_algorithms/src/intersection/primitive_3d.rs` の高頻度 entrypoint で `pair_base` 委譲していた経路を、同ファイル内で直接実装に置換しました。

## 変更点
`pair_base::...` 委譲を直接実装へ移行（11箇所）:

- `triangle3d_line_segment3d_intersection`
- `triangle3d_ray3d_intersection`
- `plane3d_line_segment3d_intersection`
- `plane3d_ray3d_intersection`
- `plane3d_infinite_line3d_intersection`
- `ray3d_line_segment3d_intersection`
- `ray3d_infinite_line3d_intersection`
- `line_segment3d_line_segment3d_intersection`
- `infinite_line3d_infinite_line3d_intersection`
- `infinite_line3d_line_segment3d_intersection`
- `infinite_line3d_ray3d_intersection`

## トレランス運用根拠（追加）
- 本PRでのトレランス運用は `dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md` を根拠とする。
- API入力トレランスは呼び出し元が与えるため、判定閾値は原則として引数 `tolerance` を使用。
- `T::EPSILON` をドメイン判定閾値として使うことは避け、必要な箇所は `tolerance` に統一。

## トレランス適用範囲（追加）
対象ファイル: `model/geo_algorithms/src/intersection/primitive_3d.rs`

- 適用対象:
  - 1stバッチで直接実装化した上記11関数の判定ロジック
- 非適用（このPRの対象外）:
  - spherical_surface 系と ray-ray 系の残委譲経路
  - トレランス定義の体系再編（#455 で設計対応）

## 補足
- 現時点で `pair_base` 委譲は 4 箇所残しています（spherical_surface 系・ray-ray 系）。
- #453 は継続Issueとして、残経路の扱いと責務明確化を次バッチで実施予定です。

## 検証
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --all`
- [x] `cargo test --workspace`