### PR TITLE
[docs] issue #455: tolerance単一正本化のルール正規化と着手準備

### DIFF
--- a/dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md
+++ b/dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md
@@ -1,5 +1,7 @@
 # Geometric Tolerance Usage Rules
 
+最終更新: 2026-03-29
+
 ## 目的
 
 幾何演算におけるトレランスの責務を明確化し、正本と互換層の混在を段階的に解消するための運用ルールを定義する。
@@ -11,62 +13,84 @@
 - スケーリング責務は呼び出し元に置く。
 - 互換層は暫定運用とし、新規実装での依存追加を禁止する。
 
-## 現状の3層構造
+## 現状の責務構造
 
-### 層1: 正本（維持）
+### 正本（維持）
 
 - `model/geo_contracts/src/tolerance.rs`
 - 提供: `ToleranceSettings<T>`
 - 役割: 幾何演算で使用する標準トレランスの単一の情報源
 
-### 層2: 過渡期互換層（段階的廃止）
+### 派生利用（維持）
+
+- `model/geo_algorithms/src/octree/tolerance.rs`
+- 提供: `OctreeTolerance<T>`
+- 役割: `ToleranceSettings::relaxed().distance_tolerance` から Octree 用閾値を派生
+- 方針: 幾何判定の別正本を作らず、用途特化の派生のみ許可
+
+### 廃止済み互換層（履歴）
 
 - `model/geo_contracts/src/tolerance_migration.rs`
 - 提供: `DefaultTolerances`, `ScalarToleranceExt`
-- 役割: 旧呼び出し経路の暫定サポート
-- 方針: 新規利用禁止、`ToleranceSettings` へ順次移行後に削除
-
-### 層3: geo_algorithms レガシー互換層（段階的廃止）
+- 状態: 廃止済み
 
 - `model/geo_algorithms/src/tolerance.rs`
 - 提供: `ToleranceContext`
-- 役割: 旧実装互換の最小定義
-- 方針: `ToleranceSettings` ベースへ順次移行後に削除
+- 状態: 廃止済み（Issue #377）
+
+## 判定種別ごとの選択ルール
+
+| 判定種別 | 既定参照元 | 運用ルール |
+| --- | --- | --- |
+| 距離しきい値（包含、近接、一致） | `ToleranceSettings::distance_tolerance` | 呼び出し境界で受け渡した値を優先する |
+| 角度しきい値（平行、垂直、角度比較） | `ToleranceSettings::angle_tolerance` | API呼び出し側でプロファイルを選択して渡す |
+| 外積誤差（平行判定補助） | `default_parallel_cross_error_tolerance<T>()` | 型依存閾値を使用し、関数内マジックナンバーを追加しない |
+| 内積誤差（直交判定補助） | `default_orthogonality_dot_error_tolerance<T>()` | 型依存閾値を使用し、用途を直交判定に限定する |
+| 数値解法の収束補助 | `foundation/analysis/src/consts.rs` | 幾何意味判定の正本としては使わない |
+
+## 呼び出し境界ルール
+
+1. API入力トレランスは呼び出し元が `ToleranceSettings` を選択して渡す。
+2. 下位処理は受け取った `tolerance` をそのまま伝播させる。
+3. `T::EPSILON` は数値安定化の局所用途に限定し、ドメイン判定の既定値にしない。
+4. 新規実装で互換層や別正本となるトレランス定義を追加しない。
 
 ## 廃止ロードマップ
 
-### フェーズ1（Issue #361）
+### フェーズ1（Issue #361 / #377）
 
-- 本ドキュメントを整備する。
-- 互換層ファイルに廃止予定コメントと参照Issueを明記する。
+- 本ドキュメントを整備。
+- 旧互換層を廃止。
 
-### フェーズ2（別Issue）
+### フェーズ2（Issue #455）
 
-- `geo_primitives` の `DefaultTolerances` 依存を `ToleranceSettings` へ移行する。
-- 移行完了後に `model/geo_contracts/src/tolerance_migration.rs` を削除する。
+- 単一正本の運用ルールと判定種別ルールを確定。
+- 影響範囲の棚卸しと分割Issue化を完了。
 
