### PR TITLE
[Phase 4.1] #408 geo_topology最小導入（TopoId/Vertex/CurveRef/Edge/Wire）

### DIFF
--- a/model/geo_topology/src/lib.rs
+++ b/model/geo_topology/src/lib.rs
@@ -12,9 +12,14 @@
 //! - HalfEdge: 隣接情報を持つ有向エッジ
 
 pub mod composite_curve;
+pub mod topology_core;
+pub mod wire;
 
 pub use composite_curve::{CompositeCurve3D, CurveSegment3D};
 pub use geo_core::{Point3D, Vector3D};
+pub use topology_core::{CurveRef, Edge, TopoId, Vertex};
+pub use wire::Wire;
 
 pub type TopoArc3D<T> = geo_primitives::Arc3D<T>;
+pub type TopoEllipseArc3D<T> = geo_primitives::EllipseArc3D<T>;
 pub type TopoLineSegment3D<T> = geo_primitives::LineSegment3D<T>;

--- a/model/geo_topology/src/topology_core.rs
+++ b/model/geo_topology/src/topology_core.rs
@@ -1,0 +1,266 @@
+//! topo正規形の最小構成要素
+//!
+//! #408 の最小導入として、Vertex/Edge/CurveRef を提供する。
+
+use crate::{Point3D, TopoArc3D, TopoEllipseArc3D, TopoLineSegment3D};
+use geo_contracts::{Arc3DMeasure, EllipseArc3DMeasure, Scalar};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// トポロジー要素の識別子
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TopoId(u64);
+
+impl TopoId {
+    /// 一意IDを採番する
+    pub fn new() -> Self {
+        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+        Self(NEXT_ID.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// 生のID値を返す
+    pub fn value(self) -> u64 {
+        self.0
+    }
+}
+
+impl Default for TopoId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// 頂点（Vertex）
+#[derive(Debug, Clone)]
+pub struct Vertex<T: Scalar> {
+    id: TopoId,
+    point: Point3D<T>,
+}
+
+impl<T: Scalar> Vertex<T> {
+    /// 座標から頂点を生成する
+    pub fn new(point: Point3D<T>) -> Self {
+        Self {
+            id: TopoId::new(),
+            point,
+        }
+    }
+
+    pub fn id(&self) -> TopoId {
+        self.id
+    }
+
+    pub fn point(&self) -> Point3D<T> {
+        self.point
+    }
+
+    /// 他頂点と同一点かを許容誤差付きで判定する
+    pub fn is_coincident(&self, other: &Self, tolerance: T) -> bool {
+        self.point.distance_to(&other.point) <= tolerance
+    }
+}
+
+/// Edge が参照する母曲線
+#[derive(Debug, Clone)]
+pub enum CurveRef<T: Scalar> {
+    Line(TopoLineSegment3D<T>),
+    Arc(TopoArc3D<T>),
+    EllipseArc(TopoEllipseArc3D<T>),
+}
+
+impl<T: Scalar> CurveRef<T> {
+    pub fn start_point(&self) -> Point3D<T> {
+        match self {
+            Self::Line(line) => line.start(),
+            Self::Arc(arc) => {
+                let (x, y, z) = <TopoArc3D<T> as Arc3DMeasure<T>>::start_point(arc);
+                Point3D::new(x, y, z)
+            }
+            Self::EllipseArc(arc) => {
+                let (x, y, z) = <TopoEllipseArc3D<T> as EllipseArc3DMeasure<T>>::start_point(arc);
+                Point3D::new(x, y, z)
+            }
+        }
+    }
+
+    pub fn end_point(&self) -> Point3D<T> {
+        match self {
+            Self::Line(line) => line.end(),
+            Self::Arc(arc) => {
+                let (x, y, z) = <TopoArc3D<T> as Arc3DMeasure<T>>::end_point(arc);
+                Point3D::new(x, y, z)
+            }
+            Self::EllipseArc(arc) => {
+                let (x, y, z) = <TopoEllipseArc3D<T> as EllipseArc3DMeasure<T>>::end_point(arc);
+                Point3D::new(x, y, z)
+            }
+        }
+    }
+
+    pub fn point_at_parameter(&self, t: T) -> Point3D<T> {
+        match self {
+            Self::Line(line) => line.line().point_at_parameter(t),
+            Self::Arc(arc) => {
+                let (x, y, z) = <TopoArc3D<T> as Arc3DMeasure<T>>::point_at_parameter(arc, t);
+                Point3D::new(x, y, z)
+            }
+            Self::EllipseArc(arc) => {
+                let (x, y, z) =
+                    <TopoEllipseArc3D<T> as EllipseArc3DMeasure<T>>::point_at_parameter(arc, t);
+                Point3D::new(x, y, z)
+            }
+        }
+    }
+
+    pub fn length(&self) -> T {
+        match self {
+            Self::Line(line) => line.length(),
+            Self::Arc(arc) => arc.arc_length(),
+            Self::EllipseArc(arc) => arc.measure(),
+        }
+    }
+}
+
+/// 辺（Edge）
+#[derive(Debug, Clone)]
+pub struct Edge<T: Scalar> {
+    id: TopoId,
+    start_vertex: Arc<Vertex<T>>,
+    end_vertex: Arc<Vertex<T>>,
+    curve: CurveRef<T>,
+    parameter_range: (T, T),
+    same_sense: bool,
+}
+
+impl<T: Scalar> Edge<T> {
+    /// Edge を生成する
+    pub fn new(
+        start_vertex: Arc<Vertex<T>>,
+        end_vertex: Arc<Vertex<T>>,
+        curve: CurveRef<T>,
+        parameter_range: (T, T),
+    ) -> Option<Self> {
+        if parameter_range.0 >= parameter_range.1 {
+            return None;
+        }
+
+        Some(Self {
+            id: TopoId::new(),
+            start_vertex,
+            end_vertex,
+            curve,
+            parameter_range,
+            same_sense: true,
+        })
+    }
+
+    pub fn id(&self) -> TopoId {
+        self.id
+    }
+
+    pub fn start_vertex(&self) -> &Arc<Vertex<T>> {
+        &self.start_vertex
+    }
+
+    pub fn end_vertex(&self) -> &Arc<Vertex<T>> {
+        &self.end_vertex
+    }
+
+    pub fn curve(&self) -> &CurveRef<T> {
+        &self.curve
+    }
+
+    pub fn parameter_range(&self) -> (T, T) {
+        self.parameter_range
+    }
+
+    pub fn same_sense(&self) -> bool {
+        self.same_sense
+    }
+
+    /// Edge の向きを反転する（母曲線は変更しない）
+    pub fn reverse(&mut self) {
+        self.same_sense = !self.same_sense;
+        std::mem::swap(&mut self.start_vertex, &mut self.end_vertex);
+    }
+
+    /// Edge の始端点（向き適用後）
+    pub fn oriented_start_point(&self) -> Point3D<T> {
+        self.start_vertex.point()
+    }
+
+    /// Edge の終端点（向き適用後）
+    pub fn oriented_end_point(&self) -> Point3D<T> {
+        self.end_vertex.point()
+    }
+
+    /// 曲線評価（0..1 のローカルパラメータ）
+    pub fn point_at(&self, local_t: T) -> Option<Point3D<T>> {
+        if local_t < T::ZERO || local_t > T::ONE {
+            return None;
+        }
+
+        let (t0, t1) = self.parameter_range;
+        let mapped_t = if self.same_sense {
+            t0 + (t1 - t0) * local_t
+        } else {
+            t1 - (t1 - t0) * local_t
+        };
+
+        Some(self.curve.point_at_parameter(mapped_t))
+    }
+
+    /// Edge が保持する頂点と幾何端点の整合を確認する
+    pub fn is_vertex_binding_consistent(&self, tolerance: T) -> bool {
+        let (t0, t1) = self.parameter_range;
+        let curve_start = self.curve.point_at_parameter(t0);
+        let curve_end = self.curve.point_at_parameter(t1);
+
+        let (expected_start, expected_end) = if self.same_sense {
+            (curve_start, curve_end)
+        } else {
+            (curve_end, curve_start)
+        };
+
+        self.start_vertex.point().distance_to(&expected_start) <= tolerance
+            && self.end_vertex.point().distance_to(&expected_end) <= tolerance
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn edge_new_rejects_invalid_range() {
+        let v0 = Arc::new(Vertex::new(Point3D::new(0.0, 0.0, 0.0)));
+        let v1 = Arc::new(Vertex::new(Point3D::new(1.0, 0.0, 0.0)));
+        let line = TopoLineSegment3D::new(v0.point(), v1.point()).unwrap();
+
+        assert!(Edge::new(v0, v1, CurveRef::Line(line), (1.0, 0.0)).is_none());
+    }
+
+    #[test]
+    fn edge_reverse_swaps_vertices() {
+        let v0 = Arc::new(Vertex::new(Point3D::new(0.0, 0.0, 0.0)));
+        let v1 = Arc::new(Vertex::new(Point3D::new(1.0, 0.0, 0.0)));
+        let line = TopoLineSegment3D::new(v0.point(), v1.point()).unwrap();
+        let mut edge = Edge::new(v0.clone(), v1.clone(), CurveRef::Line(line), (0.0, 1.0)).unwrap();
+
+        edge.reverse();
+
+        assert!(!edge.same_sense());
+        assert_eq!(edge.start_vertex().point(), v1.point());
+        assert_eq!(edge.end_vertex().point(), v0.point());
+    }
+
+    #[test]
+    fn edge_vertex_binding_consistency() {
+        let v0 = Arc::new(Vertex::new(Point3D::new(0.0, 0.0, 0.0)));
+        let v1 = Arc::new(Vertex::new(Point3D::new(1.0, 0.0, 0.0)));
+        let line = TopoLineSegment3D::new(v0.point(), v1.point()).unwrap();
+        let edge = Edge::new(v0, v1, CurveRef::Line(line), (0.0, 1.0)).unwrap();
+
+        assert!(edge.is_vertex_binding_consistent(1e-9));
+    }
+}

--- a/model/geo_topology/src/wire.rs
+++ b/model/geo_topology/src/wire.rs
@@ -1,0 +1,122 @@
+//! Wire: Edge 連続列
+
+use crate::{Edge, TopoId};
+use geo_contracts::Scalar;
+
+/// 連続した Edge 列
+#[derive(Debug, Clone)]
+pub struct Wire<T: Scalar> {
+    id: TopoId,
+    edges: Vec<Edge<T>>,
+}
+
+impl<T: Scalar> Wire<T> {
+    /// 連続性を検証した上で Wire を生成する
+    pub fn new(edges: Vec<Edge<T>>, tolerance: T) -> Option<Self> {
+        if edges.is_empty() {
+            return None;
+        }
+
+        let wire = Self {
+            id: TopoId::new(),
+            edges,
+        };
+
+        if wire.is_continuous(tolerance) {
+            Some(wire)
+        } else {
+            None
+        }
+    }
+
+    pub fn id(&self) -> TopoId {
+        self.id
+    }
+
+    pub fn edges(&self) -> &[Edge<T>] {
+        &self.edges
+    }
+
+    /// 端点連続性 + 各 Edge の頂点拘束整合を検証
+    pub fn is_continuous(&self, tolerance: T) -> bool {
+        if self.edges.is_empty() {
+            return false;
+        }
+
+        if !self
+            .edges
+            .iter()
+            .all(|edge| edge.is_vertex_binding_consistent(tolerance))
+        {
+            return false;
+        }
+
+        for i in 0..self.edges.len() - 1 {
+            let end = self.edges[i].oriented_end_point();
+            let next_start = self.edges[i + 1].oriented_start_point();
+            if end.distance_to(&next_start) > tolerance {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// 閉ループかを判定
+    pub fn is_closed(&self, tolerance: T) -> bool {
+        let first = self.edges.first().expect("wire has at least one edge");
+        let last = self.edges.last().expect("wire has at least one edge");
+        first
+            .oriented_start_point()
+            .distance_to(&last.oriented_end_point())
+            <= tolerance
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CurveRef, Point3D, TopoLineSegment3D, Vertex};
+    use std::sync::Arc;
+
+    fn make_edge(start: Point3D<f64>, end: Point3D<f64>) -> Edge<f64> {
+        let v0 = Arc::new(Vertex::new(start));
+        let v1 = Arc::new(Vertex::new(end));
+        let line = TopoLineSegment3D::new(start, end).unwrap();
+        Edge::new(
+            v0,
+            v1,
+            CurveRef::Line(line),
+            (line.start_param(), line.end_param()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn wire_continuous_edges() {
+        let e1 = make_edge(Point3D::new(0.0, 0.0, 0.0), Point3D::new(1.0, 0.0, 0.0));
+        let e2 = make_edge(Point3D::new(1.0, 0.0, 0.0), Point3D::new(2.0, 0.0, 0.0));
+
+        let wire = Wire::new(vec![e1, e2], 1e-9).unwrap();
+        assert!(wire.is_continuous(1e-9));
+        assert!(!wire.is_closed(1e-9));
+    }
+
+    #[test]
+    fn wire_disconnected_edges_fails() {
+        let e1 = make_edge(Point3D::new(0.0, 0.0, 0.0), Point3D::new(1.0, 0.0, 0.0));
+        let e2 = make_edge(Point3D::new(3.0, 0.0, 0.0), Point3D::new(4.0, 0.0, 0.0));
+
+        assert!(Wire::new(vec![e1, e2], 1e-9).is_none());
+    }
+
+    #[test]
+    fn wire_closed_loop() {
+        let e1 = make_edge(Point3D::new(0.0, 0.0, 0.0), Point3D::new(1.0, 0.0, 0.0));
+        let e2 = make_edge(Point3D::new(1.0, 0.0, 0.0), Point3D::new(1.0, 1.0, 0.0));
+        let e3 = make_edge(Point3D::new(1.0, 1.0, 0.0), Point3D::new(0.0, 0.0, 0.0));
+
+        let wire = Wire::new(vec![e1, e2, e3], 1e-9).unwrap();
+        assert!(wire.is_closed(1e-9));
+    }
+}


### PR DESCRIPTION
## 概要

#408 の最小スコープとして `geo_topology` にトポロジー基礎型を追加し、Edge/Wire の連続性チェックを実装しました。

## 変更内容

### 1) トポロジー基礎型を追加

- 追加: [model/geo_topology/src/topology_core.rs](model/geo_topology/src/topology_core.rs)
  - `TopoId`
  - `Vertex<T>`
  - `CurveRef<T>`（`LineSegment3D` / `Arc3D` / `EllipseArc3D`）
  - `Edge<T>`

### 2) Wire を追加

- 追加: [model/geo_topology/src/wire.rs](model/geo_topology/src/wire.rs)
  - `Wire<T>`
  - `Wire::new(edges, tolerance)` で生成時に連続性検証
  - `is_continuous` / `is_closed` を提供

### 3) 公開 API の更新

- 更新: [model/geo_topology/src/lib.rs](model/geo_topology/src/lib.rs)
  - `topology_core`, `wire` モジュール公開
  - `TopoId`, `Vertex`, `CurveRef`, `Edge`, `Wire` を re-export
  - `TopoEllipseArc3D<T>` 型エイリアス追加

## #408 受け入れ条件への対応

- [x] Edge/Wire の連続性・向き整合チェック
- [x] 最小ユニットテスト追加
- [x] `cargo build/test` 通過
- [x] アーキテクチャ検証スクリプト通過
- [ ] （既に完了済み）`geo_topology` crate 作成
- [ ] （既に完了済み）依存ルール追加

## 検証

- `cargo clippy -p geo_topology -- -D warnings` ✅
- `cargo fmt` ✅
- `cargo test -p geo_topology` ✅ (13 passed)
- `./scripts/check_architecture_dependencies_simple.ps1` ✅

## 補足

Issue #408 本文のうち crate 作成と依存ルール追加は先行対応済みのため、本PRでは未実装部分（TopoId/Vertex/CurveRef/Edge/Wire）を対象にしています。

## 関連

- #408
- #406
- #407
- #458