### PR TITLE
feat: Application層PoC導線移設とorchestrationコメント日本語化 (#335)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "application"
+version = "0.1.0"
+dependencies = [
+ "analysis",
+ "cam_core",
+ "cam_sim",
+ "geo_algorithms",
+ "job_domain",
+ "job_runtime",
+]
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,6 +2807,7 @@ name = "viewmodel"
 version = "0.1.0"
 dependencies = [
  "analysis",
+ "application",
  "cam_core",
  "cam_entity",
  "cam_sim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "model/cam_sim",        # Model層：CAMシミュレーション実行クレート
   "model/job_runtime", # Model層：共通ジョブマネージャー基盤（CAD/CAM/CAE非依存）
   "model/job_domain", # Model層：ジョブ投入ポリシー/ユースケース抽象化
+  "model/application", # Application層：orchestration受け皿（PoC段階は単一クレート）
   "viewmodel/converter",  # ViewModel層：データ変換・架け橋
   "viewmodel/graphics",   # ViewModel層：グラフィックス制御（カメラ等）
   "view/render",          # View層：GPU描画基盤

--- a/dev/architecture/APPLICATION_ORCHESTRATION_LAYER_DESIGN.md
+++ b/dev/architecture/APPLICATION_ORCHESTRATION_LAYER_DESIGN.md
@@ -1,0 +1,273 @@
+# Application Orchestration Layer Design
+
+**作成日**: 2026年3月29日
+**関連Issue**: #335
+**ステータス**: 設計検討中
+
+---
+
+## 1. 背景
+
+- 現在、ユースケース実行責務が `job_domain` / `cam_sim` / `viewmodel` / `view` に分散している
+- ViewModel 側に処理実行導線が残ると、表示変換責務と業務フロー責務が混在する
+- 将来の ECS / 非ECS 差し替えを ViewModel 側で吸収すると、導線が不安定になりやすい
+
+本設計では、ViewModel と domain/algorithm/job 系クレートの間に **Application Layer** を導入し、
+その主要責務を **orchestration** として定義する。
+
+---
+
+## 2. 命名方針
+
+### 2.1 層名
+
+- 論理層名は **Application Layer** とする
+- `usecase` や `workflow` は説明語としては使用可能だが、層の総称には使用しない
+
+### 2.2 クレート/モジュール名
+
+- Application Layer の実体は `*_orchestration` を基本命名とする
+- 例:
+  - `job_orchestration`
+  - `cam_orchestration`
+  - `feature_orchestration`
+  - `geometry_orchestration`
+
+### 2.3 命名理由
+
+- `usecase` は個別機能を連想しやすく、複数処理の調停責務を表しにくい
+- `workflow` は順序制御には適するが、port/adapter の選択や境界DTOの集約まで含めるにはやや狭い
+- `orchestration` は「どこに委譲するか」「どういう順序で進めるか」「どの境界で返すか」をまとめて表現しやすい
+
+---
+
+## 3. 役割定義
+
+Application Layer は、通知や入力を受けた後の処理の進め方を決定し、下位機能を調停する層とする。
+
+### 3.1 責務
+
+1. **入口APIの統一**
+   - ViewModel や将来の外部入口から見える呼び出し窓口を安定化する
+   - 下位クレートの内部型をそのまま公開しない
+
+2. **委譲先の選択**
+   - request 内容に応じて、どの domain / algorithm / runtime / adapter を利用するかを決定する
+   - ECS / 非ECS の差分吸収点をここに置く
+
+3. **実行順序の調停**
+   - 検証、変換、domain 実行、job 投入、結果整形などの順序を管理する
+
+4. **境界DTO変換**
+   - 上位層向け request/result DTO と下位層向け DTO の橋渡しを行う
+
+5. **エラー境界の正規化**
+   - 下位層の詳細エラーを、上位層が扱いやすい契約へ寄せる
+
+6. **実行文脈の管理**
+   - ユースケース単位で必要な context、依存、設定、関連リソースを束ねる
+
+7. **port契約の維持**
+   - 下位実装を差し替えても上位APIを崩さないようにする
+
+8. **実行方式境界の明示**
+   - 同期実行、非同期実行、job 投入のどれを選ぶかを決める
+   - ただし task/thread/queue/executor などの実装詳細は adapter / runtime に委譲する
+
+### 3.2 非責務
+
+- 幾何計算アルゴリズムそのものは持たない
+- CAM 計算ロジックそのものは持たない
+- `job_runtime` の低レベル状態遷移や内部実行制御は持たない
+- UI 表示用の最終変換や文言解決は持たない
+- 永続化の実装詳細は持たない
+
+---
+
+## 4. 依存境界
+
+```text
+View / ViewModel
+      ↓
+Application Layer (`*_orchestration`)
+      ↓
+Domain / Algorithm / Runtime / Adapter
+  - geo_*
+  - cam_*
+  - job_*
+```
+
+### 4.1 上位境界
+
+- ViewModel は orchestration の request/result DTO を扱う
+- ViewModel は domain 固有の内部制約や adapter 切り替え方針を持たない
+
+### 4.2 下位境界
+
+- `job_domain` は投入制約やポリシー判定を担当する
+- `job_runtime` は実行制御、状態遷移、イベント契約を担当する
+- `cam_sim` は計算接続アダプタ責務へ寄せる
+- `geo_algorithms` / `cam_algorithms` は純粋計算責務に留める
+
+---
+
+## 5. port / adapter 方針
+
+### 5.1 port の責務
+
+- orchestration から見た依存先を trait で抽象化する
+- ECS / 非ECS / batch / local 実装差分を port の背後に隠す
+
+### 5.2 adapter の責務
+
+- 下位クレートや実行基盤の具体実装へ接続する
+- 非同期実装、イベント配送、永続化アクセスなどの詳細を持つ
+
+### 5.3 初期方針
+
+- 最初から全ユースケースを port 化しない
+- PoC 対象の導線で必要な最小 port から始める
+- adapter 差し替えが必要になる箇所から先に切り出す
+
+---
+
+## 6. 既存クレートとの整理方針
+
+### 6.1 現在の位置づけ
+
+- `job_domain`: ドメインポリシー、投入制約、WorkflowSnapshot などの domain 寄り責務
+- `job_runtime`: 実行基盤
+- `cam_sim`: CAM 特化の実行ファサードと接続アダプタが混在
+- `viewmodel/converter`: DTO 変換に加えて debug 実行導線が一部残存
+
+### 6.2 移行方針
+
+- `job_domain` は domain policy に集中させる
+- `cam_sim` は計算接続アダプタ責務へ縮退させる
+- ViewModel / View に残る debug 実行導線は orchestration 側へ移す
+
+---
+
+## 7. 最小PoC候補
+
+Issue #335 の最小 PoC は、既存の debug snapshot / toolpath 可視化導線を Application Layer へ移す案を第一候補とする。
+
+### 理由
+
+- ViewModel / View に残っている実行責務を直接減らせる
+- `job_domain` / `job_runtime` の既存責務と衝突しにくい
+- orchestration 導入の効果を小さい変更で確認しやすい
+
+### 初期候補
+
+- `cam_orchestration`
+  - debug snapshot series の生成要求を受ける
+  - simulation 実行経路を選択する
+  - ViewModel 向け境界DTOへ返す
+
+---
+
+## 8. 段階導入案
+
+1. **Phase 0: 設計固定**
+   - 本文書で責務、命名、境界、PoC対象を固定する
+
+2. **Phase 1: 骨組み導入**
+   - Application Layer 用の最小クレート/モジュールと依存ルールを追加する
+
+3. **Phase 2: PoC移設**
+   - debug snapshot / toolpath 導線のうち 1 系統を orchestration へ移す
+
+4. **Phase 3: 展開計画**
+   - job / feature / geometry 系へ横展開する
+
+### 8.1 適用ポリシー（合意事項）
+
+- 初期導入は **PoC から段階適用** を基本方針とする
+- 初手で `Application/*_orchestration` の複数クレート分割は行わない
+- まずは単一の Application 層受け皿を置き、内部を module 分割で開始する
+- PoC は `cam_orchestration` 相当の最小導線を優先する
+
+### 8.2 module から crate への昇格基準
+
+以下のいずれかを満たす場合に、`*_orchestration` module の独立クレート化を検討する。
+
+1. 依存先が明確に分岐し、同居すると依存ルールが複雑化する
+2. 公開API契約（request/result/error/port）が安定し、他機能と独立に版管理したい
+3. テスト戦略や変更頻度が明確に分かれ、分離で保守性が上がる
+4. architecture check の運用上、独立レイヤー管理した方が違反検出が明確になる
+5. PoC後の実運用で責務境界が固定され、再統合より分離維持の方が低コストと判断できる
+
+---
+
+## 9. 未決事項
+
+- 初期配置を `model/` 直下の単一受け皿クレートにするか、既存クレート内 module から開始するか
+   - 方針: PoC では単一受け皿 + module 分割を優先し、複数クレート化は 8.2 の基準で判断する
+- `job_orchestration` の初回導入タイミング（PoC直後か、Phase 3 展開時か）
+- architecture check における Layer Group 名を `Application` として追加する時期
+
+---
+
+## 10. 関連文書
+
+- `dev/architecture/ARCHITECTURE.md`
+- `dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md`
+- `dev/architecture/VIEWMODEL_ARCHITECTURE_DESIGN.md`
+
+---
+
+## 11. cam_core 型露出方針（2026-03-29 追記）
+
+Application Layer の PoC 以降では、CAM 計算・表示連携・制約適用の実要件を踏まえ、
+`cam_core` の ToolPath / MachineConstraint / ToolSet 系の詳細型を orchestration 境界で扱うことを許容する。
+
+### 11.1 方針
+
+1. ToolPath / ToolSet / 機械特性の正本は `cam_core` とする
+2. Application Layer は干渉チェック、姿勢制御、制約適用に必要な項目へ直接アクセスしてよい
+3. ViewModel は最終表示形式の生成に集中し、表示向け投影を担当する
+4. `cam_core` への依存は Application Layer で許可し、再エクスポートに依存しない
+
+### 11.2 境界の使い分け
+
+1. Command 系（編集/実行）
+   - 詳細型を受け取る境界を許容する
+2. Query 系（一覧/概要表示）
+   - 軽量 DTO を返す境界を優先する
+
+### 11.3 非責務の維持
+
+上記を許容しても、Application Layer は次を持たない。
+
+- CAM 計算アルゴリズム本体
+- `job_runtime` の低レベル状態遷移実装
+- UI 文言解決や最終表示表現
+
+---
+
+## 12. Phase 2 PoC 実施メモ（2026-03-29）
+
+debug snapshot 導線のうち、cam_sim export DTO の正規化を Application Layer へ移設した。
+
+### 12.1 実施内容
+
+1. `model/application/src/cam_orchestration.rs` に境界DTOを追加
+   - `CamSnapshotFrame`
+   - `CamSnapshotSeriesRequest`
+   - `CamSnapshotSeriesResult`
+2. orchestration 実装を追加
+   - `CamSnapshotSeriesOrchestrator`
+   - `create_snapshot_series_from_exports`
+3. `viewmodel/converter/src/snapshot_converter.rs` から
+   `cam_sim` export DTO の直接整形ロジックを外し、Application 経由へ変更
+
+### 12.2 意図
+
+- ViewModel 側に残っていた実行責務の一部を削減し、境界変換を Application 層へ寄せる
+- `cam_sim` の出力形式に追従する責務を converter 単体で持たないようにする
+
+### 12.3 継続項目
+
+- toolpath + simulation 実行そのものの導線移設は次段階で実施する
+- Query 系の軽量DTO境界を別途定義する

--- a/dev/architecture/ARCHITECTURE.md
+++ b/dev/architecture/ARCHITECTURE.md
@@ -56,6 +56,8 @@ foundation/analysis（将来改名候補）
 - **`geo_nurbs`**: NURBS形状のtrait定義と実装（Curve/Surface等）
 - **`geo_algorithms`**: `geo_primitives` / `geo_nurbs` を利用した高レベル幾何アルゴリズム（intersect, collision 等）
 - **`application::*`（新設方針）**: テセレーション、シミュレーション、ジョブ管理など業務ユースケース
+    - Application Layer の主要責務は orchestration とし、入口API、委譲順序、境界DTO、port/adapter 切り替えを集約する
+    - 詳細方針は `dev/architecture/APPLICATION_ORCHESTRATION_LAYER_DESIGN.md` を参照
 - **`geo_io`**: ファイル I/O（STL/OBJ/PLY 等）
 - **`cam_core`**: CAM の中立データ基盤（ToolPath / Tool / artifact I/O / 最小機械制約）
 - **`cam_algorithms`（新設方針）**: CAM 固有アルゴリズム（経路生成、順序最適化、干渉回避、機械制約検証）
@@ -69,6 +71,7 @@ foundation/analysis（将来改名候補）
 - **`geo_foundation`廃止（完了）**: 形状trait定義は`geo_contracts`へ統一済み
 - **依存と import の区別**: `geo_algorithms -> geo_primitives/geo_nurbs` 依存は許可だが、`geo_algorithms` 実装ファイルでの `use geo_primitives::...` 直接 import は禁止（`use crate::...` 再エクスポート経由を使用）
 - **上位責務分離**: tessellation/simulation/job managerは`geo_algorithms`より上位のapplication層へ集約
+- **Application Layer の役割**: 非同期実装詳細そのものは持たず、同期/非同期/job投入の実行方式境界だけを管理する
 - **CAM責務分離**: `cam_core` は中立データ、`cam_algorithms` は計算ロジック、`cam_sim` はCAM特化ユースケース実行として分離する
 - **`cam_sim` の位置づけ**: 物理配置は `model/` 配下だが、責務としては純粋データ層ではなく CAM ドメイン専用の application 層に近い
 - **循環依存回避**: `geo_primitives` ↔ `geo_nurbs` の直接依存は禁止（交差処理は`geo_algorithms`に集約）
@@ -86,6 +89,8 @@ foundation/analysis（将来改名候補）
 3. **Phase 3: application層分離**
 - tessellation/simulation/job manager を application層クレートに移動
 - `geo_algorithms` は純粋幾何アルゴリズム責務に限定
+- 初期導入は PoC から段階適用とし、初手は単一受け皿 + module 分割を優先する
+- `*_orchestration` の独立クレート化は、責務境界と依存分岐が安定した段階で判断する
 
 4. **Phase 4: analysis再編**
 - `foundation/analysis` の名称変更を検討
@@ -212,6 +217,7 @@ redring ← stage ← render
 ## 🔗 関連ドキュメント
 
 - **[📖 オンラインドキュメント](https://redring2020.github.io/RedRing/)** - GitHub Pages（自動更新）
+- [`dev/architecture/APPLICATION_ORCHESTRATION_LAYER_DESIGN.md`](dev/architecture/APPLICATION_ORCHESTRATION_LAYER_DESIGN.md) - Application Layer / orchestration 層の責務定義
 - [`model/GEOMETRY_README.ja.md`](model/GEOMETRY_README.ja.md) - 幾何抽象化の詳細仕様
 - [`manual/philosophy.md`](manual/philosophy.md) - 設計思想・エラー処理ガイドライン
 - [`MIGRATION_VECTOR_F64.md`](MIGRATION_VECTOR_F64.md) - f64 正準化移行履歴

--- a/model/application/Cargo.toml
+++ b/model/application/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "application"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Application-layer orchestration entrypoints and boundary DTO contracts"
+
+[dependencies]
+analysis = { path = "../../foundation/analysis" }
+geo_algorithms = { path = "../geo_algorithms" }
+cam_core = { path = "../cam_core" }
+cam_sim = { path = "../cam_sim" }
+job_runtime = { path = "../job_runtime" }
+job_domain = { path = "../job_domain" }

--- a/model/application/src/cam_orchestration.rs
+++ b/model/application/src/cam_orchestration.rs
@@ -1,4 +1,4 @@
-//! CAM-specific orchestration boundaries.
+//! CAM向け orchestration 境界。
 
 use cam_core::{Tool, ToolPath};
 use cam_sim::{CuttingSimulator, SimulationError, SimulationSnapshotExport, SnapshotInterval};
@@ -13,14 +13,14 @@ pub struct CamSnapshotFrame {
     pub remaining_volume_mm3: f64,
 }
 
-/// Request boundary for CAM snapshot series generation.
+/// CAMスナップショット系列生成の入力境界。
 #[derive(Debug, Clone, PartialEq)]
 pub struct CamSnapshotSeriesRequest {
     pub source: String,
     pub frames: Vec<CamSnapshotFrame>,
 }
 
-/// Result boundary for CAM snapshot series generation.
+/// CAMスナップショット系列生成の出力境界。
 #[derive(Debug, Clone, PartialEq)]
 pub struct CamSnapshotSeriesResult {
     pub frame_count: usize,
@@ -28,7 +28,7 @@ pub struct CamSnapshotSeriesResult {
     pub frames: Vec<CamSnapshotFrame>,
 }
 
-/// Orchestration port for CAM snapshot-related use cases.
+/// CAMスナップショット関連ユースケースの orchestration port。
 pub trait CamSnapshotSeriesOrchestration {
     fn create_snapshot_series(
         &self,
@@ -36,7 +36,7 @@ pub trait CamSnapshotSeriesOrchestration {
     ) -> Result<CamSnapshotSeriesResult, String>;
 }
 
-/// Default implementation for snapshot series orchestration.
+/// スナップショット系列 orchestration の既定実装。
 #[derive(Debug, Default, Clone, Copy)]
 pub struct CamSnapshotSeriesOrchestrator;
 
@@ -77,7 +77,7 @@ pub fn create_snapshot_series_from_exports(
     })
 }
 
-/// Request boundary for cam_sim snapshot execution.
+/// cam_sim スナップショット実行の入力境界。
 #[derive(Debug, Clone)]
 pub struct CamSimulationExecutionRequest {
     pub toolpath: ToolPath<f64>,
@@ -87,13 +87,13 @@ pub struct CamSimulationExecutionRequest {
     pub snapshot_interval: SnapshotInterval,
 }
 
-/// Result boundary for cam_sim snapshot execution.
+/// cam_sim スナップショット実行の出力境界。
 #[derive(Debug, Clone, PartialEq)]
 pub struct CamSimulationExecutionResult {
     pub exports: Vec<SimulationSnapshotExport>,
 }
 
-/// Execute cam_sim and return snapshot exports as an application boundary result.
+/// cam_sim を実行し、スナップショット出力を Application 境界結果として返す。
 pub fn execute_simulation_snapshot_exports(
     request: CamSimulationExecutionRequest,
 ) -> Result<CamSimulationExecutionResult, SimulationError> {

--- a/model/application/src/cam_orchestration.rs
+++ b/model/application/src/cam_orchestration.rs
@@ -1,6 +1,8 @@
 //! CAM-specific orchestration boundaries.
 
-use cam_sim::SimulationSnapshotExport;
+use cam_core::{Tool, ToolPath};
+use cam_sim::{CuttingSimulator, SimulationError, SimulationSnapshotExport, SnapshotInterval};
+use geo_algorithms::{Aabb3D, octree::VoxelOctree};
 
 /// CAMシミュレーション由来の最小スナップショットDTO。
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -75,9 +77,40 @@ pub fn create_snapshot_series_from_exports(
     })
 }
 
+/// Request boundary for cam_sim snapshot execution.
+#[derive(Debug, Clone)]
+pub struct CamSimulationExecutionRequest {
+    pub toolpath: ToolPath<f64>,
+    pub tool: Tool<f64>,
+    pub work_bounds: Aabb3D<f64>,
+    pub max_depth: usize,
+    pub snapshot_interval: SnapshotInterval,
+}
+
+/// Result boundary for cam_sim snapshot execution.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CamSimulationExecutionResult {
+    pub exports: Vec<SimulationSnapshotExport>,
+}
+
+/// Execute cam_sim and return snapshot exports as an application boundary result.
+pub fn execute_simulation_snapshot_exports(
+    request: CamSimulationExecutionRequest,
+) -> Result<CamSimulationExecutionResult, SimulationError> {
+    let voxel_tree = VoxelOctree::new(request.work_bounds, request.max_depth);
+    let mut simulator = CuttingSimulator::new(voxel_tree, request.snapshot_interval);
+    simulator.simulate(&request.toolpath, &request.tool)?;
+
+    Ok(CamSimulationExecutionResult {
+        exports: simulator.snapshot_exports_f64(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cam_core::CuttingDirection;
+    use geo_algorithms::Point3D;
 
     #[test]
     fn test_create_snapshot_series_from_frames() {
@@ -115,5 +148,28 @@ mod tests {
         assert_eq!(result.frame_count, 1);
         assert_eq!(result.frames[0].segment_index, 2);
         assert_eq!(result.frames[0].segment_t, 0.75);
+    }
+
+    #[test]
+    fn test_execute_simulation_snapshot_exports() {
+        let request = CamSimulationExecutionRequest {
+            toolpath: ToolPath::new(
+                "endmill_3mm".to_string(),
+                CuttingDirection::Down,
+                vec![],
+                vec![],
+                vec![],
+            ),
+            tool: Tool::flat_end_mill("endmill_3mm".to_string(), 10.0, 50.0),
+            work_bounds: Aabb3D::new(
+                Point3D::new(-60.0, -60.0, -20.0),
+                Point3D::new(60.0, 60.0, 30.0),
+            ),
+            max_depth: 4,
+            snapshot_interval: SnapshotInterval::default(),
+        };
+
+        let result = execute_simulation_snapshot_exports(request);
+        assert!(matches!(result, Err(SimulationError::EmptyToolpath)));
     }
 }

--- a/model/application/src/cam_orchestration.rs
+++ b/model/application/src/cam_orchestration.rs
@@ -1,0 +1,119 @@
+//! CAM-specific orchestration boundaries.
+
+use cam_sim::SimulationSnapshotExport;
+
+/// CAMシミュレーション由来の最小スナップショットDTO。
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CamSnapshotFrame {
+    pub segment_index: usize,
+    pub segment_t: f64,
+    pub accumulated_distance_mm: f64,
+    pub remaining_volume_mm3: f64,
+}
+
+/// Request boundary for CAM snapshot series generation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CamSnapshotSeriesRequest {
+    pub source: String,
+    pub frames: Vec<CamSnapshotFrame>,
+}
+
+/// Result boundary for CAM snapshot series generation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CamSnapshotSeriesResult {
+    pub frame_count: usize,
+    pub source: String,
+    pub frames: Vec<CamSnapshotFrame>,
+}
+
+/// Orchestration port for CAM snapshot-related use cases.
+pub trait CamSnapshotSeriesOrchestration {
+    fn create_snapshot_series(
+        &self,
+        request: CamSnapshotSeriesRequest,
+    ) -> Result<CamSnapshotSeriesResult, String>;
+}
+
+/// Default implementation for snapshot series orchestration.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CamSnapshotSeriesOrchestrator;
+
+impl CamSnapshotSeriesOrchestration for CamSnapshotSeriesOrchestrator {
+    fn create_snapshot_series(
+        &self,
+        request: CamSnapshotSeriesRequest,
+    ) -> Result<CamSnapshotSeriesResult, String> {
+        Ok(CamSnapshotSeriesResult {
+            frame_count: request.frames.len(),
+            source: request.source,
+            frames: request.frames,
+        })
+    }
+}
+
+/// cam_sim の export DTO を Application境界DTOに正規化する。
+pub fn snapshot_exports_to_frames(exports: &[SimulationSnapshotExport]) -> Vec<CamSnapshotFrame> {
+    exports
+        .iter()
+        .map(|export| CamSnapshotFrame {
+            segment_index: export.segment_index,
+            segment_t: export.segment_t,
+            accumulated_distance_mm: export.accumulated_distance_mm,
+            remaining_volume_mm3: export.remaining_volume_mm3,
+        })
+        .collect()
+}
+
+/// cam_sim export DTO から境界シリーズを組み立てる。
+pub fn create_snapshot_series_from_exports(
+    source: impl Into<String>,
+    exports: &[SimulationSnapshotExport],
+) -> Result<CamSnapshotSeriesResult, String> {
+    CamSnapshotSeriesOrchestrator.create_snapshot_series(CamSnapshotSeriesRequest {
+        source: source.into(),
+        frames: snapshot_exports_to_frames(exports),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_snapshot_series_from_frames() {
+        let request = CamSnapshotSeriesRequest {
+            source: "cam_sim".to_string(),
+            frames: vec![CamSnapshotFrame {
+                segment_index: 1,
+                segment_t: 0.5,
+                accumulated_distance_mm: 12.0,
+                remaining_volume_mm3: 980.0,
+            }],
+        };
+
+        let result = CamSnapshotSeriesOrchestrator
+            .create_snapshot_series(request)
+            .expect("series creation should succeed");
+
+        assert_eq!(result.frame_count, 1);
+        assert_eq!(result.source, "cam_sim");
+        assert_eq!(result.frames[0].segment_index, 1);
+    }
+
+    #[test]
+    fn test_snapshot_exports_to_frames() {
+        let exports = vec![SimulationSnapshotExport {
+            segment_index: 2,
+            segment_t: 0.75,
+            accumulated_distance_mm: 33.0,
+            remaining_volume_mm3: 812.0,
+        }];
+
+        let result = create_snapshot_series_from_exports("cam_sim", &exports)
+            .expect("series creation from exports should succeed");
+
+        assert_eq!(result.frame_count, 1);
+        assert_eq!(result.frames[0].segment_index, 2);
+        assert_eq!(result.frames[0].segment_t, 0.75);
+    }
+}

--- a/model/application/src/feature_orchestration.rs
+++ b/model/application/src/feature_orchestration.rs
@@ -1,0 +1,7 @@
+//! Feature orchestration boundaries.
+
+/// Marker request boundary for future feature orchestration use cases.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeatureOrchestrationRequest {
+    pub feature_name: String,
+}

--- a/model/application/src/feature_orchestration.rs
+++ b/model/application/src/feature_orchestration.rs
@@ -1,6 +1,6 @@
-//! Feature orchestration boundaries.
+//! Feature向け orchestration 境界。
 
-/// Marker request boundary for future feature orchestration use cases.
+/// 将来の feature orchestration ユースケース向けマーカー入力境界。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FeatureOrchestrationRequest {
     pub feature_name: String,

--- a/model/application/src/geometry_orchestration.rs
+++ b/model/application/src/geometry_orchestration.rs
@@ -1,0 +1,7 @@
+//! Geometry orchestration boundaries.
+
+/// Marker request boundary for future geometry orchestration use cases.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GeometryOrchestrationRequest {
+    pub operation_name: String,
+}

--- a/model/application/src/geometry_orchestration.rs
+++ b/model/application/src/geometry_orchestration.rs
@@ -1,6 +1,6 @@
-//! Geometry orchestration boundaries.
+//! Geometry向け orchestration 境界。
 
-/// Marker request boundary for future geometry orchestration use cases.
+/// 将来の geometry orchestration ユースケース向けマーカー入力境界。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GeometryOrchestrationRequest {
     pub operation_name: String,

--- a/model/application/src/job_orchestration.rs
+++ b/model/application/src/job_orchestration.rs
@@ -1,19 +1,19 @@
-//! Job orchestration boundaries.
+//! Job向け orchestration 境界。
 
-/// Request boundary for a generic workflow submission.
+/// 汎用 workflow 送信の入力境界。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct JobWorkflowSubmitRequest {
     pub job_type: String,
     pub input_ref: String,
 }
 
-/// Result boundary for a workflow submission.
+/// workflow 送信の出力境界。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct JobWorkflowSubmitResult {
     pub job_id: u64,
 }
 
-/// Orchestration port for job submission use cases.
+/// job 送信ユースケースの orchestration port。
 pub trait JobWorkflowOrchestration {
     fn submit_workflow(
         &self,

--- a/model/application/src/job_orchestration.rs
+++ b/model/application/src/job_orchestration.rs
@@ -1,0 +1,22 @@
+//! Job orchestration boundaries.
+
+/// Request boundary for a generic workflow submission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JobWorkflowSubmitRequest {
+    pub job_type: String,
+    pub input_ref: String,
+}
+
+/// Result boundary for a workflow submission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JobWorkflowSubmitResult {
+    pub job_id: u64,
+}
+
+/// Orchestration port for job submission use cases.
+pub trait JobWorkflowOrchestration {
+    fn submit_workflow(
+        &self,
+        request: JobWorkflowSubmitRequest,
+    ) -> Result<JobWorkflowSubmitResult, String>;
+}

--- a/model/application/src/lib.rs
+++ b/model/application/src/lib.rs
@@ -1,0 +1,9 @@
+//! application - Application Layer orchestration entrypoints
+//!
+//! This crate is a single receiver for orchestration responsibilities during PoC.
+//! The initial phase keeps modules in one crate and promotes them only when boundaries stabilize.
+
+pub mod cam_orchestration;
+pub mod feature_orchestration;
+pub mod geometry_orchestration;
+pub mod job_orchestration;

--- a/model/application/src/lib.rs
+++ b/model/application/src/lib.rs
@@ -1,7 +1,7 @@
-//! application - Application Layer orchestration entrypoints
+//! application - Application Layer の orchestration エントリポイント
 //!
-//! This crate is a single receiver for orchestration responsibilities during PoC.
-//! The initial phase keeps modules in one crate and promotes them only when boundaries stabilize.
+//! このクレートは、PoC段階における orchestration 責務の単一受け皿です。
+//! 初期フェーズでは単一クレート内を module 分割し、境界安定後に必要に応じて昇格します。
 
 pub mod cam_orchestration;
 pub mod feature_orchestration;

--- a/scripts/_arch_rules_data.ps1
+++ b/scripts/_arch_rules_data.ps1
@@ -5,6 +5,7 @@
 # Workspace crate path mapping
 $ARCH_LAYER_MAPPING = @{
     analysis       = "foundation/analysis"
+    application    = "model/application"
     geo_contracts  = "model/geo_contracts"
     geo_commons    = "model/geo_commons"
     geo_core       = "model/geo_core"
@@ -29,37 +30,30 @@ $ARCH_LAYER_MAPPING = @{
 # Layer groups
 $ARCH_LAYERS = @{
     Analysis  = @("analysis")
+    Application = @("application")
     Model     = @("geo_contracts", "geo_commons", "geo_core", "geo_primitives", "geo_topology", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "job_runtime", "job_domain")
     ViewModel = @("converter", "graphics")
     View      = @("render", "stage", "app")
 }
 
 # Issue #413 design note:
-# `cam_algorithms` 新設時は以下を同一変更セットで反映する。
-# 1. ARCH_LAYER_MAPPING に `cam_algorithms = "model/cam_algorithms"` を追加
-# 2. ARCH_LAYERS.Model に `cam_algorithms` を追加
-# 3. ARCH_ALLOWED_DEPS に以下を追加
-#    cam_algorithms = @("analysis", "cam_core", "geo_contracts", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs")
-# 4. 既存クレート側の許可依存を更新
-#    - cam_sim: `cam_algorithms` を限定的に許可
-#    - converter: 必要になるまで `cam_algorithms` は許可しない
-#    - cam_entity: `cam_algorithms` は許可しない
-# 5. ARCH_FORBIDDEN_DEPS に以下を反映
-#    - cam_core -> cam_algorithms を禁止
-#    - cam_entity -> cam_algorithms を禁止
-#    - cam_algorithms -> cam_sim を禁止
-#    - geo_* -> cam_algorithms を禁止
-# 6. クレート作成後に ARCH_REQUIRED_MODEL_CRATES へ追加する
-# 注意: クレート未作成の段階で ARCH_REQUIRED_MODEL_CRATES へ追加すると、依存チェックが必須クレート不足で失敗する。
+# When adding `cam_algorithms`, update this file in one change set:
+# 1. Add `cam_algorithms = "model/cam_algorithms"` to ARCH_LAYER_MAPPING.
+# 2. Add `cam_algorithms` to ARCH_LAYERS.Model.
+# 3. Add ARCH_ALLOWED_DEPS entry for cam_algorithms.
+# 4. Update allowed dependencies in related crates.
+# 5. Add reverse dependency guards to ARCH_FORBIDDEN_DEPS.
+# 6. Add cam_algorithms to ARCH_REQUIRED_MODEL_CRATES only after crate creation.
 
 # Required model crates
 $ARCH_REQUIRED_MODEL_CRATES = @("geo_contracts", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity")
 
 # Allowed dependency rules
 # Last updated: 2026-03-20 (#318 Phase C: contracts-first dependency alignment)
-# Pending update: Issue #413 で `cam_algorithms` 新設時に CAM 依存ルールを追加する。
+# Pending update: add CAM dependency rules when `cam_algorithms` is created.
 $ARCH_ALLOWED_DEPS = @{
     analysis       = @()
+    application    = @("analysis", "geo_algorithms", "cam_core", "cam_sim", "job_runtime", "job_domain")
     geo_contracts  = @("analysis", "geo_commons")
     geo_commons    = @("analysis")
     geo_core       = @("analysis", "geo_entity")
@@ -74,7 +68,17 @@ $ARCH_ALLOWED_DEPS = @{
     cam_sim        = @("analysis", "cam_core", "geo_algorithms", "job_runtime", "job_domain")
     job_runtime    = @("analysis")
     job_domain     = @("analysis", "job_runtime")
-    converter      = @("geo_contracts", "geo_algorithms", "geo_io", "cam_core", "cam_entity", "cam_sim", "job_domain", "analysis")
+    converter      = @(
+        "application",
+        "geo_contracts",
+        "geo_algorithms",
+        "geo_io",
+        "cam_core",
+        "cam_entity",
+        "cam_sim",
+        "job_domain",
+        "analysis"
+    );
     graphics       = @("geo_contracts", "geo_core", "geo_primitives", "analysis")
     render         = @("analysis")
     stage          = @("render", "analysis")
@@ -82,8 +86,9 @@ $ARCH_ALLOWED_DEPS = @{
 }
 
 # Forbidden dependency rules
-# Pending update: `cam_algorithms` 新設時は CAM 内の逆依存禁止をここへ追加する。
+# Pending update: add reverse dependency guards when `cam_algorithms` is created.
 $ARCH_FORBIDDEN_DEPS = @{
+    application    = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_nurbs", "geo_io", "geo_entity", "cam_entity", "converter", "graphics", "render", "stage", "app")
     geo_foundation = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
     geo_contracts  = @("geo_foundation", "geo_core", "geo_primitives", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "job_runtime", "graphics", "render", "stage", "app")
     geo_commons    = @("converter", "graphics", "render", "stage", "app", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "cam_core", "cam_entity", "cam_sim", "job_runtime")
@@ -99,12 +104,16 @@ $ARCH_FORBIDDEN_DEPS = @{
     cam_sim        = @("converter", "graphics", "render", "stage", "app", "geo_entity", "geo_foundation", "geo_core", "geo_primitives", "geo_nurbs", "geo_io", "cam_entity")
     job_runtime    = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "converter", "graphics", "render", "stage", "app")
     job_domain     = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "converter", "graphics", "render", "stage", "app")
-    converter      = @("render", "stage", "app")
+    converter      = @(
+        "render",
+        "stage",
+        "app"
+    );
     graphics       = @("render", "stage", "app")
     render         = @("geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "converter", "graphics")
-    stage          = @("geo_foundation", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "converter", "graphics")
-    app            = @("geo_foundation", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim")
-    analysis       = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "job_runtime", "converter", "graphics", "render", "stage", "app")
+    stage          = @("geo_foundation", "application", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "converter", "graphics")
+    app            = @("geo_foundation", "application", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim")
+    analysis       = @("geo_foundation", "application", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "job_runtime", "converter", "graphics", "render", "stage", "app")
 }
 
 # Shared helper: extract workspace dependencies from Cargo.toml

--- a/viewmodel/converter/Cargo.toml
+++ b/viewmodel/converter/Cargo.toml
@@ -14,6 +14,7 @@ geo_io = { path = "../../model/geo_io" }
 cam_core = { path = "../../model/cam_core" }
 cam_entity = { path = "../../model/cam_entity" }
 cam_sim = { path = "../../model/cam_sim" }
+application = { path = "../../model/application" }
 job_domain = { path = "../../model/job_domain" }
 analysis = { path = "../../foundation/analysis" }
 i18n_foundation = { path = "../../foundation/i18n_foundation" }

--- a/viewmodel/converter/src/cam_sim_visualization_converter.rs
+++ b/viewmodel/converter/src/cam_sim_visualization_converter.rs
@@ -3,11 +3,14 @@
 //! CAMシミュレーション（toolpath + tool + work octree）の実行と、
 //! 可視化に必要な ViewModel データ（wireframe + snapshot）の結合を担当します。
 
+use application::cam_orchestration::{
+    execute_simulation_snapshot_exports, CamSimulationExecutionRequest,
+};
 use cam_core::{
     validate_toolpath_machine_constraints, CamTolerance, MachineConstraint, PathGeometry, Tool,
     ToolPath, ValidationError,
 };
-use cam_sim::{CuttingSimulator, SimulationError, SnapshotInterval};
+use cam_sim::{SimulationError, SnapshotInterval};
 use geo_algorithms::{
     octree::{VoxelOctree, VoxelState},
     Aabb3D, LineSegment3D, Point3D,
@@ -547,8 +550,6 @@ pub fn create_sample_cam_simulation_visualization_bundle_with_settings(
     let segments = collect_line_segments_with_flags(&toolpath)?;
 
     let work_bounds = compute_work_bounds_from_toolpath(&segments, tool.radius());
-    let voxel_tree = VoxelOctree::new(work_bounds, settings.max_depth);
-
     let non_cutting_interference_count =
         count_non_cutting_interference_segments(&segments, &work_bounds, tool.radius());
     if non_cutting_interference_count > 0 {
@@ -559,10 +560,14 @@ pub fn create_sample_cam_simulation_visualization_bundle_with_settings(
         );
     }
 
-    let mut simulator = CuttingSimulator::new(voxel_tree, SnapshotInterval::default());
-    simulator.simulate(&toolpath, &tool)?;
-
-    let exports = simulator.snapshot_exports_f64();
+    let exports = execute_simulation_snapshot_exports(CamSimulationExecutionRequest {
+        toolpath: toolpath.clone(),
+        tool: tool.clone(),
+        work_bounds,
+        max_depth: settings.max_depth,
+        snapshot_interval: SnapshotInterval::default(),
+    })?
+    .exports;
     let snapshot_inputs = cam_snapshot_exports_to_inputs(&exports);
     let snapshot_series = cam_snapshot_inputs_to_domain_series("cam_sim", &snapshot_inputs);
 

--- a/viewmodel/converter/src/snapshot_converter.rs
+++ b/viewmodel/converter/src/snapshot_converter.rs
@@ -4,9 +4,12 @@
 //! ドメイン固有情報は `payload` に閉じ込め、CAM以外（例: プレス）にも
 //! 同じ構造で適用できることを目的とします。
 
-use application::cam_orchestration::create_snapshot_series_from_exports;
+use application::cam_orchestration::{
+    create_snapshot_series_from_exports, execute_simulation_snapshot_exports,
+    CamSimulationExecutionRequest,
+};
 use cam_core::Tool;
-use cam_sim::{CuttingSimulator, SimulationError, SimulationSnapshotExport, SnapshotInterval};
+use cam_sim::{SimulationError, SimulationSnapshotExport, SnapshotInterval};
 use geo_algorithms::{Aabb3D, Point3D};
 
 use crate::toolpath_converter::create_sample_toolpath;
@@ -173,14 +176,17 @@ pub fn create_sample_cam_snapshot_domain_series(
         Point3D::new(-60.0, -60.0, -20.0),
         Point3D::new(60.0, 60.0, 30.0),
     );
-    let voxel = geo_algorithms::octree::VoxelOctree::new(bounds, 4);
-
-    let mut simulator = CuttingSimulator::new(voxel, SnapshotInterval::default());
     let toolpath = create_sample_toolpath();
     let tool = Tool::flat_end_mill("endmill_3mm".to_string(), 10.0, 50.0);
 
-    simulator.simulate(&toolpath, &tool)?;
-    let exports = simulator.snapshot_exports_f64();
+    let exports = execute_simulation_snapshot_exports(CamSimulationExecutionRequest {
+        toolpath,
+        tool,
+        work_bounds: bounds,
+        max_depth: 4,
+        snapshot_interval: SnapshotInterval::default(),
+    })?
+    .exports;
     let inputs = cam_snapshot_exports_to_inputs(&exports);
 
     Ok(cam_snapshot_inputs_to_domain_series("cam_sim", &inputs))

--- a/viewmodel/converter/src/snapshot_converter.rs
+++ b/viewmodel/converter/src/snapshot_converter.rs
@@ -4,6 +4,7 @@
 //! ドメイン固有情報は `payload` に閉じ込め、CAM以外（例: プレス）にも
 //! 同じ構造で適用できることを目的とします。
 
+use application::cam_orchestration::create_snapshot_series_from_exports;
 use cam_core::Tool;
 use cam_sim::{CuttingSimulator, SimulationError, SimulationSnapshotExport, SnapshotInterval};
 use geo_algorithms::{Aabb3D, Point3D};
@@ -150,13 +151,17 @@ pub fn cam_export_rows_to_inputs(
 pub fn cam_snapshot_exports_to_inputs(
     exports: &[SimulationSnapshotExport],
 ) -> Vec<CamSimulationSnapshotInput> {
-    exports
-        .iter()
-        .map(|export| CamSimulationSnapshotInput {
-            segment_index: export.segment_index,
-            segment_t: export.segment_t,
-            accumulated_distance_mm: export.accumulated_distance_mm,
-            remaining_volume_mm3: export.remaining_volume_mm3,
+    let result = create_snapshot_series_from_exports("cam_sim", exports)
+        .expect("snapshot series conversion in application layer should not fail");
+
+    result
+        .frames
+        .into_iter()
+        .map(|frame| CamSimulationSnapshotInput {
+            segment_index: frame.segment_index,
+            segment_t: frame.segment_t,
+            accumulated_distance_mm: frame.accumulated_distance_mm,
+            remaining_volume_mm3: frame.remaining_volume_mm3,
         })
         .collect()
 }


### PR DESCRIPTION
## 概要
Issue #335 の Phase 1/2 に相当する変更を反映しました。

- Application 層の受け皿クレート (`model/application`) を追加
- `cam_orchestration` に CAM snapshot 系の境界DTO/導線を追加
- ViewModel 側の debug 系導線で、cam_sim export DTO 正規化と simulation 実行経路を Application 経由へ移設
- Application クレート内コメントを日本語に統一

## 主な変更
- `model/application/src/cam_orchestration.rs`
- `model/application/src/lib.rs`
- `model/application/src/feature_orchestration.rs`
- `model/application/src/geometry_orchestration.rs`
- `model/application/src/job_orchestration.rs`
- `viewmodel/converter/src/snapshot_converter.rs`
- `viewmodel/converter/src/cam_sim_visualization_converter.rs`
- `viewmodel/converter/Cargo.toml`
- `dev/architecture/APPLICATION_ORCHESTRATION_LAYER_DESIGN.md`
- `scripts/_arch_rules_data.ps1`

## 検証
- `cargo clippy -p application -p viewmodel -- -D warnings`
- `cargo fmt`
- `cargo test -p application -p viewmodel`
- `./scripts/check_architecture_dependencies_simple.ps1`

## 補足
- `dev/architecture/CAM_ALGORITHMS_DESIGN.md` は別Issue対応のため、本PRには含めていません。