### PR TITLE
feat: introduce application port boundary for CAM simulation (#508)

### DIFF
--- a/model/application/src/cam_orchestration.rs
+++ b/model/application/src/cam_orchestration.rs
@@ -4,6 +4,28 @@ use cam_core::{Tool, ToolPath};
 use cam_sim::{CuttingSimulator, SimulationError, SimulationSnapshotExport, SnapshotInterval};
 use geo_algorithms::{Aabb3D, octree::VoxelOctree};
 
+/// Application境界で返却する統一エラー。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApplicationError {
+    Simulation(String),
+}
+
+impl std::fmt::Display for ApplicationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Simulation(message) => write!(f, "{}", message),
+        }
+    }
+}
+
+impl std::error::Error for ApplicationError {}
+
+impl From<SimulationError> for ApplicationError {
+    fn from(value: SimulationError) -> Self {
+        Self::Simulation(value.to_string())
+    }
+}
+
 /// CAMシミュレーション由来の最小スナップショットDTO。
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CamSnapshotFrame {
@@ -93,6 +115,27 @@ pub struct CamSimulationExecutionResult {
     pub exports: Vec<SimulationSnapshotExport>,
 }
 
+/// CAMシミュレーション実行ユースケースの orchestration port。
+pub trait CamSimulationExecutionOrchestration {
+    fn execute_simulation_snapshot_exports(
+        &self,
+        request: CamSimulationExecutionRequest,
+    ) -> Result<CamSimulationExecutionResult, ApplicationError>;
+}
+
+/// CAMシミュレーション実行 orchestration の既定実装。
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CamSimulationExecutionOrchestrator;
+
+impl CamSimulationExecutionOrchestration for CamSimulationExecutionOrchestrator {
+    fn execute_simulation_snapshot_exports(
+        &self,
+        request: CamSimulationExecutionRequest,
+    ) -> Result<CamSimulationExecutionResult, ApplicationError> {
+        execute_simulation_snapshot_exports(request).map_err(ApplicationError::from)
+    }
+}
+
 /// cam_sim を実行し、スナップショット出力を Application 境界結果として返す。
 pub fn execute_simulation_snapshot_exports(
     request: CamSimulationExecutionRequest,
@@ -171,5 +214,34 @@ mod tests {
 
         let result = execute_simulation_snapshot_exports(request);
         assert!(matches!(result, Err(SimulationError::EmptyToolpath)));
+    }
+
+    #[test]
+    fn test_cam_simulation_execution_orchestrator_normalizes_error() {
+        let request = CamSimulationExecutionRequest {
+            toolpath: ToolPath::new(
+                "endmill_3mm".to_string(),
+                CuttingDirection::Down,
+                vec![],
+                vec![],
+                vec![],
+            ),
+            tool: Tool::flat_end_mill("endmill_3mm".to_string(), 10.0, 50.0),
+            work_bounds: Aabb3D::new(
+                Point3D::new(-60.0, -60.0, -20.0),
+                Point3D::new(60.0, 60.0, 30.0),
+            ),
+            max_depth: 4,
+            snapshot_interval: SnapshotInterval::default(),
+        };
+
+        let result =
+            CamSimulationExecutionOrchestrator.execute_simulation_snapshot_exports(request);
+        assert_eq!(
+            result,
+            Err(ApplicationError::Simulation(
+                SimulationError::EmptyToolpath.to_string()
+            ))
+        );
     }
 }

--- a/view/app/src/app_state/debug_scene/toolpath.rs
+++ b/view/app/src/app_state/debug_scene/toolpath.rs
@@ -160,6 +160,16 @@ impl AppState {
                 );
                 return;
             }
+            Err(ToolPathBuildError::Converter(CamSimulationVisualizationError::Application(
+                ref err,
+            ))) => {
+                tracing::error!(
+                    error_kind = ERROR_KIND_SIMULATION,
+                    "cam simulation visualization failed: {}",
+                    err
+                );
+                return;
+            }
         };
 
         self.apply_toolpath_debug_data(data);

--- a/viewmodel/converter/src/cam_sim_visualization_converter.rs
+++ b/viewmodel/converter/src/cam_sim_visualization_converter.rs
@@ -4,7 +4,8 @@
 //! 可視化に必要な ViewModel データ（wireframe + snapshot）の結合を担当します。
 
 use application::cam_orchestration::{
-    execute_simulation_snapshot_exports, CamSimulationExecutionRequest,
+    ApplicationError, CamSimulationExecutionOrchestration, CamSimulationExecutionOrchestrator,
+    CamSimulationExecutionRequest,
 };
 use cam_core::{
     validate_toolpath_machine_constraints, CamTolerance, MachineConstraint, PathGeometry, Tool,
@@ -35,6 +36,7 @@ use logging_foundation::ERROR_KIND_SIMULATION;
 #[derive(Debug, Clone, PartialEq)]
 pub enum CamSimulationVisualizationError {
     Validation(ValidationError),
+    Application(ApplicationError),
     Simulation(SimulationError),
 }
 
@@ -42,6 +44,7 @@ impl std::fmt::Display for CamSimulationVisualizationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Validation(error) => write!(f, "{}", error),
+            Self::Application(error) => write!(f, "{}", error),
             Self::Simulation(error) => write!(f, "{}", error),
         }
     }
