### PR TITLE
refactor: basic types の measure 系を minimal extension へ分離

### DIFF
--- a/model/geo_contracts/src/geometry/core/mod.rs
+++ b/model/geo_contracts/src/geometry/core/mod.rs
@@ -93,8 +93,8 @@ pub use nurbs_surface_3d_traits::{
 };
 pub use plane3d_traits::Plane3DProperties;
 pub use point_traits::{
-    Point2DConstructor, Point2DCore, Point2DMeasure, Point2DProperties, Point3DConstructor,
-    Point3DCore, Point3DMeasure, Point3DProperties,
+    Point2DConstructor, Point2DCore, Point2DProperties, Point3DConstructor, Point3DCore,
+    Point3DProperties,
 };
 pub use ray_traits::{
     Ray2DConstructor, Ray2DCore, Ray2DMeasure, Ray2DProperties, Ray3DConstructor, Ray3DCore,
@@ -123,6 +123,6 @@ pub use triangle_traits::{
     Triangle3DConstructor, Triangle3DCore, Triangle3DMeasure, Triangle3DProperties,
 };
 pub use vector_traits::{
-    Vector2DConstructor, Vector2DCore, Vector2DMeasure, Vector2DProperties, Vector3DConstructor,
-    Vector3DCore, Vector3DMeasure, Vector3DProperties,
+    Vector2DConstructor, Vector2DCore, Vector2DProperties, Vector3DConstructor, Vector3DCore,
+    Vector3DProperties,
 };

--- a/model/geo_contracts/src/geometry/core/point_traits.rs
+++ b/model/geo_contracts/src/geometry/core/point_traits.rs
@@ -66,51 +66,6 @@ pub trait Point3DProperties<T: Scalar> {
     }
 }
 
-// TODO(#318): Measure contracts are temporarily colocated and will be split by responsibility.
-pub trait Point2DMeasure<T: Scalar> {
-    fn distance_to(&self, other: &Self) -> T;
-    fn distance_squared_to(&self, other: &Self) -> T;
-    fn distance_from_origin(&self) -> T;
-    fn norm_squared(&self) -> T;
-
-    fn midpoint(&self, other: &Self) -> Self;
-    fn lerp(&self, other: &Self, t: T) -> Self;
-    fn manhattan_distance_to(&self, other: &Self) -> T;
-    fn chebyshev_distance_to(&self, other: &Self) -> T;
-
-    fn area(&self) -> Option<T> {
-        None
-    }
-
-    fn length(&self) -> Option<T> {
-        None
-    }
-}
-
-pub trait Point3DMeasure<T: Scalar> {
-    fn distance_to(&self, other: &Self) -> T;
-    fn distance_squared_to(&self, other: &Self) -> T;
-    fn distance_from_origin(&self) -> T;
-    fn norm_squared(&self) -> T;
-
-    fn midpoint(&self, other: &Self) -> Self;
-    fn lerp(&self, other: &Self, t: T) -> Self;
-    fn manhattan_distance_to(&self, other: &Self) -> T;
-    fn chebyshev_distance_to(&self, other: &Self) -> T;
-
-    fn area(&self) -> Option<T> {
-        None
-    }
-
-    fn volume(&self) -> Option<T> {
-        None
-    }
-
-    fn length(&self) -> Option<T> {
-        None
-    }
-}
-
 pub trait Point2DCore<T: Scalar>: Point2DConstructor<T> + Point2DProperties<T> {}
 
 pub trait Point3DCore<T: Scalar>: Point3DConstructor<T> + Point3DProperties<T> {}

--- a/model/geo_contracts/src/geometry/core/vector_traits.rs
+++ b/model/geo_contracts/src/geometry/core/vector_traits.rs
@@ -85,60 +85,6 @@ pub trait Vector3DProperties<T: Scalar> {
     }
 }
 
-// TODO(#318): Measure contracts are temporarily colocated and will be split by responsibility.
-pub trait Vector2DMeasure<T: Scalar> {
-    fn dot(&self, other: &Self) -> T;
-    fn cross_2d(&self, other: &Self) -> T;
-    fn angle_to(&self, other: &Self) -> Option<T>;
-    fn distance_to(&self, other: &Self) -> T;
-    fn distance_squared_to(&self, other: &Self) -> T;
-    fn magnitude(&self) -> T;
-    fn manhattan_distance(&self) -> T;
-    fn is_parallel_to(&self, other: &Self) -> bool;
-    fn is_perpendicular_to(&self, other: &Self) -> bool;
-    fn project_onto(&self, other: &Self) -> Option<Self>
-    where
-        Self: Sized;
-
-    fn area(&self) -> Option<T> {
-        None
-    }
-
-    fn length(&self) -> Option<T> {
-        Some(self.magnitude())
-    }
-}
-
-pub trait Vector3DMeasure<T: Scalar> {
-    fn dot(&self, other: &Self) -> T;
-    fn cross_3d(&self, other: &Self) -> Self;
-    fn angle_to(&self, other: &Self) -> Option<T>;
-    fn distance_to(&self, other: &Self) -> T;
-    fn distance_squared_to(&self, other: &Self) -> T;
-    fn magnitude(&self) -> T;
-    fn manhattan_distance(&self) -> T;
-    fn is_parallel_to(&self, other: &Self) -> bool;
-    fn is_perpendicular_to(&self, other: &Self) -> bool;
-    fn project_onto(&self, other: &Self) -> Option<Self>
-    where
-        Self: Sized;
-    fn project_onto_plane(&self, normal: &Self) -> Option<Self>
-    where
-        Self: Sized;
-
-    fn area(&self) -> Option<T> {
-        None
-    }
-
-    fn volume(&self) -> Option<T> {
-        None
-    }
-
-    fn length(&self) -> Option<T> {
-        Some(self.magnitude())
-    }
-}
-
 pub trait Vector2DCore<T: Scalar>: Vector2DConstructor<T> + Vector2DProperties<T> {}
 
 pub trait Vector3DCore<T: Scalar>: Vector3DConstructor<T> + Vector3DProperties<T> {}

