### PR TITLE
[Issue #484] intersection返り値意味論を代表2Dペアへ適用（Coincident/Segment2D）

### DIFF
--- a/dev/archive/issues/architecture/ISSUE_484_IMPLEMENTATION_PREP.md
+++ b/dev/archive/issues/architecture/ISSUE_484_IMPLEMENTATION_PREP.md
@@ -1,0 +1,67 @@
+# Issue #484 実施準備チェックリスト
+
+対象Issue: [#484 intersection返り値意味論の個別適用: Coincident/Segment2D を具体ペアへ反映](https://github.com/RedRing2020/RedRing/issues/484)
+
+## 1. 目的
+
+- #357 で定義した `IntersectionResult` 意味論を、2D 代表ペアへ具体適用する
+- `Disjoint` / `Touching` / `Crossing` / `Coincident` と `Segment2D` の使い分けを実装で固定する
+- 代表ケースの回帰テストを追加し、今後の退行を防ぐ
+
+## 2. 現状確認（2026-03-29）
+
+- `circle2d_circle2d_intersections_algo` は点群変換のみで、同一円と同心円半径違いを区別していない
+- `line_segment2d_line_segment2d_intersection_algo` は `Option<Point2D>` 前提で、コリニア重複を `Segment2D` 化できない
+- `ray2d_line_segment2d_intersection` / `infinite_line2d_line_segment2d_intersection` / `infinite_line2d_ray2d_intersection` は平行・共線時に空へ潰れる
+
+## 3. 設計オプション
+
+### Option A: `pair_base` 側で返り値を `IntersectionResult` 化
+
+- 長所: 意味論が低層で一元化できる
+- 短所: 既存呼び出し面の影響が大きく、差分が肥大化しやすい
+
+### Option B: `primitive_2d` 入口で意味論を付与（採用）
+
+- 長所: 公開APIの振る舞い修正に集中でき、最小差分で #484 の受け入れ条件を満たしやすい
+- 短所: `pair_base` の幾何計算は旧形のまま残る
+
+### Option C: 一部ペアのみ先行対応
+
+- 長所: 最小リスク
+- 短所: #484 の「主要線形ペア」条件が満たしにくい
+
+## 4. 実装方針（Option B）
+
+- `model/geo_algorithms/src/intersection/primitive_2d.rs` のみを修正対象にする
+- 次の入口関数で共線/重複分岐を追加する
+  - `circle2d_circle2d_intersections_algo`
+  - `line_segment2d_line_segment2d_intersection_algo`
+  - `ray2d_line_segment2d_intersection`
+  - `infinite_line2d_line_segment2d_intersection`
+  - `infinite_line2d_ray2d_intersection`
+- 既存の非共線分岐は現行ロジックを維持する
+
+## 5. 意味論ルール（本実装で固定）
+
+- 同一円: `topology=Coincident`, `geometry=Coincident`
+- 同心円・半径違い: `Disjoint`
+- コリニア線分の部分重複: `topology=Coincident`, `geometry=Segment2D`
+- コリニア線分の一点接触: `topology=Touching`, `geometry=Point2D`
+- 直線×線分の共線: `topology=Coincident`, `geometry=Segment2D`
+- 直線×半直線の共線: `topology=Coincident`, `geometry=Coincident`（連続重複を表現）
+- 半直線×線分の共線重複: 一点は `Touching/Point2D`、区間は `Coincident/Segment2D`
+
+## 6. 追加テスト
+
+- 同一円と同心円半径違いの判定
+- コリニア線分の部分重複 / 一点接触 / 完全一致
+- 共線 `Ray2D×LineSegment2D` の区間重複
+- 共線 `InfiniteLine2D×LineSegment2D` の `Segment2D`
+- 共線 `InfiniteLine2D×Ray2D` の `Coincident`
+
+## 7. 検証
+
+- `cargo test -p geo_algorithms`
+- `cargo clippy -p geo_algorithms -- -D warnings`
+- `cargo fmt --all -- --check`

--- a/model/geo_algorithms/src/intersection/primitive_2d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_2d.rs
@@ -9,8 +9,8 @@ use crate::intersection::pair_base::{
     line_segment2d_circle2d_intersections, line_segment2d_line_segment2d_intersection,
 };
 use crate::{
-    Arc2D, Circle2D, Ellipse2D, EllipseArc2D, InfiniteLine2D, IntersectionResult, LineSegment2D,
-    Point2D, Ray2D, Triangle2D, Vector2D,
+    Arc2D, Circle2D, Ellipse2D, EllipseArc2D, InfiniteLine2D, IntersectionGeometry,
+    IntersectionResult, IntersectionTopology, LineSegment2D, Point2D, Ray2D, Triangle2D, Vector2D,
 };
 use geo_contracts::{
     Arc2DProperties, Circle2DProperties, Ellipse2DProperties, InfiniteLine2DProperties,
@@ -39,6 +39,22 @@ pub fn circle2d_circle2d_intersections_algo<T: Scalar>(
     circle2: &Circle2D<T>,
     tolerance: T,
 ) -> IntersectionResult<T> {
+    let dx = circle2.center().0 - circle1.center().0;
+    let dy = circle2.center().1 - circle1.center().1;
+    let center_distance = (dx * dx + dy * dy).sqrt();
+
+    if center_distance <= tolerance {
+        if (circle1.radius() - circle2.radius()).abs() <= tolerance {
+            return IntersectionResult::new(
+                IntersectionGeometry::Coincident,
+                IntersectionTopology::Coincident,
+                false,
+                tolerance,
+            );
+        }
+        return IntersectionResult::disjoint(tolerance);
+    }
+
     let points = circle2d_circle2d_intersections(circle1, circle2, tolerance);
     IntersectionResult::from_option_points2d(points, false, tolerance)
 }
@@ -102,6 +118,10 @@ pub fn line_segment2d_line_segment2d_intersection_algo<T: Scalar>(
     segment2: &LineSegment2D<T>,
     tolerance: T,
 ) -> IntersectionResult<T> {
+    if let Some(result) = collinear_segment_overlap_result(segment1, segment2, tolerance) {
+        return result;
+    }
+
     let opt = line_segment2d_line_segment2d_intersection(segment1, segment2, tolerance);
     IntersectionResult::from_option_point2d(opt, false, tolerance)
 }
@@ -124,6 +144,11 @@ pub fn ray2d_line_segment2d_intersection<T: Scalar>(
 
     let denominator = d1.x() * d2.y() - d1.y() * d2.x();
     if denominator.abs() <= tolerance {
+        if is_point_on_line(origin, d1, s1, tolerance)
+            && is_point_on_line(origin, d1, s2, tolerance)
+        {
+            return collinear_ray_segment_overlap_result(ray, segment, tolerance);
+        }
         return IntersectionResult::from_option_point2d(None, false, tolerance);
     }
 
@@ -354,7 +379,24 @@ pub fn infinite_line2d_line_segment2d_intersection<T: Scalar>(
     let dx_seg = s2x - s1x;
     let dy_seg = s2y - s1y;
     let denominator = ldx * dy_seg - ldy * dx_seg;
-    if denominator.abs() < T::EPSILON {
+    if denominator.abs() <= tolerance {
+        let line_point = Point2D::new(lx, ly);
+        let line_dir = Vector2D::new(ldx, ldy);
+        let seg_start = Point2D::new(s1x, s1y);
+        let seg_end = Point2D::new(s2x, s2y);
+        if is_point_on_line(line_point, line_dir, seg_start, tolerance)
+            && is_point_on_line(line_point, line_dir, seg_end, tolerance)
+        {
+            if let Some(overlap_segment) = LineSegment2D::new(seg_start, seg_end) {
+                return IntersectionResult::new(
+                    IntersectionGeometry::Segment2D(overlap_segment),
+                    IntersectionTopology::Coincident,
+                    false,
+                    tolerance,
+                );
+            }
+            return IntersectionResult::from_option_point2d(Some(seg_start), true, tolerance);
+        }
         return IntersectionResult::from_option_point2d(None, false, tolerance);
     }
     let t2 = ((s1x - lx) * ldy - (s1y - ly) * ldx) / denominator;
@@ -384,7 +426,18 @@ pub fn infinite_line2d_ray2d_intersection<T: Scalar>(
     let (lx, ly) = InfiniteLine2DProperties::point(line);
     let (ldx, ldy) = InfiniteLine2DProperties::direction(line);
     let denominator = ldx * rdy - ldy * rdx;
-    if denominator.abs() < T::EPSILON {
+    if denominator.abs() <= tolerance {
+        let line_point = Point2D::new(lx, ly);
+        let line_dir = Vector2D::new(ldx, ldy);
+        let ray_origin = Point2D::new(ox, oy);
+        if is_point_on_line(line_point, line_dir, ray_origin, tolerance) {
+            return IntersectionResult::new(
+                IntersectionGeometry::Coincident,
+                IntersectionTopology::Coincident,
+                false,
+                tolerance,
+            );
+        }
         return IntersectionResult::from_option_point2d(None, false, tolerance);
     }
     let t2 = ((ox - lx) * ldy - (oy - ly) * ldx) / denominator;
@@ -474,6 +527,154 @@ pub fn ellipse_arc2d_point2d_intersection<T: Scalar>(
     IntersectionResult::from_option_point2d(opt, false, tolerance)
 }
 
+fn squared_norm<T: Scalar>(v: Vector2D<T>) -> T {
+    v.x() * v.x() + v.y() * v.y()
+}
+
+fn cross_2d<T: Scalar>(a: Vector2D<T>, b: Vector2D<T>) -> T {
+    a.x() * b.y() - a.y() * b.x()
+}
+
+fn is_point_on_line<T: Scalar>(
+    line_point: Point2D<T>,
+    line_dir: Vector2D<T>,
+    p: Point2D<T>,
+    tolerance: T,
+) -> bool {
+    cross_2d(Vector2D::from_points(line_point, p), line_dir).abs() <= tolerance
+}
+
+fn points_near<T: Scalar>(a: Point2D<T>, b: Point2D<T>, tolerance: T) -> bool {
+    (a.x() - b.x()).abs() <= tolerance && (a.y() - b.y()).abs() <= tolerance
+}
+
+fn collinear_segment_overlap_result<T: Scalar>(
+    seg1: &LineSegment2D<T>,
+    seg2: &LineSegment2D<T>,
+    tolerance: T,
+) -> Option<IntersectionResult<T>> {
+    let p1 = Point2D::new(seg1.start().0, seg1.start().1);
+    let p2 = Point2D::new(seg1.end().0, seg1.end().1);
+    let p3 = Point2D::new(seg2.start().0, seg2.start().1);
+    let p4 = Point2D::new(seg2.end().0, seg2.end().1);
+    let d1 = Vector2D::from_points(p1, p2);
+    let d2 = Vector2D::from_points(p3, p4);
+
+    if cross_2d(d1, d2).abs() > tolerance {
+        return None;
+    }
+    if cross_2d(Vector2D::from_points(p1, p3), d1).abs() > tolerance {
+        return None;
+    }
+
+    let d1_norm = squared_norm(d1);
+    if d1_norm <= tolerance * tolerance {
+        return Some(IntersectionResult::disjoint(tolerance));
+    }
+
+    let t3 = Vector2D::from_points(p1, p3).dot(&d1) / d1_norm;
+    let t4 = Vector2D::from_points(p1, p4).dot(&d1) / d1_norm;
+    let seg2_min = if t3 < t4 { t3 } else { t4 };
+    let seg2_max = if t3 > t4 { t3 } else { t4 };
+
+    let overlap_min = if seg2_min > T::ZERO {
+        seg2_min
+    } else {
+        T::ZERO
+    };
+    let overlap_max = if seg2_max < T::ONE { seg2_max } else { T::ONE };
+
+    if overlap_max < overlap_min - tolerance {
+        return Some(IntersectionResult::disjoint(tolerance));
+    }
+
+    let overlap_start = Point2D::new(p1.x() + overlap_min * d1.x(), p1.y() + overlap_min * d1.y());
+    let overlap_end = Point2D::new(p1.x() + overlap_max * d1.x(), p1.y() + overlap_max * d1.y());
+
+    if (overlap_max - overlap_min).abs() <= tolerance {
+        return Some(IntersectionResult::from_option_point2d(
+            Some(overlap_start),
+            true,
+            tolerance,
+        ));
+    }
+
+    let same_direction = points_near(p1, p3, tolerance) && points_near(p2, p4, tolerance);
+    let opposite_direction = points_near(p1, p4, tolerance) && points_near(p2, p3, tolerance);
+    if same_direction || opposite_direction {
+        return Some(IntersectionResult::new(
+            IntersectionGeometry::Coincident,
+            IntersectionTopology::Coincident,
+            false,
+            tolerance,
+        ));
+    }
+
+    let overlap_segment = LineSegment2D::new(overlap_start, overlap_end)?;
+    Some(IntersectionResult::new(
+        IntersectionGeometry::Segment2D(overlap_segment),
+        IntersectionTopology::Coincident,
+        false,
+        tolerance,
+    ))
+}
+
+fn collinear_ray_segment_overlap_result<T: Scalar>(
+    ray: &Ray2D<T>,
+    segment: &LineSegment2D<T>,
+    tolerance: T,
+) -> IntersectionResult<T> {
+    let origin = Point2D::new(ray.origin().0, ray.origin().1);
+    let direction = Vector2D::new(ray.direction().0, ray.direction().1);
+    let s1 = Point2D::new(segment.start().0, segment.start().1);
+    let s2 = Point2D::new(segment.end().0, segment.end().1);
+    let dir_norm = squared_norm(direction);
+
+    if dir_norm <= tolerance * tolerance {
+        return IntersectionResult::disjoint(tolerance);
+    }
+
+    let t1 = Vector2D::from_points(origin, s1).dot(&direction) / dir_norm;
+    let t2 = Vector2D::from_points(origin, s2).dot(&direction) / dir_norm;
+    let seg_min = if t1 < t2 { t1 } else { t2 };
+    let seg_max = if t1 > t2 { t1 } else { t2 };
+
+    if seg_max < T::ZERO - tolerance {
+        return IntersectionResult::disjoint(tolerance);
+    }
+
+    let overlap_min = if seg_min > T::ZERO { seg_min } else { T::ZERO };
+    let overlap_max = seg_max;
+    if overlap_max < overlap_min - tolerance {
+        return IntersectionResult::disjoint(tolerance);
+    }
+
+    let overlap_start = Point2D::new(
+        origin.x() + overlap_min * direction.x(),
+        origin.y() + overlap_min * direction.y(),
+    );
+
+    if (overlap_max - overlap_min).abs() <= tolerance {
+        return IntersectionResult::from_option_point2d(Some(overlap_start), true, tolerance);
+    }
+
+    let overlap_end = Point2D::new(
+        origin.x() + overlap_max * direction.x(),
+        origin.y() + overlap_max * direction.y(),
+    );
+
+    if let Some(overlap_segment) = LineSegment2D::new(overlap_start, overlap_end) {
+        return IntersectionResult::new(
+            IntersectionGeometry::Segment2D(overlap_segment),
+            IntersectionTopology::Coincident,
+            false,
+            tolerance,
+        );
+    }
+
+    IntersectionResult::from_option_point2d(Some(overlap_start), true, tolerance)
+}
+
 fn edge_segment_intersection<T: Scalar>(
     edge_p1: Point2D<T>,
     edge_p2: Point2D<T>,
@@ -523,6 +724,7 @@ mod tests {
         IntersectionTopology, LineSegment2D, Point2D, Ray2D, Vector2D,
     };
     use analysis::test_constants;
+    use geo_contracts::LineSegment2DProperties;
 
     const STANDARD_TEST_TOLERANCE_F64: f64 = test_constants::DISTANCE_TOLERANCE_F64;
     const ELLIPSE_ENTRY_TEST_TOLERANCE_F64: f64 = 1.0e-6;
@@ -621,6 +823,71 @@ mod tests {
     }
 
     #[test]
+    fn circle_circle_identical_returns_coincident() {
+        let circle1 = Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap();
+        let circle2 = Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap();
+
+        let result =
+            circle2d_circle2d_intersections_algo(&circle1, &circle2, STANDARD_TEST_TOLERANCE_F64);
+        assert_eq!(result.topology, IntersectionTopology::Coincident);
+        match result.geometry {
+            IntersectionGeometry::Coincident => {}
+            _ => panic!("expected Coincident geometry"),
+        }
+    }
+
+    #[test]
+    fn circle_circle_concentric_different_radius_is_disjoint() {
+        let circle1 = Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap();
+        let circle2 = Circle2D::new(Point2D::new(0.0, 0.0), 2.0).unwrap();
+
+        let result =
+            circle2d_circle2d_intersections_algo(&circle1, &circle2, STANDARD_TEST_TOLERANCE_F64);
+        assert_eq!(result.topology, IntersectionTopology::Disjoint);
+    }
+
+    #[test]
+    fn line_segment_line_segment_collinear_overlap_returns_segment2d() {
+        let segment1 = LineSegment2D::new(Point2D::new(0.0, 0.0), Point2D::new(3.0, 0.0)).unwrap();
+        let segment2 = LineSegment2D::new(Point2D::new(1.0, 0.0), Point2D::new(4.0, 0.0)).unwrap();
+
+        let result = line_segment2d_line_segment2d_intersection_algo(
+            &segment1,
+            &segment2,
+            STANDARD_TEST_TOLERANCE_F64,
+        );
+        assert_eq!(result.topology, IntersectionTopology::Coincident);
+        match result.geometry {
+            IntersectionGeometry::Segment2D(seg) => {
+                let start = seg.start();
+                let end = seg.end();
+                assert!((start.0 - 1.0).abs() < STANDARD_TEST_TOLERANCE_F64);
+                assert!((end.0 - 3.0).abs() < STANDARD_TEST_TOLERANCE_F64);
+            }
+            _ => panic!("expected Segment2D geometry"),
+        }
+    }
+
+    #[test]
+    fn line_segment_line_segment_collinear_touching_endpoint_returns_touching() {
+        let segment1 = LineSegment2D::new(Point2D::new(0.0, 0.0), Point2D::new(1.0, 0.0)).unwrap();
+        let segment2 = LineSegment2D::new(Point2D::new(1.0, 0.0), Point2D::new(2.0, 0.0)).unwrap();
+
+        let result = line_segment2d_line_segment2d_intersection_algo(
+            &segment1,
+            &segment2,
+            STANDARD_TEST_TOLERANCE_F64,
+        );
+        assert_eq!(result.topology, IntersectionTopology::Touching);
+        match result.geometry {
+            IntersectionGeometry::Point2D(p) => {
+                assert!((p.x() - 1.0).abs() < STANDARD_TEST_TOLERANCE_F64);
+            }
+            _ => panic!("expected Point2D geometry"),
+        }
+    }
+
+    #[test]
     fn ray_circle_intersection_returns_forward_hits_only() {
         let ray = Ray2D::new(Point2D::new(-2.0, 0.0), Vector2D::new(1.0, 0.0)).unwrap();
         let circle = Circle2D::new(Point2D::new(0.0, 0.0), 1.0).unwrap();
@@ -697,6 +964,49 @@ mod tests {
         let line_ray = infinite_line2d_ray2d_intersection(&line, &ray, tol);
         assert_eq!(ray_line.topology, line_ray.topology);
         assert_eq!(ray_line.is_tangent, line_ray.is_tangent);
+    }
+
+    #[test]
+    fn ray_segment_collinear_overlap_returns_segment2d() {
+        let ray = Ray2D::new(Point2D::new(0.0, 0.0), Vector2D::new(1.0, 0.0)).unwrap();
+        let segment = LineSegment2D::new(Point2D::new(1.0, 0.0), Point2D::new(3.0, 0.0)).unwrap();
+
+        let result = ray2d_line_segment2d_intersection(&ray, &segment, STANDARD_TEST_TOLERANCE_F64);
+        assert_eq!(result.topology, IntersectionTopology::Coincident);
+        match result.geometry {
+            IntersectionGeometry::Segment2D(_) => {}
+            _ => panic!("expected Segment2D geometry"),
+        }
+    }
+
+    #[test]
+    fn infinite_line_segment_collinear_returns_segment2d() {
+        let line = InfiniteLine2D::new(Point2D::new(0.0, 0.0), Vector2D::new(1.0, 0.0)).unwrap();
+        let segment = LineSegment2D::new(Point2D::new(-2.0, 0.0), Point2D::new(2.0, 0.0)).unwrap();
+
+        let result = infinite_line2d_line_segment2d_intersection(
+            &line,
+            &segment,
+            STANDARD_TEST_TOLERANCE_F64,
+        );
+        assert_eq!(result.topology, IntersectionTopology::Coincident);
+        match result.geometry {
+            IntersectionGeometry::Segment2D(_) => {}
+            _ => panic!("expected Segment2D geometry"),
+        }
+    }
+
+    #[test]
+    fn infinite_line_ray_collinear_returns_coincident() {
+        let line = InfiniteLine2D::new(Point2D::new(0.0, 0.0), Vector2D::new(1.0, 0.0)).unwrap();
+        let ray = Ray2D::new(Point2D::new(1.0, 0.0), Vector2D::new(2.0, 0.0)).unwrap();
+
+        let result = infinite_line2d_ray2d_intersection(&line, &ray, STANDARD_TEST_TOLERANCE_F64);
+        assert_eq!(result.topology, IntersectionTopology::Coincident);
+        match result.geometry {
+            IntersectionGeometry::Coincident => {}
+            _ => panic!("expected Coincident geometry"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Refs #484

## 概要
Issue #484 の初期着手として、`primitive_2d` の代表ペアに `Coincident/Segment2D` の意味論を適用しました。

## 変更内容
- `circle2d_circle2d_intersections_algo`
  - 同一円を `Coincident`
  - 同心円・半径違いを `Disjoint`
- `line_segment2d_line_segment2d_intersection_algo`
  - コリニア重複を判定し、
    - 部分重複: `Coincident + Segment2D`
    - 一点接触: `Touching + Point2D`
    - 完全一致: `Coincident + Coincident`
- `ray2d_line_segment2d_intersection`
  - 共線重複を `Touching/Segment2D` で返却
- `infinite_line2d_line_segment2d_intersection`
  - 共線時を `Coincident + Segment2D` で返却
- `infinite_line2d_ray2d_intersection`
  - 共線時を `Coincident + Coincident` で返却
- 回帰テストを追加（同一円/同心円、コリニア線分重複、共線 linear pair）

## ドキュメント
- `dev/archive/issues/architecture/ISSUE_484_IMPLEMENTATION_PREP.md` を追加（差分計画・設計オプション・意味論ルール）

## 検証
- `cargo fmt --all`
- `cargo test -p geo_algorithms`（233 passed）
- `cargo clippy -p geo_algorithms -- -D warnings`

## 補足
最小差分で #484 の受け入れ条件に直結する代表ペアへ適用しています。`pair_base` の返り値設計変更は本PRの非スコープです。