### PR TITLE
test(tolerance): テスト生数値を共有定数/意味付き定数へ整理 (#485 PR-E)

### DIFF
--- a/model/geo_nurbs/src/curve_3d_foundation.rs
+++ b/model/geo_nurbs/src/curve_3d_foundation.rs
@@ -164,6 +164,7 @@ mod tests {
 
     #[test]
     fn test_core_traits_measure() {
+        use analysis::test_constants::INTEGRATION_TOLERANCE_STRICT;
         use geo_contracts::{NurbsCurve3DConstructor, NurbsCurve3DMeasure};
 
         let curve = <NurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(
@@ -173,7 +174,7 @@ mod tests {
         .unwrap();
 
         // Measureトレイトメソッド確認
-        let tolerance = 1e-6;
+        let tolerance = INTEGRATION_TOLERANCE_STRICT;
         let total_length = curve.arc_length_total(tolerance);
         assert!((total_length - 3.0).abs() < 1e-3);
 

--- a/model/geo_primitives/src/arc_2d_tests.rs
+++ b/model/geo_primitives/src/arc_2d_tests.rs
@@ -8,6 +8,7 @@ use geo_contracts::{Arc2DMeasure, Arc2DProperties};
 
 #[cfg(test)]
 mod tests {
+    use analysis::test_constants::TOLERANCE_F32;
     use super::*;
 
     // ヘルパー関数：ラジアンから Angle を作成
@@ -244,11 +245,11 @@ mod tests {
 
         let length = arc.arc_length();
         let expected_length = 3.0f32 * std::f32::consts::PI;
-        assert!((length - expected_length).abs() < 1e-6);
+        assert!((length - expected_length).abs() < TOLERANCE_F32);
 
         let start = arc.start_point();
-        assert!((start.x() - 3.0f32).abs() < 1e-6);
-        assert!((start.y() - 0.0f32).abs() < 1e-6);
+        assert!((start.x() - 3.0f32).abs() < TOLERANCE_F32);
+        assert!((start.y() - 0.0f32).abs() < TOLERANCE_F32);
     }
 }
 

--- a/model/geo_primitives/src/arc_3d_tests.rs
+++ b/model/geo_primitives/src/arc_3d_tests.rs
@@ -8,6 +8,7 @@ use geo_contracts::Arc3DProperties;
 
 #[cfg(test)]
 mod tests {
+    use analysis::test_constants::TOLERANCE_F32;
     use super::*;
 
     // ヘルパー関数：ラジアンから Angle を作成
@@ -228,11 +229,11 @@ mod tests {
 
         let length = arc.arc_length();
         let expected_length = 3.0f32 * std::f32::consts::PI;
-        assert!((length - expected_length).abs() < 1e-6);
+        assert!((length - expected_length).abs() < TOLERANCE_F32);
 
         let start = arc.start_point();
-        assert!((start.x() - 3.0f32).abs() < 1e-6);
-        assert!((start.y() - 0.0f32).abs() < 1e-6);
+        assert!((start.x() - 3.0f32).abs() < TOLERANCE_F32);
+        assert!((start.y() - 0.0f32).abs() < TOLERANCE_F32);
     }
 }
 

--- a/model/geo_primitives/src/circle_2d_tests.rs
+++ b/model/geo_primitives/src/circle_2d_tests.rs
@@ -1,6 +1,7 @@
 //! Circle2D のテスト
 
 use crate::{Circle2D, Point2D, Vector2D};
+use analysis::test_constants::TOLERANCE_F32;
 use std::f64::consts::{PI, TAU};
 
 /// 基本作成テスト
@@ -352,7 +353,7 @@ fn test_circle2d_f32() {
     assert_eq!(circle.diameter(), 6.0f32);
 
     let area = circle.area();
-    assert!((area - (std::f32::consts::PI * 9.0f32)).abs() < 1e-6);
+    assert!((area - (std::f32::consts::PI * 9.0f32)).abs() < TOLERANCE_F32);
 }
 
 // ============================================================================

--- a/model/geo_primitives/src/cylindrical_surface_3d_tests.rs
+++ b/model/geo_primitives/src/cylindrical_surface_3d_tests.rs
@@ -6,6 +6,7 @@
 #[cfg(test)]
 mod tests {
     use crate::{CylindricalSurface3D, Point3D, Vector3D};
+    use analysis::test_constants::TOLERANCE_F32;
     use approx::assert_relative_eq;
     use geo_contracts::{CylindricalSurface3DMeasure, CylindricalSurface3DProperties, Scalar};
 
@@ -75,7 +76,7 @@ mod tests {
         assert_relative_eq!(
             CylindricalSurface3DProperties::radius(&surface),
             5.0f32,
-            epsilon = 1e-6
+            epsilon = TOLERANCE_F32
         );
         let center_tuple = CylindricalSurface3DProperties::center(&surface);
         assert_eq!(center_tuple, (1.0f32, 2.0f32, 3.0f32));

--- a/model/geo_primitives/src/ellipse_2d_tests.rs
+++ b/model/geo_primitives/src/ellipse_2d_tests.rs
@@ -5,6 +5,7 @@ use geo_contracts::Scalar;
 
 #[cfg(test)]
 mod tests {
+    use analysis::test_constants::TOLERANCE_F32;
     use super::*;
 
     #[test]
@@ -346,7 +347,7 @@ mod tests {
 
         let area = ellipse.area();
         let expected_area = std::f32::consts::PI * 3.0f32 * 2.0f32;
-        assert!((area - expected_area).abs() < 1e-6);
+        assert!((area - expected_area).abs() < TOLERANCE_F32);
 
         // foundation トレイト
         let bbox = ellipse.bounding_box();

--- a/model/geo_primitives/src/ellipse_3d_tests.rs
+++ b/model/geo_primitives/src/ellipse_3d_tests.rs
@@ -8,6 +8,7 @@ use geo_contracts::Ellipse3DProperties;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use analysis::test_constants::TOLERANCE_F32;
 
     #[test]
     fn test_basic_creation() {
@@ -141,6 +142,6 @@ mod tests {
 
         let area = ellipse.area();
         let expected_area = std::f32::consts::PI * 3.0f32 * 2.0f32;
-        assert!((area - expected_area).abs() < 1e-6);
+        assert!((area - expected_area).abs() < TOLERANCE_F32);
     }
 }

--- a/model/geo_primitives/src/rectangle_3d.rs
+++ b/model/geo_primitives/src/rectangle_3d.rs
@@ -226,6 +226,8 @@ impl<T: Scalar> Rect3DMeasure<T> for Rect3D<T> {
 mod tests {
     use super::*;
 
+    const POINT_CONTAINMENT_TOLERANCE: f64 = 1e-9;
+
     #[test]
     fn contains_and_resize() {
         let mut rect = Rect3D::new(
@@ -237,8 +239,8 @@ mod tests {
         )
         .unwrap();
 
-        assert!(rect.contains_point(&Point3D::new(5.0, 2.5, 0.0), 1e-9));
-        assert!(!rect.contains_point(&Point3D::new(11.0, 2.5, 0.0), 1e-9));
+        assert!(rect.contains_point(&Point3D::new(5.0, 2.5, 0.0), POINT_CONTAINMENT_TOLERANCE,));
+        assert!(!rect.contains_point(&Point3D::new(11.0, 2.5, 0.0), POINT_CONTAINMENT_TOLERANCE,));
         assert!(!rect.contains_point(&Point3D::new(5.0, 2.5, 0.1), 1e-3));
 
         assert!(rect.resize(20.0, 10.0));


### PR DESCRIPTION
## 概要
#485 PR-E 相当として、テスト内の `1e-6` / `1e-9` 直書きを整理しました。

## 変更方針
- 通常ケース: `analysis::test_constants` の共有定数へ置換
- 境界ケース: 意味付きローカル定数へ置換

## 変更ファイル
- `model/geo_primitives/src/arc_2d_tests.rs`
- `model/geo_primitives/src/arc_3d_tests.rs`
- `model/geo_primitives/src/circle_2d_tests.rs`
- `model/geo_primitives/src/cylindrical_surface_3d_tests.rs`
- `model/geo_primitives/src/ellipse_2d_tests.rs`
- `model/geo_primitives/src/ellipse_3d_tests.rs`
- `model/geo_primitives/src/rectangle_3d.rs`
- `model/geo_nurbs/src/curve_3d_foundation.rs`

## 代表例
- f32比較 `1e-6` → `analysis::test_constants::TOLERANCE_F32`
- NURBS測度トレランス `1e-6` → `analysis::test_constants::INTEGRATION_TOLERANCE_STRICT`
- `rectangle_3d` の点包含 `1e-9` → `POINT_CONTAINMENT_TOLERANCE`（意味付きローカル定数）

## 検証
- `cargo build -p geo_primitives -p geo_nurbs`
- `cargo clippy -p geo_primitives -p geo_nurbs -- -D warnings`
- `cargo test -p geo_primitives -p geo_nurbs`
- `cargo fmt --all -- --check`

すべて成功。