### PR TITLE
feat: add minimal E2E demo success/failure flow (#509)

### DIFF
--- a/dev/architecture/VIEWMODEL_MODEL_ROUTING_DESIGN.md
+++ b/dev/architecture/VIEWMODEL_MODEL_ROUTING_DESIGN.md
@@ -163,3 +163,21 @@ Phase3:
 2. 合意後に実装Issueへ分解して起票
 3. #502を先行実施（最小実装 + デモリリース）
 4. 実測結果を入力に #215 のECS評価/実装へ進む
+
+## 11. Phase3 最小E2Eデモ手順（#509）
+
+デモ対象操作:
+- `p` キーで `load_sample_toolpath` を実行し、ViewModel -> Application -> Model更新結果DTO -> View反映を確認する
+
+成功ケース確認:
+1. アプリ起動後に `p` キーを押す
+2. CAMシミュレーション可視化が表示されることを確認する
+3. ログに `entity_id=` を含む完了メッセージが出ることを確認する
+
+失敗ケース確認:
+1. `cargo test --workspace cam_sim_visualization_converter::tests::test_create_cam_simulation_visualization_bundle_for_demo_failure_empty_toolpath`
+2. 空ToolPathシナリオで `ApplicationError::Simulation` が返ることを確認する
+
+観測ポイント:
+- 成功時: `CamSimulationVisualizationBundle.tool_entity_id` が非空
+- 失敗時: Application境界で失敗が正規化され、ViewModelで `CamSimulationVisualizationError::Application` として観測できる

--- a/dev/architecture/VIEWMODEL_MODEL_ROUTING_DESIGN.md
+++ b/dev/architecture/VIEWMODEL_MODEL_ROUTING_DESIGN.md
@@ -167,10 +167,11 @@ Phase3:
 ## 11. Phase3 最小E2Eデモ手順（#509）
 
 デモ対象操作:
-- `p` キーで `load_sample_toolpath` を実行し、ViewModel -> Application -> Model更新結果DTO -> View反映を確認する
+- `Shift+P`（大文字 `P`）で `load_sample_toolpath` を実行し、ViewModel -> Application -> Model更新結果DTO -> View反映を確認する
+- `p`（小文字）は `load_sample_toolpath_only` であり、ツールパス線のみ表示する（Entity更新観測対象外）
 
 成功ケース確認:
-1. アプリ起動後に `p` キーを押す
+1. アプリ起動後に `Shift+P`（大文字 `P`）を押す
 2. CAMシミュレーション可視化が表示されることを確認する
 3. ログに `entity_id=` を含む完了メッセージが出ることを確認する
 

--- a/view/app/src/app_state/debug_scene/toolpath.rs
+++ b/view/app/src/app_state/debug_scene/toolpath.rs
@@ -15,6 +15,7 @@ enum ToolPathBuildError {
 }
 
 struct ToolPathDebugData {
+    tool_entity_id: String,
     snapshot_series: DomainSnapshotSeries<CamSimulationSnapshotInput>,
     snapshot_wireframes: Vec<Vec<viewmodel::octree_converter::WireframeVertex>>,
     snapshot_solids: Vec<(Vec<MeshVertex>, Vec<u32>)>,
@@ -79,6 +80,7 @@ impl AppState {
             .collect();
 
         Ok(ToolPathDebugData {
+            tool_entity_id: bundle.tool_entity_id,
             snapshot_series: bundle.snapshot_series,
             snapshot_wireframes: bundle.snapshot_wireframes,
             snapshot_solids,
@@ -114,7 +116,8 @@ impl AppState {
         self.log_current_snapshot_frame(true);
 
         tracing::info!(
-            "CAMシミュレーション可視化デバッグ完了: frame={}/{}（k/スクラブで時系列再生）",
+            "CAMシミュレーション可視化デバッグ完了: entity_id={}, frame={}/{}（k/スクラブで時系列再生）",
+            data.tool_entity_id,
             1,
             data.frame_count
         );

--- a/viewmodel/converter/src/cam_sim_visualization_converter.rs
+++ b/viewmodel/converter/src/cam_sim_visualization_converter.rs
@@ -85,6 +85,12 @@ pub struct CamSimulationVisualizationBundle {
     pub snapshot_series: DomainSnapshotSeries<CamSimulationSnapshotInput>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CamSimulationDemoScenario {
+    Success,
+    FailureEmptyToolpath,
+}
+
 fn push_face(
     vertices: &mut Vec<VertexData>,
     indices: &mut Vec<u32>,
@@ -549,16 +555,29 @@ fn apply_cutting_progress(
 
 /// デバッグ用：テストToolPath + Tool + ワークOctreeで切削シミュレーションを実行し、
 /// 可視化に必要な深さ別ワイヤーフレームとスナップショット系列を返す。
-pub fn create_sample_cam_simulation_visualization_bundle_with_settings(
+pub fn create_cam_simulation_visualization_bundle_for_demo(
     settings: &OctreeVisualizationSettings,
+    scenario: CamSimulationDemoScenario,
 ) -> Result<CamSimulationVisualizationBundle, CamSimulationVisualizationError> {
-    let toolpath = create_sample_toolpath();
+    let toolpath = match scenario {
+        CamSimulationDemoScenario::Success => create_sample_toolpath(),
+        CamSimulationDemoScenario::FailureEmptyToolpath => ToolPath::new(
+            "endmill_3mm".to_string(),
+            cam_core::CuttingDirection::Down,
+            vec![],
+            vec![],
+            vec![],
+        ),
+    };
     let tool = Tool::flat_end_mill("endmill_3mm".to_string(), 10.0, 50.0);
     let tool_entity_result =
         ToolEntityManagementOrchestrator.add_tool_to_storage(AddToolToEntityStorageRequest {
             tool: tool.clone(),
             feature_id: "cam_sim_visualization".to_string(),
-            output_index: 0,
+            output_index: match scenario {
+                CamSimulationDemoScenario::Success => 0,
+                CamSimulationDemoScenario::FailureEmptyToolpath => 1,
+            },
             local_key: "sample_tool".to_string(),
             description: Some("CAM simulation sample tool".to_string()),
         })?;
@@ -657,6 +676,17 @@ pub fn create_sample_cam_simulation_visualization_bundle_with_settings(
     })
 }
 
+/// デバッグ用：テストToolPath + Tool + ワークOctreeで切削シミュレーションを実行し、
+/// 可視化に必要な深さ別ワイヤーフレームとスナップショット系列を返す。
+pub fn create_sample_cam_simulation_visualization_bundle_with_settings(
+    settings: &OctreeVisualizationSettings,
+) -> Result<CamSimulationVisualizationBundle, CamSimulationVisualizationError> {
+    create_cam_simulation_visualization_bundle_for_demo(
+        settings,
+        CamSimulationDemoScenario::Success,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -692,5 +722,27 @@ mod tests {
             .snapshot_solid_meshes
             .iter()
             .any(|(vertices, indices)| !vertices.is_empty() && !indices.is_empty()));
+    }
+
+    #[test]
+    fn test_create_cam_simulation_visualization_bundle_for_demo_failure_empty_toolpath() {
+        let settings = OctreeVisualizationSettings {
+            max_depth: 3,
+            gradient_start: [0.2, 1.0, 1.0],
+            gradient_end: [1.0, 0.4, 0.4],
+            octree_tolerance: OctreeTolerance::default(),
+        };
+
+        let result = create_cam_simulation_visualization_bundle_for_demo(
+            &settings,
+            CamSimulationDemoScenario::FailureEmptyToolpath,
+        );
+
+        assert!(matches!(
+            result,
+            Err(CamSimulationVisualizationError::Application(
+                ApplicationError::Simulation(_)
+            ))
+        ));
     }
 }


### PR DESCRIPTION
## Summary
[#500][Phase 3] #509 として、最小E2Eデモ導線（操作1本）に成功/失敗の再現パスを追加しました。

## Changes
- ViewModel
  - `CamSimulationDemoScenario` を追加（`Success` / `FailureEmptyToolpath`）
  - `create_cam_simulation_visualization_bundle_for_demo` を追加
  - 既存の `create_sample_cam_simulation_visualization_bundle_with_settings` は Success シナリオのラッパーに変更
  - 失敗シナリオ（空ToolPath）テストを追加
- View
  - ToolPathデバッグ表示で `tool_entity_id` を保持し、完了ログで `entity_id` を出力
- Document
  - `VIEWMODEL_MODEL_ROUTING_DESIGN.md` に Phase3 最小E2Eデモ手順（成功/失敗確認）を追記

## Why
- #509 の受け入れ条件である「成功/失敗の両ケース確認」を同一導線上で再現可能にするため
- Entity/Topology更新の観測ポイントをログ上で確認可能にするため

## Validation
- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo test --workspace`
  - `cam_sim_visualization_converter::tests::test_create_cam_simulation_visualization_bundle_for_demo_failure_empty_toolpath` が追加で通過

## Related
- Parent design: #500
- Current issue: #509
- Demo target: #502
- Previous phase: #510