--- a/model/geo_contracts/src/geometry/foundation/mod.rs
+++ b/model/geo_contracts/src/geometry/foundation/mod.rs
@@ -4,8 +4,14 @@
 //! - `ExtensionFoundation<T>`: Primitive kind identification and measurement
 //! - `Bounded<T>`: Axis-aligned bounding box (AABB)
 
+pub mod point_measure_traits;
+pub mod vector_measure_traits;
+
 use crate::classification::PrimitiveKind;
 use analysis::abstract_types::Scalar;
+
+pub use point_measure_traits::{Point2DMeasure, Point3DMeasure};
+pub use vector_measure_traits::{Vector2DMeasure, Vector3DMeasure};
 
 /// Base trait for all geometric primitives (Extension Foundation).
 ///

--- a/model/geo_contracts/src/geometry/foundation/point_measure_traits.rs
+++ b/model/geo_contracts/src/geometry/foundation/point_measure_traits.rs
@@ -1,0 +1,47 @@
+//! Point measure capability traits.
+
+use crate::Scalar;
+
+pub trait Point2DMeasure<T: Scalar> {
+    fn distance_to(&self, other: &Self) -> T;
+    fn distance_squared_to(&self, other: &Self) -> T;
+    fn distance_from_origin(&self) -> T;
+    fn norm_squared(&self) -> T;
+
+    fn midpoint(&self, other: &Self) -> Self;
+    fn lerp(&self, other: &Self, t: T) -> Self;
+    fn manhattan_distance_to(&self, other: &Self) -> T;
+    fn chebyshev_distance_to(&self, other: &Self) -> T;
+
+    fn area(&self) -> Option<T> {
+        None
+    }
+
+    fn length(&self) -> Option<T> {
+        None
+    }
+}
+
+pub trait Point3DMeasure<T: Scalar> {
+    fn distance_to(&self, other: &Self) -> T;
+    fn distance_squared_to(&self, other: &Self) -> T;
+    fn distance_from_origin(&self) -> T;
+    fn norm_squared(&self) -> T;
+
+    fn midpoint(&self, other: &Self) -> Self;
+    fn lerp(&self, other: &Self, t: T) -> Self;
+    fn manhattan_distance_to(&self, other: &Self) -> T;
+    fn chebyshev_distance_to(&self, other: &Self) -> T;
+
+    fn area(&self) -> Option<T> {
+        None
+    }
+
+    fn volume(&self) -> Option<T> {
+        None
+    }
+
+    fn length(&self) -> Option<T> {
+        None
+    }
+}

