### PR TITLE
[Phase2] refactor(tolerance): circle primitives の T::EPSILON を意味別トレランスへ置換 (#485 PR-B)

### DIFF
--- a/model/geo_primitives/src/circle_2d.rs
+++ b/model/geo_primitives/src/circle_2d.rs
@@ -4,6 +4,7 @@
 //! STEP (ISO 10303) 準拠の ref_direction フィールドでArc変換に対応
 
 use crate::{Direction2D, Point2D};
+use geo_contracts::{default_distance_tolerance, default_kernel_numerical_zero_tolerance};
 use geo_contracts::{Circle2DConstructor, Circle2DMeasure, Circle2DProperties, Scalar};
 
 /// 2次元円
@@ -107,7 +108,7 @@ impl<T: Scalar> Circle2D<T> {
 
     /// 点円（半径がゼロに近い）かどうか
     pub fn is_point(&self) -> bool {
-        self.radius <= T::EPSILON
+        self.radius <= default_distance_tolerance::<T>()
     }
 
     /// 点が円周上にあるか判定
@@ -115,7 +116,7 @@ impl<T: Scalar> Circle2D<T> {
         let dx = point.x() - self.center.x();
         let dy = point.y() - self.center.y();
         let distance = (dx * dx + dy * dy).sqrt();
-        (distance - self.radius).abs() <= T::EPSILON
+        (distance - self.radius).abs() <= default_distance_tolerance::<T>()
     }
 
     /// 点に最も近い円周上の点を取得
@@ -124,7 +125,7 @@ impl<T: Scalar> Circle2D<T> {
         let dy = point.y() - self.center.y();
         let distance = (dx * dx + dy * dy).sqrt();
 
-        if distance <= T::EPSILON {
+        if distance <= default_kernel_numerical_zero_tolerance::<T>() {
             // 点が中心にある場合、任意の円周上の点を返す
             Point2D::new(self.center.x() + self.radius, self.center.y())
         } else {
@@ -188,7 +189,7 @@ impl<T: Scalar> Circle2D<T> {
         let dy2 = point3.y() - point2.y();
 
         let cross = dx1 * dy2 - dy1 * dx2;
-        if cross.abs() <= T::EPSILON {
+        if cross.abs() <= default_kernel_numerical_zero_tolerance::<T>() {
             return None; // 3点が一直線上
         }
 
@@ -198,7 +199,7 @@ impl<T: Scalar> Circle2D<T> {
                 + point2.x() * (point3.y() - point1.y())
                 + point3.x() * (point1.y() - point2.y()));
 
-        if d.abs() <= T::EPSILON {
+        if d.abs() <= default_kernel_numerical_zero_tolerance::<T>() {
             return None;
         }
 
@@ -304,16 +305,17 @@ impl<T: Scalar> Circle2DProperties<T> for Circle2D<T> {
     // Phase 2 メソッド実装
 
     fn is_unit_circle(&self) -> bool {
-        (self.radius_internal() - T::ONE).abs() <= T::EPSILON
+        (self.radius_internal() - T::ONE).abs() <= default_distance_tolerance::<T>()
     }
 
     fn is_centered_at_origin(&self) -> bool {
         let c = self.center_internal();
-        c.x().abs() <= T::EPSILON && c.y().abs() <= T::EPSILON
+        c.x().abs() <= default_distance_tolerance::<T>()
+            && c.y().abs() <= default_distance_tolerance::<T>()
     }
 
     fn is_degenerate(&self) -> bool {
-        self.radius_internal() <= T::EPSILON
+        self.radius_internal() <= default_distance_tolerance::<T>()
     }
 }
 

--- a/model/geo_primitives/src/circle_2d_extensions.rs
+++ b/model/geo_primitives/src/circle_2d_extensions.rs
@@ -3,6 +3,7 @@
 //! Extension Foundation パターンに基づく Circle2D の拡張実装
 
 use crate::{Circle2D, Point2D, Vector2D};
+use geo_contracts::default_kernel_numerical_zero_tolerance;
 use geo_contracts::Scalar;
 
 // ============================================================================
@@ -21,7 +22,7 @@ impl<T: Scalar> Circle2D<T> {
         let v2 = Vector2D::from_points(p1, p3);
 
         let cross = v1.cross(&v2);
-        if cross.abs() <= T::EPSILON {
+        if cross.abs() <= default_kernel_numerical_zero_tolerance::<T>() {
             return None; // 共線点
         }
 
@@ -38,7 +39,7 @@ impl<T: Scalar> Circle2D<T> {
                 + p2.x() * (p3.y() - p1.y())
                 + p3.x() * (p1.y() - p2.y()));
 
-        if div.abs() <= T::EPSILON {
+        if div.abs() <= default_kernel_numerical_zero_tolerance::<T>() {
             return None;
         }
 

--- a/model/geo_primitives/src/circle_3d.rs
+++ b/model/geo_primitives/src/circle_3d.rs
@@ -5,6 +5,7 @@
 
 use crate::{Direction3D, Point3D, Vector3D};
 use geo_contracts::default_angle_tolerance;
+use geo_contracts::{default_distance_tolerance, default_kernel_numerical_zero_tolerance};
 use geo_contracts::{Circle3DConstructor, Circle3DMeasure, Circle3DProperties, Scalar};
 
 /// 3次元空間の円
@@ -86,7 +87,7 @@ impl<T: Scalar> Circle3D<T> {
             axis.x() * x_axis.y() - axis.y() * x_axis.x(),
         );
 
-        if cross_x.length() > T::EPSILON {
+        if cross_x.length() > default_kernel_numerical_zero_tolerance::<T>() {
             Direction3D::from_vector(cross_x).unwrap()
         } else {
             // axisがX軸と平行な場合はY軸との外積を使用
@@ -191,7 +192,7 @@ impl<T: Scalar> Circle3D<T> {
         let axis_vec = self.axis.as_vector();
         let dot =
             to_point.x() * axis_vec.x() + to_point.y() * axis_vec.y() + to_point.z() * axis_vec.z();
-        if dot.abs() > T::EPSILON {
+        if dot.abs() > default_distance_tolerance::<T>() {
             return false; // 平面上にない
         }
 
@@ -249,7 +250,7 @@ impl<T: Scalar> Circle3D<T> {
         );
 
         let normal = v1.cross(&v2);
-        if normal.magnitude() <= T::EPSILON {
+        if normal.magnitude() <= default_kernel_numerical_zero_tolerance::<T>() {
             return None; // 3点が一直線上
         }
         let axis = Direction3D::from_vector(normal)?;
@@ -387,22 +388,24 @@ impl<T: Scalar> Circle3DProperties<T> for Circle3D<T> {
     // Phase 2 メソッド実装
 
     fn is_unit_circle(&self) -> bool {
-        (self.radius_internal() - T::ONE).abs() <= T::EPSILON
+        (self.radius_internal() - T::ONE).abs() <= default_distance_tolerance::<T>()
     }
 
     fn is_centered_at_origin(&self) -> bool {
         let c = self.center_internal();
-        c.x().abs() <= T::EPSILON && c.y().abs() <= T::EPSILON && c.z().abs() <= T::EPSILON
+        c.x().abs() <= default_distance_tolerance::<T>()
+            && c.y().abs() <= default_distance_tolerance::<T>()
+            && c.z().abs() <= default_distance_tolerance::<T>()
     }
 
     fn is_degenerate(&self) -> bool {
-        self.radius_internal() <= T::EPSILON
+        self.radius_internal() <= default_distance_tolerance::<T>()
     }
 
     fn is_on_xy_plane(&self) -> bool {
         // Z軸に平行かどうかを確認
         let z_component = self.axis_internal().z().abs();
-        (z_component - T::ONE).abs() <= T::EPSILON
+        (z_component - T::ONE).abs() <= default_distance_tolerance::<T>()
     }
 }
 


### PR DESCRIPTION
## 概要

#485 PR-B: `circle_2d.rs`, `circle_2d_extensions.rs`, `circle_3d.rs` の `T::EPSILON` を意味に応じたトレランスに置換します。

## 変更内容

### 置換分類

| 用途 | 置換前 | 置換後 |
|------|--------|--------|
| 幾何意味判定（半径・距離・座標） | `T::EPSILON` | `default_distance_tolerance` |
| ベクトル退化・分母ゼロ（数値安定化） | `T::EPSILON` | `default_kernel_numerical_zero_tolerance` |

### 変更ファイル

- `model/geo_primitives/src/circle_2d.rs`
  - `is_point`, `point_on_circumference`: 距離トレランスへ
  - `closest_point_to` 中心ガード: カーネル固定しきい値へ
  - `from_three_points_internal` 外積・外心計算: カーネル固定しきい値へ
  - `is_unit_circle`, `is_centered_at_origin`, `is_degenerate`: 距離トレランスへ
- `model/geo_primitives/src/circle_2d_extensions.rs`
  - `from_three_points` 外積・除算ゼロガード: カーネル固定しきい値へ
- `model/geo_primitives/src/circle_3d.rs`
  - `compute_perpendicular` 外積長さ: カーネル固定しきい値へ
  - `contains_point_3d` 平面距離判定: 距離トレランスへ
  - `from_three_points_internal` 法線長さ: カーネル固定しきい値へ
  - `is_unit_circle`, `is_centered_at_origin`, `is_degenerate`, `is_on_xy_plane`: 距離トレランスへ

## 検証

- `cargo build -p geo_primitives`: 成功
- `cargo clippy -p geo_primitives -- -D warnings`: 警告なし
- `cargo fmt --all -- --check`: 差分なし

## 関連

- closes 方向: #485 の部分達成（PR-B分）
- 前PR: PR-A (#491) マージ済み
- 次PR予定: PR-C (`infinite_line`, `ray` 系)