-### フェーズ3（別Issue）
+### フェーズ3（分割Issueで実施）
 
-- `geo_algorithms` 内で `ToleranceContext` 依存箇所を `ToleranceSettings` ベースへ移行する。
-- 移行完了後に `model/geo_algorithms/src/tolerance.rs` を削除する。
+- `geo_algorithms` の高頻度経路移行。
+- `geo_primitives` / `geo_nurbs` の残存参照を移行。
+- 残存参照排除と回帰テストで収束。
 
-### フェーズ3 実績（Issue #377）
+## #455 分割実行計画
 
-- `interpolation.rs` / `numerical.rs` / `statistics.rs` / `sampling.rs` の
-	`ToleranceContext` 依存を `geo_contracts::ToleranceSettings<f64>` ベースへ移行。
-- `model/geo_algorithms/src/tolerance.rs` を削除。
-- `geo_algorithms` 側の新規トレランス定義追加は行わず、
-	呼び出し境界で `ToleranceSettings` を受け渡す方針に統一。
+1. ルール固定（文書正規化）
+2. `geo_algorithms` 高頻度経路の移行
+3. `geo_primitives` / `geo_nurbs` の残存参照移行
+4. 収束（残存参照の排除、回帰確認）
 
 ## 運用ルール
 
 - 新規コードでは `ToleranceSettings` を使用し、互換層APIを増やさない。
-- 互換層に変更を入れる場合は、削除に向けた移行目的を明記する。
+- `analysis::consts` は数値計算のための定数として扱い、幾何判定の正本にはしない。
 - 既存コード移行時は、呼び出し境界でトレランス取得元を統一する。
 
 ## 関連Issue
 
+- #455
 - #361
+- #377
 - #318
 - #320
 - #360