--- a/model/geo_contracts/src/geometry/foundation/vector_measure_traits.rs
+++ b/model/geo_contracts/src/geometry/foundation/vector_measure_traits.rs
@@ -1,0 +1,56 @@
+//! Vector measure capability traits.
+
+use crate::Scalar;
+
+pub trait Vector2DMeasure<T: Scalar> {
+    fn dot(&self, other: &Self) -> T;
+    fn cross_2d(&self, other: &Self) -> T;
+    fn angle_to(&self, other: &Self) -> Option<T>;
+    fn distance_to(&self, other: &Self) -> T;
+    fn distance_squared_to(&self, other: &Self) -> T;
+    fn magnitude(&self) -> T;
+    fn manhattan_distance(&self) -> T;
+    fn is_parallel_to(&self, other: &Self) -> bool;
+    fn is_perpendicular_to(&self, other: &Self) -> bool;
+    fn project_onto(&self, other: &Self) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn area(&self) -> Option<T> {
+        None
+    }
+
+    fn length(&self) -> Option<T> {
+        Some(self.magnitude())
+    }
+}
+
+pub trait Vector3DMeasure<T: Scalar> {
+    fn dot(&self, other: &Self) -> T;
+    fn cross_3d(&self, other: &Self) -> Self;
+    fn angle_to(&self, other: &Self) -> Option<T>;
+    fn distance_to(&self, other: &Self) -> T;
+    fn distance_squared_to(&self, other: &Self) -> T;
+    fn magnitude(&self) -> T;
+    fn manhattan_distance(&self) -> T;
+    fn is_parallel_to(&self, other: &Self) -> bool;
+    fn is_perpendicular_to(&self, other: &Self) -> bool;
+    fn project_onto(&self, other: &Self) -> Option<Self>
+    where
+        Self: Sized;
+    fn project_onto_plane(&self, normal: &Self) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn area(&self) -> Option<T> {
+        None
+    }
+
+    fn volume(&self) -> Option<T> {
+        None
+    }
+
+    fn length(&self) -> Option<T> {
+        Some(self.magnitude())
+    }
+}

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -34,15 +34,14 @@ pub use geometry::core::{
     EllipsoidalSolid3DConstructor, EllipsoidalSolid3DCore, EllipsoidalSolid3DMeasure,
     EllipsoidalSolid3DProperties, EllipsoidalSurface3DConstructor, EllipsoidalSurface3DCore,
     EllipsoidalSurface3DMeasure, EllipsoidalSurface3DProperties, Point2DConstructor, Point2DCore,
-    Point2DMeasure, Point2DProperties, Point3DConstructor, Point3DCore, Point3DMeasure,
-    Point3DProperties, Rect2DConstructor, Rect2DCore, Rect2DMeasure, Rect2DProperties,
-    Rect3DConstructor, Rect3DCore, Rect3DMeasure, Rect3DProperties, SphericalSolid3DConstructor,
-    SphericalSolid3DCore, SphericalSolid3DMeasure, SphericalSolid3DProperties,
-    SphericalSurface3DConstructor, SphericalSurface3DCore, SphericalSurface3DMeasure,
-    SphericalSurface3DProperties, TorusSolid3DConstructor, TorusSolid3DCore, TorusSolid3DMeasure,
-    TorusSolid3DProperties, TorusSurface3DConstructor, TorusSurface3DCore, TorusSurface3DMeasure,
-    TorusSurface3DProperties, Vector2DConstructor, Vector2DCore, Vector2DMeasure,
-    Vector2DProperties, Vector3DConstructor, Vector3DCore, Vector3DMeasure, Vector3DProperties,
+    Point2DProperties, Point3DConstructor, Point3DCore, Point3DProperties, Rect2DConstructor,
+    Rect2DCore, Rect2DMeasure, Rect2DProperties, Rect3DConstructor, Rect3DCore, Rect3DMeasure,
+    Rect3DProperties, SphericalSolid3DConstructor, SphericalSolid3DCore, SphericalSolid3DMeasure,
+    SphericalSolid3DProperties, SphericalSurface3DConstructor, SphericalSurface3DCore,
+    SphericalSurface3DMeasure, SphericalSurface3DProperties, TorusSolid3DConstructor,
+    TorusSolid3DCore, TorusSolid3DMeasure, TorusSolid3DProperties, TorusSurface3DConstructor,
+    TorusSurface3DCore, TorusSurface3DMeasure, TorusSurface3DProperties, Vector2DConstructor,
+    Vector2DCore, Vector2DProperties, Vector3DConstructor, Vector3DCore, Vector3DProperties,
 };
 pub use geometry::core::{
     InfiniteLine2DConstructor, InfiniteLine2DCore, InfiniteLine2DMeasure, InfiniteLine2DProperties,
@@ -59,7 +58,9 @@ pub use geometry::core::{
     Triangle2DConstructor, Triangle2DCore, Triangle2DMeasure, Triangle2DProperties,
     Triangle3DConstructor, Triangle3DCore, Triangle3DMeasure, Triangle3DProperties,
 };
-pub use geometry::foundation::{Bounded, ExtensionFoundation};
+pub use geometry::foundation::{
+    Bounded, ExtensionFoundation, Point2DMeasure, Point3DMeasure, Vector2DMeasure, Vector3DMeasure,
+};
 pub use geometry::operations::{
     AdvancedCollision, BBoxCollision, BasicCollision, BasicIntersection, CrossDistance,
     DistanceConvergenceError, EllipseAccuracyAnalysis, EllipseAdaptiveCalculation,


### PR DESCRIPTION
## 概要
- Point / Vector の `*Measure` trait を definition core から分離
- basic types の measure capability を foundation 側へ移設
- root の公開面は re-export で維持

## 対応内容
- `point_traits.rs` と `vector_traits.rs` から Point / Vector の `*Measure` 定義を削除
- `geometry/foundation/point_measure_traits.rs` と `geometry/foundation/vector_measure_traits.rs` を追加
- `geometry/foundation/mod.rs` から Point / Vector の `*Measure` を再公開
- `geometry::core` からは Point / Vector の `*Measure` を外し、`lib.rs` では foundation 経由で公開を維持

## 検証
- cargo clippy -- -D warnings
- cargo fmt
- cargo test --workspace

Closes #539