### PR TITLE
[Phase C] #338 arc/circle公開APIをIntersectionResultへ直接置換（direct replacement）

### DIFF
--- a/dev/architecture/GEO_ALGORITHMS_MODULE_STRUCTURE_RULES.md
+++ b/dev/architecture/GEO_ALGORITHMS_MODULE_STRUCTURE_RULES.md
@@ -157,6 +157,22 @@
   - `arc3d_point3d_intersection_result`
   - `circle3d_point3d_intersection_result`
 
+### 10.2.1 継続スライス（同一PR系列で拡張する範囲）
+
+- point系の次は、同じ形状対の 1次元入力を対象に広げる。
+  - `arc3d_line_segment3d_intersection_result`
+  - `arc3d_ray3d_intersection_result`
+  - `arc3d_infinite_line3d_intersection_result`
+  - `circle3d_line_segment3d_intersection_result`
+  - `circle3d_ray3d_intersection_result`
+  - `circle3d_infinite_line3d_intersection_result`
+
+選定理由:
+
+- 既存実装が `Option<Point3D<T>>` の単一点返却で揃っている
+- `IntersectionResult::from_option_point()` をそのまま適用できる
+- `arc` / `circle` 系で命名・テストパターンを揃えやすい
+
 ### 10.3 実装順序
 
 1. `*_intersection_result` 追加（旧APIは変更しない）

--- a/dev/architecture/GEO_ALGORITHMS_MODULE_STRUCTURE_RULES.md
+++ b/dev/architecture/GEO_ALGORITHMS_MODULE_STRUCTURE_RULES.md
@@ -141,31 +141,31 @@
 
 ## 10. #338 再開時の戻り値移行ルール
 
-`#338` では、`Option<Point3D<T>>` を返す既存関数を一括置換せず、
-`IntersectionResult<T>` への段階移行を行う。
+`#338` では、公開関数の戻り値を `IntersectionResult<T>` へ直接置換する。
+互換層として公開 API を二重化しない。
 
 ### 10.1 基本方針
 
-- 既存の `*_intersection` 関数は互換のため当面維持する。
-- 新規に `*_intersection_result` 関数を追加し、呼び出し側を段階的に移行する。
+- 既存の `*_intersection` 関数名は維持しつつ、戻り値型を `IntersectionResult<T>` に切り替える。
+- 旧 `Option<Point3D<T>>` ロジックが必要な場合は private helper へ下げ、公開面には残さない。
 - `IntersectionResult::from_option_point()` / `from_option_points()` を使用して変換規約を統一する。
 - 一度に多数ペアを移行せず、1～2ペア単位の小PRで進める。
 
 ### 10.2 初期スライス（Phase C 再開の最小単位）
 
 - `intersection/primitive_3d.rs` の point系ペアから開始する。
-  - `arc3d_point3d_intersection_result`
-  - `circle3d_point3d_intersection_result`
+  - `arc3d_point3d_intersection`
+  - `circle3d_point3d_intersection`
 
 ### 10.2.1 継続スライス（同一PR系列で拡張する範囲）
 
 - point系の次は、同じ形状対の 1次元入力を対象に広げる。
-  - `arc3d_line_segment3d_intersection_result`
-  - `arc3d_ray3d_intersection_result`
-  - `arc3d_infinite_line3d_intersection_result`
-  - `circle3d_line_segment3d_intersection_result`
-  - `circle3d_ray3d_intersection_result`
-  - `circle3d_infinite_line3d_intersection_result`
+  - `arc3d_line_segment3d_intersection`
+  - `arc3d_ray3d_intersection`
+  - `arc3d_infinite_line3d_intersection`
+  - `circle3d_line_segment3d_intersection`
+  - `circle3d_ray3d_intersection`
+  - `circle3d_infinite_line3d_intersection`
 
 選定理由:
 
@@ -175,7 +175,7 @@
 
 ### 10.3 実装順序
 
-1. `*_intersection_result` 追加（旧APIは変更しない）
-2. 変換規約テスト追加（Disjoint / Crossing を最低限確認）
-3. 呼び出し側を1箇所ずつ移行
-4. 十分な移行完了後に旧API整理を検討
+1. 公開 `*_intersection` の戻り値を `IntersectionResult<T>` へ変更
+2. private helper 化で旧単一点ロジックを局所化
+3. 変換規約テスト追加（Disjoint / Crossing を最低限確認）
+4. 次ペアへ同じ置換を展開

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -124,6 +124,19 @@ pub fn arc3d_line_segment3d_intersection<T: Scalar>(
     }
 }
 
