### PR TITLE
[Phase 1] feat(geo_algorithms): angle utils・constraint validation API 追加（#426）

### DIFF
--- a/model/geo_algorithms/src/angle_utils.rs
+++ b/model/geo_algorithms/src/angle_utils.rs
@@ -5,6 +5,32 @@
 pub const FULL_TURN_DEG: f64 = 360.0;
 pub const HALF_TURN_DEG: f64 = 180.0;
 
+/// 回転軸の実移動量を「周数 + 剰余角」で保持する。
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AngularPosition {
+    /// 完全回転の周数（負値は逆方向）
+    pub full_rotations: i32,
+    /// 剰余角 [deg], 常に 0 <= remainder_deg < 360
+    pub remainder_deg: f64,
+}
+
+impl AngularPosition {
+    /// 総角度 [deg] を返す。
+    pub fn total_deg(self) -> f64 {
+        self.full_rotations as f64 * FULL_TURN_DEG + self.remainder_deg
+    }
+
+    /// 総角度 [deg] から AngularPosition を構築する。
+    pub fn from_total_deg(total_deg: f64) -> Self {
+        let full_rotations = (total_deg / FULL_TURN_DEG).floor() as i32;
+        let remainder = total_deg.rem_euclid(FULL_TURN_DEG);
+        Self {
+            full_rotations,
+            remainder_deg: remainder,
+        }
+    }
+}
+
 /// [0, 360) に正規化する。
 pub fn normalize_angle_deg(angle_deg: f64) -> f64 {
     let normalized = angle_deg.rem_euclid(FULL_TURN_DEG);
@@ -13,6 +39,13 @@ pub fn normalize_angle_deg(angle_deg: f64) -> f64 {
     } else {
         normalized
     }
+}
+
+/// [0, 360) に正規化する。
+///
+/// 設計側で使用する用語に合わせた公開名。挙動は `normalize_angle_deg` と同じ。
+pub fn normalize_to_0_360(angle_deg: f64) -> f64 {
+    normalize_angle_deg(angle_deg)
 }
 
 /// (-180, 180] に正規化する。
@@ -24,6 +57,13 @@ pub fn normalize_angle_signed_deg(angle_deg: f64) -> f64 {
     normalized
 }
 
+/// (-180, 180] に正規化する。
+///
+/// 設計側で使用する用語に合わせた公開名。挙動は `normalize_angle_signed_deg` と同じ。
+pub fn normalize_to_minus180_180(angle_deg: f64) -> f64 {
+    normalize_angle_signed_deg(angle_deg)
+}
+
 /// `from_deg` から `to_deg` への最短角差を返す。
 ///
 /// 戻り値は [-180, 180]。
@@ -31,9 +71,23 @@ pub fn shortest_angular_delta_deg(from_deg: f64, to_deg: f64) -> f64 {
     normalize_angle_signed_deg(to_deg - from_deg)
 }
 
+/// from から to への最短角度差を返す。
+///
+/// 設計側で使用する用語に合わせた公開名。挙動は `shortest_angular_delta_deg` と同じ。
+pub fn shortest_angle(from_deg: f64, to_deg: f64) -> f64 {
+    shortest_angular_delta_deg(from_deg, to_deg)
+}
+
 /// 許容誤差付きで角度同値を判定する。
 pub fn are_angles_equivalent_deg(a_deg: f64, b_deg: f64, tolerance_deg: f64) -> bool {
     shortest_angular_delta_deg(a_deg, b_deg).abs() <= tolerance_deg.abs()
+}
+
+/// 0/360 同値を許容誤差付きで判定する。
+///
+/// 設計側で使用する用語に合わせた公開名。挙動は `are_angles_equivalent_deg` と同じ。
+pub fn is_equivalent_0_360(a_deg: f64, b_deg: f64, tolerance_deg: f64) -> bool {
+    are_angles_equivalent_deg(a_deg, b_deg, tolerance_deg)
 }
 
 /// 巻き戻し（rewind）方針。