--- a/dev/architecture/TOLERANCE_SINGLE_SOURCE_455_PREP.md
+++ b/dev/architecture/TOLERANCE_SINGLE_SOURCE_455_PREP.md
@@ -1,0 +1,129 @@
+# Issue #455 着手準備: Tolerance 単一正本化
+
+最終更新: 2026-03-29
+関連Issue: #455, #361, #377
+
+## 1. 目的
+
+Issue #455 の着手前に、現状のトレランス責務を再確認し、実装時の判断基準と作業順序を固定する。
+本ドキュメントは「設計合意と分割計画の確定」までを対象とし、全コード一括置換は対象外とする。
+
+## 2. 現状確認（2026-03-29）
+
+### 2.1 正本として利用可能な定義
+
+- `model/geo_contracts/src/tolerance.rs`
+  - `ToleranceSettings<T>`
+  - `GeometryContext<T>`
+  - `default_distance_tolerance` / `default_angle_tolerance`
+  - 型依存閾値 (`default_parallel_cross_error_tolerance`, `default_orthogonality_dot_error_tolerance`)
+
+### 2.2 既存方針の文書
+
+- `dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md`
+  - 正本は `geo_contracts::ToleranceSettings` と定義済み
+  - ただし本文に `tolerance_migration.rs` / `geo_algorithms/src/tolerance.rs` の記述が残っており、現実装との差分確認が必要
+
+### 2.3 実装側の利用状況（抜粋）
+
+- `model/geo_algorithms/src/octree/tolerance.rs`
+  - `ToleranceSettings::relaxed()` 起点で `OctreeTolerance` を派生
+- `foundation/analysis/src/consts.rs`
+  - 数値安定用定数に加え、幾何判定で誤用され得る定数群が存在
+
+## 3. #455 で解消すべきギャップ
+
+1. 「単一正本」の定義はあるが、適用境界（どこで取得しどこへ渡すか）の記述が不足
+2. 判定種別ごとの選択基準（距離/角度/内積・外積）が規約として十分に機械化されていない
+3. `analysis::consts` のうち「数値計算定数」と「幾何判定閾値」の責務境界が読み手に伝わりづらい
+4. 移行計画が Issue 分割まで落ちていない
+
+## 4. 設計オプション
+
+### Option A（推奨）
+
+- 幾何判定の正本を `geo_contracts::ToleranceSettings` に統一
+- 呼び出し境界で `ToleranceSettings` を受け渡し、実装内の新規閾値定義を抑止
+- `analysis::consts` は数値解法・数学定数の責務へ限定し、幾何判定閾値は参照しない
+
+利点:
+- #455 の目的（単一正本化）と直接整合
+- #484 など intersection 意味論適用時の閾値揺れを抑制
+
+注意点:
+- 既存関数シグネチャの変更範囲を段階化しないと差分が大きくなる
+
+### Option B
+
+- `analysis::consts` にも幾何判定閾値を残し、用途別に使い分ける
+
+利点:
+- 既存コード変更量を抑えやすい
+
+注意点:
+- 正本が再び二重化し、#455 の受け入れ条件を満たしにくい
+
+## 5. 推奨方針（着手時の採用案）
+
+Option A を採用する。
+
+固定ルール:
+1. 幾何判定の既定値は `ToleranceSettings` 起点
+2. 呼び出し境界で受け取り、下位処理へ明示伝播
+3. `T::EPSILON` は局所的な数値安定化用途に限定（ドメイン判定の既定値にしない）
+4. 新規に互換層を増やさない
+
+## 6. 実施順（#455 の準備対象）
+
+### Step 1: 規約文書更新（Doc-first）
+
+更新対象:
+- `dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md`
+
+反映内容:
+- 現在存在しない層の記述を整理
+- 判定種別ごとの選択ルールを表形式で明記
+- 呼び出し境界の責務（取得/受渡し/消費）を明文化
+
+### Step 2: 影響範囲の棚卸し
+
+対象:
+- `model/geo_algorithms`
+- `model/geo_primitives`
+- `model/geo_nurbs`
+
+成果物:
+- 「既定閾値参照」「ハードコード」「`T::EPSILON` 利用」を分類した一覧
+
+### Step 3: 分割Issue化
+
+最小分割案:
+1. 文書正規化（ルール固定）
+2. `geo_algorithms` 高頻度経路移行
+3. 残りクレート移行
+4. 仕上げ（残存参照排除 + 回帰テスト）
+
+## 7. 受け入れ条件トレース（#455 対応）
+
+- [ ] 単一正本の定義合意
+  - 判定: `GEOMETRIC_TOLERANCE_USAGE_RULES.md` で正本が一意に定義されている
+- [ ] 判定種別ごとの選択ルール文書化
+  - 判定: 距離/角度/内積/外積の選択表が存在する
+- [ ] 移行フェーズIssue分割
+  - 判定: 実行順を持つ分割Issueが作成されている
+
+## 8. 着手時チェックコマンド
+
+```powershell
+git status -sb
+cargo fmt --all -- --check
+cargo clippy --workspace -- -D warnings
+cargo test --workspace
+.\scripts\check_architecture_dependencies_simple.ps1
+```
+
+## 9. 実装を始める前の確認事項
+
+- #455 は設計Issueなので、まず文書更新の差分を先に提示する
+- 一括置換は行わず、分割Issue単位で小さく進める
+- #484（intersection 返り値意味論適用）は #455 の方針確定後に着手する


### PR DESCRIPTION
## 概要
- #455 の Doc-first 着手として、トレランス運用ルール文書を現行実装に整合
- #455 着手準備用の設計概要書を追加

## 変更内容
- `dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md`
  - 現状の責務構造に更新（廃止済み互換層の履歴化を明記）
  - 判定種別ごとの選択ルール（距離/角度/内積/外積/数値解法）を追加
  - 呼び出し境界ルールを明文化
  - #455 分割実行計画を追加
- `dev/architecture/TOLERANCE_SINGLE_SOURCE_455_PREP.md` を新規追加
  - 現状ギャップ、設計オプション、推奨方針、実施順、受け入れ条件トレースを整理

## 目的
- #455 の受け入れ条件である「単一正本定義」「判定種別ルール文書化」「移行フェーズ分割」を実行可能状態にする

## Issue
- refs #455
- closes #488
