### PR TITLE
refactor: helper generalization investigation と transform 支点整理を反映

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -60,6 +60,7 @@ ls model/geo_primitives/src/*_solid_3d*.rs
 2. **継続作業確認**: 既存の途中実装がないか `dev/` フォルダと `model/geo_core` を確認
 3. **アーキテクチャ遵守**: `geo_core` ブリッジパターンを厳守（例: `geo_nurbs → geo_core → geo_contracts`）
 4. **依存関係不変**: `scripts/check_architecture_dependencies_simple.ps1` の改変は絶対禁止
+5. **表示不具合とカーネル変換の分離確認**: wgpu表示の症状だけを根拠に `geo_core` / `geo_nurbs` の行列積順や transform 実装を変更しない。変更前に、対象の transform 経路が実際に呼ばれていることを確認する
 
 ### 依存関係と import の運用ルール（重要）
 
@@ -75,6 +76,7 @@ ls model/geo_primitives/src/*_solid_3d*.rs
 - ❌ レイヤールールに反する `geo_primitives` への直接依存の許可
 - ❌ `geo_algorithms` 実装ファイル内での `use geo_primitives::...` 直接 import
 - ❌ アーキテクチャチェックスクリプトの例外追加
+- ❌ 表示の見え方だけを理由に、呼び出し経路未確認のまま transform の積順・座標変換カーネルを変更すること
 
 ### 実装許可が必要な作業
 

--- a/dev/foundation/FOUNDATION_CORE_EXTENSION_REDESIGN_PROPOSAL.md
+++ b/dev/foundation/FOUNDATION_CORE_EXTENSION_REDESIGN_PROPOSAL.md
@@ -81,9 +81,9 @@ pub trait AnalysisTransform3D<T: Scalar> {
 
     fn transform_point_matrix(&self, matrix: &Self::Matrix4x4) -> Self::Output;
     fn translate_analysis(&self, translation: &Vector3<T>) -> Result<Self::Output, TransformError>;
-    fn rotate_analysis(&self, center: &Self, axis: &Vector3<T>, angle: Self::Angle) -> Result<Self::Output, TransformError>;
-    fn scale_analysis(&self, center: &Self, scale_x: T, scale_y: T, scale_z: T) -> Result<Self::Output, TransformError>;
-    fn uniform_scale_analysis(&self, center: &Self, scale_factor: T) -> Result<Self::Output, TransformError>;
+    fn rotate_analysis(&self, center: &Vector3<T>, axis: &Vector3<T>, angle: Self::Angle) -> Result<Self::Output, TransformError>;
+    fn scale_analysis(&self, center: &Vector3<T>, scale_x: T, scale_y: T, scale_z: T) -> Result<Self::Output, TransformError>;
+    fn uniform_scale_analysis(&self, center: &Vector3<T>, scale_factor: T) -> Result<Self::Output, TransformError>;
 }
 
 // エラーハンドリング版（SafeTransform）

--- a/manual/transform.md
+++ b/manual/transform.md
@@ -10,6 +10,7 @@ RedRingの幾何変換システムについて説明します。Transform trait 
 - **型変換効率**: geo_primitives⇔analysis間の最適化された変換
 - **2層責務分離**: 共通Transform責務は `geo_core`、形状適用は各図形クレート
 - **エラーハンドリング**: TransformErrorによる安全な変換操作
+- **汎用座標変換**: 支点や平行移動量は `analysis::Vector2/Vector3` で明示指定
 
 ### シンプルな構成
 
@@ -43,15 +44,15 @@ pub trait AnalysisTransform3D<T: Scalar> {
 
     // 基本変換操作
     fn translate_analysis(&self, translation: &Vector3<T>) -> Result<Self::Output, TransformError>;
-    fn rotate_analysis(&self, center: &Self, axis: &Vector3<T>, angle: Self::Angle) -> Result<Self::Output, TransformError>;
-    fn scale_analysis(&self, center: &Self, scale_x: T, scale_y: T, scale_z: T) -> Result<Self::Output, TransformError>;
-    fn uniform_scale_analysis(&self, center: &Self, scale_factor: T) -> Result<Self::Output, TransformError>;
+    fn rotate_analysis(&self, center: &Vector3<T>, axis: &Vector3<T>, angle: Self::Angle) -> Result<Self::Output, TransformError>;
+    fn scale_analysis(&self, center: &Vector3<T>, scale_x: T, scale_y: T, scale_z: T) -> Result<Self::Output, TransformError>;
+    fn uniform_scale_analysis(&self, center: &Vector3<T>, scale_factor: T) -> Result<Self::Output, TransformError>;
 
     // 複合変換
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>
     ) -> Result<Self::Output, TransformError>;
 }
@@ -198,8 +199,8 @@ trait AnalysisTransform3D<T: Scalar> {
 
     // Analysisベースの字全な変換操作
     fn translate_analysis(&self, translation: &Vector3<T>) -> Result<Self::Output, TransformError>;
-    fn rotate_analysis(&self, center: &Self, axis: &Vector3<T>, angle: Self::Angle) -> Result<Self::Output, TransformError>;
-    fn scale_analysis(&self, center: &Self, scale_x: T, scale_y: T, scale_z: T) -> Result<Self::Output, TransformError>;
+    fn rotate_analysis(&self, center: &Vector3<T>, axis: &Vector3<T>, angle: Self::Angle) -> Result<Self::Output, TransformError>;
+    fn scale_analysis(&self, center: &Vector3<T>, scale_x: T, scale_y: T, scale_z: T) -> Result<Self::Output, TransformError>;
 }
 ```
 

--- a/model/cam_core/src/toolpath.rs
+++ b/model/cam_core/src/toolpath.rs
@@ -518,20 +518,10 @@ impl<T: Scalar> PathSegment<T> {
     /// 円弧の場合は円弧長。
     pub fn length(&self) -> T {
         match &self.geometry {
-            PathGeometry::Line { end } => {
-                let dx = end.x() - self.start.x();
-                let dy = end.y() - self.start.y();
-                let dz = end.z() - self.start.z();
-                (dx * dx + dy * dy + dz * dz).sqrt()
-            }
+            PathGeometry::Line { end } => self.start.distance_to(end),
             PathGeometry::Arc { end, center, .. } => {
                 // 円弧長 = 半径 × 中心角
-                let radius = {
-                    let dx = self.start.x() - center.x();
-                    let dy = self.start.y() - center.y();
-                    let dz = self.start.z() - center.z();
-                    (dx * dx + dy * dy + dz * dz).sqrt()
-                };
+                let radius = self.start.distance_to(center);
 
                 // 始点→中心、終点→中心のベクトル
                 let v1_x = self.start.x() - center.x();

--- a/model/cam_core/src/validation.rs
+++ b/model/cam_core/src/validation.rs
@@ -299,9 +299,7 @@ pub fn validate_2d_contour<T: Scalar>(
     let start = &points[0];
     let end = &points[points.len() - 1];
 
-    let dx = end.x() - start.x();
-    let dy = end.y() - start.y();
-    let distance = (dx * dx + dy * dy).sqrt();
+    let distance = start.distance_to(end);
 
     // トレランス比較
     if distance > tolerance.closure_tolerance {

--- a/model/cam_sim/src/simulator/segments.rs
+++ b/model/cam_sim/src/simulator/segments.rs
@@ -11,10 +11,9 @@ const MIN_ARC_DIVISIONS: usize = 4;
 impl<T: geo_algorithms::Scalar> super::CuttingSimulator<T> {
     /// 線分長を `f64` で計算する（距離ベース間隔計算用）。
     pub(super) fn segment_length(&self, segment: &geo_algorithms::LineSegment3D<T>) -> f64 {
-        let dx = segment.end().x() - segment.start().x();
-        let dy = segment.end().y() - segment.start().y();
-        let dz = segment.end().z() - segment.start().z();
-        (dx * dx + dy * dy + dz * dz).sqrt().to_f64()
+        let start = segment.start();
+        let end = segment.end();
+        start.distance_to(&end).to_f64()
     }
 
     /// ToolPathから線分セグメントを抽出し、切削フラグ付きで返す。

--- a/model/geo_algorithms/src/collision/nurbs_3d.rs
+++ b/model/geo_algorithms/src/collision/nurbs_3d.rs
@@ -137,11 +137,8 @@ impl<T: Scalar> BasicCollision<T, Point3D<T>> for NurbsCurveCollider<T> {
         for i in 0..=num_samples {
             let u = u_min + delta_u * T::from_usize(i);
             let curve_point = self.0.evaluate_at(u);
-
-            let dx = curve_point.x() - point.x();
-            let dy = curve_point.y() - point.y();
-            let dz = curve_point.z() - point.z();
-            let dist_sq = dx * dx + dy * dy + dz * dz;
+            let sample_point = CorePoint3D::new(curve_point.x(), curve_point.y(), curve_point.z());
+            let dist_sq = sample_point.distance_squared_to(point);
 
             if dist_sq < min_dist_sq {
                 min_dist_sq = dist_sq;
@@ -156,10 +153,9 @@ impl<T: Scalar> BasicCollision<T, Point3D<T>> for NurbsCurveCollider<T> {
 
         // 最終的な距離を計算
         let closest_point = self.0.evaluate_at(refined_u);
-        let dx = closest_point.x() - point.x();
-        let dy = closest_point.y() - point.y();
-        let dz = closest_point.z() - point.z();
-        (dx * dx + dy * dy + dz * dz).sqrt()
+        let closest_point =
+            CorePoint3D::new(closest_point.x(), closest_point.y(), closest_point.z());
+        closest_point.distance_to(point)
     }
 }
 
@@ -218,10 +214,9 @@ impl<T: Scalar> BasicCollision<T, LineSegment3D<T>> for NurbsCurveCollider<T> {
             let closest_z = start.z() + t * seg_dir_z;
 
             // 距離を計算
-            let dx = curve_point.x() - closest_x;
-            let dy = curve_point.y() - closest_y;
-            let dz = curve_point.z() - closest_z;
-            let distance = (dx * dx + dy * dy + dz * dz).sqrt();
+            let sample_point = CorePoint3D::new(curve_point.x(), curve_point.y(), curve_point.z());
+            let closest_point = CorePoint3D::new(closest_x, closest_y, closest_z);
+            let distance = sample_point.distance_to(&closest_point);
 
             min_distance = min_distance.min(distance);
         }
@@ -275,10 +270,9 @@ impl<T: Scalar> BasicCollision<T, Ray3D<T>> for NurbsCurveCollider<T> {
             let closest_z = origin.z() + t * direction_vec.z();
 
             // 距離を計算
-            let dx = curve_point.x() - closest_x;
-            let dy = curve_point.y() - closest_y;
-            let dz = curve_point.z() - closest_z;
-            let distance = (dx * dx + dy * dy + dz * dz).sqrt();
+            let sample_point = CorePoint3D::new(curve_point.x(), curve_point.y(), curve_point.z());
+            let closest_point = CorePoint3D::new(closest_x, closest_y, closest_z);
+            let distance = sample_point.distance_to(&closest_point);
 
             min_distance = min_distance.min(distance);
         }
@@ -333,10 +327,9 @@ impl<T: Scalar> BasicCollision<T, InfiniteLine3D<T>> for NurbsCurveCollider<T> {
             let closest_z = point_on_line.z() + t * direction_vec.z();
 
             // 距離を計算
-            let dx = curve_point.x() - closest_x;
-            let dy = curve_point.y() - closest_y;
-            let dz = curve_point.z() - closest_z;
-            let distance = (dx * dx + dy * dy + dz * dz).sqrt();
+            let sample_point = CorePoint3D::new(curve_point.x(), curve_point.y(), curve_point.z());
+            let closest_point = CorePoint3D::new(closest_x, closest_y, closest_z);
+            let distance = sample_point.distance_to(&closest_point);
 
             min_distance = min_distance.min(distance);
         }
@@ -375,10 +368,8 @@ impl<T: Scalar> BasicCollision<T, Circle3D<T>> for NurbsCurveCollider<T> {
             let center = CorePoint3D::new(cx, cy, cz);
             let radius = <Circle3D<T> as Circle3DProperties<T>>::radius(circle);
 
-            let dx = curve_point.x() - center.x();
-            let dy = curve_point.y() - center.y();
-            let dz = curve_point.z() - center.z();
-            let dist_to_center = (dx * dx + dy * dy + dz * dz).sqrt();
+            let sample_point = CorePoint3D::new(curve_point.x(), curve_point.y(), curve_point.z());
+            let dist_to_center = sample_point.distance_to(&center);
 
             // 円周までの距離
             let distance = (dist_to_center - radius).abs();
@@ -577,10 +568,7 @@ impl<T: Scalar> NurbsSurfaceCollider<T> {
                 let p = self.0.evaluate_at(u, v);
                 let surface_point = Point3D::new(p.x(), p.y(), p.z());
 
-                let dx = surface_point.x() - point.x();
-                let dy = surface_point.y() - point.y();
-                let dz = surface_point.z() - point.z();
-                let d = (dx * dx + dy * dy + dz * dz).sqrt();
+                let d = surface_point.distance_to(point);
 
                 if d < min_dist {
                     min_dist = d;
@@ -650,10 +638,9 @@ impl<T: Scalar> NurbsSurfaceCollider<T> {
                 let closest_y = origin.y() + t * direction.y();
                 let closest_z = origin.z() + t * direction.z();
 
-                let dx = p.x() - closest_x;
-                let dy = p.y() - closest_y;
-                let dz = p.z() - closest_z;
-                let d = (dx * dx + dy * dy + dz * dz).sqrt();
+                let surface_point = Point3D::new(p.x(), p.y(), p.z());
+                let closest_point = Point3D::new(closest_x, closest_y, closest_z);
+                let d = surface_point.distance_to(&closest_point);
 
                 min_dist = min_dist.min(d);
             }
@@ -674,7 +661,7 @@ impl<T: Scalar> NurbsSurfaceCollider<T> {
         let seg_dx = end.x() - start.x();
         let seg_dy = end.y() - start.y();
         let seg_dz = end.z() - start.z();
-        let seg_len_sq = seg_dx * seg_dx + seg_dy * seg_dy + seg_dz * seg_dz;
+        let seg_len_sq = start.distance_squared_to(&end);
 
         let mut min_dist = T::INFINITY;
 
@@ -699,10 +686,9 @@ impl<T: Scalar> NurbsSurfaceCollider<T> {
                 let cy = start.y() + t * seg_dy;
                 let cz = start.z() + t * seg_dz;
 
-                let dx = p.x() - cx;
-                let dy = p.y() - cy;
-                let dz = p.z() - cz;
-                let d = (dx * dx + dy * dy + dz * dz).sqrt();
+                let surface_point = Point3D::new(p.x(), p.y(), p.z());
+                let closest_point = Point3D::new(cx, cy, cz);
+                let d = surface_point.distance_to(&closest_point);
                 min_dist = min_dist.min(d);
             }
         }
@@ -737,10 +723,9 @@ impl<T: Scalar> NurbsSurfaceCollider<T> {
                 let cy = py + t * dy;
                 let cz = pz + t * dz;
 
-                let ddx = p.x() - cx;
-                let ddy = p.y() - cy;
-                let ddz = p.z() - cz;
-                let d = (ddx * ddx + ddy * ddy + ddz * ddz).sqrt();
+                let surface_point = Point3D::new(p.x(), p.y(), p.z());
+                let closest_point = Point3D::new(cx, cy, cz);
+                let d = surface_point.distance_to(&closest_point);
                 min_dist = min_dist.min(d);
             }
         }
@@ -766,10 +751,9 @@ impl<T: Scalar> NurbsSurfaceCollider<T> {
                 let v = v_min + dv * T::from_usize(j);
                 let p = self.0.evaluate_at(u, v);
 
-                let dx = p.x() - cx;
-                let dy = p.y() - cy;
-                let dz = p.z() - cz;
-                let distance_to_center = (dx * dx + dy * dy + dz * dz).sqrt();
+                let surface_point = Point3D::new(p.x(), p.y(), p.z());
+                let center = Point3D::new(cx, cy, cz);
+                let distance_to_center = surface_point.distance_to(&center);
                 let d = (distance_to_center - radius).abs();
                 min_dist = min_dist.min(d);
             }

--- a/model/geo_algorithms/src/collision/primitive_2d.rs
+++ b/model/geo_algorithms/src/collision/primitive_2d.rs
@@ -26,9 +26,8 @@ pub fn circle2d_point2d_collides<T: Scalar>(
     point: &Point2D<T>,
     tolerance: T,
 ) -> bool {
-    let dx = point.x() - circle.center().0;
-    let dy = point.y() - circle.center().1;
-    let distance = (dx * dx + dy * dy).sqrt();
+    let center = Point2D::from_tuple(circle.center());
+    let distance = point.distance_to(&center);
     (distance - circle.radius()).abs() <= tolerance
 }
 
@@ -37,9 +36,9 @@ pub fn circle2d_circle2d_collides<T: Scalar>(
     circle2: &Circle2D<T>,
     tolerance: T,
 ) -> bool {
-    let dx = circle2.center().0 - circle1.center().0;
-    let dy = circle2.center().1 - circle1.center().1;
-    let center_distance = (dx * dx + dy * dy).sqrt();
+    let center1 = Point2D::from_tuple(circle1.center());
+    let center2 = Point2D::from_tuple(circle2.center());
+    let center_distance = center1.distance_to(&center2);
 
     let radii_sum = circle1.radius() + circle2.radius();
     let radii_diff = (circle1.radius() - circle2.radius()).abs();
@@ -53,15 +52,15 @@ pub fn line_segment2d_point2d_distance<T: Scalar>(
 ) -> T {
     let start = segment.start();
     let end = segment.end();
+    let start_point = Point2D::from_tuple(start);
+    let end_point = Point2D::from_tuple(end);
 
     let dx = end.0 - start.0;
     let dy = end.1 - start.1;
-    let length_sq = dx * dx + dy * dy;
+    let length_sq = start_point.distance_squared_to(&end_point);
 
     if length_sq == T::ZERO {
-        let dist_x = point.x() - start.0;
-        let dist_y = point.y() - start.1;
-        return (dist_x * dist_x + dist_y * dist_y).sqrt();
+        return point.distance_to(&start_point);
     }
 
     let t = {
@@ -72,9 +71,8 @@ pub fn line_segment2d_point2d_distance<T: Scalar>(
     let closest_x = start.0 + t * dx;
     let closest_y = start.1 + t * dy;
 
-    let dist_x = point.x() - closest_x;
-    let dist_y = point.y() - closest_y;
-    (dist_x * dist_x + dist_y * dist_y).sqrt()
+    let closest_point = Point2D::new(closest_x, closest_y);
+    point.distance_to(&closest_point)
 }
 
 pub fn line_segment2d_circle2d_collides<T: Scalar>(
@@ -88,10 +86,8 @@ pub fn line_segment2d_circle2d_collides<T: Scalar>(
 }
 
 pub fn arc2d_point2d_collides<T: Scalar>(arc: &Arc2D<T>, point: &Point2D<T>, tolerance: T) -> bool {
-    let (center_x, center_y) = <Arc2D<T> as Arc2DProperties<T>>::center(arc);
-    let dx = point.x() - center_x;
-    let dy = point.y() - center_y;
-    let distance = (dx * dx + dy * dy).sqrt();
+    let center = Point2D::from_tuple(<Arc2D<T> as Arc2DProperties<T>>::center(arc));
+    let distance = point.distance_to(&center);
 
     (distance - arc.radius()).abs() <= tolerance
 }
@@ -101,12 +97,9 @@ pub fn arc2d_circle2d_collides<T: Scalar>(
     circle: &Circle2D<T>,
     tolerance: T,
 ) -> bool {
-    let (center1_x, center1_y) = <Arc2D<T> as Arc2DProperties<T>>::center(arc);
-    let (center2_x, center2_y) = circle.center();
-
-    let dx = center2_x - center1_x;
-    let dy = center2_y - center1_y;
-    let center_distance = (dx * dx + dy * dy).sqrt();
+    let center1 = Point2D::from_tuple(<Arc2D<T> as Arc2DProperties<T>>::center(arc));
+    let center2 = Point2D::from_tuple(circle.center());
+    let center_distance = center1.distance_to(&center2);
 
     let radii_sum = arc.radius() + circle.radius();
     let radii_diff = (arc.radius() - circle.radius()).abs();

--- a/model/geo_algorithms/src/collision/primitive_3d.rs
+++ b/model/geo_algorithms/src/collision/primitive_3d.rs
@@ -97,10 +97,9 @@ pub fn spherical_solid3d_spherical_solid3d_collides<T: Scalar>(
 ) -> bool {
     let (ax, ay, az) = SphericalSolid3DProperties::center(sphere_a);
     let (bx, by, bz) = SphericalSolid3DProperties::center(sphere_b);
-    let dx = bx - ax;
-    let dy = by - ay;
-    let dz = bz - az;
-    let dist = (dx * dx + dy * dy + dz * dz).sqrt();
+    let center_a = Point3D::new(ax, ay, az);
+    let center_b = Point3D::new(bx, by, bz);
+    let dist = center_a.distance_to(&center_b);
     let r1 = SphericalSolid3DProperties::radius(sphere_a);
     let r2 = SphericalSolid3DProperties::radius(sphere_b);
     dist <= r1 + r2 + tolerance
@@ -208,10 +207,9 @@ pub fn cylindrical_solid3d_cylindrical_solid3d_collides<T: Scalar>(
 ) -> bool {
     let (ax, ay, az) = <CylindricalSolid3D<T> as CylindricalSolid3DProperties<T>>::center(cyl_a);
     let (bx, by, bz) = <CylindricalSolid3D<T> as CylindricalSolid3DProperties<T>>::center(cyl_b);
-    let dx = bx - ax;
-    let dy = by - ay;
-    let dz = bz - az;
-    let dist = (dx * dx + dy * dy + dz * dz).sqrt();
+    let center_a = Point3D::new(ax, ay, az);
+    let center_b = Point3D::new(bx, by, bz);
+    let dist = center_a.distance_to(&center_b);
     let max_a = <CylindricalSolid3D<T> as CylindricalSolid3DProperties<T>>::radius(cyl_a)
         + <CylindricalSolid3D<T> as CylindricalSolid3DProperties<T>>::height(cyl_a);
     let max_b = <CylindricalSolid3D<T> as CylindricalSolid3DProperties<T>>::radius(cyl_b)
@@ -328,10 +326,9 @@ pub fn cylindrical_surface3d_cylindrical_surface3d_collides<T: Scalar>(
         <CylindricalSurface3D<T> as CylindricalSurface3DProperties<T>>::center(cyl_a);
     let (bx, by, bz) =
         <CylindricalSurface3D<T> as CylindricalSurface3DProperties<T>>::center(cyl_b);
-    let dx = bx - ax;
-    let dy = by - ay;
-    let dz = bz - az;
-    let dist = (dx * dx + dy * dy + dz * dz).sqrt();
+    let center_a = Point3D::new(ax, ay, az);
+    let center_b = Point3D::new(bx, by, bz);
+    let dist = center_a.distance_to(&center_b);
     let radius_sum = <CylindricalSurface3D<T> as CylindricalSurface3DProperties<T>>::radius(cyl_a)
         + <CylindricalSurface3D<T> as CylindricalSurface3DProperties<T>>::radius(cyl_b);
     dist <= radius_sum + tolerance
@@ -448,10 +445,7 @@ pub fn ellipse3d_ellipse3d_collides<T: Scalar>(
 ) -> bool {
     let c1 = ellipse_a.center();
     let c2 = ellipse_b.center();
-    let dx = c2.x() - c1.x();
-    let dy = c2.y() - c1.y();
-    let dz = c2.z() - c1.z();
-    let center_dist = (dx * dx + dy * dy + dz * dz).sqrt();
+    let center_dist = c1.distance_to(&c2);
     let sum_semi_major = ellipse_a.semi_major_axis() + ellipse_b.semi_major_axis();
     center_dist <= sum_semi_major + tolerance
 }
@@ -538,10 +532,9 @@ pub fn ellipsoidal_solid3d_ellipsoidal_solid3d_collides<T: Scalar>(
 ) -> bool {
     let (ax, ay, az) = <EllipsoidalSolid3D<T> as EllipsoidalSolid3DProperties<T>>::center(ell_a);
     let (bx, by, bz) = <EllipsoidalSolid3D<T> as EllipsoidalSolid3DProperties<T>>::center(ell_b);
-    let dx = bx - ax;
-    let dy = by - ay;
-    let dz = bz - az;
-    let center_dist = (dx * dx + dy * dy + dz * dz).sqrt();
+    let center_a = Point3D::new(ax, ay, az);
+    let center_b = Point3D::new(bx, by, bz);
+    let center_dist = center_a.distance_to(&center_b);
     let max_1 = {
         let a = <EllipsoidalSolid3D<T> as EllipsoidalSolid3DProperties<T>>::a_radius(ell_a);
         let b = <EllipsoidalSolid3D<T> as EllipsoidalSolid3DProperties<T>>::b_radius(ell_a);
@@ -782,10 +775,9 @@ pub fn circle3d_circle3d_collides<T: Scalar>(
 ) -> bool {
     let (ax, ay, az) = circle_a.center();
     let (bx, by, bz) = circle_b.center();
-    let dx = bx - ax;
-    let dy = by - ay;
-    let dz = bz - az;
-    let dist = (dx * dx + dy * dy + dz * dz).sqrt();
+    let center_a = Point3D::new(ax, ay, az);
+    let center_b = Point3D::new(bx, by, bz);
+    let dist = center_a.distance_to(&center_b);
     dist <= circle_a.radius() + circle_b.radius() + tolerance
 }
 

--- a/model/geo_algorithms/src/intersection/pair_base.rs
+++ b/model/geo_algorithms/src/intersection/pair_base.rs
@@ -25,12 +25,14 @@ pub fn circle2d_circle2d_intersections<T: Scalar>(
 
     let center1 = circle1.center();
     let center2 = circle2.center();
+    let center1_point = Point2D::from_tuple(center1);
+    let center2_point = Point2D::from_tuple(center2);
     let r1 = circle1.radius();
     let r2 = circle2.radius();
 
     let dx = center2.0 - center1.0;
     let dy = center2.1 - center1.1;
-    let d = (dx * dx + dy * dy).sqrt();
+    let d = center1_point.distance_to(&center2_point);
 
     if d > r1 + r2 + tolerance || d + tolerance < (r1 - r2).abs() || d.abs() <= tolerance {
         return result;
@@ -108,7 +110,9 @@ pub fn line_segment2d_circle2d_intersections<T: Scalar>(
     let fx = start.0 - center.0;
     let fy = start.1 - center.1;
 
-    let a = dx * dx + dy * dy;
+    let start_point = Point2D::from_tuple(start);
+    let end_point = Point2D::from_tuple(end);
+    let a = start_point.distance_squared_to(&end_point);
     if a.abs() <= tolerance {
         return result;
     }

--- a/model/geo_algorithms/src/intersection/primitive_2d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_2d.rs
@@ -524,21 +524,13 @@ pub fn ellipse_arc2d_point2d_intersection<T: Scalar>(
     IntersectionResult::from_option_point2d(opt, false, tolerance)
 }
 
-fn squared_norm<T: Scalar>(v: Vector2D<T>) -> T {
-    v.x() * v.x() + v.y() * v.y()
-}
-
-fn cross_2d<T: Scalar>(a: Vector2D<T>, b: Vector2D<T>) -> T {
-    a.x() * b.y() - a.y() * b.x()
-}
-
 fn is_point_on_line<T: Scalar>(
     line_point: Point2D<T>,
     line_dir: Vector2D<T>,
     p: Point2D<T>,
     tolerance: T,
 ) -> bool {
-    cross_2d(Vector2D::from_points(line_point, p), line_dir).abs() <= tolerance
+    Vector2D::from_points(line_point, p).cross(&line_dir).abs() <= tolerance
 }
 
 fn points_near<T: Scalar>(a: Point2D<T>, b: Point2D<T>, tolerance: T) -> bool {
@@ -557,14 +549,14 @@ fn collinear_segment_overlap_result<T: Scalar>(
     let d1 = Vector2D::from_points(p1, p2);
     let d2 = Vector2D::from_points(p3, p4);
 
-    if cross_2d(d1, d2).abs() > tolerance {
+    if d1.cross(&d2).abs() > tolerance {
         return None;
     }
-    if cross_2d(Vector2D::from_points(p1, p3), d1).abs() > tolerance {
+    if Vector2D::from_points(p1, p3).cross(&d1).abs() > tolerance {
         return None;
     }
 
-    let d1_norm = squared_norm(d1);
+    let d1_norm = d1.length_squared();
     if d1_norm <= tolerance * tolerance {
         return Some(IntersectionResult::disjoint(tolerance));
     }
@@ -625,7 +617,7 @@ fn collinear_ray_segment_overlap_result<T: Scalar>(
     let direction = Vector2D::new(ray.direction().0, ray.direction().1);
     let s1 = Point2D::new(segment.start().0, segment.start().1);
     let s2 = Point2D::new(segment.end().0, segment.end().1);
-    let dir_norm = squared_norm(direction);
+    let dir_norm = direction.length_squared();
 
     if dir_norm <= tolerance * tolerance {
         return IntersectionResult::disjoint(tolerance);

--- a/model/geo_algorithms/src/intersection/primitive_2d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_2d.rs
@@ -22,9 +22,8 @@ pub fn circle2d_point2d_intersection<T: Scalar>(
     point: &Point2D<T>,
     tolerance: T,
 ) -> IntersectionResult<T> {
-    let dx = point.x() - circle.center().0;
-    let dy = point.y() - circle.center().1;
-    let distance = (dx * dx + dy * dy).sqrt();
+    let center = Point2D::from_tuple(circle.center());
+    let distance = point.distance_to(&center);
 
     let opt = if (distance - circle.radius()).abs() <= tolerance {
         Some(*point)
@@ -39,9 +38,9 @@ pub fn circle2d_circle2d_intersections_algo<T: Scalar>(
     circle2: &Circle2D<T>,
     tolerance: T,
 ) -> IntersectionResult<T> {
-    let dx = circle2.center().0 - circle1.center().0;
-    let dy = circle2.center().1 - circle1.center().1;
-    let center_distance = (dx * dx + dy * dy).sqrt();
+    let center1 = Point2D::from_tuple(circle1.center());
+    let center2 = Point2D::from_tuple(circle2.center());
+    let center_distance = center1.distance_to(&center2);
 
     if center_distance <= tolerance {
         if (circle1.radius() - circle2.radius()).abs() <= tolerance {
@@ -278,10 +277,8 @@ pub fn arc2d_point2d_intersection<T: Scalar>(
     point: &Point2D<T>,
     tolerance: T,
 ) -> IntersectionResult<T> {
-    let (center_x, center_y) = <Arc2D<T> as Arc2DProperties<T>>::center(arc);
-    let dx = point.x() - center_x;
-    let dy = point.y() - center_y;
-    let distance = (dx * dx + dy * dy).sqrt();
+    let center = Point2D::from_tuple(<Arc2D<T> as Arc2DProperties<T>>::center(arc));
+    let distance = point.distance_to(&center);
 
     if (distance - arc.radius()).abs() > tolerance {
         return IntersectionResult::from_option_point2d(None, false, tolerance);

--- a/model/geo_algorithms/src/octree/nearest_impl.rs
+++ b/model/geo_algorithms/src/octree/nearest_impl.rs
@@ -49,10 +49,7 @@ where
 
         for item in node.data().iter() {
             let pos = item.position();
-            let dx = point.x() - pos.x();
-            let dy = point.y() - pos.y();
-            let dz = point.z() - pos.z();
-            let dist = (dx * dx + dy * dy + dz * dz).sqrt();
+            let dist = point.distance_to(&pos);
 
             if best.is_none() || dist < best.unwrap().1 {
                 best = Some((item, dist));
@@ -110,6 +107,7 @@ where
             point.z() - point.z()
         };
 
-        dx * dx + dy * dy + dz * dz
+        let point_on_box = Point3D::new(point.x() + dx, point.y() + dy, point.z() + dz);
+        point.distance_squared_to(&point_on_box)
     }
 }

--- a/model/geo_algorithms/src/octree/voxel/node_impl.rs
+++ b/model/geo_algorithms/src/octree/voxel/node_impl.rs
@@ -1,4 +1,5 @@
 use super::*;
+use analysis::linalg::vector::Vector2;
 use geo_contracts::CrossDistance;
 
 impl<T: Scalar> VoxelNode<T> {
@@ -416,10 +417,9 @@ impl<T: Scalar> VoxelNode<T> {
         let closest_y = sy + axis_y * t;
         let closest_z = sz + axis_z * t;
 
-        let dx = px - closest_x;
-        let dy = py - closest_y;
-        let dz = pz - closest_z;
-        let distance = (dx * dx + dy * dy + dz * dz).sqrt();
+        let point = Point3D::new(px, py, pz);
+        let closest = Point3D::new(closest_x, closest_y, closest_z);
+        let distance = point.distance_to(&closest);
         // 半径方向距離で円柱断面内判定。
         distance <= radius
     }
@@ -442,7 +442,9 @@ impl<T: Scalar> VoxelNode<T> {
         let to_py = py - sy;
         let to_pz = pz - sz;
 
-        let len_sq = dx * dx + dy * dy + dz * dz;
+        let start_point = Point3D::new(sx, sy, sz);
+        let end_point = Point3D::new(ex, ey, ez);
+        let len_sq = start_point.distance_squared_to(&end_point);
         let t = if len_sq <= T::EPSILON {
             T::ZERO
         } else {
@@ -454,10 +456,9 @@ impl<T: Scalar> VoxelNode<T> {
         let closest_y = sy + dy * t;
         let closest_z = sz + dz * t;
 
-        let diff_x = px - closest_x;
-        let diff_y = py - closest_y;
-        let diff_z = pz - closest_z;
-        (diff_x * diff_x + diff_y * diff_y + diff_z * diff_z).sqrt()
+        let point = Point3D::new(px, py, pz);
+        let closest = Point3D::new(closest_x, closest_y, closest_z);
+        point.distance_to(&closest)
     }
 
     /// Z軸平行の軸付き形状に特化した高速除去を行う。
@@ -542,8 +543,7 @@ impl<T: Scalar> VoxelNode<T> {
 
         let dx = center_x - closest_x;
         let dy = center_y - closest_y;
-
-        (dx * dx + dy * dy).sqrt()
+        Vector2::new(dx, dy).norm()
     }
 
     /// Z軸平行カプセルにAABB全体が内包されるかを判定する。
@@ -570,9 +570,7 @@ impl<T: Scalar> VoxelNode<T> {
         ];
 
         for &(x, y) in &corners_2d {
-            let dx = x - center_x;
-            let dy = y - center_y;
-            let distance = (dx * dx + dy * dy).sqrt();
+            let distance = Vector2::new(x - center_x, y - center_y).norm();
             if distance > radius {
                 return false;
             }

--- a/model/geo_commons/src/approximations/curves.rs
+++ b/model/geo_commons/src/approximations/curves.rs
@@ -1,6 +1,7 @@
 //! 曲線長計算の近似
 
 use analysis::abstract_types::Scalar;
+use analysis::linalg::vector::Vector2;
 
 /// ベジェ曲線の長さ近似（分割近似法）
 pub fn bezier_length_approximation<T: Scalar>(control_points: &[[T; 2]], num_segments: usize) -> T {
@@ -17,10 +18,7 @@ pub fn bezier_length_approximation<T: Scalar>(control_points: &[[T; 2]], num_seg
 
         let p1 = evaluate_bezier(control_points, t1);
         let p2 = evaluate_bezier(control_points, t2);
-
-        let dx = p2[0] - p1[0];
-        let dy = p2[1] - p1[1];
-        total_length += (dx * dx + dy * dy).sqrt();
+        total_length += Vector2::new(p2[0] - p1[0], p2[1] - p1[1]).norm();
     }
 
     total_length
@@ -79,9 +77,11 @@ pub fn spline_length_approximation<T: Scalar>(
     // 簡単な近似：各点間を直線で結んだ長さ
     let mut total_length = T::ZERO;
     for i in 0..points.len() - 1 {
-        let dx = points[i + 1][0] - points[i][0];
-        let dy = points[i + 1][1] - points[i][1];
-        total_length += (dx * dx + dy * dy).sqrt();
+        total_length += Vector2::new(
+            points[i + 1][0] - points[i][0],
+            points[i + 1][1] - points[i][1],
+        )
+        .norm();
     }
 
     // スプライン補正係数（経験的な値）
@@ -107,10 +107,7 @@ where
 
         let p1 = curve_fn(t1);
         let p2 = curve_fn(t2);
-
-        let dx = p2[0] - p1[0];
-        let dy = p2[1] - p1[1];
-        total_length += (dx * dx + dy * dy).sqrt();
+        total_length += Vector2::new(p2[0] - p1[0], p2[1] - p1[1]).norm();
     }
 
     total_length

--- a/model/geo_commons/src/metrics/distance.rs
+++ b/model/geo_commons/src/metrics/distance.rs
@@ -2,6 +2,7 @@
 //!
 //! 幾何形状間の距離計算アルゴリズムを提供します。
 
+use analysis::linalg::vector::Vector3;
 use analysis::Scalar;
 
 /// 2D楕円上の点から任意の点への距離を計算
@@ -111,7 +112,7 @@ pub fn sphere_to_infinite_line_distance<T: Scalar>(
     let to_cz = cz - pz;
 
     // direction の内積
-    let dir_dot = dx * dx + dy * dy + dz * dz;
+    let dir_dot = Vector3::new(dx, dy, dz).norm_squared();
 
     // パラメータ t = to_center · direction / |direction|²
     let t = (to_cx * dx + to_cy * dy + to_cz * dz) / dir_dot;
@@ -176,7 +177,7 @@ pub fn sphere_to_ray_distance<T: Scalar>(
     let to_cz = cz - oz;
 
     // direction の内積
-    let dir_dot = dx * dx + dy * dy + dz * dz;
+    let dir_dot = Vector3::new(dx, dy, dz).norm_squared();
 
     // パラメータ t
     let t = (to_cx * dx + to_cy * dy + to_cz * dz) / dir_dot;
@@ -260,7 +261,7 @@ pub fn sphere_to_line_segment_distance<T: Scalar>(
     let to_cz = cz - sz;
 
     // direction の内積
-    let dir_dot = dx * dx + dy * dy + dz * dz;
+    let dir_dot = Vector3::new(dx, dy, dz).norm_squared();
 
     // パラメータ t
     let t = (to_cx * dx + to_cy * dy + to_cz * dz) / dir_dot;
@@ -339,10 +340,7 @@ pub fn line_segment_to_aabb_distance<T: Scalar>(
 
     // ヘルパー関数: 2点間の距離
     let distance = |p1x: T, p1y: T, p1z: T, p2x: T, p2y: T, p2z: T| -> T {
-        let dx = p1x - p2x;
-        let dy = p1y - p2y;
-        let dz = p1z - p2z;
-        (dx * dx + dy * dy + dz * dz).sqrt()
+        Vector3::new(p1x - p2x, p1y - p2y, p1z - p2z).norm()
     };
 
     // 1. 線分の端点がAABB内部にあれば距離0
@@ -396,7 +394,7 @@ pub fn line_segment_to_aabb_distance<T: Scalar>(
         let to_vz = vz - sz;
 
         let dot = to_vx * dx + to_vy * dy + to_vz * dz;
-        let len_sq = dx * dx + dy * dy + dz * dz;
+        let len_sq = Vector3::new(dx, dy, dz).norm_squared();
 
         let t = if len_sq <= T::EPSILON {
             T::ZERO

--- a/model/geo_core/src/point_2d_transform.rs
+++ b/model/geo_core/src/point_2d_transform.rs
@@ -64,14 +64,14 @@ pub mod analysis_transform {
     }
 
     /// 回転行列の生成（中心点指定版）
-    pub fn rotation_matrix_2d<T: Scalar>(center: &Point2D<T>, angle: Angle<T>) -> Matrix3x3<T> {
+    pub fn rotation_matrix_2d<T: Scalar>(center: &Vector2<T>, angle: Angle<T>) -> Matrix3x3<T> {
         let center_vec = Vector2::new(center.x(), center.y());
         Matrix3x3::rotation_around_point_2d(&center_vec, angle.to_radians())
     }
 
     /// スケール行列の生成（中心点・個別軸指定版）
     pub fn scale_matrix_2d<T: Scalar>(
-        center: &Point2D<T>,
+        center: &Vector2<T>,
         scale_x: T,
         scale_y: T,
     ) -> Result<Matrix3x3<T>, TransformError> {
@@ -93,7 +93,7 @@ pub mod analysis_transform {
 
     /// 均等スケール行列の生成（中心点指定版）
     pub fn uniform_scale_matrix_2d<T: Scalar>(
-        center: &Point2D<T>,
+        center: &Vector2<T>,
         scale_factor: T,
     ) -> Result<Matrix3x3<T>, TransformError> {
         if scale_factor.is_zero() {
@@ -114,14 +114,14 @@ pub mod analysis_transform {
     /// 複合変換行列の構築
     pub fn composite_point_transform_2d<T: Scalar>(
         translation: Option<&Vector2D<T>>,
-        rotation: Option<(&Point2D<T>, Angle<T>)>,
+        rotation: Option<(&Vector2<T>, Angle<T>)>,
         scale: Option<(T, T)>,
     ) -> Result<Matrix3x3<T>, TransformError> {
         let mut result = Matrix3x3::identity();
 
         // スケール適用
         if let Some((sx, sy)) = scale {
-            let origin = Point2D::origin();
+            let origin = Vector2::new(T::ZERO, T::ZERO);
             let scale_matrix = scale_matrix_2d(&origin, sx, sy)?;
             result = result * scale_matrix;
         }
@@ -144,14 +144,14 @@ pub mod analysis_transform {
     /// 複合変換行列の構築（均等スケール版）
     pub fn composite_point_transform_uniform_2d<T: Scalar>(
         translation: Option<&Vector2D<T>>,
-        rotation: Option<(&Point2D<T>, Angle<T>)>,
+        rotation: Option<(&Vector2<T>, Angle<T>)>,
         scale: Option<T>,
     ) -> Result<Matrix3x3<T>, TransformError> {
         let mut result = Matrix3x3::identity();
 
         // 均等スケール適用
         if let Some(scale_factor) = scale {
-            let origin = Point2D::origin();
+            let origin = Vector2::new(T::ZERO, T::ZERO);
             let scale_matrix = uniform_scale_matrix_2d(&origin, scale_factor)?;
             result = result * scale_matrix;
         }
@@ -189,14 +189,18 @@ impl<T: Scalar> AnalysisTransform2D<T> for Point2D<T> {
         Ok(self.transform_point_matrix_2d(&matrix))
     }
 
-    fn rotate_analysis_2d(&self, center: &Self, angle: Angle<T>) -> Result<Self, TransformError> {
+    fn rotate_analysis_2d(
+        &self,
+        center: &Vector2<T>,
+        angle: Angle<T>,
+    ) -> Result<Self, TransformError> {
         let matrix = analysis_transform::rotation_matrix_2d(center, angle);
         Ok(self.transform_point_matrix_2d(&matrix))
     }
 
     fn scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_x: T,
         scale_y: T,
     ) -> Result<Self, TransformError> {
@@ -206,7 +210,7 @@ impl<T: Scalar> AnalysisTransform2D<T> for Point2D<T> {
 
     fn uniform_scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_factor: T,
     ) -> Result<Self, TransformError> {
         let matrix = analysis_transform::uniform_scale_matrix_2d(center, scale_factor)?;
@@ -231,7 +235,7 @@ mod tests {
     #[test]
     fn test_analysis_rotation_2d() {
         let point = Point2D::new(1.0, 0.0);
-        let center = Point2D::origin();
+        let center = Vector2::new(0.0, 0.0);
         let angle = Angle::from_radians(std::f64::consts::PI / 2.0); // 90度
 
         let result = point.rotate_analysis_2d(&center, angle).unwrap();
@@ -244,7 +248,7 @@ mod tests {
     #[test]
     fn test_analysis_scale_2d() {
         let point = Point2D::new(2.0, 3.0);
-        let center = Point2D::origin();
+        let center = Vector2::new(0.0, 0.0);
 
         // 個別スケール
         let result = point.scale_analysis_2d(&center, 2.0, 3.0).unwrap();
@@ -259,7 +263,7 @@ mod tests {
     fn test_composite_transform_2d() {
         let point = Point2D::new(1.0, 0.0);
         let translation_vector2d = Vector2D::new(1.0, 1.0);
-        let center = Point2D::origin();
+        let center = Vector2::new(0.0, 0.0);
         let angle = Angle::from_radians(std::f64::consts::PI / 2.0);
         let scale = (2.0, 2.0);
 
@@ -301,7 +305,7 @@ mod tests {
     #[test]
     fn test_error_handling_2d() {
         let point = Point2D::new(1.0, 2.0);
-        let center = Point2D::origin();
+        let center = Vector2::new(0.0, 0.0);
 
         // ゼロスケール（個別）
         assert!(point.scale_analysis_2d(&center, 0.0, 1.0).is_err());

--- a/model/geo_core/src/point_3d_transform.rs
+++ b/model/geo_core/src/point_3d_transform.rs
@@ -87,7 +87,7 @@ pub mod analysis_transform {
 
     /// スケール行列の生成（中心点・個別軸指定版）
     pub fn scale_matrix_3d<T: Scalar>(
-        center: &Point3D<T>,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
@@ -109,7 +109,7 @@ pub mod analysis_transform {
 
     /// 均等スケール行列の生成（中心点指定版）
     pub fn uniform_scale_matrix_3d<T: Scalar>(
-        center: &Point3D<T>,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Matrix4x4<T>, TransformError> {
         if scale_factor.is_zero() {
@@ -136,7 +136,7 @@ pub mod analysis_transform {
 
         // スケール適用
         if let Some((sx, sy, sz)) = scale {
-            let origin = Point3D::origin();
+            let origin = Vector3::new(T::ZERO, T::ZERO, T::ZERO);
             let scale_matrix = scale_matrix_3d(&origin, sx, sy, sz)?;
             result = result * scale_matrix;
         }
@@ -166,7 +166,7 @@ pub mod analysis_transform {
 
         // 均等スケール適用
         if let Some(scale_factor) = scale {
-            let origin = Point3D::origin();
+            let origin = Vector3::new(T::ZERO, T::ZERO, T::ZERO);
             let scale_matrix = uniform_scale_matrix_3d(&origin, scale_factor)?;
             result = result * scale_matrix;
         }
@@ -205,7 +205,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Point3D<T> {
 
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Angle<T>,
     ) -> Result<Self, TransformError> {
@@ -230,7 +230,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Point3D<T> {
 
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
@@ -241,7 +241,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Point3D<T> {
 
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self, TransformError> {
         let matrix = analysis_transform::uniform_scale_matrix_3d(center, scale_factor)?;
@@ -251,7 +251,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Point3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Angle<T>)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Angle<T>)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self, TransformError> {
         let mut matrix = Matrix4x4::identity();
@@ -285,7 +285,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Point3D<T> {
 
         // スケールを最後に適用（逆順なので最初に適用される）
         if let Some((sx, sy, sz)) = scale {
-            let center = Point3D::origin();
+            let center = Vector3::new(T::ZERO, T::ZERO, T::ZERO);
             let scale_matrix = analysis_transform::scale_matrix_3d(&center, sx, sy, sz)?;
             matrix = scale_matrix * matrix;
         }
@@ -296,7 +296,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Point3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Angle<T>)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Angle<T>)>,
         scale: Option<T>,
     ) -> Result<Self, TransformError> {
         let mut matrix = Matrix4x4::identity();
@@ -330,7 +330,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Point3D<T> {
 
         // 均等スケールを最後に適用（逆順なので最初に適用される）
         if let Some(scale_factor) = scale {
-            let center = Point3D::origin();
+            let center = Vector3::new(T::ZERO, T::ZERO, T::ZERO);
             let scale_matrix = analysis_transform::uniform_scale_matrix_3d(&center, scale_factor)?;
             matrix = scale_matrix * matrix;
         }
@@ -358,7 +358,7 @@ mod tests {
     #[test]
     fn test_analysis_rotation_axis_3d() {
         let point = Point3D::new(1.0, 0.0, 0.0);
-        let center = Point3D::origin();
+        let center = Vector3::new(0.0, 0.0, 0.0);
         let axis = Vector3::new(0.0, 0.0, 1.0); // Z軸
         let angle = Angle::from_radians(PI / 2.0); // 90度
 
@@ -373,7 +373,7 @@ mod tests {
     #[test]
     fn test_analysis_scale_3d() {
         let point = Point3D::new(2.0, 3.0, 4.0);
-        let center = Point3D::origin();
+        let center = Vector3::new(0.0, 0.0, 0.0);
 
         // 個別スケール
         let result = point.scale_analysis(&center, 2.0, 3.0, 4.0).unwrap();
@@ -388,7 +388,7 @@ mod tests {
     fn test_composite_transform_3d() {
         let point = Point3D::new(1.0, 0.0, 0.0);
         let translation = Vector3::new(1.0, 1.0, 1.0);
-        let center = Point3D::origin();
+        let center = Vector3::new(0.0, 0.0, 0.0);
         let axis = Vector3::new(0.0, 0.0, 1.0); // Z軸
         let angle = Angle::from_radians(PI / 2.0);
         let scale = (2.0, 2.0, 2.0);
@@ -441,7 +441,7 @@ mod tests {
     #[test]
     fn test_error_handling_3d() {
         let point = Point3D::new(1.0, 2.0, 3.0);
-        let center = Point3D::origin();
+        let center = Vector3::new(0.0, 0.0, 0.0);
         let zero_axis = Vector3::new(0.0, 0.0, 0.0);
         let angle = Angle::from_radians(PI / 4.0);
 

--- a/model/geo_core/src/transform_traits.rs
+++ b/model/geo_core/src/transform_traits.rs
@@ -18,7 +18,7 @@ pub trait AnalysisTransform3D<T: Scalar> {
 
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError>
@@ -27,7 +27,7 @@ pub trait AnalysisTransform3D<T: Scalar> {
 
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
@@ -37,7 +37,7 @@ pub trait AnalysisTransform3D<T: Scalar> {
 
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError>
     where
@@ -46,7 +46,7 @@ pub trait AnalysisTransform3D<T: Scalar> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError>
     where
@@ -55,7 +55,7 @@ pub trait AnalysisTransform3D<T: Scalar> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError>
     where
@@ -79,7 +79,7 @@ pub trait AnalysisTransform2D<T: Scalar> {
 
     fn rotate_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError>
     where
@@ -87,7 +87,7 @@ pub trait AnalysisTransform2D<T: Scalar> {
 
     fn scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_x: T,
         scale_y: T,
     ) -> Result<Self::Output, TransformError>
@@ -96,7 +96,7 @@ pub trait AnalysisTransform2D<T: Scalar> {
 
     fn uniform_scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError>
     where

--- a/model/geo_io/src/svg.rs
+++ b/model/geo_io/src/svg.rs
@@ -471,7 +471,7 @@ mod tests {
     #[test]
     fn test_parse_nurbs_curve() {
         let svg = r#"<svg xmlns="http://www.w3.org/2000/svg">
-                <path 
+                <path
                     data-nurbs="true"
                     data-degree="3"
                     data-control-points="0,0,0; 1,0,0; 1,1,0; 0,1,0"
@@ -493,7 +493,7 @@ mod tests {
     #[test]
     fn test_parse_nurbs_without_weights() {
         let svg = r#"<svg xmlns="http://www.w3.org/2000/svg">
-                <path 
+                <path
                     data-nurbs="true"
                     data-degree="2"
                     data-control-points="0,0,0; 1,0,0; 1,1,0"

--- a/model/geo_nurbs/src/curve_2d.rs
+++ b/model/geo_nurbs/src/curve_2d.rs
@@ -228,9 +228,7 @@ impl<T: Scalar> NurbsCurve2D<T> {
             let t = t_min + dt * T::from_usize(i);
             let current_point = self.evaluate_at(t);
 
-            let dx = current_point.x() - prev_point.x();
-            let dy = current_point.y() - prev_point.y();
-            let segment_length = (dx * dx + dy * dy).sqrt();
+            let segment_length = (current_point - prev_point).norm();
 
             total_length += segment_length;
             prev_point = current_point;

--- a/model/geo_nurbs/src/curve_2d_transform.rs
+++ b/model/geo_nurbs/src/curve_2d_transform.rs
@@ -115,18 +115,13 @@ impl<T: Scalar> AnalysisTransform2D<T> for NurbsCurve2D<T> {
     /// 回転変換（Analysis Matrix3x3使用）
     fn rotate_analysis_2d(
         &self,
-        _center: &Self,
+        center: &Vector2<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        // centerからNurbsCurve2Dの重心を計算
-        let centroid = self.compute_centroid();
-
-        // 回転行列を生成
         let rotation = rotation_matrix_2d(angle);
 
-        // 複合変換: center → 原点 → 回転 → 元の位置
-        let to_origin = translation_matrix_2d(-centroid.x(), -centroid.y());
-        let from_origin = translation_matrix_2d(centroid.x(), centroid.y());
+        let to_origin = translation_matrix_2d(-center.x(), -center.y());
+        let from_origin = translation_matrix_2d(center.x(), center.y());
 
         let combined = from_origin * rotation * to_origin;
         transform_control_points(self, &combined)
@@ -135,19 +130,14 @@ impl<T: Scalar> AnalysisTransform2D<T> for NurbsCurve2D<T> {
     /// スケール変換（Analysis Matrix3x3使用）
     fn scale_analysis_2d(
         &self,
-        _center: &Self,
+        center: &Vector2<T>,
         scale_x: T,
         scale_y: T,
     ) -> Result<Self::Output, TransformError> {
-        // centerからNurbsCurve2Dの重心を計算
-        let centroid = self.compute_centroid();
-
-        // スケール行列を生成
         let scale = scale_matrix_2d(scale_x, scale_y)?;
 
-        // 複合変換: center → 原点 → スケール → 元の位置
-        let to_origin = translation_matrix_2d(-centroid.x(), -centroid.y());
-        let from_origin = translation_matrix_2d(centroid.x(), centroid.y());
+        let to_origin = translation_matrix_2d(-center.x(), -center.y());
+        let from_origin = translation_matrix_2d(center.x(), center.y());
 
         let combined = from_origin * scale * to_origin;
         transform_control_points(self, &combined)
@@ -156,32 +146,10 @@ impl<T: Scalar> AnalysisTransform2D<T> for NurbsCurve2D<T> {
     /// 均等スケール変換（Analysis Matrix3x3使用）
     fn uniform_scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis_2d(center, scale_factor, scale_factor)
-    }
-}
-
-// ============================================================================
-// Helper Methods
-// ============================================================================
-
-impl<T: Scalar> NurbsCurve2D<T> {
-    /// 制御点の重心を計算
-    fn compute_centroid(&self) -> Vector2<T> {
-        let num_points = self.num_points();
-        let mut sum_x = T::ZERO;
-        let mut sum_y = T::ZERO;
-
-        for i in 0..num_points {
-            let point = self.control_point(i);
-            sum_x += point.x();
-            sum_y += point.y();
-        }
-
-        let n = T::from_usize(num_points);
-        Vector2::new(sum_x / n, sum_y / n)
     }
 }
 
@@ -212,47 +180,46 @@ mod tests {
     #[test]
     fn test_rotate_analysis_2d() {
         let curve = <NurbsCurve2D<f64> as NurbsCurve2DConstructor<f64>>::unit_line();
+        let center = Vector2::new(10.0, 0.0);
 
         let angle = Angle::from_degrees(90.0);
         let result = <NurbsCurve2D<f64> as AnalysisTransform2D<f64>>::rotate_analysis_2d(
-            &curve, &curve, angle,
+            &curve, &center, angle,
         );
 
         assert!(result.is_ok());
         let rotated = result.unwrap();
 
-        // 90度回転後、制御点が変化していることを確認
-        let original_p1 = curve.control_point(1);
-        let rotated_p1 = rotated.control_point(1);
-
-        let changed = (original_p1.x() - rotated_p1.x()).abs() > 1e-10
-            || (original_p1.y() - rotated_p1.y()).abs() > 1e-10;
-        assert!(changed, "Control point should change after rotation");
+        let p0 = rotated.control_point(0);
+        let p1 = rotated.control_point(1);
+        assert!((p0.x() - 10.0).abs() < 1e-10);
+        assert!((p0.y() + 10.0).abs() < 1e-10);
+        assert!((p1.x() - 10.0).abs() < 1e-10);
+        assert!((p1.y() + 9.0).abs() < 1e-10);
     }
 
     #[test]
     fn test_uniform_scale_analysis_2d() {
         let curve = <NurbsCurve2D<f64> as NurbsCurve2DConstructor<f64>>::unit_line();
+        let center = Vector2::new(10.0, 0.0);
 
         let scale_factor = 2.0;
         let result = <NurbsCurve2D<f64> as AnalysisTransform2D<f64>>::uniform_scale_analysis_2d(
             &curve,
-            &curve,
+            &center,
             scale_factor,
         );
 
         assert!(result.is_ok());
         let scaled = result.unwrap();
 
-        // 重心からの距離が2倍になっているか確認
-        let centroid = curve.compute_centroid();
-        let original_p1 = curve.control_point(1);
+        let scaled_p0 = scaled.control_point(0);
         let scaled_p1 = scaled.control_point(1);
 
-        let original_dist = (original_p1.x() - centroid.x()).abs();
-        let scaled_dist = (scaled_p1.x() - centroid.x()).abs();
-
-        assert!((scaled_dist - original_dist * 2.0).abs() < 1e-10);
+        assert!((scaled_p0.x() + 10.0).abs() < 1e-10);
+        assert!((scaled_p0.y() - 0.0).abs() < 1e-10);
+        assert!((scaled_p1.x() + 8.0).abs() < 1e-10);
+        assert!((scaled_p1.y() - 0.0).abs() < 1e-10);
     }
 
     #[test]
@@ -276,9 +243,10 @@ mod tests {
     #[test]
     fn test_scale_analysis_2d() {
         let curve = <NurbsCurve2D<f64> as NurbsCurve2DConstructor<f64>>::unit_line();
+        let center = Vector2::new(0.0, 0.0);
 
         let result = <NurbsCurve2D<f64> as AnalysisTransform2D<f64>>::scale_analysis_2d(
-            &curve, &curve, 2.0, 3.0,
+            &curve, &center, 2.0, 3.0,
         );
 
         assert!(result.is_ok());

--- a/model/geo_nurbs/src/curve_3d.rs
+++ b/model/geo_nurbs/src/curve_3d.rs
@@ -466,10 +466,8 @@ impl<T: Scalar> NurbsCurve3DConstructor<T> for NurbsCurve3D<T> {
 
     fn line_segment(start: (T, T, T), end: (T, T, T)) -> std::result::Result<Self, String> {
         // 始点と終点が一致するかチェック
-        let dx = end.0 - start.0;
-        let dy = end.1 - start.1;
-        let dz = end.2 - start.2;
-        let distance_sq = dx * dx + dy * dy + dz * dz;
+        let segment = Vector3::new(end.0 - start.0, end.1 - start.1, end.2 - start.2);
+        let distance_sq = segment.norm_squared();
 
         if distance_sq <= T::EPSILON * T::EPSILON {
             return Err("Start and end points must be different".to_string());
@@ -539,10 +537,7 @@ impl<T: Scalar> NurbsCurve3DMeasure<T> for NurbsCurve3D<T> {
             let u = u_start + step * T::from_f64(i as f64);
             let current_point = self.evaluate_at(u);
 
-            let dx = current_point.x() - prev_point.x();
-            let dy = current_point.y() - prev_point.y();
-            let dz = current_point.z() - prev_point.z();
-            let segment_length = (dx * dx + dy * dy + dz * dz).sqrt();
+            let segment_length = (current_point - prev_point).norm();
 
             total_length += segment_length;
             prev_point = current_point;

--- a/model/geo_nurbs/src/curve_3d_transform.rs
+++ b/model/geo_nurbs/src/curve_3d_transform.rs
@@ -9,6 +9,8 @@ use analysis::linalg::{
     vector::{Vector3, Vector4},
 };
 use geo_contracts::default_kernel_numerical_zero_tolerance;
+#[cfg(test)]
+use geo_contracts::Bounded;
 use geo_contracts::NurbsCurve3DProperties;
 use geo_contracts::{Angle, Scalar};
 use geo_core::{AnalysisTransform3D, TransformError};
@@ -108,6 +110,17 @@ fn scale_matrix_3d<T: Scalar>(sx: T, sy: T, sz: T) -> Result<Matrix4x4<T>, Trans
     Ok(Matrix4x4::scale_3d(&scale))
 }
 
+#[cfg(test)]
+fn pivot_from_curve_aabb<T: Scalar>(curve: &NurbsCurve3D<T>) -> Result<Vector3<T>, TransformError> {
+    let center = curve
+        .aabb()
+        .ok_or_else(|| {
+            TransformError::InvalidGeometry("Center curve has no bounding box".to_string())
+        })?
+        .center();
+    Ok(Vector3::new(center.x(), center.y(), center.z()))
+}
+
 // ============================================================================
 // AnalysisTransform3D Implementation
 // ============================================================================
@@ -131,19 +144,14 @@ impl<T: Scalar> AnalysisTransform3D<T> for NurbsCurve3D<T> {
     /// 軸回転変換（Analysis Matrix4x4使用）
     fn rotate_analysis(
         &self,
-        _center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        // centerからNurbsCurve3Dの重心を計算
-        let centroid = self.compute_centroid();
-
-        // 回転行列を生成
         let rotation = rotation_matrix_3d(axis, angle)?;
 
-        // 複合変換: center → 原点 → 回転 → 元の位置
-        let to_origin = translation_matrix_3d(-centroid.x(), -centroid.y(), -centroid.z());
-        let from_origin = translation_matrix_3d(centroid.x(), centroid.y(), centroid.z());
+        let to_origin = translation_matrix_3d(-center.x(), -center.y(), -center.z());
+        let from_origin = translation_matrix_3d(center.x(), center.y(), center.z());
 
         let combined = from_origin * rotation * to_origin;
         transform_control_points(self, &combined)
@@ -152,20 +160,15 @@ impl<T: Scalar> AnalysisTransform3D<T> for NurbsCurve3D<T> {
     /// スケール変換（Analysis Matrix4x4使用）
     fn scale_analysis(
         &self,
-        _center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self::Output, TransformError> {
-        // centerからNurbsCurve3Dの重心を計算
-        let centroid = self.compute_centroid();
-
-        // スケール行列を生成
         let scale = scale_matrix_3d(scale_x, scale_y, scale_z)?;
 
-        // 複合変換: center → 原点 → スケール → 元の位置
-        let to_origin = translation_matrix_3d(-centroid.x(), -centroid.y(), -centroid.z());
-        let from_origin = translation_matrix_3d(centroid.x(), centroid.y(), centroid.z());
+        let to_origin = translation_matrix_3d(-center.x(), -center.y(), -center.z());
+        let from_origin = translation_matrix_3d(center.x(), center.y(), center.z());
 
         let combined = from_origin * scale * to_origin;
         transform_control_points(self, &combined)
@@ -174,7 +177,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for NurbsCurve3D<T> {
     /// 均等スケール変換（Analysis Matrix4x4使用）
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -184,7 +187,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for NurbsCurve3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut matrix = Matrix4x4::identity();
@@ -196,11 +199,10 @@ impl<T: Scalar> AnalysisTransform3D<T> for NurbsCurve3D<T> {
         }
 
         // 回転適用
-        if let Some((_center, axis, angle)) = rotation {
-            let centroid = self.compute_centroid();
+        if let Some((center, axis, angle)) = rotation {
             let rotation_mat = rotation_matrix_3d(axis, angle)?;
-            let to_origin = translation_matrix_3d(-centroid.x(), -centroid.y(), -centroid.z());
-            let from_origin = translation_matrix_3d(centroid.x(), centroid.y(), centroid.z());
+            let to_origin = translation_matrix_3d(-center.x(), -center.y(), -center.z());
+            let from_origin = translation_matrix_3d(center.x(), center.y(), center.z());
             matrix = matrix * from_origin * rotation_mat * to_origin;
         }
 
@@ -217,36 +219,11 @@ impl<T: Scalar> AnalysisTransform3D<T> for NurbsCurve3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));
         self.apply_composite_transform(translation, rotation, scale_tuple)
-    }
-}
-
-// ============================================================================
-// Helper Methods
-// ============================================================================
-
-impl<T: Scalar> NurbsCurve3D<T> {
-    /// 制御点の重心を計算
-    fn compute_centroid(&self) -> Vector3<T> {
-        let num_points = self.num_points();
-        let mut sum_x = T::ZERO;
-        let mut sum_y = T::ZERO;
-        let mut sum_z = T::ZERO;
-
-        for i in 0..num_points {
-            let point = self.control_point(i);
-            sum_x += point.x();
-            sum_y += point.y();
-            sum_z += point.z();
-        }
-
-        #[allow(clippy::cast_precision_loss)]
-        let n = T::from_f64(num_points as f64);
-        Vector3::new(sum_x / n, sum_y / n, sum_z / n)
     }
 }
 
@@ -291,13 +268,19 @@ mod tests {
         )
         .unwrap();
 
-        let center = curve.clone(); // 自身を中心として使用
+        let center_curve = curve
+            .translate_analysis(&Vector3::new(10.0, 0.0, 0.0))
+            .expect("center curve should translate");
+        let center = pivot_from_curve_aabb(&center_curve).expect("center curve should have pivot");
         let result = curve.uniform_scale_analysis(&center, 2.0);
         assert!(result.is_ok());
 
         let transformed = result.unwrap();
-        // スケール2倍後、元の長さの2倍になる
+        let p0 = transformed.control_point(0);
+        let p1 = transformed.control_point(1);
         assert_eq!(transformed.num_points(), 2);
+        assert!((p0.x() + 11.0).abs() < 1e-10);
+        assert!((p1.x() + 7.0).abs() < 1e-10);
     }
 
     #[test]
@@ -308,7 +291,10 @@ mod tests {
         )
         .unwrap();
 
-        let center = curve.clone();
+        let center_curve = curve
+            .translate_analysis(&Vector3::new(10.0, 0.0, 0.0))
+            .expect("center curve should translate");
+        let center = pivot_from_curve_aabb(&center_curve).expect("center curve should have pivot");
         let z_axis = Vector3::new(0.0, 0.0, 1.0);
         let angle = Angle::from_degrees(90.0);
 
@@ -316,10 +302,13 @@ mod tests {
         assert!(result.is_ok());
 
         let transformed = result.unwrap();
-        // Z軸周りに90度回転 → X方向がY方向へ
-        // (1,0,0) と (2,0,0) の平num_points
-        // 回転後は約 (0, 1.5, 0) 付近に分布
+        let p0 = transformed.control_point(0);
+        let p1 = transformed.control_point(1);
         assert_eq!(transformed.control_points_count(), 2);
+        assert!((p0.x() - 11.5).abs() < 1e-10);
+        assert!((p0.y() + 10.5).abs() < 1e-10);
+        assert!((p1.x() - 11.5).abs() < 1e-10);
+        assert!((p1.y() + 9.5).abs() < 1e-10);
     }
 
     #[test]
@@ -331,9 +320,12 @@ mod tests {
         .unwrap();
 
         let translation = Vector3::new(5.0, 0.0, 0.0);
-        let center = curve.clone();
+        let center_curve = curve
+            .translate_analysis(&Vector3::new(10.0, 0.0, 0.0))
+            .expect("center curve should translate");
+        let center = pivot_from_curve_aabb(&center_curve).expect("center curve should have pivot");
         let z_axis = Vector3::new(0.0, 0.0, 1.0);
-        let angle = Angle::from_degrees(0.0);
+        let angle = Angle::from_degrees(90.0);
 
         let result = curve.apply_composite_transform(
             Some(&translation),
@@ -344,6 +336,9 @@ mod tests {
 
         let transformed = result.unwrap();
         assert_eq!(transformed.num_points(), 2);
+        let p0 = transformed.control_point(0);
+        assert!((p0.x() - 21.0).abs() < 1e-10);
+        assert!((p0.y() + 11.0).abs() < 1e-10);
     }
 
     #[test]

--- a/model/geo_nurbs/src/surface_3d_transform.rs
+++ b/model/geo_nurbs/src/surface_3d_transform.rs
@@ -358,8 +358,8 @@ mod tests {
         assert!(result.is_ok());
         let transformed = result.unwrap();
         let p00 = transformed.control_point(0, 0);
-        assert!((p00.x() - 12.0).abs() < 1e-10);
-        assert!((p00.y() + 10.0).abs() < 1e-10);
+        assert!((p00.x() - 22.0).abs() < 1e-10);
+        assert!((p00.y() + 18.0).abs() < 1e-10);
     }
 
     #[test]

--- a/model/geo_nurbs/src/surface_3d_transform.rs
+++ b/model/geo_nurbs/src/surface_3d_transform.rs
@@ -9,6 +9,8 @@ use analysis::linalg::{
     vector::{Vector3, Vector4},
 };
 use geo_contracts::default_kernel_numerical_zero_tolerance;
+#[cfg(test)]
+use geo_contracts::Bounded;
 use geo_contracts::NurbsSurface3DProperties;
 use geo_contracts::{Angle, Scalar};
 use geo_core::{AnalysisTransform3D, TransformError};
@@ -119,6 +121,19 @@ fn scale_matrix_3d<T: Scalar>(sx: T, sy: T, sz: T) -> Result<Matrix4x4<T>, Trans
     Ok(Matrix4x4::scale_3d(&scale))
 }
 
+#[cfg(test)]
+fn pivot_from_surface_aabb<T: Scalar>(
+    surface: &NurbsSurface3D<T>,
+) -> Result<Vector3<T>, TransformError> {
+    let center = surface
+        .aabb()
+        .ok_or_else(|| {
+            TransformError::InvalidGeometry("Center surface has no bounding box".to_string())
+        })?
+        .center();
+    Ok(Vector3::new(center.x(), center.y(), center.z()))
+}
+
 // ============================================================================
 // AnalysisTransform3D Implementation
 // ============================================================================
@@ -142,19 +157,14 @@ impl<T: Scalar> AnalysisTransform3D<T> for NurbsSurface3D<T> {
     /// 軸回転変換（Analysis Matrix4x4使用）
     fn rotate_analysis(
         &self,
-        _center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        // centerからNurbsSurface3Dの重心を計算
-        let centroid = self.compute_centroid();
-
-        // 回転行列を生成
         let rotation = rotation_matrix_3d(axis, angle)?;
 
-        // 複合変換: center → 原点 → 回転 → 元の位置
-        let to_origin = translation_matrix_3d(-centroid.x(), -centroid.y(), -centroid.z());
-        let from_origin = translation_matrix_3d(centroid.x(), centroid.y(), centroid.z());
+        let to_origin = translation_matrix_3d(-center.x(), -center.y(), -center.z());
+        let from_origin = translation_matrix_3d(center.x(), center.y(), center.z());
 
         let combined = from_origin * rotation * to_origin;
         transform_control_points(self, &combined)
@@ -163,20 +173,15 @@ impl<T: Scalar> AnalysisTransform3D<T> for NurbsSurface3D<T> {
     /// スケール変換（Analysis Matrix4x4使用）
     fn scale_analysis(
         &self,
-        _center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self::Output, TransformError> {
-        // centerからNurbsSurface3Dの重心を計算
-        let centroid = self.compute_centroid();
-
-        // スケール行列を生成
         let scale = scale_matrix_3d(scale_x, scale_y, scale_z)?;
 
-        // 複合変換: center → 原点 → スケール → 元の位置
-        let to_origin = translation_matrix_3d(-centroid.x(), -centroid.y(), -centroid.z());
-        let from_origin = translation_matrix_3d(centroid.x(), centroid.y(), centroid.z());
+        let to_origin = translation_matrix_3d(-center.x(), -center.y(), -center.z());
+        let from_origin = translation_matrix_3d(center.x(), center.y(), center.z());
 
         let combined = from_origin * scale * to_origin;
         transform_control_points(self, &combined)
@@ -185,7 +190,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for NurbsSurface3D<T> {
     /// 均等スケール変換（Analysis Matrix4x4使用）
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -195,7 +200,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for NurbsSurface3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut matrix = Matrix4x4::identity();
@@ -207,18 +212,17 @@ impl<T: Scalar> AnalysisTransform3D<T> for NurbsSurface3D<T> {
         }
 
         // 回転適用
-        if let Some((_center, axis, angle)) = rotation {
-            let centroid = self.compute_centroid();
+        if let Some((center, axis, angle)) = rotation {
             let rotation_mat = rotation_matrix_3d(axis, angle)?;
-            let to_origin = translation_matrix_3d(-centroid.x(), -centroid.y(), -centroid.z());
-            let from_origin = translation_matrix_3d(centroid.x(), centroid.y(), centroid.z());
+            let to_origin = translation_matrix_3d(-center.x(), -center.y(), -center.z());
+            let from_origin = translation_matrix_3d(center.x(), center.y(), center.z());
             matrix = matrix * from_origin * rotation_mat * to_origin;
         }
 
         // 平行移動適用
         if let Some(trans) = translation {
             let trans_mat = translation_matrix_3d(trans.x(), trans.y(), trans.z());
-            matrix = trans_mat * matrix;
+            matrix = matrix * trans_mat;
         }
 
         transform_control_points(self, &matrix)
@@ -228,40 +232,11 @@ impl<T: Scalar> AnalysisTransform3D<T> for NurbsSurface3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));
         self.apply_composite_transform(translation, rotation, scale_tuple)
-    }
-}
-
-// ============================================================================
-// Helper Methods
-// ============================================================================
-
-impl<T: Scalar> NurbsSurface3D<T> {
-    /// 制御点の重心を計算
-    fn compute_centroid(&self) -> Vector3<T> {
-        let u_count = self.u_count();
-        let v_count = self.v_count();
-        let total_points = u_count * v_count;
-
-        let mut sum_x = T::ZERO;
-        let mut sum_y = T::ZERO;
-        let mut sum_z = T::ZERO;
-
-        for u in 0..u_count {
-            for v in 0..v_count {
-                let point = self.control_point(u, v);
-                sum_x += point.x();
-                sum_y += point.y();
-                sum_z += point.z();
-            }
-        }
-
-        let count = T::from_usize(total_points);
-        Vector3::new(sum_x / count, sum_y / count, sum_z / count)
     }
 }
 
@@ -294,51 +269,51 @@ mod tests {
     #[test]
     fn test_rotate_analysis_z_axis() {
         let surface = <NurbsSurface3D<f64> as NurbsSurface3DConstructor<f64>>::unit_plane();
+        let center_surface = surface
+            .translate_analysis(&Vector3::new(10.0, 0.0, 0.0))
+            .expect("center surface should translate");
+        let center =
+            pivot_from_surface_aabb(&center_surface).expect("center surface should have pivot");
 
         let axis = Vector3::new(0.0, 0.0, 1.0);
         let angle = Angle::from_degrees(90.0);
 
         let result = <NurbsSurface3D<f64> as AnalysisTransform3D<f64>>::rotate_analysis(
-            &surface, &surface, &axis, angle,
+            &surface, &center, &axis, angle,
         );
 
         assert!(result.is_ok());
         let rotated = result.unwrap();
 
-        // 回転が適用されたことを確認（具体的な座標は重心回転のため複雑）
-        // 少なくとも制御点が変化していることを確認
-        let original_p10 = surface.control_point(1, 0);
         let rotated_p10 = rotated.control_point(1, 0);
-
-        // 何らかの変化があることを確認
-        let changed = (original_p10.x() - rotated_p10.x()).abs() > 1e-10
-            || (original_p10.y() - rotated_p10.y()).abs() > 1e-10;
-        assert!(changed, "Control point should change after rotation");
+        assert!((rotated_p10.x() - 11.0).abs() < 1e-10);
+        assert!((rotated_p10.y() + 9.0).abs() < 1e-10);
     }
 
     #[test]
     fn test_uniform_scale_analysis() {
         let surface = <NurbsSurface3D<f64> as NurbsSurface3DConstructor<f64>>::unit_plane();
+        let center_surface = surface
+            .translate_analysis(&Vector3::new(10.0, 0.0, 0.0))
+            .expect("center surface should translate");
+        let center =
+            pivot_from_surface_aabb(&center_surface).expect("center surface should have pivot");
 
         let scale_factor = 2.0;
         let result = <NurbsSurface3D<f64> as AnalysisTransform3D<f64>>::uniform_scale_analysis(
             &surface,
-            &surface,
+            &center,
             scale_factor,
         );
 
         assert!(result.is_ok());
         let scaled = result.unwrap();
 
-        // 重心からの距離が2倍になっているか確認
-        let centroid = surface.compute_centroid();
-        let original_p10 = surface.control_point(1, 0);
+        let scaled_p00 = scaled.control_point(0, 0);
         let scaled_p10 = scaled.control_point(1, 0);
 
-        let original_dist_x = (original_p10.x() - centroid.x()).abs();
-        let scaled_dist_x = (scaled_p10.x() - centroid.x()).abs();
-
-        assert!((scaled_dist_x - original_dist_x * 2.0).abs() < 1e-10);
+        assert!((scaled_p00.x() + 10.5).abs() < 1e-10);
+        assert!((scaled_p10.x() + 8.5).abs() < 1e-10);
     }
 
     #[test]
@@ -365,17 +340,64 @@ mod tests {
 
         let translation = Vector3::new(1.0, 0.0, 0.0);
         let axis = Vector3::new(0.0, 0.0, 1.0);
-        let angle = Angle::from_degrees(45.0);
+        let angle = Angle::from_degrees(90.0);
         let scale = (2.0, 2.0, 2.0);
+        let center_surface = surface
+            .translate_analysis(&Vector3::new(10.0, 0.0, 0.0))
+            .expect("center surface should translate");
+        let center =
+            pivot_from_surface_aabb(&center_surface).expect("center surface should have pivot");
 
         let result = <NurbsSurface3D<f64> as AnalysisTransform3D<f64>>::apply_composite_transform(
             &surface,
             Some(&translation),
-            Some((&surface, &axis, angle)),
+            Some((&center, &axis, angle)),
             Some(scale),
         );
 
         assert!(result.is_ok());
-        // 複合変換が成功すればOK（詳細な検証は省略）
+        let transformed = result.unwrap();
+        let p00 = transformed.control_point(0, 0);
+        assert!((p00.x() - 12.0).abs() < 1e-10);
+        assert!((p00.y() + 10.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_apply_composite_transform_matches_sequential_operations() {
+        let surface = <NurbsSurface3D<f64> as NurbsSurface3DConstructor<f64>>::unit_plane();
+        let translation = Vector3::new(1.0, 0.0, 0.0);
+        let axis = Vector3::new(0.0, 0.0, 1.0);
+        let angle = Angle::from_degrees(90.0);
+        let scale = (2.0, 2.0, 2.0);
+        let center_surface = surface
+            .translate_analysis(&Vector3::new(10.0, 0.0, 0.0))
+            .expect("center surface should translate");
+        let center =
+            pivot_from_surface_aabb(&center_surface).expect("center surface should have pivot");
+
+        let composite =
+            <NurbsSurface3D<f64> as AnalysisTransform3D<f64>>::apply_composite_transform(
+                &surface,
+                Some(&translation),
+                Some((&center, &axis, angle)),
+                Some(scale),
+            )
+            .expect("composite transform should succeed");
+
+        let sequential = surface
+            .translate_analysis(&translation)
+            .and_then(|translated| translated.rotate_analysis(&center, &axis, angle))
+            .and_then(|rotated| {
+                rotated.scale_analysis(&Vector3::new(0.0, 0.0, 0.0), scale.0, scale.1, scale.2)
+            })
+            .expect("sequential transform should succeed");
+
+        for (u, v) in [(0, 0), (1, 0), (0, 1), (1, 1)] {
+            let composite_point = composite.control_point(u, v);
+            let sequential_point = sequential.control_point(u, v);
+            assert!((composite_point.x() - sequential_point.x()).abs() < 1e-10);
+            assert!((composite_point.y() - sequential_point.y()).abs() < 1e-10);
+            assert!((composite_point.z() - sequential_point.z()).abs() < 1e-10);
+        }
     }
 }

--- a/model/geo_primitives/src/arc_2d.rs
+++ b/model/geo_primitives/src/arc_2d.rs
@@ -373,9 +373,7 @@ impl<T: Scalar> Arc2DMeasure<T> for Arc2D<T> {
     fn distance_to_point(&self, point: (T, T)) -> T {
         // 簡易実装: 円弧の中心からの距離との差分
         let center = self.center_internal();
-        let dx = point.0 - center.x();
-        let dy = point.1 - center.y();
-        let distance_from_center = (dx * dx + dy * dy).sqrt();
+        let distance_from_center = center.distance_to(&Point2D::new(point.0, point.1));
         (distance_from_center - self.radius_internal()).abs()
     }
 

--- a/model/geo_primitives/src/arc_2d_transform.rs
+++ b/model/geo_primitives/src/arc_2d_transform.rs
@@ -115,11 +115,11 @@ impl<T: Scalar> AnalysisTransform2D<T> for Arc2D<T> {
     /// 回転変換（中心点指定）
     fn rotate_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
         // 中心点への移動 -> 回転 -> 元位置への移動の合成変換
-        let center_point = center.circle().center();
+        let center_point = Point2D::new(center.x(), center.y());
         let to_origin =
             analysis_transform::translation_matrix_2d(-center_point.x(), -center_point.y());
         let rotation = analysis_transform::rotation_matrix_2d(angle);
@@ -133,7 +133,7 @@ impl<T: Scalar> AnalysisTransform2D<T> for Arc2D<T> {
     /// スケール変換
     fn scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_x: T,
         scale_y: T,
     ) -> Result<Self::Output, TransformError> {
@@ -143,7 +143,7 @@ impl<T: Scalar> AnalysisTransform2D<T> for Arc2D<T> {
             ));
         }
 
-        let center_point = center.circle().center();
+        let center_point = Point2D::new(center.x(), center.y());
         let to_origin =
             analysis_transform::translation_matrix_2d(-center_point.x(), -center_point.y());
         let scale = analysis_transform::scale_matrix_2d(scale_x, scale_y);
@@ -157,7 +157,7 @@ impl<T: Scalar> AnalysisTransform2D<T> for Arc2D<T> {
     /// 均等スケール変換
     fn uniform_scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis_2d(center, scale_factor, scale_factor)
@@ -199,10 +199,10 @@ mod tests {
     #[test]
     fn test_rotation_analysis_transform() {
         let arc = create_test_arc();
-        let center_arc = create_test_arc();
+        let center = Vector2::new(0.0, 0.0);
         let rotation_angle = Angle::from_degrees(45.0);
 
-        let result = arc.rotate_analysis_2d(&center_arc, rotation_angle).unwrap();
+        let result = arc.rotate_analysis_2d(&center, rotation_angle).unwrap();
 
         // 回転後の角度チェック
         assert!((result.start_angle().to_degrees() - 45.0).abs() < 1e-10);
@@ -213,9 +213,9 @@ mod tests {
     #[test]
     fn test_scale_analysis_transform() {
         let arc = create_test_arc();
-        let center_arc = create_test_arc();
+        let center = Vector2::new(0.0, 0.0);
 
-        let result = arc.scale_analysis_2d(&center_arc, 2.0, 2.0).unwrap();
+        let result = arc.scale_analysis_2d(&center, 2.0, 2.0).unwrap();
 
         assert_eq!(result.circle().radius(), 2.0);
         assert_eq!(result.start_angle().to_degrees(), 0.0);
@@ -225,9 +225,9 @@ mod tests {
     #[test]
     fn test_uniform_scale_analysis_transform() {
         let arc = create_test_arc();
-        let center_arc = create_test_arc();
+        let center = Vector2::new(0.0, 0.0);
 
-        let result = arc.uniform_scale_analysis_2d(&center_arc, 3.0).unwrap();
+        let result = arc.uniform_scale_analysis_2d(&center, 3.0).unwrap();
 
         assert_eq!(result.circle().radius(), 3.0);
     }
@@ -246,9 +246,9 @@ mod tests {
     #[test]
     fn test_zero_scale_error() {
         let arc = create_test_arc();
-        let center_arc = create_test_arc();
+        let center = Vector2::new(0.0, 0.0);
 
-        let result = arc.scale_analysis_2d(&center_arc, 0.0, 1.0);
+        let result = arc.scale_analysis_2d(&center, 0.0, 1.0);
 
         assert!(result.is_err());
     }

--- a/model/geo_primitives/src/arc_3d.rs
+++ b/model/geo_primitives/src/arc_3d.rs
@@ -393,19 +393,14 @@ impl<T: Scalar> Arc3DMeasure<T> for Arc3D<T> {
     fn distance_to_point(&self, point: (T, T, T)) -> T {
         // 簡易実装: 円弧上の最近点までの距離
         let center_pt = self.center_internal();
-        let dx = point.0 - center_pt.x();
-        let dy = point.1 - center_pt.y();
-        let dz = point.2 - center_pt.z();
-        ((dx * dx + dy * dy + dz * dz).sqrt() - self.radius_internal()).abs()
+        (center_pt.distance_to(&Point3D::new(point.0, point.1, point.2)) - self.radius_internal())
+            .abs()
     }
 
     fn contains_point(&self, point: (T, T, T)) -> bool {
         // 簡易実装: 半径と角度範囲をチェック
         let center_pt = self.center_internal();
-        let dx = point.0 - center_pt.x();
-        let dy = point.1 - center_pt.y();
-        let dz = point.2 - center_pt.z();
-        let dist = (dx * dx + dy * dy + dz * dz).sqrt();
+        let dist = center_pt.distance_to(&Point3D::new(point.0, point.1, point.2));
         (dist - self.radius_internal()).abs() <= default_distance_tolerance::<T>()
     }
 }

--- a/model/geo_primitives/src/arc_3d_transform.rs
+++ b/model/geo_primitives/src/arc_3d_transform.rs
@@ -150,14 +150,13 @@ impl<T: Scalar> AnalysisTransform3D<T> for Arc3D<T> {
     /// 軸回転変換（Analysis Matrix4x4使用）
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let (cx, cy, cz) = Arc3DProperties::center(center);
-        let to_origin = analysis_transform::translation_matrix_3d(-cx, -cy, -cz);
+        let to_origin = analysis_transform::translation_matrix_3d(-center.x(), -center.y(), -center.z());
         let rotation = analysis_transform::axis_rotation_matrix_3d(axis, angle);
-        let from_origin = analysis_transform::translation_matrix_3d(cx, cy, cz);
+        let from_origin = analysis_transform::translation_matrix_3d(center.x(), center.y(), center.z());
 
         let combined_matrix = from_origin.mul_matrix(&rotation.mul_matrix(&to_origin));
         analysis_transform::transform_arc_3d(self, &combined_matrix)
@@ -166,7 +165,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Arc3D<T> {
     /// スケール変換
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
@@ -185,10 +184,9 @@ impl<T: Scalar> AnalysisTransform3D<T> for Arc3D<T> {
             ));
         }
 
-        let (cx, cy, cz) = Arc3DProperties::center(center);
-        let to_origin = analysis_transform::translation_matrix_3d(-cx, -cy, -cz);
+        let to_origin = analysis_transform::translation_matrix_3d(-center.x(), -center.y(), -center.z());
         let scale = analysis_transform::scale_matrix_3d(scale_x, scale_y, scale_z);
-        let from_origin = analysis_transform::translation_matrix_3d(cx, cy, cz);
+        let from_origin = analysis_transform::translation_matrix_3d(center.x(), center.y(), center.z());
 
         let combined_matrix = from_origin.mul_matrix(&scale.mul_matrix(&to_origin));
         analysis_transform::transform_arc_3d(self, &combined_matrix)
@@ -197,7 +195,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Arc3D<T> {
     /// 均等スケール変換
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -207,10 +205,12 @@ impl<T: Scalar> AnalysisTransform3D<T> for Arc3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut result = self.clone();
+        let origin = Vector3::new(T::ZERO, T::ZERO, T::ZERO);
+        let scale_center = rotation.as_ref().map(|(center, _, _)| *center);
 
         // 平行移動
         if let Some(trans) = translation {
@@ -229,8 +229,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Arc3D<T> {
                     "Arc3D requires uniform scaling".to_string(),
                 ));
             }
-            let center = result.clone(); // 現在の円弧を中心として使用
-            result = result.uniform_scale_analysis(&center, sx)?;
+            result = result.uniform_scale_analysis(scale_center.unwrap_or(&origin), sx)?;
         }
 
         Ok(result)
@@ -240,7 +239,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Arc3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));
@@ -303,12 +302,12 @@ mod tests {
     #[test]
     fn test_rotation_analysis_transform() {
         let arc = create_test_arc();
-        let center_arc = create_test_arc();
+        let center = Vector3::new(0.0, 0.0, 0.0);
         let z_axis = Vector3::new(0.0, 0.0, 1.0);
         let rotation_angle = Angle::from_degrees(45.0);
 
         let result = arc
-            .rotate_analysis(&center_arc, &z_axis, rotation_angle)
+            .rotate_analysis(&center, &z_axis, rotation_angle)
             .unwrap();
 
         // Z軸回転後も半径と角度範囲は保持
@@ -325,12 +324,12 @@ mod tests {
     #[test]
     fn test_arbitrary_axis_rotation() {
         let arc = create_xz_arc();
-        let center_arc = create_xz_arc();
+        let center = Vector3::new(1.0, 2.0, 3.0);
         let axis = Vector3::new(1.0, 0.0, 0.0); // X軸回転
         let rotation_angle = Angle::from_degrees(90.0);
 
         let result = arc
-            .rotate_analysis(&center_arc, &axis, rotation_angle)
+            .rotate_analysis(&center, &axis, rotation_angle)
             .unwrap();
 
         // 半径と角度は保持
@@ -342,9 +341,9 @@ mod tests {
     #[test]
     fn test_uniform_scale_analysis_transform() {
         let arc = create_test_arc();
-        let center_arc = create_test_arc();
+        let center = Vector3::new(0.0, 0.0, 0.0);
 
-        let result = arc.uniform_scale_analysis(&center_arc, 2.5).unwrap();
+        let result = arc.uniform_scale_analysis(&center, 2.5).unwrap();
 
         assert_eq!(result.radius(), 5.0); // 2.0 * 2.5
         assert_eq!(result.start_angle().to_degrees(), 0.0);
@@ -359,9 +358,9 @@ mod tests {
     #[test]
     fn test_non_uniform_scale_error() {
         let arc = create_test_arc();
-        let center_arc = create_test_arc();
+        let center = Vector3::new(0.0, 0.0, 0.0);
 
-        let result = arc.scale_analysis(&center_arc, 2.0, 1.5, 2.0);
+        let result = arc.scale_analysis(&center, 2.0, 1.5, 2.0);
 
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -373,9 +372,9 @@ mod tests {
     #[test]
     fn test_zero_scale_error() {
         let arc = create_test_arc();
-        let center_arc = create_test_arc();
+        let center = Vector3::new(0.0, 0.0, 0.0);
 
-        let result = arc.scale_analysis(&center_arc, 0.0, 1.0, 1.0);
+        let result = arc.scale_analysis(&center, 0.0, 1.0, 1.0);
 
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -414,7 +413,7 @@ mod tests {
     fn test_composite_transform() {
         let arc = create_test_arc();
         let translation = Vector3::new(2.0, 1.0, -1.0);
-        let center_arc = create_test_arc();
+        let center = Vector3::new(0.0, 0.0, 0.0);
         let axis = Vector3::new(0.0, 1.0, 0.0); // Y軸回転
         let rotation_angle = Angle::from_degrees(45.0);
         let scale = 1.5;
@@ -422,7 +421,7 @@ mod tests {
         let result = arc
             .apply_composite_transform_uniform(
                 Some(&translation),
-                Some((&center_arc, &axis, rotation_angle)),
+                Some((&center, &axis, rotation_angle)),
                 Some(scale),
             )
             .unwrap();
@@ -436,9 +435,9 @@ mod tests {
     #[test]
     fn test_negative_scale_transform() {
         let arc = create_test_arc();
-        let center_arc = create_test_arc();
+        let center = Vector3::new(0.0, 0.0, 0.0);
 
-        let result = arc.uniform_scale_analysis(&center_arc, -2.0).unwrap();
+        let result = arc.uniform_scale_analysis(&center, -2.0).unwrap();
 
         // 負のスケールでも半径は正
         assert_eq!(result.radius(), 4.0); // abs(-2.0) * 2.0

--- a/model/geo_primitives/src/circle_2d.rs
+++ b/model/geo_primitives/src/circle_2d.rs
@@ -83,9 +83,7 @@ impl<T: Scalar> Circle2D<T> {
 
     /// 点が円内部にあるか判定
     pub fn contains_point(&self, point: Point2D<T>) -> bool {
-        let dx = point.x() - self.center.x();
-        let dy = point.y() - self.center.y();
-        let distance_squared = dx * dx + dy * dy;
+        let distance_squared = point.distance_squared_to(&self.center);
         distance_squared < self.radius * self.radius
     }
 
@@ -100,9 +98,7 @@ impl<T: Scalar> Circle2D<T> {
 
     /// 点から円周への距離
     pub fn distance_to_point(&self, point: Point2D<T>) -> T {
-        let dx = point.x() - self.center.x();
-        let dy = point.y() - self.center.y();
-        let center_distance = (dx * dx + dy * dy).sqrt();
+        let center_distance = point.distance_to(&self.center);
         (center_distance - self.radius).abs()
     }
 
@@ -113,9 +109,7 @@ impl<T: Scalar> Circle2D<T> {
 
     /// 点が円周上にあるか判定
     pub fn point_on_circumference(&self, point: Point2D<T>) -> bool {
-        let dx = point.x() - self.center.x();
-        let dy = point.y() - self.center.y();
-        let distance = (dx * dx + dy * dy).sqrt();
+        let distance = point.distance_to(&self.center);
         (distance - self.radius).abs() <= default_distance_tolerance::<T>()
     }
 
@@ -123,7 +117,7 @@ impl<T: Scalar> Circle2D<T> {
     pub fn closest_point_to(&self, point: Point2D<T>) -> Point2D<T> {
         let dx = point.x() - self.center.x();
         let dy = point.y() - self.center.y();
-        let distance = (dx * dx + dy * dy).sqrt();
+        let distance = point.distance_to(&self.center);
 
         if distance <= default_kernel_numerical_zero_tolerance::<T>() {
             // 点が中心にある場合、任意の円周上の点を返す
@@ -156,11 +150,7 @@ impl<T: Scalar> Circle2D<T> {
 
     /// 2つの円の距離
     pub fn distance_to_circle(&self, other: &Self) -> T {
-        let center_distance = {
-            let dx = other.center.x() - self.center.x();
-            let dy = other.center.y() - self.center.y();
-            (dx * dx + dy * dy).sqrt()
-        };
+        let center_distance = self.center.distance_to(&other.center);
 
         let radii_sum = self.radius + other.radius;
 
@@ -219,9 +209,7 @@ impl<T: Scalar> Circle2D<T> {
         let center = Point2D::new(cx, cy);
 
         // 半径を計算
-        let dx = point1.x() - cx;
-        let dy = point1.y() - cy;
-        let radius = (dx * dx + dy * dy).sqrt();
+        let radius = center.distance_to(&point1);
 
         Self::new(center, radius)
     }
@@ -252,9 +240,7 @@ impl<T: Scalar> Circle2DConstructor<T> for Circle2D<T> {
         let center_point = Point2D::new(center.0, center.1);
         let point = Point2D::new(point_on_circle.0, point_on_circle.1);
 
-        let dx = point.x() - center_point.x();
-        let dy = point.y() - center_point.y();
-        let radius = (dx * dx + dy * dy).sqrt();
+        let radius = point.distance_to(&center_point);
 
         if radius <= T::ZERO {
             None

--- a/model/geo_primitives/src/circle_2d_metrics.rs
+++ b/model/geo_primitives/src/circle_2d_metrics.rs
@@ -11,9 +11,7 @@ impl<T: Scalar> Circle2D<T> {
 
     /// 点から円の中心までの距離
     pub fn distance_to_center(&self, point: Point2D<T>) -> T {
-        let dx = point.x() - self.center_internal().x();
-        let dy = point.y() - self.center_internal().y();
-        (dx * dx + dy * dy).sqrt()
+        point.distance_to(&self.center_internal())
     }
 
     /// 点から円周までの符号付き距離

--- a/model/geo_primitives/src/circle_2d_transform.rs
+++ b/model/geo_primitives/src/circle_2d_transform.rs
@@ -161,10 +161,10 @@ impl<T: Scalar> AnalysisTransform2D<T> for Circle2D<T> {
     /// Analysis統合回転（中心点指定）
     fn rotate_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, crate::TransformError> {
-        let center_point = Point2D::new(center.center_internal().x(), center.center_internal().y());
+        let center_point = Point2D::new(center.x(), center.y());
         let matrix = analysis_transform::rotation_matrix_2d(&center_point, angle);
         analysis_transform::transform_circle_2d(self, &matrix)
     }
@@ -172,7 +172,7 @@ impl<T: Scalar> AnalysisTransform2D<T> for Circle2D<T> {
     /// Analysis統合スケール（中心点指定）
     fn scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_x: T,
         scale_y: T,
     ) -> Result<Self::Output, crate::TransformError> {
@@ -188,10 +188,10 @@ impl<T: Scalar> AnalysisTransform2D<T> for Circle2D<T> {
     /// Analysis統合均等スケール（中心点指定）
     fn uniform_scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_factor: T,
     ) -> Result<Self::Output, crate::TransformError> {
-        let center_point = Point2D::new(center.center_internal().x(), center.center_internal().y());
+        let center_point = Point2D::new(center.x(), center.y());
         let matrix = analysis_transform::uniform_scale_matrix_2d(&center_point, scale_factor)?;
         analysis_transform::transform_circle_2d(self, &matrix)
     }
@@ -261,10 +261,10 @@ mod tests {
     #[test]
     fn test_analysis_rotation() {
         let circle = Circle2D::new(Point2D::new(1.0, 0.0), 2.0).unwrap();
-        let center_circle = Circle2D::new(Point2D::origin(), 1.0).unwrap(); // 中心として使用する円
+        let center = Vector2::new(0.0, 0.0);
         let angle = Angle::from_degrees(90.0);
 
-        let transformed = circle.rotate_analysis_2d(&center_circle, angle).unwrap();
+        let transformed = circle.rotate_analysis_2d(&center, angle).unwrap();
 
         // 90度回転で (1,0) -> (0,1)
         assert!((transformed.center_internal().x() - 0.0).abs() < 1e-10);
@@ -275,11 +275,11 @@ mod tests {
     #[test]
     fn test_analysis_scale() {
         let circle = Circle2D::new(Point2D::new(2.0, 4.0), 3.0).unwrap();
-        let center_circle = Circle2D::new(Point2D::origin(), 1.0).unwrap(); // 中心として使用する円
+        let center = Vector2::new(0.0, 0.0);
         let scale_factor = 2.0;
 
         let transformed = circle
-            .uniform_scale_analysis_2d(&center_circle, scale_factor)
+            .uniform_scale_analysis_2d(&center, scale_factor)
             .unwrap();
 
         assert!((transformed.center_internal().x() - 4.0).abs() < 1e-10);
@@ -355,10 +355,8 @@ mod tests {
     #[test]
     fn test_error_handling_zero_scale() {
         let circle = Circle2D::new(Point2D::new(1.0, 1.0), 2.0).unwrap();
-        let center = Point2D::origin();
-
-        let center_circle = Circle2D::new(center, 1.0).unwrap();
-        let result = circle.uniform_scale_analysis_2d(&center_circle, 0.0);
+        let center = Vector2::new(0.0, 0.0);
+        let result = circle.uniform_scale_analysis_2d(&center, 0.0);
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),

--- a/model/geo_primitives/src/circle_3d.rs
+++ b/model/geo_primitives/src/circle_3d.rs
@@ -274,12 +274,8 @@ impl<T: Scalar> Circle3D<T> {
         // パラメトリック方程式を解く
         // mid1 + t * perp1 = mid2 + s * perp2
         // 簡易実装：点1からの距離が等しい点を中心とする
-        let dx = point1.x() - mid1.x();
-        let dy = point1.y() - mid1.y();
-        let dz = point1.z() - mid1.z();
-
         let center = mid1; // 簡易的に中点を使用
-        let radius = (dx * dx + dy * dy + dz * dz).sqrt();
+        let radius = center.distance_to(&point1);
 
         Self::new(center, axis, radius)
     }
@@ -477,10 +473,7 @@ impl<T: Scalar> Circle3DMeasure<T> for Circle3D<T> {
 
     fn distance_to_circle(&self, other: &Self) -> T {
         // 簡易実装：中心間距離から半径を考慮
-        let dx = other.center.x() - self.center.x();
-        let dy = other.center.y() - self.center.y();
-        let dz = other.center.z() - self.center.z();
-        let center_distance = (dx * dx + dy * dy + dz * dz).sqrt();
+        let center_distance = self.center.distance_to(&other.center);
 
         let radii_sum = self.radius + other.radius;
 

--- a/model/geo_primitives/src/circle_3d_transform.rs
+++ b/model/geo_primitives/src/circle_3d_transform.rs
@@ -165,18 +165,22 @@ impl<T: Scalar> AnalysisTransform3D<T> for Circle3D<T> {
     /// 軸回転変換
     fn rotate_analysis(
         &self,
-        _center: &Self, // 現在の実装では原点中心回転のみサポート
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::rotation_matrix_3d(axis, angle)?;
+        let rotation = analysis_transform::rotation_matrix_3d(axis, angle)?;
+        let center_vec = Vector3::new(center.x(), center.y(), center.z());
+        let to_origin = Matrix4x4::translation_3d(&(-center_vec));
+        let back_to_center = Matrix4x4::translation_3d(&center_vec);
+        let matrix = back_to_center * rotation * to_origin;
         analysis_transform::transform_circle_3d(self, &matrix)
     }
 
     /// 非均等スケール変換
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
@@ -188,17 +192,19 @@ impl<T: Scalar> AnalysisTransform3D<T> for Circle3D<T> {
             ));
         }
 
-        let matrix = analysis_transform::uniform_scale_matrix_3d(&center.center_internal(), scale_x)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::uniform_scale_matrix_3d(&center_point, scale_x)?;
         analysis_transform::transform_circle_3d(self, &matrix)
     }
 
     /// 均等スケール変換
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::uniform_scale_matrix_3d(&center.center_internal(), scale_factor)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::uniform_scale_matrix_3d(&center_point, scale_factor)?;
         analysis_transform::transform_circle_3d(self, &matrix)
     }
 
@@ -206,10 +212,12 @@ impl<T: Scalar> AnalysisTransform3D<T> for Circle3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut result = self.clone();
+        let origin = Vector3::new(T::ZERO, T::ZERO, T::ZERO);
+        let scale_center = rotation.as_ref().map(|(center, _, _)| *center);
 
         // 平行移動
         if let Some(trans) = translation {
@@ -228,11 +236,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Circle3D<T> {
                     "Non-uniform scale not supported for Circle3D".to_string(),
                 ));
             }
-            let center_circle = Circle3D::new(result.center_internal(), result.normal_internal(), T::ONE)
-                .ok_or_else(|| {
-                    TransformError::InvalidGeometry("Failed to create center circle".to_string())
-                })?;
-            result = result.uniform_scale_analysis(&center_circle, sx)?;
+            result = result.uniform_scale_analysis(scale_center.unwrap_or(&origin), sx)?;
         }
 
         Ok(result)
@@ -242,10 +246,12 @@ impl<T: Scalar> AnalysisTransform3D<T> for Circle3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let mut result = self.clone();
+        let origin = Vector3::new(T::ZERO, T::ZERO, T::ZERO);
+        let scale_center = rotation.as_ref().map(|(center, _, _)| *center);
 
         // 平行移動
         if let Some(trans) = translation {
@@ -259,11 +265,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Circle3D<T> {
 
         // 均等スケール
         if let Some(scale_factor) = scale {
-            let center_circle = Circle3D::new(result.center_internal(), result.normal_internal(), T::ONE)
-                .ok_or_else(|| {
-                    TransformError::InvalidGeometry("Failed to create center circle".to_string())
-                })?;
-            result = result.uniform_scale_analysis(&center_circle, scale_factor)?;
+            result = result.uniform_scale_analysis(scale_center.unwrap_or(&origin), scale_factor)?;
         }
 
         Ok(result)
@@ -285,17 +287,9 @@ impl<T: Scalar> Circle3D<T> {
     ///
     /// Z軸を中心とした回転の最適化版
     pub fn rotate_z_analysis_origin(&self, angle: Angle<T>) -> Result<Self, TransformError> {
-        let origin = Point3D::origin();
+        let origin = Vector3::new(T::ZERO, T::ZERO, T::ZERO);
         let z_axis = Vector3::new(T::ZERO, T::ZERO, T::ONE);
-        let center_circle = Circle3D::new(
-            origin,
-            Direction3D::from_vector(Vector3D::unit_z()).unwrap(),
-            T::ONE,
-        )
-        .ok_or_else(|| {
-            TransformError::InvalidGeometry("Failed to create center circle".to_string())
-        })?;
-        self.rotate_analysis(&center_circle, &z_axis, angle)
+        self.rotate_analysis(&origin, &z_axis, angle)
     }
 
     /// 半径のみのスケール変換
@@ -345,18 +339,11 @@ mod tests {
             2.0,
         )
         .unwrap();
-        let center_circle = Circle3D::new(
-            Point3D::<f64>::origin(),
-            Direction3D::from_vector(Vector3D::unit_z()).unwrap(),
-            1.0,
-        )
-        .unwrap();
+        let center = Vector3::new(0.0_f64, 0.0, 0.0);
         let z_axis = Vector3::new(0.0_f64, 0.0, 1.0);
         let angle = Angle::from_degrees(90.0_f64);
 
-        let transformed = circle
-            .rotate_analysis(&center_circle, &z_axis, angle)
-            .unwrap();
+        let transformed = circle.rotate_analysis(&center, &z_axis, angle).unwrap();
 
         // 90度回転で (1,0,0) -> (0,1,0)
         assert!((transformed.center_internal().x() - 0.0).abs() < 1e-10);
@@ -373,17 +360,10 @@ mod tests {
             3.0,
         )
         .unwrap();
-        let center_circle = Circle3D::new(
-            Point3D::<f64>::origin(),
-            Direction3D::from_vector(Vector3D::unit_y()).unwrap(),
-            1.0,
-        )
-        .unwrap();
+        let center = Vector3::new(0.0_f64, 0.0, 0.0);
         let scale_factor = 2.0_f64;
 
-        let transformed = circle
-            .uniform_scale_analysis(&center_circle, scale_factor)
-            .unwrap();
+        let transformed = circle.uniform_scale_analysis(&center, scale_factor).unwrap();
 
         assert!((transformed.center_internal().x() - 4.0).abs() < 1e-10);
         assert!((transformed.center_internal().y() - 8.0).abs() < 1e-10);
@@ -466,14 +446,9 @@ mod tests {
             2.0,
         )
         .unwrap();
-        let center_circle = Circle3D::new(
-            Point3D::<f64>::origin(),
-            Direction3D::from_vector(Vector3D::unit_z()).unwrap(),
-            1.0,
-        )
-        .unwrap();
+        let center = Vector3::new(0.0_f64, 0.0, 0.0);
 
-        let result = circle.uniform_scale_analysis(&center_circle, 0.0);
+        let result = circle.uniform_scale_analysis(&center, 0.0);
 
         assert!(result.is_err());
         match result {
@@ -490,14 +465,9 @@ mod tests {
             2.0,
         )
         .unwrap();
-        let center_circle = Circle3D::new(
-            Point3D::<f64>::origin(),
-            Direction3D::from_vector(Vector3D::unit_z()).unwrap(),
-            1.0,
-        )
-        .unwrap();
+        let center = Vector3::new(0.0_f64, 0.0, 0.0);
 
-        let result = circle.scale_analysis(&center_circle, 2.0, 3.0, 2.0); // 非均等スケール
+        let result = circle.scale_analysis(&center, 2.0, 3.0, 2.0); // 非均等スケール
 
         assert!(result.is_err());
         match result {

--- a/model/geo_primitives/src/conical_solid_3d_transform.rs
+++ b/model/geo_primitives/src/conical_solid_3d_transform.rs
@@ -190,30 +190,32 @@ impl<T: Scalar> AnalysisTransform3D<T> for ConicalSolid3D<T> {
     /// 軸回転（中心点指定）
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::rotation_matrix(&center.center_internal(), axis, angle)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// スケール変換（中心点指定）
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::scale_matrix(&center.center(), scale_x, scale_y, scale_z)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::scale_matrix(&center_point, scale_x, scale_y, scale_z)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// 均等スケール変換
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -223,15 +225,18 @@ impl<T: Scalar> AnalysisTransform3D<T> for ConicalSolid3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut matrix = Matrix4x4::identity();
+        let origin = Point3D::origin();
 
         if let Some(scale_factors) = scale {
-            let scale_center = rotation.as_ref().map_or(self, |(center, _, _)| center);
+            let scale_center = rotation
+                .as_ref()
+                .map(|(center, _, _)| Point3D::new(center.x(), center.y(), center.z()));
             let scale_mat = analysis_transform::scale_matrix(
-                &scale_center.center(),
+                scale_center.as_ref().unwrap_or(&origin),
                 scale_factors.0,
                 scale_factors.1,
                 scale_factors.2,
@@ -240,7 +245,8 @@ impl<T: Scalar> AnalysisTransform3D<T> for ConicalSolid3D<T> {
         }
 
         if let Some((center, axis, angle)) = rotation {
-            let rot_mat = analysis_transform::rotation_matrix(&center.center(), axis, angle)?;
+            let center_point = Point3D::new(center.x(), center.y(), center.z());
+            let rot_mat = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
             matrix = rot_mat * matrix;
         }
 
@@ -256,7 +262,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for ConicalSolid3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));

--- a/model/geo_primitives/src/conical_surface_3d_transform.rs
+++ b/model/geo_primitives/src/conical_surface_3d_transform.rs
@@ -192,30 +192,32 @@ impl<T: Scalar> AnalysisTransform3D<T> for ConicalSurface3D<T> {
     /// 軸回転（中心点指定）
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::rotation_matrix(&center.center_internal(), axis, angle)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// スケール変換（中心点指定）
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::scale_matrix(&center.center(), scale_x, scale_y, scale_z)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::scale_matrix(&center_point, scale_x, scale_y, scale_z)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// 均等スケール変換
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -225,15 +227,18 @@ impl<T: Scalar> AnalysisTransform3D<T> for ConicalSurface3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut matrix = Matrix4x4::identity();
+        let origin = Point3D::origin();
 
         if let Some(scale_factors) = scale {
-            let scale_center = rotation.as_ref().map_or(self, |(center, _, _)| center);
+            let scale_center = rotation
+                .as_ref()
+                .map(|(center, _, _)| Point3D::new(center.x(), center.y(), center.z()));
             let scale_mat = analysis_transform::scale_matrix(
-                &scale_center.center(),
+                scale_center.as_ref().unwrap_or(&origin),
                 scale_factors.0,
                 scale_factors.1,
                 scale_factors.2,
@@ -242,7 +247,8 @@ impl<T: Scalar> AnalysisTransform3D<T> for ConicalSurface3D<T> {
         }
 
         if let Some((center, axis, angle)) = rotation {
-            let rot_mat = analysis_transform::rotation_matrix(&center.center(), axis, angle)?;
+            let center_point = Point3D::new(center.x(), center.y(), center.z());
+            let rot_mat = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
             matrix = rot_mat * matrix;
         }
 
@@ -258,7 +264,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for ConicalSurface3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));

--- a/model/geo_primitives/src/cylindrical_solid_3d_transform.rs
+++ b/model/geo_primitives/src/cylindrical_solid_3d_transform.rs
@@ -201,30 +201,32 @@ impl<T: Scalar> AnalysisTransform3D<T> for CylindricalSolid3D<T> {
     /// 軸回転（中心点指定）
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::rotation_matrix(&center.center(), axis, angle)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// スケール変換（中心点指定）
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::scale_matrix(&center.center(), scale_x, scale_y, scale_z)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::scale_matrix(&center_point, scale_x, scale_y, scale_z)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// 均等スケール変換
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -234,15 +236,18 @@ impl<T: Scalar> AnalysisTransform3D<T> for CylindricalSolid3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut matrix = Matrix4x4::identity();
+        let origin = Point3D::origin();
 
         if let Some(scale_factors) = scale {
-            let scale_center = rotation.as_ref().map_or(self, |(center, _, _)| center);
+            let scale_center = rotation
+                .as_ref()
+                .map(|(center, _, _)| Point3D::new(center.x(), center.y(), center.z()));
             let scale_mat = analysis_transform::scale_matrix(
-                &scale_center.center(),
+                scale_center.as_ref().unwrap_or(&origin),
                 scale_factors.0,
                 scale_factors.1,
                 scale_factors.2,
@@ -251,7 +256,8 @@ impl<T: Scalar> AnalysisTransform3D<T> for CylindricalSolid3D<T> {
         }
 
         if let Some((center, axis, angle)) = rotation {
-            let rot_mat = analysis_transform::rotation_matrix(&center.center(), axis, angle)?;
+            let center_point = Point3D::new(center.x(), center.y(), center.z());
+            let rot_mat = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
             matrix = rot_mat * matrix;
         }
 
@@ -267,7 +273,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for CylindricalSolid3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));

--- a/model/geo_primitives/src/cylindrical_surface_3d_foundation.rs
+++ b/model/geo_primitives/src/cylindrical_surface_3d_foundation.rs
@@ -40,10 +40,9 @@ impl<T: Scalar> Bounded<T> for CylindricalSurface3D<T> {
 impl<T: Scalar> TolerantEq<T> for CylindricalSurface3D<T> {
     fn tolerant_eq(&self, other: &Self, tolerance: T) -> bool {
         // 中心点の比較
-        let dx = self.center_internal().x() - other.center_internal().x();
-        let dy = self.center_internal().y() - other.center_internal().y();
-        let dz = self.center_internal().z() - other.center_internal().z();
-        let center_dist_sq = dx * dx + dy * dy + dz * dz;
+        let center_dist_sq = self
+            .center_internal()
+            .distance_squared_to(&other.center_internal());
         if center_dist_sq > tolerance * tolerance {
             return false;
         }

--- a/model/geo_primitives/src/cylindrical_surface_3d_transform.rs
+++ b/model/geo_primitives/src/cylindrical_surface_3d_transform.rs
@@ -187,30 +187,32 @@ impl<T: Scalar> AnalysisTransform3D<T> for CylindricalSurface3D<T> {
     /// 軸回転（中心点指定）
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::rotation_matrix(&center.center(), axis, angle)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// スケール変換（中心点指定）
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::scale_matrix(&center.center(), scale_x, scale_y, scale_z)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::scale_matrix(&center_point, scale_x, scale_y, scale_z)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// 均等スケール変換
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -220,15 +222,18 @@ impl<T: Scalar> AnalysisTransform3D<T> for CylindricalSurface3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut matrix = Matrix4x4::identity();
+        let origin = Point3D::origin();
 
         if let Some(scale_factors) = scale {
-            let scale_center = rotation.as_ref().map_or(self, |(center, _, _)| center);
+            let scale_center = rotation
+                .as_ref()
+                .map(|(center, _, _)| Point3D::new(center.x(), center.y(), center.z()));
             let scale_mat = analysis_transform::scale_matrix(
-                &scale_center.center(),
+                scale_center.as_ref().unwrap_or(&origin),
                 scale_factors.0,
                 scale_factors.1,
                 scale_factors.2,
@@ -237,7 +242,8 @@ impl<T: Scalar> AnalysisTransform3D<T> for CylindricalSurface3D<T> {
         }
 
         if let Some((center, axis, angle)) = rotation {
-            let rot_mat = analysis_transform::rotation_matrix(&center.center(), axis, angle)?;
+            let center_point = Point3D::new(center.x(), center.y(), center.z());
+            let rot_mat = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
             matrix = rot_mat * matrix;
         }
 
@@ -253,7 +259,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for CylindricalSurface3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));

--- a/model/geo_primitives/src/direction_2d_transform.rs
+++ b/model/geo_primitives/src/direction_2d_transform.rs
@@ -75,7 +75,11 @@ impl<T: Scalar> AnalysisTransform2D<T> for Direction2D<T> {
         Ok(*self)
     }
 
-    fn rotate_analysis_2d(&self, _center: &Self, angle: Angle<T>) -> Result<Self, TransformError> {
+    fn rotate_analysis_2d(
+        &self,
+        _center: &Vector2<T>,
+        angle: Angle<T>,
+    ) -> Result<Self, TransformError> {
         // 方向ベクトルは中心点に依存しない
         let matrix = analysis_transform::rotation_matrix_2d(angle);
         analysis_transform::transform_direction_2d(self, &matrix)
@@ -83,7 +87,7 @@ impl<T: Scalar> AnalysisTransform2D<T> for Direction2D<T> {
 
     fn scale_analysis_2d(
         &self,
-        _center: &Self,
+        _center: &Vector2<T>,
         scale_x: T,
         scale_y: T,
     ) -> Result<Self, TransformError> {
@@ -94,12 +98,10 @@ impl<T: Scalar> AnalysisTransform2D<T> for Direction2D<T> {
 
     fn uniform_scale_analysis_2d(
         &self,
-        _center: &Self,
+        _center: &Vector2<T>,
         scale_factor: T,
     ) -> Result<Self, TransformError> {
-        // 均等スケール（方向ベクトルは中心点に依存しない）
-        let matrix = analysis_transform::scale_matrix_2d(scale_factor, scale_factor)?;
-        analysis_transform::transform_direction_2d(self, &matrix)
+        self.scale_analysis_2d(_center, scale_factor, scale_factor)
     }
 }
 
@@ -126,7 +128,7 @@ mod tests {
     fn test_direction_rotation() {
         let direction = Direction2D::from_vector(Vector2D::new(1.0, 0.0)).unwrap();
         let angle = Angle::from_radians(PI / 2.0);
-        let center = Direction2D::from_vector(Vector2D::new(1.0, 0.0)).unwrap(); // 単位ベクトル使用
+        let center = Vector2::new(1.0, 0.0);
 
         let rotated = direction.rotate_analysis_2d(&center, angle).unwrap();
 
@@ -138,7 +140,7 @@ mod tests {
     #[test]
     fn test_direction_scale() {
         let direction = Direction2D::from_vector(Vector2D::new(3.0, 4.0)).unwrap();
-        let center = Direction2D::from_vector(Vector2D::new(1.0, 0.0)).unwrap();
+        let center = Vector2::new(1.0, 0.0);
 
         let scaled = direction.scale_analysis_2d(&center, 2.0, 0.5).unwrap();
 
@@ -161,7 +163,7 @@ mod tests {
     #[test]
     fn test_zero_scale_error() {
         let direction = Direction2D::from_vector(Vector2D::new(1.0, 0.0)).unwrap();
-        let center = Direction2D::from_vector(Vector2D::new(1.0, 0.0)).unwrap();
+        let center = Vector2::new(1.0, 0.0);
 
         let result = direction.scale_analysis_2d(&center, 0.0, 1.0);
         assert!(result.is_err());
@@ -173,7 +175,7 @@ mod tests {
     #[test]
     fn test_uniform_scale() {
         let direction = Direction2D::from_vector(Vector2D::new(3.0, 4.0)).unwrap();
-        let center = Direction2D::from_vector(Vector2D::new(1.0, 0.0)).unwrap();
+        let center = Vector2::new(1.0, 0.0);
 
         let scaled = direction.uniform_scale_analysis_2d(&center, 2.0).unwrap();
 

--- a/model/geo_primitives/src/direction_3d_transform.rs
+++ b/model/geo_primitives/src/direction_3d_transform.rs
@@ -93,7 +93,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Direction3D<T> {
 
     fn rotate_analysis(
         &self,
-        _center: &Self,
+        _center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Angle<T>,
     ) -> Result<Self, TransformError> {
@@ -104,7 +104,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Direction3D<T> {
 
     fn scale_analysis(
         &self,
-        _center: &Self,
+        _center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
@@ -116,7 +116,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Direction3D<T> {
 
     fn uniform_scale_analysis(
         &self,
-        _center: &Self,
+        _center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self, TransformError> {
         // 均等スケール（方向ベクトルは中心点に依存しない）
@@ -127,7 +127,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Direction3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self, TransformError> {
         // 平行移動は無視（方向ベクトルの特性）
@@ -153,7 +153,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Direction3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self, TransformError> {
         // 平行移動は無視（方向ベクトルの特性）

--- a/model/geo_primitives/src/ellipse_2d_transform.rs
+++ b/model/geo_primitives/src/ellipse_2d_transform.rs
@@ -180,32 +180,33 @@ impl<T: Scalar> AnalysisTransform2D<T> for Ellipse2D<T> {
         Ok(self.transform_point_matrix_2d(&matrix))
     }
 
-    fn rotate_analysis_2d(&self, center: &Self, angle: Angle<T>) -> Result<Self, TransformError> {
-        // Ellipse2D を Point2D として中心点を使用
-        let center_point = center.center_internal();
+    fn rotate_analysis_2d(
+        &self,
+        center: &Vector2<T>,
+        angle: Angle<T>,
+    ) -> Result<Self, TransformError> {
+        let center_point = Point2D::new(center.x(), center.y());
         let matrix = analysis_transform::rotation_matrix_2d(&center_point, angle);
         Ok(self.transform_point_matrix_2d(&matrix))
     }
 
     fn scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_x: T,
         scale_y: T,
     ) -> Result<Self, TransformError> {
-        let center_point = center.center_internal();
+        let center_point = Point2D::new(center.x(), center.y());
         let matrix = analysis_transform::scale_matrix_2d(&center_point, scale_x, scale_y)?;
         Ok(self.transform_point_matrix_2d(&matrix))
     }
 
     fn uniform_scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_factor: T,
     ) -> Result<Self, TransformError> {
-        let center_point = center.center_internal();
-        let matrix = analysis_transform::uniform_scale_matrix_2d(&center_point, scale_factor)?;
-        Ok(self.transform_point_matrix_2d(&matrix))
+        self.scale_analysis_2d(center, scale_factor, scale_factor)
     }
 }
 
@@ -224,15 +225,8 @@ mod tests {
         .unwrap()
     }
 
-    fn create_center_ellipse() -> Ellipse2D<f64> {
-        // 原点周辺の小さな楕円
-        Ellipse2D::new(
-            Point2D::new(0.0, 0.0),
-            0.1,  // semi_major
-            0.05, // semi_minor
-            0.0,  // rotation
-        )
-        .unwrap()
+    fn create_center_vector() -> Vector2<f64> {
+        Vector2::new(0.0, 0.0)
     }
 
     #[test]
@@ -254,7 +248,7 @@ mod tests {
     #[test]
     fn test_analysis_rotation() {
         let ellipse = create_test_ellipse();
-        let center = create_center_ellipse();
+        let center = create_center_vector();
         let angle = Angle::from_degrees(90.0);
 
         let result = ellipse.rotate_analysis_2d(&center, angle).unwrap();
@@ -269,7 +263,7 @@ mod tests {
     #[test]
     fn test_analysis_scale() {
         let ellipse = create_test_ellipse();
-        let center = create_center_ellipse();
+        let center = create_center_vector();
 
         let result = ellipse.scale_analysis_2d(&center, 2.0, 3.0).unwrap();
 
@@ -281,7 +275,7 @@ mod tests {
     #[test]
     fn test_analysis_uniform_scale() {
         let ellipse = create_test_ellipse();
-        let center = create_center_ellipse();
+        let center = create_center_vector();
 
         let result = ellipse.uniform_scale_analysis_2d(&center, 1.5).unwrap();
 
@@ -337,7 +331,7 @@ mod tests {
     #[test]
     fn test_error_handling_zero_scale() {
         let ellipse = create_test_ellipse();
-        let center = create_center_ellipse();
+        let center = create_center_vector();
 
         let result = ellipse.scale_analysis_2d(&center, 0.0, 1.0);
         assert!(result.is_err());

--- a/model/geo_primitives/src/ellipse_3d_transform.rs
+++ b/model/geo_primitives/src/ellipse_3d_transform.rs
@@ -252,13 +252,11 @@ impl<T: Scalar> AnalysisTransform3D<T> for Ellipse3D<T> {
 
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Angle<T>,
     ) -> Result<Self, TransformError> {
-        // Ellipse3Dから中心を取得
-        let center_point = analysis_transform::ellipse_center_3d(center);
-        // Vector3からVector3Dへの変換
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
         let axis_vector3d = Vector3D::new(axis.x(), axis.y(), axis.z());
         let matrix = analysis_transform::rotation_matrix_3d(&center_point, &axis_vector3d, angle)?;
         Ok(self.transform_point_matrix(&matrix))
@@ -266,20 +264,19 @@ impl<T: Scalar> AnalysisTransform3D<T> for Ellipse3D<T> {
 
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self, TransformError> {
-        // Ellipse3Dから中心を取得
-        let center_point = analysis_transform::ellipse_center_3d(center);
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
         let matrix = analysis_transform::scale_matrix_3d(&center_point, scale_x, scale_y, scale_z)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -288,13 +285,12 @@ impl<T: Scalar> AnalysisTransform3D<T> for Ellipse3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Angle<T>)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Angle<T>)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self, TransformError> {
-        // Vector3をVector3Dに変換（所有権の問題を回避）
         let translation_vector3d = translation.map(|t| Vector3D::new(t.x(), t.y(), t.z()));
         let rotation_adapted = rotation.map(|(rot_center, axis, angle)| {
-            let center_point = analysis_transform::ellipse_center_3d(rot_center);
+            let center_point = Point3D::new(rot_center.x(), rot_center.y(), rot_center.z());
             let axis_vector3d = Vector3D::new(axis.x(), axis.y(), axis.z());
             (center_point, axis_vector3d, angle)
         });
@@ -314,7 +310,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Ellipse3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Angle<T>)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Angle<T>)>,
         scale: Option<T>,
     ) -> Result<Self, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));
@@ -337,16 +333,8 @@ mod tests {
         .unwrap()
     }
 
-    fn create_center_ellipse() -> Ellipse3D<f64> {
-        // 原点周辺の小さな楕円
-        Ellipse3D::new(
-            Point3D::new(0.0, 0.0, 0.0),
-            0.1,                          // semi_major_axis
-            0.05,                         // semi_minor_axis
-            Vector3D::new(0.0, 0.0, 1.0), // Z軸法線
-            Vector3D::new(1.0, 0.0, 0.0), // X軸長軸方向
-        )
-        .unwrap()
+    fn create_center_vector() -> Vector3<f64> {
+        Vector3::new(0.0, 0.0, 0.0)
     }
 
     #[test]
@@ -367,7 +355,7 @@ mod tests {
     #[test]
     fn test_analysis_rotation_z() {
         let ellipse = create_test_ellipse();
-        let center = create_center_ellipse();
+        let center = create_center_vector();
         let axis = Vector3::new(0.0, 0.0, 1.0); // Z軸周り
         let angle = Angle::from_degrees(90.0);
 
@@ -386,7 +374,7 @@ mod tests {
     #[test]
     fn test_analysis_scale() {
         let ellipse = create_test_ellipse();
-        let center = create_center_ellipse();
+        let center = create_center_vector();
 
         let result = ellipse.scale_analysis(&center, 2.0, 3.0, 1.0).unwrap();
 
@@ -398,7 +386,7 @@ mod tests {
     #[test]
     fn test_analysis_uniform_scale() {
         let ellipse = create_test_ellipse();
-        let center = create_center_ellipse();
+        let center = create_center_vector();
 
         let result = ellipse.uniform_scale_analysis(&center, 1.5).unwrap();
 

--- a/model/geo_primitives/src/ellipse_arc_2d_transform.rs
+++ b/model/geo_primitives/src/ellipse_arc_2d_transform.rs
@@ -72,10 +72,10 @@ where
 
     fn rotate_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let center_point = center.center();
+        let center_point = crate::Point2D::new(center.x(), center.y());
         let matrix = crate::ellipse_2d_analysis_transform::analysis_transform::rotation_matrix_2d(
             &center_point,
             angle,
@@ -85,11 +85,11 @@ where
 
     fn scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_x: T,
         scale_y: T,
     ) -> Result<Self::Output, TransformError> {
-        let center_point = center.center();
+        let center_point = crate::Point2D::new(center.x(), center.y());
         let matrix = crate::ellipse_2d_analysis_transform::analysis_transform::scale_matrix_2d(
             &center_point,
             scale_x,
@@ -100,7 +100,7 @@ where
 
     fn uniform_scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis_2d(center, scale_factor, scale_factor)
@@ -151,13 +151,8 @@ mod tests {
         let arc = create_test_ellipse_arc();
         let rotation_center = Point2D::origin();
         let rotation_angle = Angle::from_degrees(90.0);
-
-        let center_arc = EllipseArc2D::new(
-            Ellipse2D::axis_aligned(rotation_center, 1.0, 1.0).unwrap(),
-            Angle::from_degrees(0.0),
-            Angle::from_degrees(360.0),
-        );
-        let result = arc.rotate_analysis_2d(&center_arc, rotation_angle).unwrap();
+        let center = Vector2::new(rotation_center.x(), rotation_center.y());
+        let result = arc.rotate_analysis_2d(&center, rotation_angle).unwrap();
 
         // 中心点が回転することを確認（(1,2) -> (-2,1)）
         let expected_center = Point2D::new(-2.0, 1.0);
@@ -176,14 +171,9 @@ mod tests {
         let scale_center = Point2D::origin();
         let scale_x = 2.0;
         let scale_y = 3.0;
-
-        let center_arc = EllipseArc2D::new(
-            Ellipse2D::axis_aligned(scale_center, 1.0, 1.0).unwrap(),
-            Angle::from_degrees(0.0),
-            Angle::from_degrees(360.0),
-        );
+        let center = Vector2::new(scale_center.x(), scale_center.y());
         let result = arc
-            .scale_analysis_2d(&center_arc, scale_x, scale_y)
+            .scale_analysis_2d(&center, scale_x, scale_y)
             .unwrap();
 
         // 中心点がスケールされることを確認
@@ -201,14 +191,9 @@ mod tests {
         let arc = create_test_ellipse_arc();
         let scale_center = Point2D::origin();
         let scale_factor = 2.0;
-
-        let center_arc = EllipseArc2D::new(
-            Ellipse2D::axis_aligned(scale_center, 1.0, 1.0).unwrap(),
-            Angle::from_degrees(0.0),
-            Angle::from_degrees(360.0),
-        );
+        let center = Vector2::new(scale_center.x(), scale_center.y());
         let result = arc
-            .uniform_scale_analysis_2d(&center_arc, scale_factor)
+            .uniform_scale_analysis_2d(&center, scale_factor)
             .unwrap();
 
         // 中心点がスケールされることを確認
@@ -268,26 +253,22 @@ mod tests {
     fn test_error_handling_zero_scale() {
         let arc = create_test_ellipse_arc();
         let scale_center = Point2D::origin();
+        let center = Vector2::new(scale_center.x(), scale_center.y());
 
         // ゼロスケールのテスト
-        let center_arc = EllipseArc2D::new(
-            Ellipse2D::axis_aligned(scale_center, 1.0, 1.0).unwrap(),
-            Angle::from_degrees(0.0),
-            Angle::from_degrees(360.0),
-        );
-        let result_x = arc.scale_analysis_2d(&center_arc, 0.0, 2.0);
+        let result_x = arc.scale_analysis_2d(&center, 0.0, 2.0);
         assert!(matches!(
             result_x,
             Err(TransformError::InvalidScaleFactor(_))
         ));
 
-        let result_y = arc.scale_analysis_2d(&arc, 2.0, 0.0);
+        let result_y = arc.scale_analysis_2d(&center, 2.0, 0.0);
         assert!(matches!(
             result_y,
             Err(TransformError::InvalidScaleFactor(_))
         ));
 
-        let result_uniform = arc.uniform_scale_analysis_2d(&arc, 0.0);
+        let result_uniform = arc.uniform_scale_analysis_2d(&center, 0.0);
         assert!(matches!(
             result_uniform,
             Err(TransformError::InvalidScaleFactor(_))

--- a/model/geo_primitives/src/ellipse_arc_3d_transform.rs
+++ b/model/geo_primitives/src/ellipse_arc_3d_transform.rs
@@ -127,7 +127,7 @@ where
 
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
@@ -135,7 +135,7 @@ where
             return Err(TransformError::ZeroVector("Zero rotation axis".to_string()));
         }
 
-        let center_point = center.center();
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
         let axis_vec = Vector3D::new(axis.x(), axis.y(), axis.z());
         let matrix = crate::ellipse_3d_analysis_transform::analysis_transform::rotation_matrix_3d(
             &center_point,
@@ -147,12 +147,12 @@ where
 
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self::Output, TransformError> {
-        let center_point = center.center();
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
         let matrix = crate::ellipse_3d_analysis_transform::analysis_transform::scale_matrix_3d(
             &center_point,
             scale_x,
@@ -164,7 +164,7 @@ where
 
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -173,7 +173,7 @@ where
     fn apply_composite_transform(
         &self,
         _translation: Option<&Vector3<T>>,
-        _rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        _rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         _scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         // 簡易実装: 単位行列変換
@@ -183,7 +183,7 @@ where
     fn apply_composite_transform_uniform(
         &self,
         _translation: Option<&Vector3<T>>,
-        _rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        _rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         _scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         // 簡易実装: 単位行列変換
@@ -237,15 +237,9 @@ mod tests {
         let rotation_axis = Vector3D::new(0.0, 0.0, 1.0); // Z軸回り
         let rotation_angle = Angle::from_degrees(90.0);
 
-        let center_arc = EllipseArc3D::new(
-            Ellipse3D::xy_aligned(rotation_center, 1.0, 1.0).unwrap(),
-            Angle::from_degrees(0.0),
-            Angle::from_degrees(360.0),
-        );
+        let center = Vector3::new(rotation_center.x(), rotation_center.y(), rotation_center.z());
         let axis_vec = Vector3::new(rotation_axis.x(), rotation_axis.y(), rotation_axis.z());
-        let result = arc
-            .rotate_analysis(&center_arc, &axis_vec, rotation_angle)
-            .unwrap();
+        let result = arc.rotate_analysis(&center, &axis_vec, rotation_angle).unwrap();
 
         // 中心点が回転することを確認（(1,2,3) -> (-2,1,3)）
         let expected_center = Point3D::new(-2.0, 1.0, 3.0);

--- a/model/geo_primitives/src/ellipsoidal_solid_3d_transform.rs
+++ b/model/geo_primitives/src/ellipsoidal_solid_3d_transform.rs
@@ -181,31 +181,32 @@ impl<T: Scalar> AnalysisTransform3D<T> for EllipsoidalSolid3D<T> {
     /// 軸回転（中心点指定）
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::rotation_matrix(&center.center_internal(), axis, angle)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// スケール変換（中心点指定）
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self::Output, TransformError> {
-        let matrix =
-            analysis_transform::scale_matrix(&center.center_internal(), scale_x, scale_y, scale_z)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::scale_matrix(&center_point, scale_x, scale_y, scale_z)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// 均等スケール変換
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -215,15 +216,18 @@ impl<T: Scalar> AnalysisTransform3D<T> for EllipsoidalSolid3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut matrix = Matrix4x4::identity();
+        let origin = Point3D::origin();
 
         if let Some(scale_factors) = scale {
-            let scale_center = rotation.as_ref().map_or(self, |(center, _, _)| center);
+            let scale_center = rotation
+                .as_ref()
+                .map(|(center, _, _)| Point3D::new(center.x(), center.y(), center.z()));
             let scale_mat = analysis_transform::scale_matrix(
-                &scale_center.center_internal(),
+                scale_center.as_ref().unwrap_or(&origin),
                 scale_factors.0,
                 scale_factors.1,
                 scale_factors.2,
@@ -232,8 +236,8 @@ impl<T: Scalar> AnalysisTransform3D<T> for EllipsoidalSolid3D<T> {
         }
 
         if let Some((center, axis, angle)) = rotation {
-            let rot_mat =
-                analysis_transform::rotation_matrix(&center.center_internal(), axis, angle)?;
+            let center_point = Point3D::new(center.x(), center.y(), center.z());
+            let rot_mat = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
             matrix = rot_mat * matrix;
         }
 
@@ -249,7 +253,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for EllipsoidalSolid3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));
@@ -277,10 +281,11 @@ mod tests {
     #[test]
     fn test_rotate_z_axis() {
         let ellipsoid = EllipsoidalSolid3D::new_at_origin(2.0, 3.0, 4.0).unwrap();
+        let center = Vector3::new(0.0, 0.0, 0.0);
         let axis = Vector3::new(0.0, 0.0, 1.0);
         let angle = Angle::from_degrees(90.0);
 
-        let rotated = ellipsoid.rotate_analysis(&ellipsoid, &axis, angle).unwrap();
+        let rotated = ellipsoid.rotate_analysis(&center, &axis, angle).unwrap();
 
         // 中心は変わらない
         assert!((rotated.center_internal().x() - 0.0).abs() < 1e-10);
@@ -294,8 +299,9 @@ mod tests {
     #[test]
     fn test_scale() {
         let ellipsoid = EllipsoidalSolid3D::new_at_origin(2.0, 3.0, 4.0).unwrap();
+        let center = Vector3::new(0.0, 0.0, 0.0);
 
-        let scaled = ellipsoid.scale_analysis(&ellipsoid, 2.0, 2.0, 2.0).unwrap();
+        let scaled = ellipsoid.scale_analysis(&center, 2.0, 2.0, 2.0).unwrap();
 
         // 各半径が2倍になる
         assert!((scaled.a_radius_internal() - 4.0).abs() < 1e-10);
@@ -306,9 +312,10 @@ mod tests {
     #[test]
     fn test_non_uniform_scale() {
         let ellipsoid = EllipsoidalSolid3D::new_at_origin(2.0, 3.0, 4.0).unwrap();
+        let center = Vector3::new(0.0, 0.0, 0.0);
 
         // 非均等スケール
-        let scaled = ellipsoid.scale_analysis(&ellipsoid, 2.0, 1.5, 0.5).unwrap();
+        let scaled = ellipsoid.scale_analysis(&center, 2.0, 1.5, 0.5).unwrap();
 
         assert!((scaled.a_radius_internal() - 4.0).abs() < 1e-10);
         assert!((scaled.b_radius_internal() - 4.5).abs() < 1e-10);
@@ -329,9 +336,10 @@ mod tests {
     #[test]
     fn test_invalid_scale() {
         let ellipsoid = EllipsoidalSolid3D::new_at_origin(2.0, 3.0, 4.0).unwrap();
+        let center = Vector3::new(0.0, 0.0, 0.0);
 
         // ゼロスケール
-        let result = ellipsoid.scale_analysis(&ellipsoid, 0.0, 1.0, 1.0);
+        let result = ellipsoid.scale_analysis(&center, 0.0, 1.0, 1.0);
         assert!(result.is_err());
     }
 }

--- a/model/geo_primitives/src/ellipsoidal_surface_3d_transform.rs
+++ b/model/geo_primitives/src/ellipsoidal_surface_3d_transform.rs
@@ -208,30 +208,32 @@ impl<T: Scalar> AnalysisTransform3D<T> for EllipsoidalSurface3D<T> {
     /// 軸回転（中心点指定）
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::rotation_matrix(&center.center_internal(), axis, angle)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// スケール変換（中心点指定）
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::scale_matrix(&center.center_internal(), scale_x, scale_y, scale_z)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::scale_matrix(&center_point, scale_x, scale_y, scale_z)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// 均等スケール変換
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -241,15 +243,18 @@ impl<T: Scalar> AnalysisTransform3D<T> for EllipsoidalSurface3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut matrix = Matrix4x4::identity();
+        let origin = Point3D::origin();
 
         if let Some(scale_factors) = scale {
-            let scale_center = rotation.as_ref().map_or(self, |(center, _, _)| center);
+            let scale_center = rotation
+                .as_ref()
+                .map(|(center, _, _)| Point3D::new(center.x(), center.y(), center.z()));
             let scale_mat = analysis_transform::scale_matrix(
-                &scale_center.center_internal(),
+                scale_center.as_ref().unwrap_or(&origin),
                 scale_factors.0,
                 scale_factors.1,
                 scale_factors.2,
@@ -258,7 +263,8 @@ impl<T: Scalar> AnalysisTransform3D<T> for EllipsoidalSurface3D<T> {
         }
 
         if let Some((center, axis, angle)) = rotation {
-            let rot_mat = analysis_transform::rotation_matrix(&center.center_internal(), axis, angle)?;
+            let center_point = Point3D::new(center.x(), center.y(), center.z());
+            let rot_mat = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
             matrix = rot_mat * matrix;
         }
 
@@ -274,7 +280,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for EllipsoidalSurface3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));

--- a/model/geo_primitives/src/infinite_line_2d_transform.rs
+++ b/model/geo_primitives/src/infinite_line_2d_transform.rs
@@ -112,11 +112,10 @@ impl<T: Scalar> AnalysisTransform2D<T> for InfiniteLine2D<T> {
     /// Analysis統合回転（中心点指定）
     fn rotate_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let center_tuple = center.point();
-        let center_point = Point2D::new(center_tuple.0, center_tuple.1);
+        let center_point = Point2D::new(center.x(), center.y());
         let matrix = analysis_transform::rotation_matrix_2d(&center_point, angle);
         analysis_transform::transform_infinite_line_2d(self, &matrix)
     }
@@ -124,12 +123,11 @@ impl<T: Scalar> AnalysisTransform2D<T> for InfiniteLine2D<T> {
     /// Analysis統合スケール（中心点指定）
     fn scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_x: T,
         scale_y: T,
     ) -> Result<Self::Output, TransformError> {
-        let center_tuple = center.point();
-        let center_point = Point2D::new(center_tuple.0, center_tuple.1);
+        let center_point = Point2D::new(center.x(), center.y());
         let matrix = analysis_transform::scale_matrix_2d(&center_point, scale_x, scale_y)?;
         analysis_transform::transform_infinite_line_2d(self, &matrix)
     }
@@ -137,11 +135,10 @@ impl<T: Scalar> AnalysisTransform2D<T> for InfiniteLine2D<T> {
     /// Analysis統合均等スケール（中心点指定）
     fn uniform_scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
-        let center_tuple = center.point();
-        let center_point = Point2D::new(center_tuple.0, center_tuple.1);
+        let center_point = Point2D::new(center.x(), center.y());
         let matrix = analysis_transform::uniform_scale_matrix_2d(&center_point, scale_factor)?;
         analysis_transform::transform_infinite_line_2d(self, &matrix)
     }
@@ -206,10 +203,10 @@ mod tests {
     #[test]
     fn test_analysis_transform_rotate() {
         let line = InfiniteLine2D::new(Point2D::new(1.0, 0.0), Vector2D::new(1.0, 0.0)).unwrap();
-        let center_line = InfiniteLine2D::new(Point2D::origin(), Vector2D::new(1.0, 0.0)).unwrap();
+        let center = Vector2::new(0.0, 0.0);
         let angle = Angle::from_degrees(90.0);
 
-        let result = line.rotate_analysis_2d(&center_line, angle).unwrap();
+        let result = line.rotate_analysis_2d(&center, angle).unwrap();
 
         // 90度回転後、点 (1,0) は (0,1) になる
         const TOLERANCE: f64 = 1e-10;
@@ -225,9 +222,9 @@ mod tests {
     #[test]
     fn test_analysis_transform_scale() {
         let line = InfiniteLine2D::new(Point2D::new(2.0, 1.0), Vector2D::new(1.0, 0.0)).unwrap();
-        let center_line = InfiniteLine2D::new(Point2D::origin(), Vector2D::new(1.0, 0.0)).unwrap();
+        let center = Vector2::new(0.0, 0.0);
 
-        let result = line.scale_analysis_2d(&center_line, 2.0, 3.0).unwrap();
+        let result = line.scale_analysis_2d(&center, 2.0, 3.0).unwrap();
 
         // 点 (2,1) が (4,3) になる
         let result_point = result.point();
@@ -242,9 +239,9 @@ mod tests {
     #[test]
     fn test_analysis_transform_uniform_scale() {
         let line = InfiniteLine2D::new(Point2D::new(1.0, 1.0), Vector2D::new(1.0, 0.0)).unwrap();
-        let center_line = InfiniteLine2D::new(Point2D::origin(), Vector2D::new(1.0, 0.0)).unwrap();
+        let center = Vector2::new(0.0, 0.0);
 
-        let result = line.uniform_scale_analysis_2d(&center_line, 2.0).unwrap();
+        let result = line.uniform_scale_analysis_2d(&center, 2.0).unwrap();
 
         // 点 (1,1) が (2,2) になる
         let result_point = result.point();
@@ -259,12 +256,12 @@ mod tests {
     #[test]
     fn test_transform_zero_scale_error() {
         let line = InfiniteLine2D::new(Point2D::new(1.0, 1.0), Vector2D::new(1.0, 0.0)).unwrap();
-        let center_line = InfiniteLine2D::new(Point2D::origin(), Vector2D::new(1.0, 0.0)).unwrap();
+        let center = Vector2::new(0.0, 0.0);
 
-        let result = line.scale_analysis_2d(&center_line, 0.0, 1.0);
+        let result = line.scale_analysis_2d(&center, 0.0, 1.0);
         assert!(result.is_err());
 
-        let result = line.uniform_scale_analysis_2d(&center_line, 0.0);
+        let result = line.uniform_scale_analysis_2d(&center, 0.0);
         assert!(result.is_err());
     }
 

--- a/model/geo_primitives/src/infinite_line_3d_transform.rs
+++ b/model/geo_primitives/src/infinite_line_3d_transform.rs
@@ -129,11 +129,11 @@ impl<T: Scalar> AnalysisTransform3D<T> for InfiniteLine3D<T> {
     /// Analysis統合軸回転（中心点指定）
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let center_point = center.point_internal();
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
         let matrix = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
         analysis_transform::transform_infinite_line_3d(self, &matrix)
     }
@@ -141,12 +141,12 @@ impl<T: Scalar> AnalysisTransform3D<T> for InfiniteLine3D<T> {
     /// Analysis統合スケール（中心点指定）
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self::Output, TransformError> {
-        let center_point = center.point_internal();
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
         let matrix = analysis_transform::scale_matrix(&center_point, scale_x, scale_y, scale_z)?;
         analysis_transform::transform_infinite_line_3d(self, &matrix)
     }
@@ -154,10 +154,10 @@ impl<T: Scalar> AnalysisTransform3D<T> for InfiniteLine3D<T> {
     /// Analysis統合均等スケール（中心点指定）
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
-        let center_point = center.point_internal();
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
         let matrix = analysis_transform::uniform_scale_matrix(&center_point, scale_factor)?;
         analysis_transform::transform_infinite_line_3d(self, &matrix)
     }
@@ -166,10 +166,12 @@ impl<T: Scalar> AnalysisTransform3D<T> for InfiniteLine3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut result = self.clone();
+        let origin = Vector3::new(T::ZERO, T::ZERO, T::ZERO);
+        let scale_center = rotation.as_ref().map(|(center, _, _)| *center);
 
         // 平行移動を適用
         if let Some(t) = translation {
@@ -183,8 +185,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for InfiniteLine3D<T> {
 
         // スケールを適用
         if let Some((sx, sy, sz)) = scale {
-            let center = result; // 自己中心スケール
-            result = center.scale_analysis(&center, sx, sy, sz)?;
+            result = result.scale_analysis(scale_center.unwrap_or(&origin), sx, sy, sz)?;
         }
 
         Ok(result)
@@ -194,10 +195,12 @@ impl<T: Scalar> AnalysisTransform3D<T> for InfiniteLine3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let mut result = self.clone();
+        let origin = Vector3::new(T::ZERO, T::ZERO, T::ZERO);
+        let scale_center = rotation.as_ref().map(|(center, _, _)| *center);
 
         // 平行移動を適用
         if let Some(t) = translation {
@@ -211,8 +214,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for InfiniteLine3D<T> {
 
         // 均等スケールを適用
         if let Some(scale_factor) = scale {
-            let center = result.clone(); // 自己中心スケール
-            result = result.uniform_scale_analysis(&center, scale_factor)?;
+            result = result.uniform_scale_analysis(scale_center.unwrap_or(&origin), scale_factor)?;
         }
 
         Ok(result)
@@ -279,12 +281,11 @@ mod tests {
     fn test_analysis_transform_rotate() {
         let line =
             InfiniteLine3D::new(Point3D::new(1.0, 0.0, 0.0), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
-        let center_line =
-            InfiniteLine3D::new(Point3D::origin(), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
+        let center = Vector3::new(0.0, 0.0, 0.0);
         let axis = Vector3::new(0.0, 0.0, 1.0); // Z軸回転
         let angle = Angle::from_degrees(90.0);
 
-        let result = line.rotate_analysis(&center_line, &axis, angle).unwrap();
+        let result = line.rotate_analysis(&center, &axis, angle).unwrap();
 
         // 90度Z軸回転後、点 (1,0,0) は (0,1,0) になる
         assert!((result.point_internal().x() - 0.0).abs() < TOLERANCE);
@@ -300,10 +301,9 @@ mod tests {
     fn test_analysis_transform_scale() {
         let line =
             InfiniteLine3D::new(Point3D::new(2.0, 1.0, 1.0), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
-        let center_line =
-            InfiniteLine3D::new(Point3D::origin(), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
+        let center = Vector3::new(0.0, 0.0, 0.0);
 
-        let result = line.scale_analysis(&center_line, 2.0, 3.0, 4.0).unwrap();
+        let result = line.scale_analysis(&center, 2.0, 3.0, 4.0).unwrap();
 
         // 点 (2,1,1) が (4,3,4) になる
         assert_eq!(result.point_internal().x(), 4.0);
@@ -319,10 +319,9 @@ mod tests {
     fn test_analysis_transform_uniform_scale() {
         let line =
             InfiniteLine3D::new(Point3D::new(1.0, 1.0, 1.0), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
-        let center_line =
-            InfiniteLine3D::new(Point3D::origin(), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
+        let center = Vector3::new(0.0, 0.0, 0.0);
 
-        let result = line.uniform_scale_analysis(&center_line, 2.0).unwrap();
+        let result = line.uniform_scale_analysis(&center, 2.0).unwrap();
 
         // 点 (1,1,1) が (2,2,2) になる
         assert_eq!(result.point_internal().x(), 2.0);
@@ -338,8 +337,7 @@ mod tests {
     fn test_composite_transform() {
         let line =
             InfiniteLine3D::new(Point3D::new(1.0, 0.0, 0.0), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
-        let center_line =
-            InfiniteLine3D::new(Point3D::origin(), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
+        let center = Vector3::new(0.0, 0.0, 0.0);
 
         let translation = Vector3::new(1.0, 1.0, 1.0);
         let axis = Vector3::new(0.0, 0.0, 1.0);
@@ -348,7 +346,7 @@ mod tests {
         let result = line
             .apply_composite_transform_uniform(
                 Some(&translation),
-                Some((&center_line, &axis, angle)),
+                Some((&center, &axis, angle)),
                 Some(2.0),
             )
             .unwrap();
@@ -363,13 +361,12 @@ mod tests {
     fn test_transform_zero_scale_error() {
         let line =
             InfiniteLine3D::new(Point3D::new(1.0, 1.0, 1.0), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
-        let center_line =
-            InfiniteLine3D::new(Point3D::origin(), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
+        let center = Vector3::new(0.0, 0.0, 0.0);
 
-        let result = line.scale_analysis(&center_line, 0.0, 1.0, 1.0);
+        let result = line.scale_analysis(&center, 0.0, 1.0, 1.0);
         assert!(result.is_err());
 
-        let result = line.uniform_scale_analysis(&center_line, 0.0);
+        let result = line.uniform_scale_analysis(&center, 0.0);
         assert!(result.is_err());
     }
 
@@ -377,12 +374,11 @@ mod tests {
     fn test_transform_zero_axis_error() {
         let line =
             InfiniteLine3D::new(Point3D::new(1.0, 0.0, 0.0), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
-        let center_line =
-            InfiniteLine3D::new(Point3D::origin(), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
+        let center = Vector3::new(0.0, 0.0, 0.0);
         let zero_axis = Vector3::new(0.0, 0.0, 0.0);
         let angle = Angle::from_degrees(90.0);
 
-        let result = line.rotate_analysis(&center_line, &zero_axis, angle);
+        let result = line.rotate_analysis(&center, &zero_axis, angle);
         assert!(result.is_err());
     }
 

--- a/model/geo_primitives/src/line_segment_2d_transform.rs
+++ b/model/geo_primitives/src/line_segment_2d_transform.rs
@@ -197,10 +197,10 @@ impl<T: Scalar> AnalysisTransform2D<T> for LineSegment2D<T> {
     /// Analysis統合回転（中心点指定）
     fn rotate_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, crate::TransformError> {
-        let center_point = center.midpoint();
+        let center_point = Point2D::new(center.x(), center.y());
         let matrix = analysis_transform::rotation_matrix_2d(&center_point, angle);
         analysis_transform::transform_line_segment_2d(self, &matrix)
     }
@@ -208,11 +208,11 @@ impl<T: Scalar> AnalysisTransform2D<T> for LineSegment2D<T> {
     /// Analysis統合スケール（中心点指定）
     fn scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_x: T,
         scale_y: T,
     ) -> Result<Self::Output, crate::TransformError> {
-        let center_point = center.midpoint();
+        let center_point = Point2D::new(center.x(), center.y());
         let matrix = analysis_transform::scale_matrix_2d(&center_point, scale_x, scale_y)?;
         analysis_transform::transform_line_segment_2d(self, &matrix)
     }
@@ -220,12 +220,10 @@ impl<T: Scalar> AnalysisTransform2D<T> for LineSegment2D<T> {
     /// Analysis統合均等スケール（中心点指定）
     fn uniform_scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_factor: T,
     ) -> Result<Self::Output, crate::TransformError> {
-        let center_point = center.midpoint();
-        let matrix = analysis_transform::uniform_scale_matrix_2d(&center_point, scale_factor)?;
-        analysis_transform::transform_line_segment_2d(self, &matrix)
+        self.scale_analysis_2d(center, scale_factor, scale_factor)
     }
 }
 
@@ -288,14 +286,10 @@ mod tests {
             LineSegment2D::new(Point2D::new(1.0_f64, 0.0), Point2D::new(3.0, 0.0)).unwrap();
 
         // 原点中心で回転させるための中心線分を原点に配置
-        let center_segment = LineSegment2D::new(
-            Point2D::origin(),
-            Point2D::new(1e-10, 0.0), // 極小線分で原点中心を表現
-        )
-        .unwrap();
+        let center = Vector2::new(0.0, 0.0);
 
         let angle = Angle::from_radians(PI / 2.0);
-        let result = segment.rotate_analysis_2d(&center_segment, angle).unwrap();
+        let result = segment.rotate_analysis_2d(&center, angle).unwrap();
 
         // 90度回転後、Y軸方向になるはず
         assert!((result.start_point().x() - 0.0).abs() < 1e-10);
@@ -311,14 +305,10 @@ mod tests {
             LineSegment2D::new(Point2D::new(1.0_f64, 1.0), Point2D::new(3.0, 3.0)).unwrap();
 
         // スケール中心を原点に設定
-        let center_segment = LineSegment2D::new(
-            Point2D::origin(),
-            Point2D::new(1e-10, 0.0), // 極小線分で原点中心を表現
-        )
-        .unwrap();
+        let center = Vector2::new(0.0, 0.0);
 
         let result = segment
-            .scale_analysis_2d(&center_segment, 2.0, 2.0)
+            .scale_analysis_2d(&center, 2.0, 2.0)
             .unwrap();
 
         // 原点中心で2倍スケール（浮動小数点誤差を考慮した許容値を使用）
@@ -334,9 +324,9 @@ mod tests {
         let segment =
             LineSegment2D::new(Point2D::new(0.0_f64, 0.0), Point2D::new(2.0, 0.0)).unwrap();
 
-        let center_segment = segment;
+        let center = Vector2::new(1.0, 0.0);
         let result = segment
-            .uniform_scale_analysis_2d(&center_segment, 1.5)
+            .uniform_scale_analysis_2d(&center, 1.5)
             .unwrap();
 
         // 中心からスケールされるため、長さが1.5倍になる
@@ -403,7 +393,7 @@ mod tests {
         let segment =
             LineSegment2D::new(Point2D::new(0.0_f64, 0.0), Point2D::new(1.0, 0.0)).unwrap();
 
-        let center = segment;
+        let center = Vector2::new(0.5, 0.0);
         let result = segment.scale_analysis_2d(&center, 0.0, 1.0);
 
         assert!(result.is_err());

--- a/model/geo_primitives/src/line_segment_3d_transform.rs
+++ b/model/geo_primitives/src/line_segment_3d_transform.rs
@@ -159,12 +159,11 @@ impl<T: Scalar> AnalysisTransform3D<T> for LineSegment3D<T> {
 
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Angle<T>,
     ) -> Result<Self, TransformError> {
-        // LineSegment3D を Point3D として中心点を使用（midpoint）
-        let center_point = center.midpoint();
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
         let axis_vector3d = Vector3D::new(axis.x(), axis.y(), axis.z());
         let matrix = analysis_transform::rotation_matrix_3d(&center_point, &axis_vector3d, angle)?;
         Ok(self.transform_point_matrix(&matrix))
@@ -172,22 +171,22 @@ impl<T: Scalar> AnalysisTransform3D<T> for LineSegment3D<T> {
 
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self, TransformError> {
-        let center_point = center.midpoint();
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
         let matrix = analysis_transform::scale_matrix_3d(&center_point, scale_x, scale_y, scale_z)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self, TransformError> {
-        let center_point = center.midpoint();
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
         let matrix = analysis_transform::uniform_scale_matrix_3d(&center_point, scale_factor)?;
         Ok(self.transform_point_matrix(&matrix))
     }
@@ -195,14 +194,13 @@ impl<T: Scalar> AnalysisTransform3D<T> for LineSegment3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self, TransformError> {
-        let center = self.midpoint();
+        let center = Point3D::origin();
 
-        // rotation の型変換
         let rotation_converted = rotation.map(|(rot_center, axis, angle)| {
-            let center_point = rot_center.midpoint();
+            let center_point = Point3D::new(rot_center.x(), rot_center.y(), rot_center.z());
             let axis_vector3d = Vector3D::new(axis.x(), axis.y(), axis.z());
             (center_point, axis_vector3d, angle)
         });
@@ -219,7 +217,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for LineSegment3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));
@@ -235,13 +233,8 @@ mod tests {
         LineSegment3D::new(Point3D::new(1.0, 2.0, 3.0), Point3D::new(4.0, 5.0, 6.0)).unwrap()
     }
 
-    fn create_center_segment() -> LineSegment3D<f64> {
-        // 極小線分で原点周辺の中心を表現
-        LineSegment3D::new(
-            Point3D::new(-1e-10, -1e-10, -1e-10),
-            Point3D::new(1e-10, 1e-10, 1e-10),
-        )
-        .unwrap()
+    fn create_center_vector() -> Vector3<f64> {
+        Vector3::new(0.0, 0.0, 0.0)
     }
 
     #[test]
@@ -262,7 +255,7 @@ mod tests {
     #[test]
     fn test_analysis_rotation() {
         let segment = create_test_segment();
-        let center = create_center_segment();
+        let center = create_center_vector();
         let axis = Vector3::new(0.0, 0.0, 1.0); // Z軸周り
         let angle = Angle::from_degrees(90.0);
 
@@ -280,7 +273,7 @@ mod tests {
     #[test]
     fn test_analysis_scale() {
         let segment = create_test_segment();
-        let center = create_center_segment();
+        let center = create_center_vector();
 
         let result = segment.scale_analysis(&center, 2.0, 2.0, 2.0).unwrap();
 
@@ -295,7 +288,7 @@ mod tests {
     #[test]
     fn test_analysis_uniform_scale() {
         let segment = create_test_segment();
-        let center = create_center_segment();
+        let center = create_center_vector();
 
         let result = segment.uniform_scale_analysis(&center, 3.0).unwrap();
 

--- a/model/geo_primitives/src/plane_3d_transform.rs
+++ b/model/geo_primitives/src/plane_3d_transform.rs
@@ -154,30 +154,32 @@ impl<T: Scalar> AnalysisTransform3D<T> for Plane3D<T> {
     /// 軸回転（中心点指定）
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::rotation_matrix(&center.point(), axis, angle)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// スケール変換（中心点指定）
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::scale_matrix(&center.point(), scale_x, scale_y, scale_z)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::scale_matrix(&center_point, scale_x, scale_y, scale_z)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// 均等スケール変換
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -187,15 +189,18 @@ impl<T: Scalar> AnalysisTransform3D<T> for Plane3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut matrix = Matrix4x4::identity();
+        let origin = Point3D::origin();
 
         if let Some(scale_factors) = scale {
-            let scale_center = rotation.as_ref().map_or(self, |(center, _, _)| center);
+            let scale_center = rotation
+                .as_ref()
+                .map(|(center, _, _)| Point3D::new(center.x(), center.y(), center.z()));
             let scale_mat = analysis_transform::scale_matrix(
-                &scale_center.point(),
+                scale_center.as_ref().unwrap_or(&origin),
                 scale_factors.0,
                 scale_factors.1,
                 scale_factors.2,
@@ -204,7 +209,8 @@ impl<T: Scalar> AnalysisTransform3D<T> for Plane3D<T> {
         }
 
         if let Some((center, axis, angle)) = rotation {
-            let rot_mat = analysis_transform::rotation_matrix(&center.point(), axis, angle)?;
+            let center_point = Point3D::new(center.x(), center.y(), center.z());
+            let rot_mat = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
             matrix = rot_mat * matrix;
         }
 
@@ -220,7 +226,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Plane3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));
@@ -265,15 +271,11 @@ mod tests {
     #[test]
     fn test_analysis_rotation() {
         let plane = create_test_plane();
-        let center_plane = Plane3D::from_point_and_normal(
-            Point3D::new(0.0, 0.0, 0.0),
-            Vector3D::new(1.0, 0.0, 0.0),
-        )
-        .unwrap();
+        let center = Vector3::new(0.0, 0.0, 0.0);
         let axis = Vector3::new(1.0, 0.0, 0.0); // x軸回転
         let angle = Angle::from_degrees(90.0);
 
-        let result = plane.rotate_analysis(&center_plane, &axis, angle).unwrap();
+        let result = plane.rotate_analysis(&center, &axis, angle).unwrap();
 
         // 90度X軸回転後の点確認
         let expected_point = Point3D::new(1.0, -3.0, 2.0);

--- a/model/geo_primitives/src/ray_2d_transform.rs
+++ b/model/geo_primitives/src/ray_2d_transform.rs
@@ -125,29 +125,30 @@ impl<T: Scalar> AnalysisTransform2D<T> for Ray2D<T> {
     /// 中心点指定回転
     fn rotate_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::rotation_matrix_2d(&center.origin_internal(), angle);
+        let center_point = Point2D::new(center.x(), center.y());
+        let matrix = analysis_transform::rotation_matrix_2d(&center_point, angle);
         Ok(self.transform_point_matrix_2d(&matrix))
     }
 
     /// 中心点指定スケール変換
     fn scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_x: T,
         scale_y: T,
     ) -> Result<Self::Output, TransformError> {
-        let matrix =
-            analysis_transform::scale_matrix_2d(&center.origin_internal(), scale_x, scale_y)?;
+        let center_point = Point2D::new(center.x(), center.y());
+        let matrix = analysis_transform::scale_matrix_2d(&center_point, scale_x, scale_y)?;
         Ok(self.transform_point_matrix_2d(&matrix))
     }
 
     /// 均等スケール変換
     fn uniform_scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis_2d(center, scale_factor, scale_factor)
@@ -193,8 +194,8 @@ mod tests {
         let center = Point2D::new(0.0, 0.0);
         let angle = Angle::from_degrees(90.0);
 
-        let center_ray = Ray2D::new(center, Vector2D::new(1.0, 0.0)).unwrap();
-        let result = ray.rotate_analysis_2d(&center_ray, angle).unwrap();
+        let center_vec = Vector2::new(center.x(), center.y());
+        let result = ray.rotate_analysis_2d(&center_vec, angle).unwrap();
 
         // 90度回転後の起点確認
         let expected_origin = Point2D::new(-2.0, 1.0);
@@ -213,9 +214,9 @@ mod tests {
         let scale_x = 2.0;
         let scale_y = 3.0;
 
-        let center_ray = Ray2D::new(center, Vector2D::new(1.0, 0.0)).unwrap();
+        let center_vec = Vector2::new(center.x(), center.y());
         let result = ray
-            .scale_analysis_2d(&center_ray, scale_x, scale_y)
+            .scale_analysis_2d(&center_vec, scale_x, scale_y)
             .unwrap();
 
         // スケール変換後の起点確認
@@ -264,8 +265,8 @@ mod tests {
         let ray = create_test_ray();
         let center = Point2D::new(0.0, 0.0);
 
-        let center_ray = Ray2D::new(center, Vector2D::new(1.0, 0.0)).unwrap();
-        let result = ray.scale_analysis_2d(&center_ray, 0.0, 1.0);
+        let center_vec = Vector2::new(center.x(), center.y());
+        let result = ray.scale_analysis_2d(&center_vec, 0.0, 1.0);
         assert!(matches!(result, Err(TransformError::InvalidScaleFactor(_))));
     }
 }

--- a/model/geo_primitives/src/ray_3d_transform.rs
+++ b/model/geo_primitives/src/ray_3d_transform.rs
@@ -162,30 +162,32 @@ impl<T: Scalar> AnalysisTransform3D<T> for Ray3D<T> {
     /// 軸回転（中心点指定）
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::rotation_matrix(&center.origin_internal(), axis, angle)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// スケール変換（中心点指定）
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::scale_matrix(&center.origin_internal(), scale_x, scale_y, scale_z)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::scale_matrix(&center_point, scale_x, scale_y, scale_z)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// 均等スケール変換
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -195,15 +197,18 @@ impl<T: Scalar> AnalysisTransform3D<T> for Ray3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut matrix = Matrix4x4::identity();
+        let origin = Point3D::origin();
 
         if let Some(scale_factors) = scale {
-            let scale_center = rotation.as_ref().map_or(self, |(center, _, _)| center);
+            let scale_center = rotation
+                .as_ref()
+                .map(|(center, _, _)| Point3D::new(center.x(), center.y(), center.z()));
             let scale_mat = analysis_transform::scale_matrix(
-                &scale_center.origin_internal(),
+                scale_center.as_ref().unwrap_or(&origin),
                 scale_factors.0,
                 scale_factors.1,
                 scale_factors.2,
@@ -212,7 +217,8 @@ impl<T: Scalar> AnalysisTransform3D<T> for Ray3D<T> {
         }
 
         if let Some((center, axis, angle)) = rotation {
-            let rot_mat = analysis_transform::rotation_matrix(&center.origin_internal(), axis, angle)?;
+            let center_point = Point3D::new(center.x(), center.y(), center.z());
+            let rot_mat = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
             matrix = rot_mat * matrix;
         }
 
@@ -228,7 +234,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Ray3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));
@@ -278,9 +284,9 @@ mod tests {
         let axis = Vector3D::new(0.0, 0.0, 1.0); // z軸回転
         let angle = Angle::from_degrees(90.0);
 
-        let center_ray = Ray3D::new(center, Vector3D::new(1.0, 0.0, 0.0)).unwrap();
+        let center_vec = Vector3::new(center.x(), center.y(), center.z());
         let axis_vec = Vector3::new(axis.x(), axis.y(), axis.z());
-        let result = ray.rotate_analysis(&center_ray, &axis_vec, angle).unwrap();
+        let result = ray.rotate_analysis(&center_vec, &axis_vec, angle).unwrap();
 
         // 90度Z軸回転後の起点確認
         let expected_origin = Point3D::new(-2.0, 1.0, 3.0);
@@ -302,9 +308,9 @@ mod tests {
         let scale_y = 3.0;
         let scale_z = 4.0;
 
-        let center_ray = Ray3D::new(center, Vector3D::new(1.0, 0.0, 0.0)).unwrap();
+        let center_vec = Vector3::new(center.x(), center.y(), center.z());
         let result = ray
-            .scale_analysis(&center_ray, scale_x, scale_y, scale_z)
+            .scale_analysis(&center_vec, scale_x, scale_y, scale_z)
             .unwrap();
 
         // スケール変換後の起点確認
@@ -333,12 +339,12 @@ mod tests {
         let scale_z = 2.0;
 
         let translation_vec = Vector3::new(translation.x(), translation.y(), translation.z());
-        let rotation_center_ray = Ray3D::new(rotation_center, rotation_axis).unwrap();
+        let rotation_center_vec = Vector3::new(rotation_center.x(), rotation_center.y(), rotation_center.z());
         let axis_vec = Vector3::new(rotation_axis.x(), rotation_axis.y(), rotation_axis.z());
         let result = ray
             .apply_composite_transform(
                 Some(&translation_vec),
-                Some((&rotation_center_ray, &axis_vec, rotation_angle)),
+                Some((&rotation_center_vec, &axis_vec, rotation_angle)),
                 Some((scale_x, scale_y, scale_z)),
             )
             .unwrap();
@@ -356,8 +362,8 @@ mod tests {
         let ray = create_test_ray();
         let center = Point3D::new(0.0, 0.0, 0.0);
 
-        let center_ray = Ray3D::new(center, Vector3D::new(1.0, 0.0, 0.0)).unwrap();
-        let result = ray.scale_analysis(&center_ray, 0.0, 1.0, 1.0);
+        let center_vec = Vector3::new(center.x(), center.y(), center.z());
+        let result = ray.scale_analysis(&center_vec, 0.0, 1.0, 1.0);
         assert!(matches!(result, Err(TransformError::InvalidScaleFactor(_))));
     }
 
@@ -368,9 +374,9 @@ mod tests {
         let zero_axis = Vector3D::new(0.0, 0.0, 0.0);
         let angle = Angle::from_degrees(90.0);
 
-        let center_ray = Ray3D::new(center, Vector3D::new(1.0, 0.0, 0.0)).unwrap();
+        let center_vec = Vector3::new(center.x(), center.y(), center.z());
         let zero_axis_vec = Vector3::new(zero_axis.x(), zero_axis.y(), zero_axis.z());
-        let result = ray.rotate_analysis(&center_ray, &zero_axis_vec, angle);
+        let result = ray.rotate_analysis(&center_vec, &zero_axis_vec, angle);
         assert!(matches!(result, Err(TransformError::InvalidRotation(_))));
     }
 }

--- a/model/geo_primitives/src/rectangle_2d_transform.rs
+++ b/model/geo_primitives/src/rectangle_2d_transform.rs
@@ -86,28 +86,28 @@ impl<T: Scalar> AnalysisTransform2D<T> for Rect2D<T> {
 
     fn rotate_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let c = center.center_point();
+        let c = Point2D::new(center.x(), center.y());
         let m = analysis_transform::rotation_matrix_2d(&c, angle);
         analysis_transform::transform_rect_2d(self, &m)
     }
 
     fn scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_x: T,
         scale_y: T,
     ) -> Result<Self::Output, TransformError> {
-        let c = center.center_point();
+        let c = Point2D::new(center.x(), center.y());
         let m = analysis_transform::scale_matrix_2d(&c, scale_x, scale_y)?;
         analysis_transform::transform_rect_2d(self, &m)
     }
 
     fn uniform_scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis_2d(center, scale_factor, scale_factor)

--- a/model/geo_primitives/src/rectangle_3d_transform.rs
+++ b/model/geo_primitives/src/rectangle_3d_transform.rs
@@ -97,29 +97,30 @@ impl<T: Scalar> AnalysisTransform3D<T> for Rect3D<T> {
 
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let m = analysis_transform::rotation_matrix(&center.center_point(), axis, angle)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let m = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
         analysis_transform::transform_rect_3d(self, &m)
     }
 
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self::Output, TransformError> {
-        let m =
-            analysis_transform::scale_matrix(&center.center_point(), scale_x, scale_y, scale_z)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let m = analysis_transform::scale_matrix(&center_point, scale_x, scale_y, scale_z)?;
         analysis_transform::transform_rect_3d(self, &m)
     }
 
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -128,21 +129,28 @@ impl<T: Scalar> AnalysisTransform3D<T> for Rect3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut matrix = Matrix4x4::identity();
+        let origin = Point3D::origin();
 
         if let Some((sx, sy, sz)) = scale {
-            let scale_center = rotation.as_ref().map_or(self, |(center, _, _)| *center);
-            let scale_matrix =
-                analysis_transform::scale_matrix(&scale_center.center_point(), sx, sy, sz)?;
+            let scale_center = rotation
+                .as_ref()
+                .map(|(center, _, _)| Point3D::new(center.x(), center.y(), center.z()));
+            let scale_matrix = analysis_transform::scale_matrix(
+                scale_center.as_ref().unwrap_or(&origin),
+                sx,
+                sy,
+                sz,
+            )?;
             matrix = scale_matrix * matrix;
         }
 
         if let Some((center, axis, angle)) = rotation {
-            let rotation_matrix =
-                analysis_transform::rotation_matrix(&center.center_point(), axis, angle)?;
+            let center_point = Point3D::new(center.x(), center.y(), center.z());
+            let rotation_matrix = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
             matrix = rotation_matrix * matrix;
         }
 
@@ -157,7 +165,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Rect3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));

--- a/model/geo_primitives/src/spherical_solid_3d_transform.rs
+++ b/model/geo_primitives/src/spherical_solid_3d_transform.rs
@@ -187,30 +187,32 @@ impl<T: Scalar> AnalysisTransform3D<T> for SphericalSolid3D<T> {
     /// 軸回転（中心点指定）
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::rotation_matrix(&center.center_internal(), axis, angle)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// スケール変換（中心点指定）
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::scale_matrix(&center.center_internal(), scale_x, scale_y, scale_z)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::scale_matrix(&center_point, scale_x, scale_y, scale_z)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// 均等スケール変換
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -220,15 +222,18 @@ impl<T: Scalar> AnalysisTransform3D<T> for SphericalSolid3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut matrix = Matrix4x4::identity();
+        let origin = Point3D::origin();
 
         if let Some(scale_factors) = scale {
-            let scale_center = rotation.as_ref().map_or(self, |(center, _, _)| center);
+            let scale_center = rotation
+                .as_ref()
+                .map(|(center, _, _)| Point3D::new(center.x(), center.y(), center.z()));
             let scale_mat = analysis_transform::scale_matrix(
-                &scale_center.center_internal(),
+                scale_center.as_ref().unwrap_or(&origin),
                 scale_factors.0,
                 scale_factors.1,
                 scale_factors.2,
@@ -237,7 +242,8 @@ impl<T: Scalar> AnalysisTransform3D<T> for SphericalSolid3D<T> {
         }
 
         if let Some((center, axis, angle)) = rotation {
-            let rot_mat = analysis_transform::rotation_matrix(&center.center_internal(), axis, angle)?;
+            let center_point = Point3D::new(center.x(), center.y(), center.z());
+            let rot_mat = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
             matrix = rot_mat * matrix;
         }
 
@@ -253,7 +259,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for SphericalSolid3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));

--- a/model/geo_primitives/src/spherical_surface_3d_transform.rs
+++ b/model/geo_primitives/src/spherical_surface_3d_transform.rs
@@ -187,30 +187,32 @@ impl<T: Scalar> AnalysisTransform3D<T> for SphericalSurface3D<T> {
     /// 軸回転（中心点指定）
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::rotation_matrix(&center.center_internal(), axis, angle)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// スケール変換（中心点指定）
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::scale_matrix(&center.center_internal(), scale_x, scale_y, scale_z)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::scale_matrix(&center_point, scale_x, scale_y, scale_z)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// 均等スケール変換
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -220,15 +222,18 @@ impl<T: Scalar> AnalysisTransform3D<T> for SphericalSurface3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut matrix = Matrix4x4::identity();
+        let origin = Point3D::origin();
 
         if let Some(scale_factors) = scale {
-            let scale_center = rotation.as_ref().map_or(self, |(center, _, _)| center);
+            let scale_center = rotation
+                .as_ref()
+                .map(|(center, _, _)| Point3D::new(center.x(), center.y(), center.z()));
             let scale_mat = analysis_transform::scale_matrix(
-                &scale_center.center_internal(),
+                scale_center.as_ref().unwrap_or(&origin),
                 scale_factors.0,
                 scale_factors.1,
                 scale_factors.2,
@@ -237,7 +242,8 @@ impl<T: Scalar> AnalysisTransform3D<T> for SphericalSurface3D<T> {
         }
 
         if let Some((center, axis, angle)) = rotation {
-            let rot_mat = analysis_transform::rotation_matrix(&center.center_internal(), axis, angle)?;
+            let center_point = Point3D::new(center.x(), center.y(), center.z());
+            let rot_mat = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
             matrix = rot_mat * matrix;
         }
 
@@ -253,7 +259,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for SphericalSurface3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));

--- a/model/geo_primitives/src/torus_solid_3d_transform.rs
+++ b/model/geo_primitives/src/torus_solid_3d_transform.rs
@@ -203,30 +203,32 @@ impl<T: Scalar> AnalysisTransform3D<T> for TorusSolid3D<T> {
     /// 軸回転（中心点指定）
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::rotation_matrix(center.origin_internal(), axis, angle)?;;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// スケール変換（中心点指定）
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::scale_matrix(center.origin_internal(), scale_x, scale_y, scale_z)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::scale_matrix(&center_point, scale_x, scale_y, scale_z)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// 均等スケール変換
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -236,15 +238,18 @@ impl<T: Scalar> AnalysisTransform3D<T> for TorusSolid3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut matrix = Matrix4x4::identity();
+        let origin = Point3D::origin();
 
         if let Some(scale_factors) = scale {
-            let scale_center = rotation.as_ref().map_or(self, |(center, _, _)| center);
+            let scale_center = rotation
+                .as_ref()
+                .map(|(center, _, _)| Point3D::new(center.x(), center.y(), center.z()));
             let scale_mat = analysis_transform::scale_matrix(
-                scale_center.origin(),
+                scale_center.as_ref().unwrap_or(&origin),
                 scale_factors.0,
                 scale_factors.1,
                 scale_factors.2,
@@ -253,7 +258,8 @@ impl<T: Scalar> AnalysisTransform3D<T> for TorusSolid3D<T> {
         }
 
         if let Some((center, axis, angle)) = rotation {
-            let rot_mat = analysis_transform::rotation_matrix(center.origin(), axis, angle)?;
+            let center_point = Point3D::new(center.x(), center.y(), center.z());
+            let rot_mat = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
             matrix = rot_mat * matrix;
         }
 
@@ -269,7 +275,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for TorusSolid3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));

--- a/model/geo_primitives/src/torus_surface_3d_transform.rs
+++ b/model/geo_primitives/src/torus_surface_3d_transform.rs
@@ -204,30 +204,32 @@ impl<T: Scalar> AnalysisTransform3D<T> for TorusSurface3D<T> {
     /// 軸回転（中心点指定）
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Self::Angle,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::rotation_matrix(&center.origin_internal(), axis, angle)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// スケール変換（中心点指定）
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self::Output, TransformError> {
-        let matrix = analysis_transform::scale_matrix(&center.origin_internal(), scale_x, scale_y, scale_z)?;
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
+        let matrix = analysis_transform::scale_matrix(&center_point, scale_x, scale_y, scale_z)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     /// 均等スケール変換
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self::Output, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -237,15 +239,18 @@ impl<T: Scalar> AnalysisTransform3D<T> for TorusSurface3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self::Output, TransformError> {
         let mut matrix = Matrix4x4::identity();
+        let origin = Point3D::origin();
 
         if let Some(scale_factors) = scale {
-            let scale_center = rotation.as_ref().map_or(self, |(center, _, _)| center);
+            let scale_center = rotation
+                .as_ref()
+                .map(|(center, _, _)| Point3D::new(center.x(), center.y(), center.z()));
             let scale_mat = analysis_transform::scale_matrix(
-                &scale_center.origin_internal(),
+                scale_center.as_ref().unwrap_or(&origin),
                 scale_factors.0,
                 scale_factors.1,
                 scale_factors.2,
@@ -254,7 +259,8 @@ impl<T: Scalar> AnalysisTransform3D<T> for TorusSurface3D<T> {
         }
 
         if let Some((center, axis, angle)) = rotation {
-            let rot_mat = analysis_transform::rotation_matrix(&center.origin_internal(), axis, angle)?;
+            let center_point = Point3D::new(center.x(), center.y(), center.z());
+            let rot_mat = analysis_transform::rotation_matrix(&center_point, axis, angle)?;
             matrix = rot_mat * matrix;
         }
 
@@ -270,7 +276,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for TorusSurface3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Self::Angle)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Self::Angle)>,
         scale: Option<T>,
     ) -> Result<Self::Output, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));

--- a/model/geo_primitives/src/triangle_2d_transform.rs
+++ b/model/geo_primitives/src/triangle_2d_transform.rs
@@ -139,32 +139,33 @@ impl<T: Scalar> AnalysisTransform2D<T> for Triangle2D<T> {
         Ok(self.transform_point_matrix_2d(&matrix))
     }
 
-    fn rotate_analysis_2d(&self, center: &Self, angle: Angle<T>) -> Result<Self, TransformError> {
-        // Triangle2D を Point2D として中心点を使用（重心）
-        let center_point = center.centroid();
+    fn rotate_analysis_2d(
+        &self,
+        center: &Vector2<T>,
+        angle: Angle<T>,
+    ) -> Result<Self, TransformError> {
+        let center_point = Point2D::new(center.x(), center.y());
         let matrix = analysis_transform::rotation_matrix_2d(&center_point, angle);
         Ok(self.transform_point_matrix_2d(&matrix))
     }
 
     fn scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_x: T,
         scale_y: T,
     ) -> Result<Self, TransformError> {
-        let center_point = center.centroid();
+        let center_point = Point2D::new(center.x(), center.y());
         let matrix = analysis_transform::scale_matrix_2d(&center_point, scale_x, scale_y)?;
         Ok(self.transform_point_matrix_2d(&matrix))
     }
 
     fn uniform_scale_analysis_2d(
         &self,
-        center: &Self,
+        center: &Vector2<T>,
         scale_factor: T,
     ) -> Result<Self, TransformError> {
-        let center_point = center.centroid();
-        let matrix = analysis_transform::uniform_scale_matrix_2d(&center_point, scale_factor)?;
-        Ok(self.transform_point_matrix_2d(&matrix))
+        self.scale_analysis_2d(center, scale_factor, scale_factor)
     }
 }
 
@@ -181,14 +182,8 @@ mod tests {
         .unwrap()
     }
 
-    fn create_center_triangle() -> Triangle2D<f64> {
-        // 原点周辺の小さな正三角形
-        Triangle2D::new(
-            Point2D::new(-0.1, -0.1),
-            Point2D::new(0.1, -0.1),
-            Point2D::new(0.0, 0.1),
-        )
-        .unwrap()
+    fn create_center_vector() -> Vector2<f64> {
+        Vector2::new(0.0, 0.0)
     }
 
     #[test]
@@ -209,7 +204,7 @@ mod tests {
     #[test]
     fn test_analysis_rotation() {
         let triangle = create_test_triangle();
-        let center = create_center_triangle();
+        let center = create_center_vector();
         let angle = Angle::from_degrees(90.0);
 
         let result = triangle.rotate_analysis_2d(&center, angle).unwrap();
@@ -227,12 +222,11 @@ mod tests {
         let result_centroid = result.centroid();
 
         // 重心の距離は保存される（回転だけなので）
-        let rotation_center = center.centroid();
-        let original_distance = ((original_centroid.x() - rotation_center.x()).powi(2)
-            + (original_centroid.y() - rotation_center.y()).powi(2))
+        let original_distance = ((original_centroid.x() - center.x()).powi(2)
+            + (original_centroid.y() - center.y()).powi(2))
         .sqrt();
-        let result_distance = ((result_centroid.x() - rotation_center.x()).powi(2)
-            + (result_centroid.y() - rotation_center.y()).powi(2))
+        let result_distance = ((result_centroid.x() - center.x()).powi(2)
+            + (result_centroid.y() - center.y()).powi(2))
         .sqrt();
 
         assert!((original_distance - result_distance).abs() < 1e-10);
@@ -241,7 +235,7 @@ mod tests {
     #[test]
     fn test_analysis_scale() {
         let triangle = create_test_triangle();
-        let center = create_center_triangle();
+        let center = create_center_vector();
 
         let result = triangle.scale_analysis_2d(&center, 2.0, 2.0).unwrap();
 
@@ -256,7 +250,7 @@ mod tests {
     #[test]
     fn test_analysis_uniform_scale() {
         let triangle = create_test_triangle();
-        let center = create_center_triangle();
+        let center = create_center_vector();
 
         let result = triangle.uniform_scale_analysis_2d(&center, 3.0).unwrap();
 
@@ -315,7 +309,7 @@ mod tests {
     #[test]
     fn test_error_handling_zero_scale() {
         let triangle = create_test_triangle();
-        let center = create_center_triangle();
+        let center = create_center_vector();
 
         let result = triangle.scale_analysis_2d(&center, 0.0, 1.0);
         assert!(result.is_err());

--- a/model/geo_primitives/src/triangle_3d_transform.rs
+++ b/model/geo_primitives/src/triangle_3d_transform.rs
@@ -195,13 +195,11 @@ impl<T: Scalar> AnalysisTransform3D<T> for Triangle3D<T> {
 
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Angle<T>,
     ) -> Result<Self, TransformError> {
-        // Triangle3Dから重心を取得（3頂点の平均）
-        let center_point = analysis_transform::triangle_centroid_3d(center);
-        // Vector3からVector3Dへの変換
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
         let axis_vector3d = Vector3D::new(axis.x(), axis.y(), axis.z());
         let matrix = analysis_transform::rotation_matrix_3d(&center_point, &axis_vector3d, angle)?;
         Ok(self.transform_point_matrix(&matrix))
@@ -209,20 +207,19 @@ impl<T: Scalar> AnalysisTransform3D<T> for Triangle3D<T> {
 
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
     ) -> Result<Self, TransformError> {
-        // Triangle3Dから重心を取得（3頂点の平均）
-        let center_point = analysis_transform::triangle_centroid_3d(center);
+        let center_point = Point3D::new(center.x(), center.y(), center.z());
         let matrix = analysis_transform::scale_matrix_3d(&center_point, scale_x, scale_y, scale_z)?;
         Ok(self.transform_point_matrix(&matrix))
     }
 
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -231,13 +228,12 @@ impl<T: Scalar> AnalysisTransform3D<T> for Triangle3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Angle<T>)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Angle<T>)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self, TransformError> {
-        // Vector3をVector3Dに変換（所有権の問題を回避）
         let translation_vector3d = translation.map(|t| Vector3D::new(t.x(), t.y(), t.z()));
         let rotation_adapted = rotation.map(|(rot_center, axis, angle)| {
-            let center_point = analysis_transform::triangle_centroid_3d(rot_center);
+            let center_point = Point3D::new(rot_center.x(), rot_center.y(), rot_center.z());
             let axis_vector3d = Vector3D::new(axis.x(), axis.y(), axis.z());
             (center_point, axis_vector3d, angle)
         });
@@ -257,7 +253,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for Triangle3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Angle<T>)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Angle<T>)>,
         scale: Option<T>,
     ) -> Result<Self, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));
@@ -278,14 +274,8 @@ mod tests {
         .unwrap()
     }
 
-    fn create_center_triangle() -> Triangle3D<f64> {
-        // 原点周辺の小さな正三角形
-        Triangle3D::new(
-            Point3D::new(-0.1, -0.1, 0.0),
-            Point3D::new(0.1, -0.1, 0.0),
-            Point3D::new(0.0, 0.1, 0.0),
-        )
-        .unwrap()
+    fn create_center_vector() -> Vector3<f64> {
+        Vector3::new(0.0, 0.0, 0.0)
     }
 
     #[test]
@@ -309,7 +299,7 @@ mod tests {
     #[test]
     fn test_analysis_rotation_z() {
         let triangle = create_test_triangle();
-        let center = create_center_triangle();
+        let center = create_center_vector();
         let axis = Vector3::new(0.0, 0.0, 1.0); // Z軸
         let angle = Angle::from_degrees(90.0);
 
@@ -330,7 +320,7 @@ mod tests {
     #[test]
     fn test_analysis_scale() {
         let triangle = create_test_triangle();
-        let center = create_center_triangle();
+        let center = create_center_vector();
 
         let result = triangle.scale_analysis(&center, 2.0, 2.0, 2.0).unwrap();
 

--- a/model/geo_primitives/src/triangle_mesh_3d_transform.rs
+++ b/model/geo_primitives/src/triangle_mesh_3d_transform.rs
@@ -61,7 +61,7 @@ pub mod analysis_transform {
 
     /// 回転行列生成（軸回転版）
     pub fn rotation_matrix_3d<T: Scalar>(
-        _center: &TriangleMesh3D<T>,
+        _center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Angle<T>,
     ) -> Result<Matrix4x4<T>, TransformError> {
@@ -81,7 +81,7 @@ pub mod analysis_transform {
 
     /// スケール行列生成（中心点指定版）
     pub fn scale_matrix_3d<T: Scalar>(
-        center: &TriangleMesh3D<T>,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
@@ -92,8 +92,7 @@ pub mod analysis_transform {
             ));
         }
 
-        // メッシュの重心を計算
-        let centroid = mesh_centroid_3d(center);
+        let centroid = *center;
         let scale_vec = Vector3::new(scale_x, scale_y, scale_z);
         let translate_to_origin = Matrix4x4::translation_3d(&(-centroid));
         let scale = Matrix4x4::scale_3d(&scale_vec);
@@ -135,7 +134,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for TriangleMesh3D<T> {
 
     fn rotate_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         axis: &Vector3<T>,
         angle: Angle<T>,
     ) -> Result<Self, TransformError> {
@@ -145,7 +144,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for TriangleMesh3D<T> {
 
     fn scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_x: T,
         scale_y: T,
         scale_z: T,
@@ -156,7 +155,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for TriangleMesh3D<T> {
 
     fn uniform_scale_analysis(
         &self,
-        center: &Self,
+        center: &Vector3<T>,
         scale_factor: T,
     ) -> Result<Self, TransformError> {
         self.scale_analysis(center, scale_factor, scale_factor, scale_factor)
@@ -165,10 +164,12 @@ impl<T: Scalar> AnalysisTransform3D<T> for TriangleMesh3D<T> {
     fn apply_composite_transform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Angle<T>)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Angle<T>)>,
         scale: Option<(T, T, T)>,
     ) -> Result<Self, TransformError> {
         let mut result = self.clone();
+        let origin = Vector3::new(T::ZERO, T::ZERO, T::ZERO);
+        let scale_center = rotation.as_ref().map(|(center, _, _)| *center);
 
         // 平行移動
         if let Some(trans) = translation {
@@ -182,7 +183,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for TriangleMesh3D<T> {
 
         // スケール
         if let Some((sx, sy, sz)) = scale {
-            result = result.scale_analysis(&result, sx, sy, sz)?;
+            result = result.scale_analysis(scale_center.unwrap_or(&origin), sx, sy, sz)?;
         }
 
         Ok(result)
@@ -191,7 +192,7 @@ impl<T: Scalar> AnalysisTransform3D<T> for TriangleMesh3D<T> {
     fn apply_composite_transform_uniform(
         &self,
         translation: Option<&Vector3<T>>,
-        rotation: Option<(&Self, &Vector3<T>, Angle<T>)>,
+        rotation: Option<(&Vector3<T>, &Vector3<T>, Angle<T>)>,
         scale: Option<T>,
     ) -> Result<Self, TransformError> {
         let scale_tuple = scale.map(|s| (s, s, s));
@@ -243,7 +244,7 @@ mod tests {
     #[test]
     fn test_analysis_rotation_z() {
         let mesh = create_test_mesh();
-        let center = mesh.clone();
+        let center = Vector3::new(0.0, 0.0, 0.0);
         let axis = Vector3::new(0.0, 0.0, 1.0); // Z軸
         let angle = Angle::from_degrees(90.0);
 
@@ -257,7 +258,7 @@ mod tests {
     #[test]
     fn test_analysis_uniform_scale() {
         let mesh = create_test_mesh();
-        let center = mesh.clone();
+        let center = Vector3::new(0.0, 0.0, 0.0);
 
         let result = mesh.uniform_scale_analysis(&center, 2.0).unwrap();
 


### PR DESCRIPTION
## 概要

Issue #339 の helper generalization investigation で扱っていた軽量リファクタを反映します。

今回の PR では以下を実施しました。
- H-1: 残存していた inline distance formula を既存 Point / Vector API に置換
- M-6: primitive_2d に残っていた local vector helper を除去
- transform API の支点指定を図形自身から明示的な Vector2 / Vector3 に整理
- NURBS の点群平均メソッドを廃止
- NURBS 曲面の複合変換で平行移動行列の演算順序不整合を修正
- 複合変換と逐次変換の整合を確認する回帰テストを追加
- render 症状だけを根拠に transform カーネル順序を変更しない運用ルールを追加

## Issue 整理

- #339 の軽量リファクタ範囲はこの PR で完了
- H-2 で見つかった trait定義の source of truth 問題は別設計課題のため #533 に分離

## 検証

- cargo clippy
- cargo fmt
- cargo test --workspace

## レビュー観点

- transform API の支点指定が Vector2 / Vector3 に統一されているか
- NURBS 曲面の複合変換順序が point / curve と整合しているか
- #533 へ切り出した設計課題がこの PR に混入していないか

Closes #339
Relates #533