### PR TITLE
refactor(tolerance): Phase 4 収束 - 残存 T::EPSILON 整理と例外箇所の明文化 (#487)

### DIFF
--- a/model/geo_primitives/src/ellipse_arc_2d.rs
+++ b/model/geo_primitives/src/ellipse_arc_2d.rs
@@ -4,7 +4,8 @@
 
 use crate::{Ellipse2D, Point2D, Vector2D};
 use geo_contracts::{
-    Angle, EllipseArc2DConstructor, EllipseArc2DMeasure, EllipseArc2DProperties, Scalar,
+    default_angle_tolerance, Angle, EllipseArc2DConstructor, EllipseArc2DMeasure,
+    EllipseArc2DProperties, Scalar,
 };
 
 /// 2次元楕円弧
@@ -148,7 +149,7 @@ impl<T: Scalar> EllipseArc2D<T> {
     /// 点から楕円弧への最短距離
     pub fn distance_to_point(&self, point: &Point2D<T>) -> T {
         // 点が角度範囲内にある場合
-        if self.point_in_angle_range(point, T::EPSILON) {
+        if self.point_in_angle_range(point, default_angle_tolerance::<T>()) {
             return self.ellipse.distance_to_point(point);
         }
 

--- a/model/geo_primitives/src/ellipse_arc_3d_extensions.rs
+++ b/model/geo_primitives/src/ellipse_arc_3d_extensions.rs
@@ -3,7 +3,7 @@
 //! Extension Foundation パターンに基づく EllipseArc3D の拡張実装
 
 use crate::{Arc3D, Circle3D, Ellipse3D, EllipseArc3D, Point3D, Vector3D};
-use geo_contracts::{Angle, Scalar};
+use geo_contracts::{default_angle_tolerance, Angle, Scalar};
 
 // ============================================================================
 // Extension Methods Implementation
@@ -188,7 +188,7 @@ impl<T: Scalar> EllipseArc3D<T> {
     /// 点から楕円弧への最短距離
     pub fn distance_to_point(&self, point: &Point3D<T>) -> T {
         // 点が角度範囲内にある場合
-        if self.point_in_angle_range(point, T::EPSILON) {
+        if self.point_in_angle_range(point, default_angle_tolerance::<T>()) {
             return self.ellipse().distance_to_point(point);
         }
 

--- a/model/geo_primitives/src/line_segment_2d.rs
+++ b/model/geo_primitives/src/line_segment_2d.rs
@@ -5,7 +5,8 @@
 
 use crate::{InfiniteLine2D, Point2D, Vector2D};
 use geo_contracts::{
-    LineSegment2DConstructor, LineSegment2DMeasure, LineSegment2DProperties, Scalar,
+    default_distance_tolerance, LineSegment2DConstructor, LineSegment2DMeasure,
+    LineSegment2DProperties, Scalar,
 };
 
 /// 2次元平面の線分
@@ -337,7 +338,7 @@ impl<T: Scalar> LineSegment2DMeasure<T> for LineSegment2D<T> {
 
     fn contains_point(&self, point: (T, T)) -> bool {
         let p = Point2D::new(point.0, point.1);
-        self.contains_point(&p, T::EPSILON)
+        self.contains_point(&p, default_distance_tolerance::<T>())
     }
 
     fn point_at_parameter(&self, t: T) -> (T, T) {

--- a/model/geo_primitives/src/line_segment_3d.rs
+++ b/model/geo_primitives/src/line_segment_3d.rs
@@ -5,8 +5,8 @@
 
 use crate::{InfiniteLine3D, Point3D, Vector3D};
 use geo_contracts::{
-    CrossDistance, LineSegment3DCollisionDetection, LineSegment3DConstructor, LineSegment3DMeasure,
-    LineSegment3DProperties, Scalar,
+    default_distance_tolerance, CrossDistance, LineSegment3DCollisionDetection,
+    LineSegment3DConstructor, LineSegment3DMeasure, LineSegment3DProperties, Scalar,
 };
 
 /// 3次元空間の線分
@@ -251,7 +251,7 @@ impl<T: Scalar> LineSegment3DMeasure<T> for LineSegment3D<T> {
 
     fn contains_point(&self, point: (T, T, T)) -> bool {
         let p = Point3D::new(point.0, point.1, point.2);
-        self.contains_point(&p, T::EPSILON)
+        self.contains_point(&p, default_distance_tolerance::<T>())
     }
 
     fn point_at_parameter(&self, t: T) -> (T, T, T) {

--- a/model/geo_primitives/src/ray_2d_extensions.rs
+++ b/model/geo_primitives/src/ray_2d_extensions.rs
@@ -4,7 +4,7 @@
 //! Core Foundation では提供しない拡張機能のみ
 
 use crate::{Direction2D, InfiniteLine2D, LineSegment2D, Point2D, Ray2D, Vector2D};
-use geo_contracts::{Angle, Scalar};
+use geo_contracts::{default_distance_tolerance, Angle, Scalar};
 
 impl<T: Scalar> Ray2D<T> {
     // === 特殊作成メソッド ===
@@ -67,7 +67,7 @@ impl<T: Scalar> Ray2D<T> {
             return None;
         }
 
-        let tolerance = T::EPSILON;
+        let tolerance = default_distance_tolerance::<T>();
         if segment.contains_point(&line_intersection, tolerance) {
             Some(line_intersection)
         } else {

--- a/model/geo_primitives/src/torus_solid_3d.rs
+++ b/model/geo_primitives/src/torus_solid_3d.rs
@@ -7,7 +7,7 @@
 // 固体としての体積と表面を持ちます。
 
 use crate::{Direction3D, Point3D, TorusSurface3D, Vector3D};
-use geo_contracts::Scalar;
+use geo_contracts::{default_kernel_numerical_zero_tolerance, Scalar};
 use std::f64::consts::PI;
 
 /// STEP AP214 準拠のトーラス固体
@@ -63,7 +63,7 @@ impl<T: Scalar> TorusSolid3D<T> {
         // 軸の直交性チェック
         let dot_product =
             x_axis.x() * z_axis.x() + x_axis.y() * z_axis.y() + x_axis.z() * z_axis.z();
-        let tolerance = T::EPSILON;
+        let tolerance = default_kernel_numerical_zero_tolerance::<T>();
         if dot_product.abs() > tolerance {
             return None;
         }


### PR DESCRIPTION
Refs #487, #455

## 概要
Phase 4「トレランス移行の収束」として、残存 `T::EPSILON` の最終整理と回帰確認を実施しました。

## 変更内容（幾何意味判定の修正 6箇所）

| ファイル | 箇所 | 置換後 |
|------|------|-------|
| `ray_2d_extensions.rs` | `intersection_with_segment` の交点包含判定 | `default_distance_tolerance` |
| `torus_solid_3d.rs` | コンストラクタの軸直交性チェック | `default_kernel_numerical_zero_tolerance` |
| `line_segment_2d.rs` | `contains_point` trait impl | `default_distance_tolerance` |
| `line_segment_3d.rs` | `contains_point` trait impl | `default_distance_tolerance` |
| `ellipse_arc_2d.rs` | `distance_to_point` の角度範囲判定 | `default_angle_tolerance` |
| `ellipse_arc_3d_extensions.rs` | `distance_to_point` の角度範囲判定 | `default_angle_tolerance` |

## 残存 T::EPSILON の分類（例外運用の明文化）

### ✅ 数値安定化ガード（正当な T::EPSILON 使用）
以下は幾何意味判定ではなく、**除算回避・正規化安定化**のための使用であり、`default_kernel_numerical_zero_tolerance` と運用上同等かつ将来的に統合候補:

- `geo_algorithms/intersection/primitive_2d.rs` (3件): `denominator.abs() < T::EPSILON` — 分母ゼロ除算防止
- `geo_algorithms/intersection/pair_base.rs` (8件): `denom/a/det` ゼロチェック
- `geo_algorithms/collision/primitive_2d.rs` (1件): `denominator.abs() < T::EPSILON`
- `geo_core/vector_3d_transform.rs` (2件): 回転軸の長さゼロガード
- `geo_core/point_3d_transform.rs` (1件): `len_sq` 正規化ガード
- `geo_nurbs/curve_3d.rs` (1件): `distance_sq` ゼロ距離ガード
- `geo_primitives/line_segment_3d_transform.rs` (1件): 軸長ゼロガード
- `geo_primitives` 各 solid/surface の `radial_distance/radial_len > T::EPSILON` 判定（torus/cone/cylinder/sphere 合計約20件): ゼロ除算防止
- `.max(T::EPSILON)` 形式 (3件): 下限値クランプ
- `geo_contracts/vector_traits.rs` (2件): 正規化ベクトル長さ判定
- `geo_io/stl.rs` (1件): STL 固有許容誤差（ドメイン固有）

### 🔄 将来移行候補（未移行形状の geometric judgment）
以下は幾何意味判定であるが、形状クレート PR が未着手のため **今後の対応課題** として記録:

- `geo_commons/metrics/distance.rs`: `dist/len_sq` ゼロ判定 → distance tolerance
- `geo_core/point_2d.rs`: `is_origin` チェック
- `geo_core/vector_3d.rs`: `is_zero_length` / `angle` チェック
- `geo_primitives/circle_2d_transform.rs`, `circle_3d_transform.rs`: scale 均一性チェック
- `geo_primitives/ellipse_2d.rs`, `ellipse_arc_2d.rs`, `ellipse_arc_3d.rs`: 楕円軸差・角度範囲
- `geo_primitives/ellipsoidal_*.rs`: 軸比較、点判定
- `geo_primitives/line_segment_2d.rs`, `line_segment_3d.rs`: length/coord 比較 3件ずつ
- `geo_primitives/spherical_surface_3d.rs`, `spherical_solid_3d.rs`: radius/is_unit/is_centered
- `geo_primitives/infinite_line_2d_extensions.rs`: direction component チェック

## 検証結果
- `cargo clippy --workspace -- -D warnings`: ✅
- `cargo test --workspace`: ✅ （全クレートで FAILED 0件）
- `cargo fmt --all -- --check`: ✅