@@ -52,6 +55,12 @@ impl std::error::Error for CamSimulationVisualizationError {}
 impl From<ValidationError> for CamSimulationVisualizationError {
     fn from(value: ValidationError) -> Self {
         Self::Validation(value)
+    }
+}
+
+impl From<ApplicationError> for CamSimulationVisualizationError {
+    fn from(value: ApplicationError) -> Self {
+        Self::Application(value)
     }
 }
 
@@ -560,14 +569,15 @@ pub fn create_sample_cam_simulation_visualization_bundle_with_settings(
         );
     }
 
-    let exports = execute_simulation_snapshot_exports(CamSimulationExecutionRequest {
-        toolpath: toolpath.clone(),
-        tool: tool.clone(),
-        work_bounds,
-        max_depth: settings.max_depth,
-        snapshot_interval: SnapshotInterval::default(),
-    })?
-    .exports;
+    let exports = CamSimulationExecutionOrchestrator
+        .execute_simulation_snapshot_exports(CamSimulationExecutionRequest {
+            toolpath: toolpath.clone(),
+            tool: tool.clone(),
+            work_bounds,
+            max_depth: settings.max_depth,
+            snapshot_interval: SnapshotInterval::default(),
+        })?
+        .exports;
     let snapshot_inputs = cam_snapshot_exports_to_inputs(&exports);
     let snapshot_series = cam_snapshot_inputs_to_domain_series("cam_sim", &snapshot_inputs);
 

--- a/viewmodel/converter/src/snapshot_converter.rs
+++ b/viewmodel/converter/src/snapshot_converter.rs
@@ -5,11 +5,11 @@
 //! 同じ構造で適用できることを目的とします。
 
 use application::cam_orchestration::{
-    create_snapshot_series_from_exports, execute_simulation_snapshot_exports,
-    CamSimulationExecutionRequest,
+    create_snapshot_series_from_exports, ApplicationError, CamSimulationExecutionOrchestration,
+    CamSimulationExecutionOrchestrator, CamSimulationExecutionRequest,
 };
 use cam_core::Tool;
-use cam_sim::{SimulationError, SimulationSnapshotExport, SnapshotInterval};
+use cam_sim::{SimulationSnapshotExport, SnapshotInterval};
 use geo_algorithms::{Aabb3D, Point3D};
 
 use crate::toolpath_converter::create_sample_toolpath;
@@ -171,7 +171,7 @@ pub fn cam_snapshot_exports_to_inputs(
 
 /// デバッグ用：cam_sim 実行結果からドメインスナップショット系列を生成する。
 pub fn create_sample_cam_snapshot_domain_series(
-) -> Result<DomainSnapshotSeries<CamSimulationSnapshotInput>, SimulationError> {
+) -> Result<DomainSnapshotSeries<CamSimulationSnapshotInput>, ApplicationError> {
     let bounds = Aabb3D::new(
         Point3D::new(-60.0, -60.0, -20.0),
         Point3D::new(60.0, 60.0, 30.0),
@@ -179,14 +179,15 @@ pub fn create_sample_cam_snapshot_domain_series(
     let toolpath = create_sample_toolpath();
     let tool = Tool::flat_end_mill("endmill_3mm".to_string(), 10.0, 50.0);
 
-    let exports = execute_simulation_snapshot_exports(CamSimulationExecutionRequest {
-        toolpath,
-        tool,
-        work_bounds: bounds,
-        max_depth: 4,
-        snapshot_interval: SnapshotInterval::default(),
-    })?
-    .exports;
+    let exports = CamSimulationExecutionOrchestrator
+        .execute_simulation_snapshot_exports(CamSimulationExecutionRequest {
+            toolpath,
+            tool,
+            work_bounds: bounds,
+            max_depth: 4,
+            snapshot_interval: SnapshotInterval::default(),
+        })?
+        .exports;
     let inputs = cam_snapshot_exports_to_inputs(&exports);
 
     Ok(cam_snapshot_inputs_to_domain_series("cam_sim", &inputs))


### PR DESCRIPTION
## 概要
Issue #508（[#500][Phase 1]）として、ViewModel -> Application の最小導線契約を CAMシミュレーション経路に導入しました。

## 変更内容
- `model/application/src/cam_orchestration.rs`
  - `ApplicationError` を追加（Simulation文字列正規化）
  - `CamSimulationExecutionOrchestration` trait を追加
  - `CamSimulationExecutionOrchestrator` を追加
  - 既存 `execute_simulation_snapshot_exports` を上記境界から利用可能に整理
  - 境界正規化のテストを追加

- `viewmodel/converter/src/cam_sim_visualization_converter.rs`
  - CAM実行を free function 直呼びから `CamSimulationExecutionOrchestrator` 経由へ変更
  - `CamSimulationVisualizationError` に `Application` バリアントを追加

- `viewmodel/converter/src/snapshot_converter.rs`
  - CAM実行を `CamSimulationExecutionOrchestrator` 経由へ変更
  - 戻り値エラーを `SimulationError` から `ApplicationError` に変更

- `view/app/src/app_state/debug_scene/toolpath.rs`
  - 新しい `CamSimulationVisualizationError::Application` 分岐を追加

## 受け入れ条件との対応（#508）
- [x] port trait定義
- [x] request/response DTO利用（既存境界DTOをport経由利用）
- [x] ApplicationError 正規化の初版導入
- [x] 既存呼び出し箇所を新境界へ接続（CAM関連2箇所）

## 検証
- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo test --workspace`

すべて成功。

## 関連
- #508
- #500
- #502