### PR TITLE
chore(circle): remove phase-specific comments missed in #492

### DIFF
--- a/model/geo_primitives/src/circle_2d.rs
+++ b/model/geo_primitives/src/circle_2d.rs
@@ -228,7 +228,7 @@ impl<T: Scalar> Circle2D<T> {
 }
 
 // ============================================================================
-// Core Traits Implementation (Phase 1)
+// Core Traits Implementation
 // ============================================================================
 
 impl<T: Scalar> Circle2DConstructor<T> for Circle2D<T> {
@@ -247,8 +247,6 @@ impl<T: Scalar> Circle2DConstructor<T> for Circle2D<T> {
         let center = Point2D::origin();
         Self::new(center, T::ONE).unwrap()
     }
-
-    // Phase 2 メソッド実装
 
     fn from_center_and_point(center: (T, T), point_on_circle: (T, T)) -> Option<Self> {
         let center_point = Point2D::new(center.0, center.1);
@@ -302,8 +300,6 @@ impl<T: Scalar> Circle2DProperties<T> for Circle2D<T> {
         2
     }
 
-    // Phase 2 メソッド実装
-
     fn is_unit_circle(&self) -> bool {
         (self.radius_internal() - T::ONE).abs() <= default_distance_tolerance::<T>()
     }
@@ -337,8 +333,6 @@ impl<T: Scalar> Circle2DMeasure<T> for Circle2D<T> {
         let p = Point2D::new(point.0, point.1);
         self.distance_to_point(p)
     }
-
-    // Phase 2 メソッド実装
 
     fn point_on_circumference(&self, point: (T, T)) -> bool {
         let p = Point2D::new(point.0, point.1);

--- a/model/geo_primitives/src/circle_3d.rs
+++ b/model/geo_primitives/src/circle_3d.rs
@@ -286,7 +286,7 @@ impl<T: Scalar> Circle3D<T> {
 }
 
 // ============================================================================
-// Core Traits Implementation (Phase 1)
+// Core Traits Implementation
 // ============================================================================
 
 impl<T: Scalar> Circle3DConstructor<T> for Circle3D<T> {
@@ -306,8 +306,6 @@ impl<T: Scalar> Circle3DConstructor<T> for Circle3D<T> {
         let center = Point3D::origin();
         Self::new_xy_plane(center, T::ONE).unwrap()
     }
-
-    // Phase 2 メソッド実装
 
     fn from_center_and_point(
         center: (T, T, T),
@@ -385,8 +383,6 @@ impl<T: Scalar> Circle3DProperties<T> for Circle3D<T> {
         3
     }
 
-    // Phase 2 メソッド実装
-
     fn is_unit_circle(&self) -> bool {
         (self.radius_internal() - T::ONE).abs() <= default_distance_tolerance::<T>()
     }
@@ -427,8 +423,6 @@ impl<T: Scalar> Circle3DMeasure<T> for Circle3D<T> {
         let p = Point3D::new(point.0, point.1, point.2);
         self.distance_to_point_3d(p)
     }
-
-    // Phase 2 メソッド実装
 
     fn point_on_circumference(&self, point: (T, T, T)) -> bool {
         let p = Point3D::new(point.0, point.1, point.2);


### PR DESCRIPTION
## 概要
PR #492 マージ後に取りこぼしたコメント整理のフォローアップです。

## 変更内容
- `Core Traits Implementation (Phase 1)` を `Core Traits Implementation` に変更
- `// Phase 2 メソッド実装` コメントを削除

## 対象ファイル
- `model/geo_primitives/src/circle_2d.rs`
- `model/geo_primitives/src/circle_3d.rs`

## 備考
- ロジック変更なし（コメントのみ）
- 取り込み漏れコミット: `cad6790d` 相当を `develop` 起点で適用