### PR TITLE
refactor: basic types の definition core を Constructor + Properties へ縮退

### DIFF
--- a/model/geo_contracts/src/geometry/core/point_traits.rs
+++ b/model/geo_contracts/src/geometry/core/point_traits.rs
@@ -111,12 +111,6 @@ pub trait Point3DMeasure<T: Scalar> {
     }
 }
 
-pub trait Point2DCore<T: Scalar>:
-    Point2DConstructor<T> + Point2DProperties<T> + Point2DMeasure<T>
-{
-}
+pub trait Point2DCore<T: Scalar>: Point2DConstructor<T> + Point2DProperties<T> {}
 
-pub trait Point3DCore<T: Scalar>:
-    Point3DConstructor<T> + Point3DProperties<T> + Point3DMeasure<T>
-{
-}
+pub trait Point3DCore<T: Scalar>: Point3DConstructor<T> + Point3DProperties<T> {}

--- a/model/geo_contracts/src/geometry/core/vector_traits.rs
+++ b/model/geo_contracts/src/geometry/core/vector_traits.rs
@@ -139,12 +139,6 @@ pub trait Vector3DMeasure<T: Scalar> {
     }
 }
 
-pub trait Vector2DCore<T: Scalar>:
-    Vector2DConstructor<T> + Vector2DProperties<T> + Vector2DMeasure<T>
-{
-}
+pub trait Vector2DCore<T: Scalar>: Vector2DConstructor<T> + Vector2DProperties<T> {}
 
-pub trait Vector3DCore<T: Scalar>:
-    Vector3DConstructor<T> + Vector3DProperties<T> + Vector3DMeasure<T>
-{
-}
+pub trait Vector3DCore<T: Scalar>: Vector3DConstructor<T> + Vector3DProperties<T> {}


### PR DESCRIPTION
## 概要
- Point2DCore / Point3DCore から Measure を分離
- Vector2DCore / Vector3DCore から Measure を分離
- basic types の definition core を Constructor + Properties のみへ縮退

## 対応内容
- geo_contracts の point_traits で Point 系 Core trait の境界を縮小
- geo_contracts の vector_traits で Vector 系 Core trait の境界を縮小
- Measure trait 自体は残し、definition core からのみ切り離し

## 検証
- cargo clippy -- -D warnings
- cargo fmt
- cargo test --workspace

Closes #538