### PR TITLE
[Phase2] refactor(tolerance): line/ray の T::EPSILON 用途分離を適用 (#485 PR-C)

### DIFF
--- a/dev/architecture/TOLERANCE_PHASE3_485_PREP.md
+++ b/dev/architecture/TOLERANCE_PHASE3_485_PREP.md
@@ -67,16 +67,28 @@
 ### PR-B
 
 対象:
-- `circle_2d.rs`, `circle_3d.rs`, `infinite_line_2d.rs`, `infinite_line_3d.rs`, `ray_2d.rs`, `ray_3d.rs`
+- `circle_2d.rs`, `circle_3d.rs`
 
 作業:
 - `default_distance_tolerance::<T>()` 依存を呼び出し境界へ寄せる。
 - `T::EPSILON` は数値安定化用途へ限定し、可能な限り意味付き固定定数へ置換。
 
 完了条件:
-- line/circle/ray の包含・平行・交点系テストが通過。
+- circle の包含・退化・近傍判定テストが通過。
 
 ### PR-C
+
+対象:
+- `infinite_line_2d.rs`, `infinite_line_3d.rs`, `ray_2d.rs`, `ray_3d.rs`
+
+作業:
+- `T::EPSILON` の用途を「数値安定化」に限定し、幾何意味判定は意味付きトレランスへ置換。
+- contains/coplanar/parallel 系の判定で、距離許容差と数値安定化ガードを分離。
+
+完了条件:
+- line/ray の包含・平行・交点系テストが通過。
+
+### PR-D（追従）
 
 対象:
 - `geo_nurbs` 変換・拡張系（`*_transform.rs`, `curve_3d_extensions.rs`, `curve_3d_foundation.rs`）
@@ -88,7 +100,7 @@
 完了条件:
 - `geo_nurbs` の既存テスト通過、変換系の退化ケース回帰なし。
 
-### PR-D（追従）
+### PR-E（追従）
 
 対象:
 - `geo_primitives`/`geo_nurbs` テストの生数値整理

--- a/model/geo_primitives/src/infinite_line_2d.rs
+++ b/model/geo_primitives/src/infinite_line_2d.rs
@@ -108,7 +108,7 @@ impl<T: Scalar> InfiniteLine2D<T> {
         // |dp.x  -D1.x|   |D2.x  -D1.x|
         // |dp.y  -D1.y| / |D2.y  -D1.y|
         let det = other.direction.cross(&(-self.direction));
-        if det.abs() <= T::EPSILON {
+        if det.abs() <= geo_contracts::default_kernel_numerical_zero_tolerance::<T>() {
             return None; // 平行（実際上はありえない）
         }
 
@@ -235,7 +235,7 @@ impl<T: Scalar> InfiniteLine2DProperties<T> for InfiniteLine2D<T> {
     }
 
     fn slope(&self) -> Option<T> {
-        if self.direction.x().abs() <= T::EPSILON {
+        if self.direction.x().abs() <= geo_contracts::default_distance_tolerance::<T>() {
             None // 垂直線
         } else {
             Some(self.direction.y() / self.direction.x())
@@ -248,7 +248,7 @@ impl<T: Scalar> InfiniteLine2DProperties<T> for InfiniteLine2D<T> {
     }
 
     fn x_intercept(&self) -> Option<T> {
-        if self.direction.y().abs() <= T::EPSILON {
+        if self.direction.y().abs() <= geo_contracts::default_distance_tolerance::<T>() {
             None // 水平線
         } else {
             // x = (y - b) / m, y=0のときのx
@@ -262,11 +262,11 @@ impl<T: Scalar> InfiniteLine2DProperties<T> for InfiniteLine2D<T> {
     }
 
     fn is_horizontal(&self) -> bool {
-        self.direction.y().abs() <= T::EPSILON
+        self.direction.y().abs() <= geo_contracts::default_distance_tolerance::<T>()
     }
 
     fn is_vertical(&self) -> bool {
-        self.direction.x().abs() <= T::EPSILON
+        self.direction.x().abs() <= geo_contracts::default_distance_tolerance::<T>()
     }
 
     fn passes_through_origin(&self) -> bool {
@@ -293,7 +293,8 @@ impl<T: Scalar> InfiniteLine2DProperties<T> for InfiniteLine2D<T> {
 
     fn is_below(&self, point: (T, T)) -> bool {
         let p = Point2D::new(point.0, point.1);
-        !self.is_above(point) && !self.contains_point(&p, T::EPSILON)
+        !self.is_above(point)
+            && !self.contains_point(&p, geo_contracts::default_distance_tolerance::<T>())
     }
 }
 

--- a/model/geo_primitives/src/ray_2d.rs
+++ b/model/geo_primitives/src/ray_2d.rs
@@ -38,7 +38,7 @@ impl<T: Scalar> Ray2D<T> {
     /// # 戻り値
     /// 方向ベクトルがゼロベクトルの場合は None を返す
     pub fn new(origin: Point2D<T>, direction: Vector2D<T>) -> Option<Self> {
-        if direction.is_zero(T::EPSILON) {
+        if direction.is_zero(geo_contracts::default_kernel_numerical_zero_tolerance::<T>()) {
             return None;
         }
 

--- a/model/geo_primitives/src/ray_3d.rs
+++ b/model/geo_primitives/src/ray_3d.rs
@@ -453,8 +453,8 @@ impl<T: Scalar> Ray3DMeasure<T> for Ray3D<T> {
         let e = other.direction.dot(&w);
 
         let denom = a * c - b * b;
-        use geo_contracts::default_distance_tolerance;
-        if denom.abs() < default_distance_tolerance::<T>() {
+        use geo_contracts::default_kernel_numerical_zero_tolerance;
+        if denom.abs() < default_kernel_numerical_zero_tolerance::<T>() {
             // 平行: 片方の起点から他方への距離
             let other_origin = other.origin;
             return self.distance_to_point(&Point3D::new(
@@ -505,8 +505,8 @@ impl<T: Scalar> Ray3DMeasure<T> for Ray3D<T> {
         // analysis::Vector3 に変換
         let axis_analysis = Vector3::new(axis.0, axis.1, axis.2);
         let norm = axis_analysis.norm();
-        use geo_contracts::default_distance_tolerance;
-        if norm < default_distance_tolerance::<T>() {
+        use geo_contracts::default_kernel_numerical_zero_tolerance;
+        if norm < default_kernel_numerical_zero_tolerance::<T>() {
             return None;
         }
 


### PR DESCRIPTION
## 概要
#485 PR-C 相当として、line/ray 系で `T::EPSILON` の用途を整理し、
幾何意味判定と数値安定化ガードを分離しました。

## 変更ファイル
- `dev/architecture/TOLERANCE_PHASE3_485_PREP.md`
- `model/geo_primitives/src/infinite_line_2d.rs`
- `model/geo_primitives/src/ray_2d.rs`
- `model/geo_primitives/src/ray_3d.rs`

## 変更内容
### 1) infinite_line_2d
- 交点計算の `det` ゼロ近傍判定: `default_kernel_numerical_zero_tolerance` へ
- 傾き/水平/垂直/x切片判定: `default_distance_tolerance` へ
- `is_below` の点上判定: `default_distance_tolerance` へ

### 2) ray_2d
- コンストラクタのゼロ方向ベクトル判定: `default_kernel_numerical_zero_tolerance` へ

### 3) ray_3d
- `distance_to_ray` の分母ゼロ近傍ガード: `default_kernel_numerical_zero_tolerance` へ
- `rotate_around_axis` の軸ノルムゼロ近傍ガード: `default_kernel_numerical_zero_tolerance` へ

### 4) ドキュメント
- PR分割の実運用順に合わせて `TOLERANCE_PHASE3_485_PREP.md` を更新
  - PR-B: circle
  - PR-C: line/ray
  - PR-D: geo_nurbs
  - PR-E: test生数値整理

## 検証
- `cargo build -p geo_primitives`
- `cargo clippy -p geo_primitives -- -D warnings`
- `cargo fmt --all -- --check`

いずれも成功。