+/// `arc3d_line_segment3d_intersection` の `IntersectionResult<T>` 版
+pub fn arc3d_line_segment3d_intersection_result<T: Scalar>(
+    arc: &Arc3D<T>,
+    segment: &LineSegment3D<T>,
+    tolerance: T,
+) -> IntersectionResult<T> {
+    IntersectionResult::from_option_point(
+        arc3d_line_segment3d_intersection(arc, segment, tolerance),
+        false,
+        tolerance,
+    )
+}
+
 pub fn arc3d_ray3d_intersection<T: Scalar>(
     arc: &Arc3D<T>,
     ray: &Ray3D<T>,
@@ -139,6 +152,19 @@ pub fn arc3d_ray3d_intersection<T: Scalar>(
     }
 }
 
+/// `arc3d_ray3d_intersection` の `IntersectionResult<T>` 版
+pub fn arc3d_ray3d_intersection_result<T: Scalar>(
+    arc: &Arc3D<T>,
+    ray: &Ray3D<T>,
+    tolerance: T,
+) -> IntersectionResult<T> {
+    IntersectionResult::from_option_point(
+        arc3d_ray3d_intersection(arc, ray, tolerance),
+        false,
+        tolerance,
+    )
+}
+
 pub fn arc3d_infinite_line3d_intersection<T: Scalar>(
     arc: &Arc3D<T>,
     line: &InfiniteLine3D<T>,
@@ -152,6 +178,19 @@ pub fn arc3d_infinite_line3d_intersection<T: Scalar>(
     } else {
         None
     }
+}
+
+/// `arc3d_infinite_line3d_intersection` の `IntersectionResult<T>` 版
+pub fn arc3d_infinite_line3d_intersection_result<T: Scalar>(
+    arc: &Arc3D<T>,
+    line: &InfiniteLine3D<T>,
+    tolerance: T,
+) -> IntersectionResult<T> {
+    IntersectionResult::from_option_point(
+        arc3d_infinite_line3d_intersection(arc, line, tolerance),
+        false,
+        tolerance,
+    )
 }
 
 pub fn arc3d_arc3d_intersection<T: Scalar>(
@@ -222,6 +261,19 @@ pub fn circle3d_line_segment3d_intersection<T: Scalar>(
     None
 }
 
+/// `circle3d_line_segment3d_intersection` の `IntersectionResult<T>` 版
+pub fn circle3d_line_segment3d_intersection_result<T: Scalar>(
+    circle: &Circle3D<T>,
+    segment: &LineSegment3D<T>,
+    tolerance: T,
+) -> IntersectionResult<T> {
+    IntersectionResult::from_option_point(
+        circle3d_line_segment3d_intersection(circle, segment, tolerance),
+        false,
+        tolerance,
+    )
+}
+
 pub fn circle3d_ray3d_intersection<T: Scalar>(
     circle: &Circle3D<T>,
     ray: &Ray3D<T>,
@@ -233,6 +285,19 @@ pub fn circle3d_ray3d_intersection<T: Scalar>(
     } else {
         None
     }
+}
+
+/// `circle3d_ray3d_intersection` の `IntersectionResult<T>` 版
+pub fn circle3d_ray3d_intersection_result<T: Scalar>(
+    circle: &Circle3D<T>,
+    ray: &Ray3D<T>,
+    tolerance: T,
+) -> IntersectionResult<T> {
+    IntersectionResult::from_option_point(
+        circle3d_ray3d_intersection(circle, ray, tolerance),
+        false,
+        tolerance,
+    )
 }
 
 pub fn circle3d_infinite_line3d_intersection<T: Scalar>(
@@ -247,6 +312,19 @@ pub fn circle3d_infinite_line3d_intersection<T: Scalar>(
     } else {
         None
     }
+}
+
+/// `circle3d_infinite_line3d_intersection` の `IntersectionResult<T>` 版
+pub fn circle3d_infinite_line3d_intersection_result<T: Scalar>(
+    circle: &Circle3D<T>,
+    line: &InfiniteLine3D<T>,
+    tolerance: T,
+) -> IntersectionResult<T> {
+    IntersectionResult::from_option_point(
+        circle3d_infinite_line3d_intersection(circle, line, tolerance),
+        false,
+        tolerance,
+    )
 }
 
 pub fn circle3d_circle3d_intersection<T: Scalar>(
@@ -1170,8 +1248,11 @@ pub fn infinite_line3d_ray3d_intersection<T: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::{
+        arc3d_infinite_line3d_intersection_result, arc3d_line_segment3d_intersection_result,
         arc3d_point3d_intersection, arc3d_point3d_intersection_result,
-        circle3d_point3d_intersection, circle3d_point3d_intersection_result,
+        arc3d_ray3d_intersection_result, circle3d_infinite_line3d_intersection_result,
+        circle3d_line_segment3d_intersection_result, circle3d_point3d_intersection,
+        circle3d_point3d_intersection_result, circle3d_ray3d_intersection_result,
         cylindrical_surface3d_point3d_intersection, ellipse3d_point3d_intersection,
         infinite_line3d_line_segment3d_intersection, infinite_line3d_point3d_intersection,
         infinite_line3d_spherical_surface3d_intersections,
@@ -1377,6 +1458,60 @@ mod tests {
     }
 
     #[test]
+    fn arc_linear_input_result_variants_convert_to_topology() {
+        let arc = Arc3D::new(
+            Point3D::new(0.0, 0.0, 0.0),
+            2.0,
+            Direction3D::new(0.0, 0.0, 1.0).unwrap(),
+            Direction3D::new(1.0, 0.0, 0.0).unwrap(),
+            Angle::from_radians(0.0),
+            Angle::from_radians(std::f64::consts::FRAC_PI_2),
+        )
+        .unwrap();
+
+        let segment_hit =
+            LineSegment3D::new(Point3D::new(2.0, 0.0, 0.0), Point3D::new(3.0, 0.0, 0.0)).unwrap();
+        let segment_miss =
+            LineSegment3D::new(Point3D::new(5.0, 0.0, 0.0), Point3D::new(6.0, 0.0, 0.0)).unwrap();
+        let ray_hit =
+            Ray3D::new(Point3D::new(2.0, 0.0, 0.0), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
+        let ray_miss =
+            Ray3D::new(Point3D::new(5.0, 0.0, 0.0), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
+        let line_hit = InfiniteLine3D::from_two_points(
+            Point3D::new(2.0, 0.0, 0.0),
+            Point3D::new(2.0, 1.0, 0.0),
+        )
+        .unwrap();
+        let line_miss = InfiniteLine3D::from_two_points(
+            Point3D::new(5.0, 0.0, 0.0),
+            Point3D::new(5.0, 1.0, 0.0),
+        )
+        .unwrap();
+
+        let hit_segment =
+            arc3d_line_segment3d_intersection_result(&arc, &segment_hit, standard_distance_tol());
+        let miss_segment =
+            arc3d_line_segment3d_intersection_result(&arc, &segment_miss, standard_distance_tol());
+        let hit_ray = arc3d_ray3d_intersection_result(&arc, &ray_hit, standard_distance_tol());
+        let miss_ray = arc3d_ray3d_intersection_result(&arc, &ray_miss, standard_distance_tol());
+        let hit_line =
+            arc3d_infinite_line3d_intersection_result(&arc, &line_hit, standard_distance_tol());
+        let miss_line =
+            arc3d_infinite_line3d_intersection_result(&arc, &line_miss, standard_distance_tol());
+
+        assert_eq!(hit_segment.topology, IntersectionTopology::Crossing);
+        assert!(matches!(
+            hit_segment.geometry,
+            IntersectionGeometry::Point(_)
+        ));
+        assert_eq!(miss_segment.topology, IntersectionTopology::Disjoint);
+        assert_eq!(hit_ray.topology, IntersectionTopology::Crossing);
+        assert_eq!(miss_ray.topology, IntersectionTopology::Disjoint);
+        assert_eq!(hit_line.topology, IntersectionTopology::Crossing);
+        assert_eq!(miss_line.topology, IntersectionTopology::Disjoint);
+    }
+
+    #[test]
     fn ellipse_point_intersection_uses_distance() {
         let ellipse = Ellipse3D::new(
             Point3D::new(0.0, 0.0, 0.0),
@@ -1403,6 +1538,71 @@ mod tests {
             ellipse3d_point3d_intersection(&ellipse, &outside_plane, standard_distance_tol()),
             None
         );
+    }
+
+    #[test]
+    fn circle_linear_input_result_variants_convert_to_topology() {
+        let circle = Circle3D::new(
+            Point3D::new(0.0, 0.0, 0.0),
+            Direction3D::new(0.0, 0.0, 1.0).unwrap(),
+            2.0,
+        )
+        .unwrap();
+
+        let segment_hit =
+            LineSegment3D::new(Point3D::new(2.0, 0.0, 0.0), Point3D::new(3.0, 0.0, 0.0)).unwrap();
+        let segment_miss =
+            LineSegment3D::new(Point3D::new(5.0, 0.0, 0.0), Point3D::new(6.0, 0.0, 0.0)).unwrap();
+        let ray_hit =
+            Ray3D::new(Point3D::new(2.0, 0.0, 0.0), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
+        let ray_miss =
+            Ray3D::new(Point3D::new(5.0, 0.0, 0.0), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
+        let line_hit = InfiniteLine3D::from_two_points(
+            Point3D::new(2.0, 0.0, 0.0),
+            Point3D::new(2.0, 1.0, 0.0),
+        )
+        .unwrap();
+        let line_miss = InfiniteLine3D::from_two_points(
+            Point3D::new(5.0, 0.0, 0.0),
+            Point3D::new(5.0, 1.0, 0.0),
+        )
+        .unwrap();
+
+        let hit_segment = circle3d_line_segment3d_intersection_result(
+            &circle,
+            &segment_hit,
+            standard_distance_tol(),
+        );
+        let miss_segment = circle3d_line_segment3d_intersection_result(
+            &circle,
+            &segment_miss,
+            standard_distance_tol(),
+        );
+        let hit_ray =
+            circle3d_ray3d_intersection_result(&circle, &ray_hit, standard_distance_tol());
+        let miss_ray =
+            circle3d_ray3d_intersection_result(&circle, &ray_miss, standard_distance_tol());
+        let hit_line = circle3d_infinite_line3d_intersection_result(
+            &circle,
+            &line_hit,
+            standard_distance_tol(),
+        );
+        let miss_line = circle3d_infinite_line3d_intersection_result(
+            &circle,
+            &line_miss,
+            standard_distance_tol(),
+        );
+
+        assert_eq!(hit_segment.topology, IntersectionTopology::Crossing);
+        assert!(matches!(
+            hit_segment.geometry,
+            IntersectionGeometry::Point(_)
+        ));
+        assert_eq!(miss_segment.topology, IntersectionTopology::Disjoint);
+        assert_eq!(hit_ray.topology, IntersectionTopology::Crossing);
+        assert_eq!(miss_ray.topology, IntersectionTopology::Disjoint);
+        assert_eq!(hit_line.topology, IntersectionTopology::Crossing);
+        assert_eq!(miss_line.topology, IntersectionTopology::Disjoint);
     }
 
     #[test]

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -60,7 +60,7 @@ fn spherical_surface_intersection_parameters<T: Scalar>(
 
 // ── Arc3D ─────────────────────────────────────────────────────────────────────
 
-pub fn arc3d_point3d_intersection<T: Scalar>(
+fn arc3d_point3d_intersection_raw<T: Scalar>(
     arc: &Arc3D<T>,
     point: &Point3D<T>,
     tolerance: T,
@@ -73,20 +73,19 @@ pub fn arc3d_point3d_intersection<T: Scalar>(
     )
 }
 
-/// `arc3d_point3d_intersection` の `IntersectionResult<T>` 版
-pub fn arc3d_point3d_intersection_result<T: Scalar>(
+pub fn arc3d_point3d_intersection<T: Scalar>(
     arc: &Arc3D<T>,
     point: &Point3D<T>,
     tolerance: T,
 ) -> IntersectionResult<T> {
     IntersectionResult::from_option_point(
-        arc3d_point3d_intersection(arc, point, tolerance),
+        arc3d_point3d_intersection_raw(arc, point, tolerance),
         false,
         tolerance,
     )
 }
 
-pub fn arc3d_line_segment3d_intersection<T: Scalar>(
+fn arc3d_line_segment3d_intersection_raw<T: Scalar>(
     arc: &Arc3D<T>,
     segment: &LineSegment3D<T>,
     tolerance: T,
@@ -124,20 +123,19 @@ pub fn arc3d_line_segment3d_intersection<T: Scalar>(
     }
 }
 
-/// `arc3d_line_segment3d_intersection` の `IntersectionResult<T>` 版
-pub fn arc3d_line_segment3d_intersection_result<T: Scalar>(
+pub fn arc3d_line_segment3d_intersection<T: Scalar>(
     arc: &Arc3D<T>,
     segment: &LineSegment3D<T>,
     tolerance: T,
 ) -> IntersectionResult<T> {
     IntersectionResult::from_option_point(
-        arc3d_line_segment3d_intersection(arc, segment, tolerance),
+        arc3d_line_segment3d_intersection_raw(arc, segment, tolerance),
         false,
         tolerance,
     )
 }
 
-pub fn arc3d_ray3d_intersection<T: Scalar>(
+fn arc3d_ray3d_intersection_raw<T: Scalar>(
     arc: &Arc3D<T>,
     ray: &Ray3D<T>,
     tolerance: T,
@@ -152,20 +150,19 @@ pub fn arc3d_ray3d_intersection<T: Scalar>(
     }
 }
 
-/// `arc3d_ray3d_intersection` の `IntersectionResult<T>` 版
-pub fn arc3d_ray3d_intersection_result<T: Scalar>(
+pub fn arc3d_ray3d_intersection<T: Scalar>(
     arc: &Arc3D<T>,
     ray: &Ray3D<T>,
     tolerance: T,
 ) -> IntersectionResult<T> {
     IntersectionResult::from_option_point(
-        arc3d_ray3d_intersection(arc, ray, tolerance),
+        arc3d_ray3d_intersection_raw(arc, ray, tolerance),
         false,
         tolerance,
     )
 }
 
-pub fn arc3d_infinite_line3d_intersection<T: Scalar>(
+fn arc3d_infinite_line3d_intersection_raw<T: Scalar>(
     arc: &Arc3D<T>,
     line: &InfiniteLine3D<T>,
     tolerance: T,
@@ -180,14 +177,13 @@ pub fn arc3d_infinite_line3d_intersection<T: Scalar>(
     }
 }
 
-/// `arc3d_infinite_line3d_intersection` の `IntersectionResult<T>` 版
-pub fn arc3d_infinite_line3d_intersection_result<T: Scalar>(
+pub fn arc3d_infinite_line3d_intersection<T: Scalar>(
     arc: &Arc3D<T>,
     line: &InfiniteLine3D<T>,
     tolerance: T,
 ) -> IntersectionResult<T> {
     IntersectionResult::from_option_point(
-        arc3d_infinite_line3d_intersection(arc, line, tolerance),
+        arc3d_infinite_line3d_intersection_raw(arc, line, tolerance),
         false,
         tolerance,
     )
@@ -223,7 +219,7 @@ pub fn arc3d_arc3d_intersection<T: Scalar>(
 
 // ── Circle3D ──────────────────────────────────────────────────────────────────
 
-pub fn circle3d_point3d_intersection<T: Scalar>(
+fn circle3d_point3d_intersection_raw<T: Scalar>(
     circle: &Circle3D<T>,
     point: &Point3D<T>,
     tolerance: T,
@@ -234,20 +230,19 @@ pub fn circle3d_point3d_intersection<T: Scalar>(
     )
 }
 
-/// `circle3d_point3d_intersection` の `IntersectionResult<T>` 版
-pub fn circle3d_point3d_intersection_result<T: Scalar>(
+pub fn circle3d_point3d_intersection<T: Scalar>(
     circle: &Circle3D<T>,
     point: &Point3D<T>,
     tolerance: T,
 ) -> IntersectionResult<T> {
     IntersectionResult::from_option_point(
-        circle3d_point3d_intersection(circle, point, tolerance),
+        circle3d_point3d_intersection_raw(circle, point, tolerance),
         false,
         tolerance,
     )
 }
 
-pub fn circle3d_line_segment3d_intersection<T: Scalar>(
+fn circle3d_line_segment3d_intersection_raw<T: Scalar>(
     circle: &Circle3D<T>,
     segment: &LineSegment3D<T>,
     _tolerance: T,
@@ -261,20 +256,19 @@ pub fn circle3d_line_segment3d_intersection<T: Scalar>(
     None
 }
 
-/// `circle3d_line_segment3d_intersection` の `IntersectionResult<T>` 版
-pub fn circle3d_line_segment3d_intersection_result<T: Scalar>(
+pub fn circle3d_line_segment3d_intersection<T: Scalar>(
     circle: &Circle3D<T>,
     segment: &LineSegment3D<T>,
     tolerance: T,
 ) -> IntersectionResult<T> {
     IntersectionResult::from_option_point(
-        circle3d_line_segment3d_intersection(circle, segment, tolerance),
+        circle3d_line_segment3d_intersection_raw(circle, segment, tolerance),
         false,
         tolerance,
     )
 }
 
-pub fn circle3d_ray3d_intersection<T: Scalar>(
+fn circle3d_ray3d_intersection_raw<T: Scalar>(
     circle: &Circle3D<T>,
     ray: &Ray3D<T>,
     _tolerance: T,
@@ -287,20 +281,19 @@ pub fn circle3d_ray3d_intersection<T: Scalar>(
     }
 }
 
-/// `circle3d_ray3d_intersection` の `IntersectionResult<T>` 版
-pub fn circle3d_ray3d_intersection_result<T: Scalar>(
+pub fn circle3d_ray3d_intersection<T: Scalar>(
     circle: &Circle3D<T>,
     ray: &Ray3D<T>,
     tolerance: T,
 ) -> IntersectionResult<T> {
     IntersectionResult::from_option_point(
-        circle3d_ray3d_intersection(circle, ray, tolerance),
+        circle3d_ray3d_intersection_raw(circle, ray, tolerance),
         false,
         tolerance,
     )
 }
 
-pub fn circle3d_infinite_line3d_intersection<T: Scalar>(
+fn circle3d_infinite_line3d_intersection_raw<T: Scalar>(
     circle: &Circle3D<T>,
     line: &InfiniteLine3D<T>,
     _tolerance: T,
@@ -314,14 +307,13 @@ pub fn circle3d_infinite_line3d_intersection<T: Scalar>(
     }
 }
 
-/// `circle3d_infinite_line3d_intersection` の `IntersectionResult<T>` 版
-pub fn circle3d_infinite_line3d_intersection_result<T: Scalar>(
+pub fn circle3d_infinite_line3d_intersection<T: Scalar>(
     circle: &Circle3D<T>,
     line: &InfiniteLine3D<T>,
     tolerance: T,
 ) -> IntersectionResult<T> {
     IntersectionResult::from_option_point(
-        circle3d_infinite_line3d_intersection(circle, line, tolerance),
+        circle3d_infinite_line3d_intersection_raw(circle, line, tolerance),
         false,
         tolerance,
     )
@@ -1248,11 +1240,10 @@ pub fn infinite_line3d_ray3d_intersection<T: Scalar>(
 #[cfg(test)]
 mod tests {
     use super::{
-        arc3d_infinite_line3d_intersection_result, arc3d_line_segment3d_intersection_result,
-        arc3d_point3d_intersection, arc3d_point3d_intersection_result,
-        arc3d_ray3d_intersection_result, circle3d_infinite_line3d_intersection_result,
-        circle3d_line_segment3d_intersection_result, circle3d_point3d_intersection,
-        circle3d_point3d_intersection_result, circle3d_ray3d_intersection_result,
+        arc3d_infinite_line3d_intersection, arc3d_line_segment3d_intersection,
+        arc3d_point3d_intersection, arc3d_ray3d_intersection,
+        circle3d_infinite_line3d_intersection, circle3d_line_segment3d_intersection,
+        circle3d_point3d_intersection, circle3d_ray3d_intersection,
         cylindrical_surface3d_point3d_intersection, ellipse3d_point3d_intersection,
         infinite_line3d_line_segment3d_intersection, infinite_line3d_point3d_intersection,
         infinite_line3d_spherical_surface3d_intersections,
@@ -1378,13 +1369,21 @@ mod tests {
         let inside_disk = Point3D::new(1.0, 0.0, 0.0);
 
         assert_eq!(
-            circle3d_point3d_intersection(&circle, &on_circle, standard_distance_tol()),
-            Some(on_circle)
+            circle3d_point3d_intersection(&circle, &on_circle, standard_distance_tol()).topology,
+            IntersectionTopology::Crossing
         );
+        assert!(matches!(
+            circle3d_point3d_intersection(&circle, &on_circle, standard_distance_tol()).geometry,
+            IntersectionGeometry::Point(point) if point == on_circle
+        ));
         assert_eq!(
-            circle3d_point3d_intersection(&circle, &inside_disk, standard_distance_tol()),
-            None
+            circle3d_point3d_intersection(&circle, &inside_disk, standard_distance_tol()).topology,
+            IntersectionTopology::Disjoint
         );
+        assert!(matches!(
+            circle3d_point3d_intersection(&circle, &inside_disk, standard_distance_tol()).geometry,
+            IntersectionGeometry::None
+        ));
     }
 
     #[test]
@@ -1398,10 +1397,8 @@ mod tests {
         let on_circle = Point3D::new(2.0, 0.0, 0.0);
         let off_circle = Point3D::new(1.0, 0.0, 0.0);
 
-        let hit =
-            circle3d_point3d_intersection_result(&circle, &on_circle, standard_distance_tol());
-        let miss =
-            circle3d_point3d_intersection_result(&circle, &off_circle, standard_distance_tol());
+        let hit = circle3d_point3d_intersection(&circle, &on_circle, standard_distance_tol());
+        let miss = circle3d_point3d_intersection(&circle, &off_circle, standard_distance_tol());
 
         assert_eq!(hit.topology, IntersectionTopology::Crossing);
         assert!(matches!(hit.geometry, IntersectionGeometry::Point(_)));
@@ -1425,13 +1422,21 @@ mod tests {
         let out_of_angle = Point3D::new(-2.0, 0.0, 0.0);
 
         assert_eq!(
-            arc3d_point3d_intersection(&arc, &on_arc, standard_distance_tol()),
-            Some(on_arc)
+            arc3d_point3d_intersection(&arc, &on_arc, standard_distance_tol()).topology,
+            IntersectionTopology::Crossing
         );
+        assert!(matches!(
+            arc3d_point3d_intersection(&arc, &on_arc, standard_distance_tol()).geometry,
+            IntersectionGeometry::Point(point) if point == on_arc
+        ));
         assert_eq!(
-            arc3d_point3d_intersection(&arc, &out_of_angle, standard_distance_tol()),
-            None
+            arc3d_point3d_intersection(&arc, &out_of_angle, standard_distance_tol()).topology,
+            IntersectionTopology::Disjoint
         );
+        assert!(matches!(
+            arc3d_point3d_intersection(&arc, &out_of_angle, standard_distance_tol()).geometry,
+            IntersectionGeometry::None
+        ));
     }
 
     #[test]
@@ -1448,8 +1453,8 @@ mod tests {
 
         let on_arc = Point3D::new(2.0, 0.0, 0.0);
         let off_arc = Point3D::new(-2.0, 0.0, 0.0);
-        let hit = arc3d_point3d_intersection_result(&arc, &on_arc, standard_distance_tol());
-        let miss = arc3d_point3d_intersection_result(&arc, &off_arc, standard_distance_tol());
+        let hit = arc3d_point3d_intersection(&arc, &on_arc, standard_distance_tol());
+        let miss = arc3d_point3d_intersection(&arc, &off_arc, standard_distance_tol());
 
         assert_eq!(hit.topology, IntersectionTopology::Crossing);
         assert!(matches!(hit.geometry, IntersectionGeometry::Point(_)));
@@ -1489,15 +1494,14 @@ mod tests {
         .unwrap();
 
         let hit_segment =
-            arc3d_line_segment3d_intersection_result(&arc, &segment_hit, standard_distance_tol());
+            arc3d_line_segment3d_intersection(&arc, &segment_hit, standard_distance_tol());
         let miss_segment =
-            arc3d_line_segment3d_intersection_result(&arc, &segment_miss, standard_distance_tol());
-        let hit_ray = arc3d_ray3d_intersection_result(&arc, &ray_hit, standard_distance_tol());
-        let miss_ray = arc3d_ray3d_intersection_result(&arc, &ray_miss, standard_distance_tol());
-        let hit_line =
-            arc3d_infinite_line3d_intersection_result(&arc, &line_hit, standard_distance_tol());
+            arc3d_line_segment3d_intersection(&arc, &segment_miss, standard_distance_tol());
+        let hit_ray = arc3d_ray3d_intersection(&arc, &ray_hit, standard_distance_tol());
+        let miss_ray = arc3d_ray3d_intersection(&arc, &ray_miss, standard_distance_tol());
+        let hit_line = arc3d_infinite_line3d_intersection(&arc, &line_hit, standard_distance_tol());
         let miss_line =
-            arc3d_infinite_line3d_intersection_result(&arc, &line_miss, standard_distance_tol());
+            arc3d_infinite_line3d_intersection(&arc, &line_miss, standard_distance_tol());
 
         assert_eq!(hit_segment.topology, IntersectionTopology::Crossing);
         assert!(matches!(
@@ -1568,30 +1572,16 @@ mod tests {
         )
         .unwrap();
 
-        let hit_segment = circle3d_line_segment3d_intersection_result(
-            &circle,
-            &segment_hit,
-            standard_distance_tol(),
-        );
-        let miss_segment = circle3d_line_segment3d_intersection_result(
-            &circle,
-            &segment_miss,
-            standard_distance_tol(),
-        );
-        let hit_ray =
-            circle3d_ray3d_intersection_result(&circle, &ray_hit, standard_distance_tol());
-        let miss_ray =
-            circle3d_ray3d_intersection_result(&circle, &ray_miss, standard_distance_tol());
-        let hit_line = circle3d_infinite_line3d_intersection_result(
-            &circle,
-            &line_hit,
-            standard_distance_tol(),
-        );
-        let miss_line = circle3d_infinite_line3d_intersection_result(
-            &circle,
-            &line_miss,
-            standard_distance_tol(),
-        );
+        let hit_segment =
+            circle3d_line_segment3d_intersection(&circle, &segment_hit, standard_distance_tol());
+        let miss_segment =
+            circle3d_line_segment3d_intersection(&circle, &segment_miss, standard_distance_tol());
+        let hit_ray = circle3d_ray3d_intersection(&circle, &ray_hit, standard_distance_tol());
+        let miss_ray = circle3d_ray3d_intersection(&circle, &ray_miss, standard_distance_tol());
+        let hit_line =
+            circle3d_infinite_line3d_intersection(&circle, &line_hit, standard_distance_tol());
+        let miss_line =
+            circle3d_infinite_line3d_intersection(&circle, &line_miss, standard_distance_tol());
 
         assert_eq!(hit_segment.topology, IntersectionTopology::Crossing);
         assert!(matches!(


### PR DESCRIPTION
## 概要

#338 の移行方針を「互換公開 API の追加」から「公開 API を `IntersectionResult<T>` へ直接置換」へ修正し、arc/circle の 8 関数すべてを置換する。

## 変更内容

### 実装

- 更新: [model/geo_algorithms/src/intersection/primitive_3d.rs](model/geo_algorithms/src/intersection/primitive_3d.rs)
  - `arc3d_point3d_intersection` / `arc3d_line_segment3d_intersection` / `arc3d_ray3d_intersection` / `arc3d_infinite_line3d_intersection`
  - `circle3d_point3d_intersection` / `circle3d_line_segment3d_intersection` / `circle3d_ray3d_intersection` / `circle3d_infinite_line3d_intersection`
  - 上記 8 関数の戻り値を `Option<Point3D<T>>` から `IntersectionResult<T>` へ直接置換
  - 旧 Option ロジックは `*_raw` private helper に下げ、公開 API は一本化
  - 互換公開 API（`*_intersection_result` 系）は削除

### テスト

- `circle_point_intersection_requires_point_on_circumference` / `arc_point_intersection_checks_angle_range` を `IntersectionTopology`/`IntersectionGeometry` ベースに更新
- `circle_point_intersection_result_converts_to_topology` / `arc_point_intersection_result_converts_to_topology` も同一 API 参照に統一
- arc/circle × line_segment/ray/infinite_line の topology 確認テストを追加

### ドキュメント

- 更新: [dev/architecture/GEO_ALGORITHMS_MODULE_STRUCTURE_RULES.md](dev/architecture/GEO_ALGORITHMS_MODULE_STRUCTURE_RULES.md)
  - #338 戻り値移行ルールを「公開 `*_intersection` を `IntersectionResult<T>` に直接置換」方針へ変更
  - 互換公開 API を二重化しない旨を明文化

## 検証

- `cargo clippy -p geo_algorithms -- -D warnings` ✅
- `cargo fmt` ✅
- `cargo test -p geo_algorithms` ✅（213 passed）
- `./scripts/check_architecture_dependencies_simple.ps1` ✅

## 方針補足

前 PR (#465) は「`*_intersection_result` を追加して互換維持」で作成されていたが、設計意図は「公開 Intersect API を result 型に置換すること」のため方針を修正した。
多点返却関数（`Vec<Point3D<T>>`）の統一は別途 #466 で設計・対応する。

## 関連

- #338（進行中）
- #406 Epic
- #466（多点交差の result 型拡張、後続 Design Issue）