### PR TITLE
[Phase2] refactor(tolerance): geo_nurbs 変換系のゼロ判定を固定しきい値化 (#485 PR-D)

### DIFF
--- a/model/geo_nurbs/src/curve_2d_transform.rs
+++ b/model/geo_nurbs/src/curve_2d_transform.rs
@@ -8,6 +8,7 @@ use analysis::linalg::{
     matrix::Matrix3x3,
     vector::{Vector2, Vector3},
 };
+use geo_contracts::default_kernel_numerical_zero_tolerance;
 use geo_contracts::NurbsCurve2DProperties;
 use geo_contracts::{Angle, Scalar};
 use geo_core::{AnalysisTransform2D, TransformError};
@@ -30,7 +31,7 @@ fn transform_control_points<T: Scalar>(
 
         // w成分で除算（透視投影対応）
         let w = transformed.z();
-        if w.abs() < T::EPSILON {
+        if w.abs() < default_kernel_numerical_zero_tolerance::<T>() {
             return Err(TransformError::InvalidGeometry(
                 "Transform resulted in zero w component".to_string(),
             ));
@@ -76,7 +77,9 @@ fn rotation_matrix_2d<T: Scalar>(angle: Angle<T>) -> Matrix3x3<T> {
 
 /// スケール行列を生成
 fn scale_matrix_2d<T: Scalar>(sx: T, sy: T) -> Result<Matrix3x3<T>, TransformError> {
-    if sx.abs() < T::EPSILON || sy.abs() < T::EPSILON {
+    if sx.abs() < default_kernel_numerical_zero_tolerance::<T>()
+        || sy.abs() < default_kernel_numerical_zero_tolerance::<T>()
+    {
         return Err(TransformError::InvalidScaleFactor(
             "Scale factors cannot be zero".to_string(),
         ));

--- a/model/geo_nurbs/src/curve_3d_extensions.rs
+++ b/model/geo_nurbs/src/curve_3d_extensions.rs
@@ -5,6 +5,7 @@ use crate::adaptive_tessellation::{
     NurbsCurveAdaptiveTessellation,
 };
 use crate::NurbsCurve3D;
+use geo_contracts::default_kernel_numerical_zero_tolerance;
 use geo_contracts::Scalar;
 use geo_core::{Aabb3D, Point3D};
 
@@ -65,7 +66,8 @@ impl<T: Scalar> NurbsCurve3D<T> {
         // トレランスから適切なサンプル数を決定
         // より小さいトレランス → より多くのサンプル
         let base_subdivisions = 100;
-        let tolerance_factor = T::ONE / tolerance.max(T::EPSILON);
+        let tolerance_factor =
+            T::ONE / tolerance.max(default_kernel_numerical_zero_tolerance::<T>());
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let subdivisions = (f64::from(base_subdivisions) * tolerance_factor.to_f64().sqrt())
             .min(10000.0)

--- a/model/geo_nurbs/src/curve_3d_transform.rs
+++ b/model/geo_nurbs/src/curve_3d_transform.rs
@@ -8,6 +8,7 @@ use analysis::linalg::{
     matrix::Matrix4x4,
     vector::{Vector3, Vector4},
 };
+use geo_contracts::default_kernel_numerical_zero_tolerance;
 use geo_contracts::NurbsCurve3DProperties;
 use geo_contracts::{Angle, Scalar};
 use geo_core::{AnalysisTransform3D, TransformError};
@@ -30,7 +31,7 @@ fn transform_control_points<T: Scalar>(
 
         // w成分で除算（透視投影対応）
         let w = transformed.w();
-        if w.abs() < T::EPSILON {
+        if w.abs() < default_kernel_numerical_zero_tolerance::<T>() {
             return Err(TransformError::InvalidGeometry(
                 "Transform resulted in zero w component".to_string(),
             ));
@@ -79,7 +80,8 @@ fn rotation_matrix_3d<T: Scalar>(
     angle: Angle<T>,
 ) -> Result<Matrix4x4<T>, TransformError> {
     let axis_norm_sq = axis.x() * axis.x() + axis.y() * axis.y() + axis.z() * axis.z();
-    if axis_norm_sq < T::EPSILON * T::EPSILON {
+    let zero_tol = default_kernel_numerical_zero_tolerance::<T>();
+    if axis_norm_sq < zero_tol * zero_tol {
         return Err(TransformError::ZeroVector(
             "Rotation axis cannot be zero".to_string(),
         ));
@@ -93,7 +95,10 @@ fn rotation_matrix_3d<T: Scalar>(
 
 /// スケール行列を生成
 fn scale_matrix_3d<T: Scalar>(sx: T, sy: T, sz: T) -> Result<Matrix4x4<T>, TransformError> {
-    if sx.abs() < T::EPSILON || sy.abs() < T::EPSILON || sz.abs() < T::EPSILON {
+    if sx.abs() < default_kernel_numerical_zero_tolerance::<T>()
+        || sy.abs() < default_kernel_numerical_zero_tolerance::<T>()
+        || sz.abs() < default_kernel_numerical_zero_tolerance::<T>()
+    {
         return Err(TransformError::InvalidScaleFactor(
             "Scale factors cannot be zero".to_string(),
         ));

--- a/model/geo_nurbs/src/surface_3d_transform.rs
+++ b/model/geo_nurbs/src/surface_3d_transform.rs
@@ -8,6 +8,7 @@ use analysis::linalg::{
     matrix::Matrix4x4,
     vector::{Vector3, Vector4},
 };
+use geo_contracts::default_kernel_numerical_zero_tolerance;
 use geo_contracts::NurbsSurface3DProperties;
 use geo_contracts::{Angle, Scalar};
 use geo_core::{AnalysisTransform3D, TransformError};
@@ -33,7 +34,7 @@ fn transform_control_points<T: Scalar>(
 
             // w成分で除算（透視投影対応）
             let w = transformed.w();
-            if w.abs() < T::EPSILON {
+            if w.abs() < default_kernel_numerical_zero_tolerance::<T>() {
                 return Err(TransformError::InvalidGeometry(
                     "Transform resulted in zero w component".to_string(),
                 ));
@@ -90,7 +91,8 @@ fn rotation_matrix_3d<T: Scalar>(
     angle: Angle<T>,
 ) -> Result<Matrix4x4<T>, TransformError> {
     let axis_norm_sq = axis.x() * axis.x() + axis.y() * axis.y() + axis.z() * axis.z();
-    if axis_norm_sq < T::EPSILON * T::EPSILON {
+    let zero_tol = default_kernel_numerical_zero_tolerance::<T>();
+    if axis_norm_sq < zero_tol * zero_tol {
         return Err(TransformError::ZeroVector(
             "Rotation axis cannot be zero".to_string(),
         ));
@@ -104,7 +106,10 @@ fn rotation_matrix_3d<T: Scalar>(
 
 /// スケール行列を生成
 fn scale_matrix_3d<T: Scalar>(sx: T, sy: T, sz: T) -> Result<Matrix4x4<T>, TransformError> {
-    if sx.abs() < T::EPSILON || sy.abs() < T::EPSILON || sz.abs() < T::EPSILON {
+    if sx.abs() < default_kernel_numerical_zero_tolerance::<T>()
+        || sy.abs() < default_kernel_numerical_zero_tolerance::<T>()
+        || sz.abs() < default_kernel_numerical_zero_tolerance::<T>()
+    {
         return Err(TransformError::InvalidScaleFactor(
             "Scale factors cannot be zero".to_string(),
         ));


### PR DESCRIPTION
## 概要
#485 PR-D 相当として、`geo_nurbs` 変換/拡張系の `T::EPSILON` を数値安定化用途の固定しきい値へ置換しました。

## 変更ファイル
- `model/geo_nurbs/src/curve_2d_transform.rs`
- `model/geo_nurbs/src/curve_3d_transform.rs`
- `model/geo_nurbs/src/surface_3d_transform.rs`
- `model/geo_nurbs/src/curve_3d_extensions.rs`

## 変更内容
- 同次座標変換時の `w` 成分ゼロ判定
- 回転軸ノルムのゼロ近傍判定
- スケール係数ゼロ近傍判定
- `tolerance.max(T::EPSILON)` の下限値ガード

上記を `default_kernel_numerical_zero_tolerance::<T>()` ベースへ統一。

## 検証
- `cargo build -p geo_nurbs`
- `cargo clippy -p geo_nurbs -- -D warnings`
- `cargo fmt --all -- --check`

いずれも成功。

## 補足
`curve_3d_foundation.rs` の `1e-6`（テスト側）は PR-E（テスト生数値整理）で扱います。