### PR TITLE
[Phase C] #338 point系交差のIntersectionResult移行スライス（arc/circle）

### DIFF
--- a/dev/architecture/GEO_ALGORITHMS_MODULE_STRUCTURE_RULES.md
+++ b/dev/architecture/GEO_ALGORITHMS_MODULE_STRUCTURE_RULES.md
@@ -1,6 +1,6 @@
 # geo_algorithms モジュール分割ルール
 
-最終更新: 2026-03-23
+最終更新: 2026-03-28
 適用範囲: `model/geo_algorithms/src/{collision,intersection,distance}`
 
 ## 1. 目的
@@ -138,3 +138,28 @@
 - #403 Phase2 では、当面 `distance/primitive_3d.rs` に NURBS×3D primitive を集約する。
 - ただし将来整理で `distance/nurbs_curve_3d.rs` / `distance/nurbs_surface_3d.rs` へ分離可能。
 - その際は本ルールを正として移行する。
+
+## 10. #338 再開時の戻り値移行ルール
+
+`#338` では、`Option<Point3D<T>>` を返す既存関数を一括置換せず、
+`IntersectionResult<T>` への段階移行を行う。
+
+### 10.1 基本方針
+
+- 既存の `*_intersection` 関数は互換のため当面維持する。
+- 新規に `*_intersection_result` 関数を追加し、呼び出し側を段階的に移行する。
+- `IntersectionResult::from_option_point()` / `from_option_points()` を使用して変換規約を統一する。
+- 一度に多数ペアを移行せず、1～2ペア単位の小PRで進める。
+
+### 10.2 初期スライス（Phase C 再開の最小単位）
+
+- `intersection/primitive_3d.rs` の point系ペアから開始する。
+  - `arc3d_point3d_intersection_result`
+  - `circle3d_point3d_intersection_result`
+
+### 10.3 実装順序
+
+1. `*_intersection_result` 追加（旧APIは変更しない）
+2. 変換規約テスト追加（Disjoint / Crossing を最低限確認）
+3. 呼び出し側を1箇所ずつ移行
+4. 十分な移行完了後に旧API整理を検討

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -9,8 +9,8 @@
 
 use crate::{
     Arc3D, Circle3D, CylindricalSurface3D, Ellipse3D, EllipsoidalSolid3D, EllipsoidalSurface3D,
-    InfiniteLine3D, LineSegment3D, Plane3D, Point3D, Ray3D, SphericalSurface3D, TorusSolid3D,
-    TorusSurface3D, Triangle3D, TriangleMesh3D,
+    InfiniteLine3D, IntersectionResult, LineSegment3D, Plane3D, Point3D, Ray3D, SphericalSurface3D,
+    TorusSolid3D, TorusSurface3D, Triangle3D, TriangleMesh3D,
 };
 use geo_contracts::{
     Arc3DMeasure, Arc3DProperties, Circle3DProperties, CylindricalSurface3DMeasure,
@@ -70,6 +70,19 @@ pub fn arc3d_point3d_intersection<T: Scalar>(
         point,
         <Arc3D<T> as Arc3DMeasure<T>>::distance_to_point(arc, point_tuple) <= tolerance
             && arc.contains_point_angle(Point3D::new(point.x(), point.y(), point.z())),
+    )
+}
+
+/// `arc3d_point3d_intersection` の `IntersectionResult<T>` 版
+pub fn arc3d_point3d_intersection_result<T: Scalar>(
+    arc: &Arc3D<T>,
+    point: &Point3D<T>,
+    tolerance: T,
+) -> IntersectionResult<T> {
+    IntersectionResult::from_option_point(
+        arc3d_point3d_intersection(arc, point, tolerance),
+        false,
+        tolerance,
     )
 }
 
@@ -179,6 +192,19 @@ pub fn circle3d_point3d_intersection<T: Scalar>(
     point_intersection_if(
         point,
         circle.distance_to_point_3d(Point3D::new(point.x(), point.y(), point.z())) <= tolerance,
+    )
+}
+
+/// `circle3d_point3d_intersection` の `IntersectionResult<T>` 版
+pub fn circle3d_point3d_intersection_result<T: Scalar>(
+    circle: &Circle3D<T>,
+    point: &Point3D<T>,
+    tolerance: T,
+) -> IntersectionResult<T> {
+    IntersectionResult::from_option_point(
+        circle3d_point3d_intersection(circle, point, tolerance),
+        false,
+        tolerance,
     )
 }
 
