### PR TITLE
[Design] refactor: Stage復元状態の共通化（capture/reload/restore）

### DIFF
--- a/view/app/src/app_state.rs
+++ b/view/app/src/app_state.rs
@@ -34,6 +34,8 @@ mod settings_accessors;
 mod settings_panel;
 // AppState の Snapshot 再生・スクラブ制御
 mod snapshot_playback;
+// AppState の stage復元スナップショット
+mod stage_restore;
 // AppState のステージ更新オーケストレーション
 mod stage_orchestration;
 

--- a/view/app/src/app_state/settings_panel.rs
+++ b/view/app/src/app_state/settings_panel.rs
@@ -2,14 +2,6 @@ use super::AppState;
 use crate::settings_panel_ui::SettingsPanelUiState;
 use viewmodel::cam_sim_visualization_converter::CamSimulationDemoScenario;
 
-fn restore_cursor_with_fallback(previous_cursor: usize, frame_count: usize) -> usize {
-    if frame_count == 0 {
-        0
-    } else {
-        previous_cursor.min(frame_count.saturating_sub(1))
-    }
-}
-
 impl AppState {
     pub fn toggle_settings_panel(&mut self) {
         self.settings_panel_open = !self.settings_panel_open;
@@ -50,45 +42,8 @@ impl AppState {
         self.tool_wireframe_visualization_settings = panel_state.tool_wireframe_settings;
 
         if panel_state.reload_demo_requested {
-            if let Some(scenario) = self.current_cam_demo_scenario {
-                let preserved_camera = self.camera.clone();
-                let preserved_cursor = self.debug_snapshot.cursor;
-                let preserved_shaded_mode = self.debug_snapshot.shaded_mode;
-
-                self.load_sample_toolpath_with_scenario(scenario, "設定パネル");
-                self.camera = preserved_camera;
-                self.update_camera_uniforms();
-
-                if let Some(series) = &self.debug_snapshot.series {
-                    let restored_cursor =
-                        restore_cursor_with_fallback(preserved_cursor, series.frames.len());
-                    let fallback_applied = restored_cursor != preserved_cursor;
-
-                    self.debug_snapshot.cursor = restored_cursor;
-
-                    if fallback_applied {
-                        tracing::info!(
-                            "設定再読込: 旧カーソル {} をフレーム末尾 {} へclampして復元",
-                            preserved_cursor,
-                            restored_cursor
-                        );
-                    } else {
-                        tracing::info!("設定再読込: カーソル {} を維持して復元", restored_cursor);
-                    }
-
-                    self.log_current_snapshot_frame(true);
-
-                    // 再読込は一旦ワイヤー初期化されるため、保存前がソリッドなら実ステージごと戻す。
-                    if preserved_shaded_mode {
-                        self.toggle_wireframe();
-                    }
-                } else {
-                    tracing::warn!(
-                        "設定再読込後にスナップショット系列が空のため、カーソルを先頭へ初期化"
-                    );
-                    self.debug_snapshot.cursor = 0;
-                }
-            }
+            // 設定反映後も表示状態の整合を保つため、共通のstage復元経路で再読込する。
+            self.reload_current_demo_with_stage_restore("設定パネル");
         }
     }
 }
@@ -98,25 +53,5 @@ fn demo_scenario_label(scenario: CamSimulationDemoScenario) -> String {
         CamSimulationDemoScenario::Success => "ボールエンドミル".to_string(),
         CamSimulationDemoScenario::SuccessFlatEndMill => "フラットエンドミル".to_string(),
         CamSimulationDemoScenario::FailureEmptyToolpath => "空ToolPath".to_string(),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::restore_cursor_with_fallback;
-
-    #[test]
-    fn restore_cursor_keeps_index_when_in_range() {
-        assert_eq!(restore_cursor_with_fallback(5, 10), 5);
-    }
-
-    #[test]
-    fn restore_cursor_clamps_to_tail_when_out_of_range() {
-        assert_eq!(restore_cursor_with_fallback(12, 8), 7);
-    }
-
-    #[test]
-    fn restore_cursor_resets_to_zero_when_empty() {
-        assert_eq!(restore_cursor_with_fallback(3, 0), 0);
     }
 }

--- a/view/app/src/app_state/stage_restore.rs
+++ b/view/app/src/app_state/stage_restore.rs
@@ -1,0 +1,130 @@
+use super::AppState;
+use viewmodel::cam_sim_visualization_converter::CamSimulationDemoScenario;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CursorRestoreDecision {
+    Kept(usize),
+    Clamped { from: usize, to: usize },
+    ResetToHead,
+}
+
+trait StageRestorePolicy {
+    fn restore_cursor(previous_cursor: usize, frame_count: usize) -> CursorRestoreDecision;
+}
+
+struct DefaultStageRestorePolicy;
+
+impl StageRestorePolicy for DefaultStageRestorePolicy {
+    fn restore_cursor(previous_cursor: usize, frame_count: usize) -> CursorRestoreDecision {
+        // 再読込で系列長が変わっても、可能な限りユーザーの位置感覚を維持する。
+        if frame_count == 0 {
+            return CursorRestoreDecision::ResetToHead;
+        }
+        let tail = frame_count.saturating_sub(1);
+        let restored = previous_cursor.min(tail);
+        if restored == previous_cursor {
+            CursorRestoreDecision::Kept(restored)
+        } else {
+            CursorRestoreDecision::Clamped {
+                from: previous_cursor,
+                to: restored,
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct StageRestoreSnapshot {
+    scenario: CamSimulationDemoScenario,
+    cursor: usize,
+    shaded_mode: bool,
+    camera: viewmodel_graphics::Camera,
+}
+
+impl AppState {
+    pub(super) fn capture_stage_restore_snapshot(&self) -> Option<StageRestoreSnapshot> {
+        let scenario = self.current_cam_demo_scenario?;
+        Some(StageRestoreSnapshot {
+            scenario,
+            cursor: self.debug_snapshot.cursor,
+            shaded_mode: self.debug_snapshot.shaded_mode,
+            camera: self.camera.clone(),
+        })
+    }
+
+    pub(super) fn reload_current_demo_with_stage_restore(&mut self, trigger_label: &str) {
+        let Some(snapshot) = self.capture_stage_restore_snapshot() else {
+            return;
+        };
+
+        // load後に snapshot を適用し、カメラ・カーソル・表示モードを一貫復元する。
+        self.load_sample_toolpath_with_scenario(snapshot.scenario, trigger_label);
+        self.restore_stage_from_snapshot(snapshot);
+    }
+
+    pub(super) fn restore_stage_from_snapshot(&mut self, snapshot: StageRestoreSnapshot) {
+        self.camera = snapshot.camera;
+        self.update_camera_uniforms();
+
+        let Some(series) = &self.debug_snapshot.series else {
+            tracing::warn!("設定再読込後にスナップショット系列が空のため、カーソルを先頭へ初期化");
+            self.debug_snapshot.cursor = 0;
+            return;
+        };
+
+        match DefaultStageRestorePolicy::restore_cursor(snapshot.cursor, series.frames.len()) {
+            CursorRestoreDecision::Kept(cursor) => {
+                self.debug_snapshot.cursor = cursor;
+                tracing::info!("設定再読込: カーソル {} を維持して復元", cursor);
+            }
+            CursorRestoreDecision::Clamped { from, to } => {
+                self.debug_snapshot.cursor = to;
+                tracing::info!(
+                    "設定再読込: 旧カーソル {} をフレーム末尾 {} へclampして復元",
+                    from,
+                    to
+                );
+            }
+            CursorRestoreDecision::ResetToHead => {
+                self.debug_snapshot.cursor = 0;
+                tracing::info!("設定再読込: カーソルを先頭へ復元");
+            }
+        }
+
+        self.log_current_snapshot_frame(true);
+
+        if snapshot.shaded_mode {
+            // 再読込後はワイヤー初期化されるため、保存前がソリッドなら戻す。
+            self.toggle_wireframe();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CursorRestoreDecision, DefaultStageRestorePolicy, StageRestorePolicy};
+
+    #[test]
+    fn restore_cursor_keeps_index_when_in_range() {
+        assert_eq!(
+            DefaultStageRestorePolicy::restore_cursor(5, 10),
+            CursorRestoreDecision::Kept(5)
+        );
+    }
+
+    #[test]
+    fn restore_cursor_clamps_to_tail_when_out_of_range() {
+        assert_eq!(
+            DefaultStageRestorePolicy::restore_cursor(12, 8),
+            CursorRestoreDecision::Clamped { from: 12, to: 7 }
+        );
+    }
+
+    #[test]
+    fn restore_cursor_resets_to_zero_when_empty() {
+        assert_eq!(
+            DefaultStageRestorePolicy::restore_cursor(3, 0),
+            CursorRestoreDecision::ResetToHead
+        );
+    }
+}


### PR DESCRIPTION
## 概要
- 設定再読込時の stage 復元を `capture -> reload -> restore` の共通パイプラインへ集約
- 既存の設定パネル内にあった個別復元ロジックを削除し、AppState 側の共通APIへ置換
- 復元ポリシー（keep / clamp / reset）を型で明示し、単体テストを追加

## 変更点
- `view/app/src/app_state/stage_restore.rs` を新規追加
  - `StageRestoreSnapshot`
  - `StageRestorePolicy` / `DefaultStageRestorePolicy`
  - `capture_stage_restore_snapshot`
  - `reload_current_demo_with_stage_restore`
  - `restore_stage_from_snapshot`
  - 復元ポリシー単体テスト（3ケース）
- `view/app/src/app_state/settings_panel.rs`
  - 個別復元実装を削除
  - `reload_current_demo_with_stage_restore("設定パネル")` 呼び出しへ統一
- `view/app/src/app_state.rs`
  - `mod stage_restore;` を追加

## 検証
- `cargo clippy -- -D warnings` : ✅
- `cargo fmt` : ✅
- `cargo build` : ✅
- `cargo test -p redring restore_cursor -- --nocapture` : ✅ (3 passed)

## 関連
- Closes #522