@@ -128,5 +182,31 @@ mod tests {
         assert!((unwound[2] - 362.0).abs() < 1e-12);
         assert!((unwound[3] - 368.0).abs() < 1e-12);
         assert!((unwound[4] - 355.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn angular_position_roundtrip_examples() {
+        let p450 = AngularPosition::from_total_deg(450.0);
+        assert_eq!(p450.full_rotations, 1);
+        assert!((p450.remainder_deg - 90.0).abs() < 1e-12);
+        assert!((p450.total_deg() - 450.0).abs() < 1e-12);
+
+        let pneg90 = AngularPosition::from_total_deg(-90.0);
+        assert_eq!(pneg90.full_rotations, -1);
+        assert!((pneg90.remainder_deg - 270.0).abs() < 1e-12);
+        assert!((pneg90.total_deg() - (-90.0)).abs() < 1e-12);
+
+        let p720 = AngularPosition::from_total_deg(720.0);
+        assert_eq!(p720.full_rotations, 2);
+        assert!((p720.remainder_deg - 0.0).abs() < 1e-12);
+        assert!((p720.total_deg() - 720.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn design_named_helpers_delegate_correctly() {
+        assert!((normalize_to_0_360(370.0) - 10.0).abs() < 1e-12);
+        assert!((normalize_to_minus180_180(350.0) + 10.0).abs() < 1e-12);
+        assert!((shortest_angle(350.0, 10.0) - 20.0).abs() < 1e-12);
+        assert!(is_equivalent_0_360(0.0, 360.0, 1e-9));
     }
 }

--- a/model/geo_algorithms/src/constraint_validation.rs
+++ b/model/geo_algorithms/src/constraint_validation.rs
@@ -77,6 +77,55 @@ pub fn validate_rotary_acceleration_deg_per_s2(
     validate_closed_range(requested, min_limit, max_limit, tolerance)
 }
 
+/// requested feed rate が machine limit を超過しないか検証する。
+///
+/// limit が None の場合は未指定として許可する。
+pub fn validate_feed_rate(
+    requested_mm_per_min: f64,
+    machine_limit_mm_per_min: Option<f64>,
+) -> ValidationResult {
+    let Some(limit) = machine_limit_mm_per_min else {
+        return ValidationResult::ok();
+    };
+    validate_linear_speed_mm_per_min(requested_mm_per_min, 0.0, limit, 0.0)
+}
+
+/// 直動トラベルを検証する。
+///
+/// 設計側で使用する用語に合わせた公開名。挙動は `validate_linear_travel_mm` と同じ。
+pub fn validate_linear_travel(
+    requested_mm: f64,
+    min_mm: f64,
+    max_mm: f64,
+    tolerance_mm: f64,
+) -> ValidationResult {
+    validate_linear_travel_mm(requested_mm, min_mm, max_mm, tolerance_mm)
+}
+
+/// 回転角を検証する。
+///
+/// 設計側で使用する用語に合わせた公開名。挙動は `validate_rotary_angle_deg` と同じ。
+pub fn validate_rotary_angle(
+    requested_deg: f64,
+    min_deg: f64,
+    max_deg: f64,
+    tolerance_deg: f64,
+) -> ValidationResult {
+    validate_rotary_angle_deg(requested_deg, min_deg, max_deg, tolerance_deg)
+}
+
+/// 加速度を検証する。
+///
+/// 設計側で使用する用語に合わせた公開名。挙動は `validate_linear_acceleration_mm_per_s2` と同じ。
+pub fn validate_acceleration(
+    requested: f64,
+    min_limit: f64,
+    max_limit: f64,
+    tolerance: f64,
+) -> ValidationResult {
+    validate_linear_acceleration_mm_per_s2(requested, min_limit, max_limit, tolerance)
+}
+
 /// 回転軸角度（deg）の範囲検証。
 ///
 /// `min_deg > max_deg` の場合は 0 度跨ぎの範囲として扱う。
@@ -189,5 +238,22 @@ mod tests {
 
         assert_eq!(invalid.violation, ConstraintViolation::InvalidRange);
         assert_eq!(non_finite.violation, ConstraintViolation::NotFinite);
+    }
+
+    #[test]
+    fn feed_rate_validator_handles_optional_machine_limit() {
+        assert!(validate_feed_rate(1200.0, None).is_valid());
+        assert!(validate_feed_rate(1200.0, Some(2000.0)).is_valid());
+        assert_eq!(
+            validate_feed_rate(2200.0, Some(2000.0)).violation,
+            ConstraintViolation::AboveMaximum
+        );
+    }
+
+    #[test]
+    fn design_named_validators_delegate_correctly() {
+        assert!(validate_linear_travel(10.0, 0.0, 10.0, 0.0).is_valid());
+        assert!(validate_rotary_angle(350.0, 300.0, 30.0, 0.0).is_valid());
+        assert!(validate_acceleration(30.0, 0.0, 50.0, 0.0).is_valid());
     }
 }

--- a/model/geo_algorithms/src/lib.rs
+++ b/model/geo_algorithms/src/lib.rs
@@ -16,12 +16,14 @@ pub mod result;
 pub use octree::{Octree, OctreeNode, OctreeTolerance};
 
 pub use angle_utils::{
-    are_angles_equivalent_deg, normalize_angle_deg, normalize_angle_signed_deg, rewound_target_deg,
-    shortest_angular_delta_deg, unwind_angles_deg, RewindPolicy,
+    are_angles_equivalent_deg, is_equivalent_0_360, normalize_angle_deg,
+    normalize_angle_signed_deg, normalize_to_0_360, normalize_to_minus180_180, rewound_target_deg,
+    shortest_angle, shortest_angular_delta_deg, unwind_angles_deg, AngularPosition, RewindPolicy,
 };
 pub use constraint_validation::{
-    validate_linear_acceleration_mm_per_s2, validate_linear_speed_mm_per_min,
-    validate_linear_travel_mm, validate_rotary_acceleration_deg_per_s2, validate_rotary_angle_deg,
+    validate_acceleration, validate_feed_rate, validate_linear_acceleration_mm_per_s2,
+    validate_linear_speed_mm_per_min, validate_linear_travel, validate_linear_travel_mm,
+    validate_rotary_acceleration_deg_per_s2, validate_rotary_angle, validate_rotary_angle_deg,
     validate_rotary_speed_deg_per_min, ConstraintViolation, ValidationResult,
 };
 


### PR DESCRIPTION
## 概要

#426 の設計仕様（PR-3相当）に基づき、`geo_algorithms` に角度演算ユーティリティと制約検証 API を追加する。

---

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `model/geo_algorithms/src/angle_utils.rs` | `AngularPosition` struct + 公開名ラッパー関数追加 |
| `model/geo_algorithms/src/constraint_validation.rs` | `validate_feed_rate` + 公開名ラッパー関数追加 |
| `model/geo_algorithms/src/lib.rs` | 新 API の再エクスポート追加 |

---

## 追加 API

### angle_utils

- `AngularPosition { full_rotations: i32, remainder_deg: f64 }`
  - `from_total_deg(deg)` / `total_deg()`
- `normalize_to_0_360(deg)` — [0, 360) 正規化
- `normalize_to_minus180_180(deg)` — (-180, 180] 正規化
- `shortest_angle(from, to)` — 最短角度差
- `is_equivalent_0_360(a, b, tol)` — 0/360 同値判定

### constraint_validation

- `validate_feed_rate(requested, machine_limit: Option<f64>)` — limit=None の場合許可
- `validate_linear_travel(requested, min, max, tol)` — 直動トラベル検証
- `validate_rotary_angle(requested, min, max, tol)` — 回転角検証
- `validate_acceleration(requested, min, max, tol)` — 加速度検証

---

## 設計方針

- 既存 API（`normalize_angle_deg` 等）との後方互換を完全維持
- 公開名は設計用語に合わせた別名として提供（内部は既存実装に委譲）
- doc コメントに Issue 番号を埋め込まない（メンテ負債を防ぐ）

---

## 確認済み

- `cargo clippy --workspace -- -D warnings` 成功
- `cargo test -p geo_algorithms angle_utils` 成功（7 passed）
- `cargo test -p geo_algorithms constraint_validation` 成功（7 passed）

---

Closes の対象外（#426 は設計 Issue のため、このPRでは閉じない）  
Refs #426