@@ -1144,7 +1170,8 @@ pub fn infinite_line3d_ray3d_intersection<T: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::{
-        arc3d_point3d_intersection, circle3d_point3d_intersection,
+        arc3d_point3d_intersection, arc3d_point3d_intersection_result,
+        circle3d_point3d_intersection, circle3d_point3d_intersection_result,
         cylindrical_surface3d_point3d_intersection, ellipse3d_point3d_intersection,
         infinite_line3d_line_segment3d_intersection, infinite_line3d_point3d_intersection,
         infinite_line3d_spherical_surface3d_intersections,
@@ -1161,8 +1188,8 @@ mod tests {
     };
     use crate::{
         Angle, Arc3D, Circle3D, CylindricalSurface3D, Direction3D, Ellipse3D, InfiniteLine3D,
-        LineSegment3D, Plane3D, Point3D, Ray3D, SphericalSurface3D, TorusSurface3D, Triangle3D,
-        TriangleMesh3D, Vector3D,
+        IntersectionGeometry, IntersectionTopology, LineSegment3D, Plane3D, Point3D, Ray3D,
+        SphericalSurface3D, TorusSurface3D, Triangle3D, TriangleMesh3D, Vector3D,
     };
     use geo_contracts::ToleranceSettings;
 
@@ -1280,6 +1307,28 @@ mod tests {
     }
 
     #[test]
+    fn circle_point_intersection_result_converts_to_topology() {
+        let circle = Circle3D::new(
+            Point3D::new(0.0, 0.0, 0.0),
+            Direction3D::new(0.0, 0.0, 1.0).unwrap(),
+            2.0,
+        )
+        .unwrap();
+        let on_circle = Point3D::new(2.0, 0.0, 0.0);
+        let off_circle = Point3D::new(1.0, 0.0, 0.0);
+
+        let hit =
+            circle3d_point3d_intersection_result(&circle, &on_circle, standard_distance_tol());
+        let miss =
+            circle3d_point3d_intersection_result(&circle, &off_circle, standard_distance_tol());
+
+        assert_eq!(hit.topology, IntersectionTopology::Crossing);
+        assert!(matches!(hit.geometry, IntersectionGeometry::Point(_)));
+        assert_eq!(miss.topology, IntersectionTopology::Disjoint);
+        assert!(matches!(miss.geometry, IntersectionGeometry::None));
+    }
+
+    #[test]
     fn arc_point_intersection_checks_angle_range() {
         let arc = Arc3D::new(
             Point3D::new(0.0, 0.0, 0.0),
@@ -1302,6 +1351,29 @@ mod tests {
             arc3d_point3d_intersection(&arc, &out_of_angle, standard_distance_tol()),
             None
         );
+    }
+
+    #[test]
+    fn arc_point_intersection_result_converts_to_topology() {
+        let arc = Arc3D::new(
+            Point3D::new(0.0, 0.0, 0.0),
+            2.0,
+            Direction3D::new(0.0, 0.0, 1.0).unwrap(),
+            Direction3D::new(1.0, 0.0, 0.0).unwrap(),
+            Angle::from_radians(0.0),
+            Angle::from_radians(std::f64::consts::FRAC_PI_2),
+        )
+        .unwrap();
+
+        let on_arc = Point3D::new(2.0, 0.0, 0.0);
+        let off_arc = Point3D::new(-2.0, 0.0, 0.0);
+        let hit = arc3d_point3d_intersection_result(&arc, &on_arc, standard_distance_tol());
+        let miss = arc3d_point3d_intersection_result(&arc, &off_arc, standard_distance_tol());
+
+        assert_eq!(hit.topology, IntersectionTopology::Crossing);
+        assert!(matches!(hit.geometry, IntersectionGeometry::Point(_)));
+        assert_eq!(miss.topology, IntersectionTopology::Disjoint);
+        assert!(matches!(miss.geometry, IntersectionGeometry::None));
     }
 
     #[test]


### PR DESCRIPTION
## 概要

#338 の段階移行方針に沿って、3D primitive の point 系2ペアを `IntersectionResult<T>` 返却へ移行する最小スライスを追加する。

## 変更内容

### 実装

- 更新: [model/geo_algorithms/src/intersection/primitive_3d.rs](model/geo_algorithms/src/intersection/primitive_3d.rs)
  - 追加: `arc3d_point3d_intersection_result`
  - 追加: `circle3d_point3d_intersection_result`
  - 既存 `*_intersection`（`Option<Point3D<T>>`）は互換のため維持
  - 変換は `IntersectionResult::from_option_point()` を利用

### テスト

- 更新: [model/geo_algorithms/src/intersection/primitive_3d.rs](model/geo_algorithms/src/intersection/primitive_3d.rs)
  - `arc`/`circle` それぞれで `IntersectionResult` 変換テストを追加
  - `Crossing` / `Disjoint` と `Point` / `None` の整合を確認

### ドキュメント（実装前更新）

- 更新: [dev/architecture/GEO_ALGORITHMS_MODULE_STRUCTURE_RULES.md](dev/architecture/GEO_ALGORITHMS_MODULE_STRUCTURE_RULES.md)
  - #338 再開時の戻り値移行ルールを追記
  - 初期スライスを point系2ペア（arc/circle）として明文化

## 検証

- `cargo clippy -p geo_algorithms -- -D warnings` ✅
- `cargo fmt` ✅
- `cargo test -p geo_algorithms` ✅（211 passed）
- `./scripts/check_architecture_dependencies_simple.ps1` ✅

## 位置づけ

- 一括置換ではなく小PR単位の段階移行
- 次スライスで line/ray/segment 系へ展開予定

## 関連

- #338
- #406
- #458
- #459