### PR TITLE
[Phase D3] impl: primitive_2d の線分/直線/ray 系 Option返却を IntersectionResult に置換

### DIFF
--- a/model/geo_algorithms/src/collision/pair_base.rs
+++ b/model/geo_algorithms/src/collision/pair_base.rs
@@ -27,7 +27,7 @@ pub fn ray2d_line_segment2d_collides<T: Scalar>(
     segment: &LineSegment2D<T>,
     tolerance: T,
 ) -> bool {
-    ray2d_line_segment2d_intersection_2d(ray, segment, tolerance).is_some()
+    ray2d_line_segment2d_intersection_2d(ray, segment, tolerance).intersects()
 }
 
 pub fn line_segment2d_ray2d_collides<T: Scalar>(
@@ -43,7 +43,7 @@ pub fn infinite_line2d_line_segment2d_collides<T: Scalar>(
     segment: &LineSegment2D<T>,
     tolerance: T,
 ) -> bool {
-    infinite_line2d_line_segment2d_intersection_2d(line, segment, tolerance).is_some()
+    infinite_line2d_line_segment2d_intersection_2d(line, segment, tolerance).intersects()
 }
 
 pub fn line_segment2d_infinite_line2d_collides<T: Scalar>(
@@ -59,7 +59,7 @@ pub fn infinite_line2d_ray2d_collides<T: Scalar>(
     ray: &Ray2D<T>,
     tolerance: T,
 ) -> bool {
-    infinite_line2d_ray2d_intersection_2d(line, ray, tolerance).is_some()
+    infinite_line2d_ray2d_intersection_2d(line, ray, tolerance).intersects()
 }
 
 pub fn ray2d_infinite_line2d_collides<T: Scalar>(

--- a/model/geo_algorithms/src/intersection/primitive_2d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_2d.rs
@@ -94,7 +94,7 @@ pub fn ray2d_line_segment2d_intersection<T: Scalar>(
     ray: &Ray2D<T>,
     segment: &LineSegment2D<T>,
     tolerance: T,
-) -> Option<Point2D<T>> {
+) -> IntersectionResult<T> {
     let s1 = Point2D::new(segment.start().0, segment.start().1);
     let s2 = Point2D::new(segment.end().0, segment.end().1);
 
@@ -108,27 +108,29 @@ pub fn ray2d_line_segment2d_intersection<T: Scalar>(
 
     let denominator = d1.x() * d2.y() - d1.y() * d2.x();
     if denominator.abs() < T::EPSILON {
-        return None;
+        return IntersectionResult::from_option_point2d(None, false, tolerance);
     }
 
     let t1 = ((s1.x() - origin.x()) * d2.y() - (s1.y() - origin.y()) * d2.x()) / denominator;
     let t2 = ((s1.x() - origin.x()) * d1.y() - (s1.y() - origin.y()) * d1.x()) / denominator;
 
-    if t1 >= T::ZERO - tolerance && t2 >= T::ZERO - tolerance && t2 <= T::ONE + tolerance {
+    let opt = if t1 >= T::ZERO - tolerance && t2 >= T::ZERO - tolerance && t2 <= T::ONE + tolerance
+    {
         Some(Point2D::new(
             origin.x() + t1 * d1.x(),
             origin.y() + t1 * d1.y(),
         ))
     } else {
         None
-    }
+    };
+    IntersectionResult::from_option_point2d(opt, false, tolerance)
 }
 
 pub fn line_segment2d_ray2d_intersection<T: Scalar>(
     segment: &LineSegment2D<T>,
     ray: &Ray2D<T>,
     tolerance: T,
-) -> Option<Point2D<T>> {
+) -> IntersectionResult<T> {
     ray2d_line_segment2d_intersection(ray, segment, tolerance)
 }
 
@@ -219,14 +221,15 @@ pub fn ray2d_ellipse2d_intersection<T: Scalar>(
     ray: &Ray2D<T>,
     ellipse: &Ellipse2D<T>,
     tolerance: T,
-) -> Option<Point2D<T>> {
+) -> IntersectionResult<T> {
     let center_tuple = ellipse.center();
     let center = Point2D::new(center_tuple.0, center_tuple.1);
-    if ray.distance_to_point(&center) <= ellipse.semi_major_axis() + tolerance {
+    let opt = if ray.distance_to_point(&center) <= ellipse.semi_major_axis() + tolerance {
         Some(center)
     } else {
         None
-    }
+    };
+    IntersectionResult::from_option_point2d(opt, false, tolerance)
 }
 
 pub fn arc2d_point2d_intersection<T: Scalar>(
@@ -267,13 +270,14 @@ pub fn infinite_line2d_circle2d_intersection<T: Scalar>(
     line: &InfiniteLine2D<T>,
     circle: &Circle2D<T>,
     tolerance: T,
-) -> Option<Point2D<T>> {
+) -> IntersectionResult<T> {
     let center = Point2D::new(circle.center().0, circle.center().1);
-    if line.distance_to_point(&center) <= circle.radius() + tolerance {
+    let opt = if line.distance_to_point(&center) <= circle.radius() + tolerance {
         Some(center)
     } else {
         None
-    }
+    };
+    IntersectionResult::from_option_point2d(opt, false, tolerance)
 }
 
 pub fn infinite_line2d_circle2d_intersections<T: Scalar>(
@@ -309,7 +313,7 @@ pub fn circle2d_infinite_line2d_intersection<T: Scalar>(
     circle: &Circle2D<T>,
     line: &InfiniteLine2D<T>,
     tolerance: T,
-) -> Option<Point2D<T>> {
+) -> IntersectionResult<T> {
     infinite_line2d_circle2d_intersection(line, circle, tolerance)
 }
 
@@ -325,7 +329,7 @@ pub fn infinite_line2d_line_segment2d_intersection<T: Scalar>(
     line: &InfiniteLine2D<T>,
     segment: &LineSegment2D<T>,
     tolerance: T,
-) -> Option<Point2D<T>> {
+) -> IntersectionResult<T> {
     let (s1x, s1y) = LineSegment2DProperties::start(segment);
     let (s2x, s2y) = LineSegment2DProperties::end(segment);
     let (lx, ly) = InfiniteLine2DProperties::point(line);
@@ -334,21 +338,22 @@ pub fn infinite_line2d_line_segment2d_intersection<T: Scalar>(
     let dy_seg = s2y - s1y;
     let denominator = ldx * dy_seg - ldy * dx_seg;
     if denominator.abs() < T::EPSILON {
-        return None;
+        return IntersectionResult::from_option_point2d(None, false, tolerance);
     }
     let t2 = ((s1x - lx) * ldy - (s1y - ly) * ldx) / denominator;
-    if t2 >= T::ZERO - tolerance && t2 <= T::ONE + tolerance {
+    let opt = if t2 >= T::ZERO - tolerance && t2 <= T::ONE + tolerance {
         Some(Point2D::new(s1x + t2 * dx_seg, s1y + t2 * dy_seg))
     } else {
         None
-    }
+    };
+    IntersectionResult::from_option_point2d(opt, false, tolerance)
 }
 
 pub fn line_segment2d_infinite_line2d_intersection<T: Scalar>(
     segment: &LineSegment2D<T>,
     line: &InfiniteLine2D<T>,
     tolerance: T,
-) -> Option<Point2D<T>> {
+) -> IntersectionResult<T> {
     infinite_line2d_line_segment2d_intersection(line, segment, tolerance)
 }
 
@@ -356,28 +361,29 @@ pub fn infinite_line2d_ray2d_intersection<T: Scalar>(
     line: &InfiniteLine2D<T>,
     ray: &Ray2D<T>,
     tolerance: T,
-) -> Option<Point2D<T>> {
+) -> IntersectionResult<T> {
     let (ox, oy) = Ray2DProperties::origin(ray);
     let (rdx, rdy) = Ray2DProperties::direction(ray);
     let (lx, ly) = InfiniteLine2DProperties::point(line);
     let (ldx, ldy) = InfiniteLine2DProperties::direction(line);
     let denominator = ldx * rdy - ldy * rdx;
     if denominator.abs() < T::EPSILON {
-        return None;
+        return IntersectionResult::from_option_point2d(None, false, tolerance);
     }
     let t2 = ((ox - lx) * ldy - (oy - ly) * ldx) / denominator;
-    if t2 >= T::ZERO - tolerance {
+    let opt = if t2 >= T::ZERO - tolerance {
         Some(Point2D::new(ox + t2 * rdx, oy + t2 * rdy))
     } else {
         None
-    }
+    };
+    IntersectionResult::from_option_point2d(opt, false, tolerance)
 }
 
 pub fn ray2d_infinite_line2d_intersection<T: Scalar>(
     ray: &Ray2D<T>,
     line: &InfiniteLine2D<T>,
     tolerance: T,
-) -> Option<Point2D<T>> {
+) -> IntersectionResult<T> {
     infinite_line2d_ray2d_intersection(line, ray, tolerance)
 }
 
@@ -628,26 +634,26 @@ mod tests {
             circle2d_ray2d_intersections(&circle, &ray, tol),
             ray2d_circle2d_intersections(&ray, &circle, tol)
         );
-        assert_eq!(
-            line_segment2d_ray2d_intersection(&segment, &ray, tol),
-            ray2d_line_segment2d_intersection(&ray, &segment, tol)
-        );
-        assert_eq!(
-            circle2d_infinite_line2d_intersection(&circle, &line, tol),
-            infinite_line2d_circle2d_intersection(&line, &circle, tol)
-        );
+        let seg_ray = line_segment2d_ray2d_intersection(&segment, &ray, tol);
+        let ray_seg = ray2d_line_segment2d_intersection(&ray, &segment, tol);
+        assert_eq!(seg_ray.topology, ray_seg.topology);
+        assert_eq!(seg_ray.is_tangent, ray_seg.is_tangent);
+        let circ_line = circle2d_infinite_line2d_intersection(&circle, &line, tol);
+        let line_circ = infinite_line2d_circle2d_intersection(&line, &circle, tol);
+        assert_eq!(circ_line.topology, line_circ.topology);
+        assert_eq!(circ_line.is_tangent, line_circ.is_tangent);
         assert_eq!(
             circle2d_infinite_line2d_intersections(&circle, &line, tol),
             infinite_line2d_circle2d_intersections(&line, &circle, tol)
         );
-        assert_eq!(
-            line_segment2d_infinite_line2d_intersection(&segment, &line, tol),
-            infinite_line2d_line_segment2d_intersection(&line, &segment, tol)
-        );
-        assert_eq!(
-            ray2d_infinite_line2d_intersection(&ray, &line, tol),
-            infinite_line2d_ray2d_intersection(&line, &ray, tol)
-        );
+        let seg_line = line_segment2d_infinite_line2d_intersection(&segment, &line, tol);
+        let line_seg = infinite_line2d_line_segment2d_intersection(&line, &segment, tol);
+        assert_eq!(seg_line.topology, line_seg.topology);
+        assert_eq!(seg_line.is_tangent, line_seg.is_tangent);
+        let ray_line = ray2d_infinite_line2d_intersection(&ray, &line, tol);
+        let line_ray = infinite_line2d_ray2d_intersection(&line, &ray, tol);
+        assert_eq!(ray_line.topology, line_ray.topology);
+        assert_eq!(ray_line.is_tangent, line_ray.is_tangent);
     }
 
     #[test]


### PR DESCRIPTION
## 概要

#478 の D3 として、`primitive_2d.rs` の線分/直線/ray 系の `Option<Point2D<T>>` 返却APIを `IntersectionResult<T>` へ置換。

## 変更ファイル

- `model/geo_algorithms/src/intersection/primitive_2d.rs`
- `model/geo_algorithms/src/collision/pair_base.rs`

## 主な変更

### 1) 交差APIの戻り値変更（9関数）

- `ray2d_line_segment2d_intersection`
- `line_segment2d_ray2d_intersection`
- `infinite_line2d_circle2d_intersection`
- `circle2d_infinite_line2d_intersection`
- `infinite_line2d_line_segment2d_intersection`
- `line_segment2d_infinite_line2d_intersection`
- `infinite_line2d_ray2d_intersection`
- `ray2d_infinite_line2d_intersection`
- `ray2d_ellipse2d_intersection`

変換は `IntersectionResult::from_option_point2d(opt, false, tolerance)` で統一。

### 2) テスト修正

`symmetric_intersection_wrappers_match_base_functions` で、`IntersectionResult<T>` は `PartialEq` を持たないため、
対称ラッパー同士の比較を `topology` / `is_tangent` ベースへ変更。

### 3) 衝突判定側の追従

`collision/pair_base.rs` の 2D 呼び出しで `.is_some()` を使用していた3箇所を `.intersects()` へ更新。

## 検証

- `cargo test -p geo_algorithms`:
  - `test result: ok. 225 passed; 0 failed`
- `cargo clippy -p geo_algorithms -- -D warnings`: クリーン
- `cargo fmt --all -- --check`: クリーン

## 関連

- D2: #476
- このPRで対応: #478
- Epic: #406