### PR TITLE
refactor: metadata capability を ExtensionFoundation から分離

### DIFF
--- a/model/geo_contracts/src/geometry/foundation/mod.rs
+++ b/model/geo_contracts/src/geometry/foundation/mod.rs
@@ -1,8 +1,10 @@
-//! Geometry extension foundation traits.
+//! 幾何 extension の foundation trait群。
 //!
-//! This module defines the minimal extension contracts for geometric primitives:
-//! - `ExtensionFoundation<T>`: Primitive kind identification and measurement
-//! - `Bounded<T>`: Axis-aligned bounding box (AABB)
+//! このモジュールは、幾何プリミティブ向けの最小 extension 契約を定義します。
+//! - `PrimitiveMetadata`: プリミティブ種別の metadata
+//! - `MeasureFoundation<T>`: 汎用的な測度 capability
+//! - `ExtensionFoundation<T>`: metadata 向けの互換 surface
+//! - `Bounded<T>`: 軸平行境界ボックス (AABB)
 
 pub mod point_measure_traits;
 pub mod vector_measure_traits;
@@ -13,34 +15,40 @@ use analysis::abstract_types::Scalar;
 pub use point_measure_traits::{Point2DMeasure, Point3DMeasure};
 pub use vector_measure_traits::{Vector2DMeasure, Vector3DMeasure};
 
-/// Base trait for all geometric primitives (Extension Foundation).
+/// 幾何プリミティブ向けの metadata capability です。
 ///
-/// Every geometric primitive must implement this trait to provide:
-/// - Type identification (`primitive_kind()`)
-/// - Measurement value access (`measure()`)
-pub trait ExtensionFoundation<T: Scalar = f64> {
-    /// Returns the primitive type.
+/// この trait は、プリミティブ種別の識別を提供します。
+pub trait PrimitiveMetadata {
+    /// プリミティブ種別を返します。
     fn primitive_kind(&self) -> PrimitiveKind;
+}
 
-    /// Returns the measurement value (length, area, volume, etc.) if applicable.
+/// 幾何プリミティブ向けの汎用的な測度 capability です。
+pub trait MeasureFoundation<T: Scalar = f64> {
+    /// 測度値を返します。長さ、面積、体積などが該当します。
     fn measure(&self) -> Option<T>;
 }
 
-/// Trait for geometric primitives with axis-aligned bounding boxes (AABB).
+/// metadata 指向の foundation 境界向け互換 trait です。
+pub trait ExtensionFoundation<T: Scalar = f64>: PrimitiveMetadata {}
+
+impl<T: Scalar, TPrimitive: PrimitiveMetadata + ?Sized> ExtensionFoundation<T> for TPrimitive {}
+
+/// 軸平行境界ボックス (AABB) を持つ幾何プリミティブ向け trait です。
 ///
-/// # Implementors
+/// # 実装対象
 ///
-/// Primitives with spatial extent (Circle, Triangle, NURBS) implement this trait.
-/// Basic elements like Point, Vector, Direction do not need AABB.
+/// Circle、Triangle、NURBS のような空間的広がりを持つプリミティブが実装します。
+/// Point、Vector、Direction のような基本要素では通常不要です。
 ///
-/// # AABB Type
+/// # AABB 型
 ///
-/// The concrete AABB type (`geo_core::Aabb2D`, `geo_core::Aabb3D`) is specified
-/// by the implementor. This trait only defines the contract.
-pub trait Bounded<T: Scalar = f64>: ExtensionFoundation<T> {
-    /// The AABB type (e.g., `geo_core::Aabb2D` or `geo_core::Aabb3D`).
+/// 具体的な AABB 型 (`geo_core::Aabb2D`, `geo_core::Aabb3D`) は実装側が決めます。
+/// この trait はその契約だけを定義します。
+pub trait Bounded<T: Scalar = f64>: PrimitiveMetadata {
+    /// AABB 型です。例: `geo_core::Aabb2D`, `geo_core::Aabb3D`
     type Aabb;
 
-    /// Returns the axis-aligned bounding box.
+    /// 軸平行境界ボックスを返します。
     fn aabb(&self) -> Option<Self::Aabb>;
 }

--- a/model/geo_contracts/src/geometry/foundation/point_measure_traits.rs
+++ b/model/geo_contracts/src/geometry/foundation/point_measure_traits.rs
@@ -1,4 +1,4 @@
-//! Point measure capability traits.
+//! Point 向けの measure capability trait群。
 
 use crate::Scalar;
 

--- a/model/geo_contracts/src/geometry/foundation/vector_measure_traits.rs
+++ b/model/geo_contracts/src/geometry/foundation/vector_measure_traits.rs
@@ -1,4 +1,4 @@
-//! Vector measure capability traits.
+//! Vector 向けの measure capability trait群。
 
 use crate::Scalar;
 

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -59,7 +59,8 @@ pub use geometry::core::{
     Triangle3DConstructor, Triangle3DCore, Triangle3DMeasure, Triangle3DProperties,
 };
 pub use geometry::foundation::{
-    Bounded, ExtensionFoundation, Point2DMeasure, Point3DMeasure, Vector2DMeasure, Vector3DMeasure,
+    Bounded, ExtensionFoundation, MeasureFoundation, Point2DMeasure, Point3DMeasure,
+    PrimitiveMetadata, Vector2DMeasure, Vector3DMeasure,
 };
 pub use geometry::operations::{
     AdvancedCollision, BBoxCollision, BasicCollision, BasicIntersection, CrossDistance,

--- a/model/geo_nurbs/src/curve_2d_foundation.rs
+++ b/model/geo_nurbs/src/curve_2d_foundation.rs
@@ -4,17 +4,19 @@
 
 use crate::{constants, NurbsCurve2D, Scalar};
 use geo_contracts::NurbsCurve2DProperties;
-use geo_contracts::{Bounded, ExtensionFoundation};
+use geo_contracts::{Bounded, MeasureFoundation, PrimitiveMetadata};
 
 // ============================================================================
 // Extension Foundation 実装
 // ============================================================================
 
-impl<T: Scalar> ExtensionFoundation<T> for NurbsCurve2D<T> {
+impl<T: Scalar> PrimitiveMetadata for NurbsCurve2D<T> {
     fn primitive_kind(&self) -> geo_contracts::PrimitiveKind {
         geo_contracts::PrimitiveKind::NurbsCurve2D
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for NurbsCurve2D<T> {
     fn measure(&self) -> Option<T> {
         Some(self.approximate_length(constants::CURVE_LENGTH_SUBDIVISIONS))
     }
@@ -53,7 +55,7 @@ impl<T: Scalar> Bounded<T> for NurbsCurve2D<T> {
 mod tests {
     use crate::knot::clamped_knot_vector;
     use crate::NurbsCurve2D;
-    use geo_contracts::{ExtensionFoundation, PrimitiveKind};
+    use geo_contracts::{MeasureFoundation, PrimitiveKind, PrimitiveMetadata};
     use geo_contracts::{NurbsCurve2DConstructor, NurbsCurve2DMeasure, NurbsCurve2DProperties};
 
     // ============================================================================

--- a/model/geo_nurbs/src/curve_3d_extensions.rs
+++ b/model/geo_nurbs/src/curve_3d_extensions.rs
@@ -130,7 +130,7 @@ impl<T: Scalar> NurbsCurve3D<T> {
     /// ```no_run
     /// # use geo_nurbs::{NurbsCurve3D, curve_3d_extensions::AabbOptions};
     /// # let curve: NurbsCurve3D<f64> = todo!();
-    /// use geo_contracts::ExtensionFoundation;
+    /// use geo_contracts::PrimitiveMetadata;
     ///
     /// // 高速・保守的
     /// let rough_bbox = curve.bounding_box_with_options(AabbOptions::Rough);

--- a/model/geo_nurbs/src/curve_3d_foundation.rs
+++ b/model/geo_nurbs/src/curve_3d_foundation.rs
@@ -2,14 +2,16 @@
 
 use crate::{constants, NurbsCurve3D};
 use geo_contracts::Scalar;
-use geo_contracts::{Bounded, ExtensionFoundation};
+use geo_contracts::{Bounded, MeasureFoundation, PrimitiveMetadata};
 use geo_core::{Aabb3D, Point3D};
 
-impl<T: Scalar> ExtensionFoundation<T> for NurbsCurve3D<T> {
+impl<T: Scalar> PrimitiveMetadata for NurbsCurve3D<T> {
     fn primitive_kind(&self) -> geo_contracts::PrimitiveKind {
         geo_contracts::PrimitiveKind::NurbsCurve3D
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for NurbsCurve3D<T> {
     /// 曲線の測度（曲線長）を返す
     ///
     /// # 注意
@@ -54,7 +56,7 @@ impl<T: Scalar> Bounded<T> for NurbsCurve3D<T> {
 mod tests {
     use super::*;
     use crate::clamped_knot_vector;
-    use geo_contracts::{Bounded, ExtensionFoundation, PrimitiveKind};
+    use geo_contracts::{Bounded, MeasureFoundation, PrimitiveKind, PrimitiveMetadata};
 
     #[test]
     fn test_nurbs_curve_3d_foundation() {

--- a/model/geo_nurbs/src/surface_3d_foundation.rs
+++ b/model/geo_nurbs/src/surface_3d_foundation.rs
@@ -5,17 +5,19 @@
 use crate::NurbsSurface3D;
 use crate::Scalar;
 use geo_contracts::NurbsSurface3DMeasure;
-use geo_contracts::{Bounded, ExtensionFoundation};
+use geo_contracts::{Bounded, MeasureFoundation, PrimitiveMetadata};
 
 // ============================================================================
 // Extension Foundation 実装
 // ============================================================================
 
-impl<T: Scalar> ExtensionFoundation<T> for NurbsSurface3D<T> {
+impl<T: Scalar> PrimitiveMetadata for NurbsSurface3D<T> {
     fn primitive_kind(&self) -> geo_contracts::PrimitiveKind {
         geo_contracts::PrimitiveKind::NurbsSurface3D
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for NurbsSurface3D<T> {
     fn measure(&self) -> Option<T> {
         Some(<Self as NurbsSurface3DMeasure<T>>::surface_area(self))
     }
@@ -326,11 +328,11 @@ mod tests {
         let surface = <NurbsSurface3D<f64> as NurbsSurface3DConstructor<f64>>::unit_plane();
 
         // PrimitiveKind
-        let kind = <NurbsSurface3D<f64> as ExtensionFoundation<f64>>::primitive_kind(&surface);
+        let kind = <NurbsSurface3D<f64> as PrimitiveMetadata>::primitive_kind(&surface);
         assert_eq!(kind, PrimitiveKind::NurbsSurface3D);
 
         // Measure (面積)
-        let measure = <NurbsSurface3D<f64> as ExtensionFoundation<f64>>::measure(&surface);
+        let measure = <NurbsSurface3D<f64> as MeasureFoundation<f64>>::measure(&surface);
         assert!(measure.is_some());
         let area = measure.unwrap();
         assert!((area - 1.0).abs() < 0.1); // 単位平面の面積は1.0

--- a/model/geo_primitives/src/arc_2d_foundation.rs
+++ b/model/geo_primitives/src/arc_2d_foundation.rs
@@ -4,13 +4,15 @@
 
 use crate::Arc2D;
 use geo_contracts::Scalar;
-use geo_contracts::{ExtensionFoundation, PrimitiveKind};
+use geo_contracts::{MeasureFoundation, PrimitiveKind, PrimitiveMetadata};
 
-impl<T: Scalar> ExtensionFoundation<T> for Arc2D<T> {
+impl<T: Scalar> PrimitiveMetadata for Arc2D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::Arc
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for Arc2D<T> {
     fn measure(&self) -> Option<T> {
         // 円弧の長さを測度として返す
         Some(self.arc_length())

--- a/model/geo_primitives/src/arc_3d_foundation.rs
+++ b/model/geo_primitives/src/arc_3d_foundation.rs
@@ -2,18 +2,20 @@
 
 use crate::Arc3D;
 use geo_contracts::Scalar;
-use geo_contracts::{Bounded, ExtensionFoundation, PrimitiveKind, TolerantEq};
+use geo_contracts::{Bounded, MeasureFoundation, PrimitiveKind, PrimitiveMetadata, TolerantEq};
 use geo_core::Aabb3D;
 
 // ============================================================================
 // Foundation Trait Implementation
 // ============================================================================
 
-impl<T: Scalar> ExtensionFoundation<T> for Arc3D<T> {
+impl<T: Scalar> PrimitiveMetadata for Arc3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::Arc
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for Arc3D<T> {
     fn measure(&self) -> Option<T> {
         Some(self.arc_length())
     }

--- a/model/geo_primitives/src/circle_3d_foundation.rs
+++ b/model/geo_primitives/src/circle_3d_foundation.rs
@@ -2,18 +2,20 @@
 
 use crate::Circle3D;
 use geo_contracts::Scalar;
-use geo_contracts::{Bounded, ExtensionFoundation, PrimitiveKind, TolerantEq};
+use geo_contracts::{Bounded, MeasureFoundation, PrimitiveKind, PrimitiveMetadata, TolerantEq};
 use geo_core::Aabb3D;
 
 // ============================================================================
 // Foundation Trait Implementation
 // ============================================================================
 
-impl<T: Scalar> ExtensionFoundation<T> for Circle3D<T> {
+impl<T: Scalar> PrimitiveMetadata for Circle3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::Circle
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for Circle3D<T> {
     fn measure(&self) -> Option<T> {
         Some(self.area())
     }

--- a/model/geo_primitives/src/conical_solid_3d_foundation.rs
+++ b/model/geo_primitives/src/conical_solid_3d_foundation.rs
@@ -6,14 +6,18 @@
 //! **最終更新: 2025年11月1日**
 
 use crate::ConicalSolid3D;
-use geo_contracts::{Bounded, ExtensionFoundation, PrimitiveKind, Scalar, TolerantEq};
+use geo_contracts::{
+    Bounded, MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar, TolerantEq,
+};
 use geo_core::Aabb3D;
 
-impl<T: Scalar> ExtensionFoundation<T> for ConicalSolid3D<T> {
+impl<T: Scalar> PrimitiveMetadata for ConicalSolid3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::ConicalSolid
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for ConicalSolid3D<T> {
     fn measure(&self) -> Option<T> {
         Some(self.volume_internal())
     }

--- a/model/geo_primitives/src/conical_surface_3d_foundation.rs
+++ b/model/geo_primitives/src/conical_surface_3d_foundation.rs
@@ -4,14 +4,16 @@
 //! 他の幾何プリミティブとの統一インターフェースを提供
 
 use crate::ConicalSurface3D;
-use geo_contracts::{Bounded, ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::{Bounded, MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar};
 use geo_core::Aabb3D;
 
-impl<T: Scalar> ExtensionFoundation<T> for ConicalSurface3D<T> {
+impl<T: Scalar> PrimitiveMetadata for ConicalSurface3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::ConicalSurface
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for ConicalSurface3D<T> {
     fn measure(&self) -> Option<T> {
         // 円錐サーフェスの表面積は無限大（無制限範囲）
         // 境界が指定された場合のみ計算可能

--- a/model/geo_primitives/src/cylindrical_solid_3d_foundation.rs
+++ b/model/geo_primitives/src/cylindrical_solid_3d_foundation.rs
@@ -1,18 +1,22 @@
 //! CylindricalSolid3D の Foundation トレイト実装
 
 use crate::CylindricalSolid3D;
-use geo_contracts::{Bounded, ExtensionFoundation, PrimitiveKind, Scalar, TolerantEq};
+use geo_contracts::{
+    Bounded, MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar, TolerantEq,
+};
 use geo_core::Aabb3D;
 
 // ============================================================================
 // Foundation Trait Implementation
 // ============================================================================
 
-impl<T: Scalar> ExtensionFoundation<T> for CylindricalSolid3D<T> {
+impl<T: Scalar> PrimitiveMetadata for CylindricalSolid3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::CylindricalSolid
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for CylindricalSolid3D<T> {
     fn measure(&self) -> Option<T> {
         Some(self.volume_internal())
     }

--- a/model/geo_primitives/src/cylindrical_surface_3d_foundation.rs
+++ b/model/geo_primitives/src/cylindrical_surface_3d_foundation.rs
@@ -4,18 +4,22 @@
 //! ハイブリッドモデラーの分類システムとの統合
 
 use crate::CylindricalSurface3D;
-use geo_contracts::{Bounded, ExtensionFoundation, PrimitiveKind, Scalar, TolerantEq};
+use geo_contracts::{
+    Bounded, MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar, TolerantEq,
+};
 use geo_core::Aabb3D;
 
 // ============================================================================
 // ExtensionFoundation Implementation
 // ============================================================================
 
-impl<T: Scalar> ExtensionFoundation<T> for CylindricalSurface3D<T> {
+impl<T: Scalar> PrimitiveMetadata for CylindricalSurface3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::CylindricalSurface
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for CylindricalSurface3D<T> {
     fn measure(&self) -> Option<T> {
         // サーフェスの測度は面積だが、無限サーフェスのため None
         // 境界制約された場合のみ有限の面積を持つ

--- a/model/geo_primitives/src/ellipse_2d_foundation.rs
+++ b/model/geo_primitives/src/ellipse_2d_foundation.rs
@@ -3,13 +3,15 @@
 //! ExtensionFoundation トレイトの実装
 
 use crate::Ellipse2D;
-use geo_contracts::{ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::{MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar};
 
-impl<T: Scalar> ExtensionFoundation<T> for Ellipse2D<T> {
+impl<T: Scalar> PrimitiveMetadata for Ellipse2D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::Ellipse
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for Ellipse2D<T> {
     fn measure(&self) -> Option<T> {
         Some(self.area())
     }

--- a/model/geo_primitives/src/ellipse_arc_2d_foundation.rs
+++ b/model/geo_primitives/src/ellipse_arc_2d_foundation.rs
@@ -3,13 +3,15 @@
 //! ExtensionFoundation トレイトの実装
 
 use crate::EllipseArc2D;
-use geo_contracts::{ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::{MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar};
 
-impl<T: Scalar> ExtensionFoundation<T> for EllipseArc2D<T> {
+impl<T: Scalar> PrimitiveMetadata for EllipseArc2D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::Arc
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for EllipseArc2D<T> {
     fn measure(&self) -> Option<T> {
         // 楕円弧の長さを測度として返す
         Some(self.arc_length())

--- a/model/geo_primitives/src/ellipse_arc_3d_foundation.rs
+++ b/model/geo_primitives/src/ellipse_arc_3d_foundation.rs
@@ -1,18 +1,20 @@
 //! EllipseArc3D の Foundation トレイト実装
 
 use crate::EllipseArc3D;
-use geo_contracts::{Bounded, ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::{Bounded, MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar};
 use geo_core::Aabb3D;
 
 // ============================================================================
 // Foundation Trait Implementation
 // ============================================================================
 
-impl<T: Scalar> ExtensionFoundation<T> for EllipseArc3D<T> {
+impl<T: Scalar> PrimitiveMetadata for EllipseArc3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::Arc
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for EllipseArc3D<T> {
     fn measure(&self) -> Option<T> {
         // 楕円弧の測度は arc_length() メソッドが実装されていないため None を返す
         // TODO: EllipseArc3D に arc_length() メソッドを実装する必要がある

--- a/model/geo_primitives/src/ellipsoidal_solid_3d_foundation.rs
+++ b/model/geo_primitives/src/ellipsoidal_solid_3d_foundation.rs
@@ -3,14 +3,16 @@
 //! ExtensionFoundation トレイトによる統一インターフェースの実装
 
 use crate::{EllipsoidalSolid3D, Point3D};
-use geo_contracts::{Bounded, ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::{Bounded, MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar};
 use geo_core::Aabb3D;
 
-impl<T: Scalar> ExtensionFoundation<T> for EllipsoidalSolid3D<T> {
+impl<T: Scalar> PrimitiveMetadata for EllipsoidalSolid3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::EllipsoidalSolid
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for EllipsoidalSolid3D<T> {
     fn measure(&self) -> Option<T> {
         Some(self.volume())
     }

--- a/model/geo_primitives/src/ellipsoidal_surface_3d_foundation.rs
+++ b/model/geo_primitives/src/ellipsoidal_surface_3d_foundation.rs
@@ -1,14 +1,16 @@
 //! EllipsoidalSurface3D の Foundation パターン実装
 
 use crate::EllipsoidalSurface3D;
-use geo_contracts::{Bounded, ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::{Bounded, MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar};
 use geo_core::Aabb3D;
 
-impl<T: Scalar> ExtensionFoundation<T> for EllipsoidalSurface3D<T> {
+impl<T: Scalar> PrimitiveMetadata for EllipsoidalSurface3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::EllipsoidalSurface
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for EllipsoidalSurface3D<T> {
     fn measure(&self) -> Option<T> {
         Some(self.surface_area())
     }

--- a/model/geo_primitives/src/infinite_line_2d_foundation.rs
+++ b/model/geo_primitives/src/infinite_line_2d_foundation.rs
@@ -4,13 +4,15 @@
 
 use crate::InfiniteLine2D;
 use geo_contracts::Scalar;
-use geo_contracts::{ExtensionFoundation, PrimitiveKind};
+use geo_contracts::{MeasureFoundation, PrimitiveKind, PrimitiveMetadata};
 
-impl<T: Scalar> ExtensionFoundation<T> for InfiniteLine2D<T> {
+impl<T: Scalar> PrimitiveMetadata for InfiniteLine2D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::InfiniteLine
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for InfiniteLine2D<T> {
     fn measure(&self) -> Option<T> {
         None // 無限直線の長さは定義されない
     }

--- a/model/geo_primitives/src/infinite_line_3d_foundation.rs
+++ b/model/geo_primitives/src/infinite_line_3d_foundation.rs
@@ -4,13 +4,15 @@
 
 use crate::InfiniteLine3D;
 use geo_contracts::Scalar;
-use geo_contracts::{ExtensionFoundation, PrimitiveKind};
+use geo_contracts::{MeasureFoundation, PrimitiveKind, PrimitiveMetadata};
 
-impl<T: Scalar> ExtensionFoundation<T> for InfiniteLine3D<T> {
+impl<T: Scalar> PrimitiveMetadata for InfiniteLine3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::InfiniteLine
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for InfiniteLine3D<T> {
     fn measure(&self) -> Option<T> {
         None // 無限直線の長さは定義されない
     }

--- a/model/geo_primitives/src/line_segment_2d_foundation.rs
+++ b/model/geo_primitives/src/line_segment_2d_foundation.rs
@@ -4,13 +4,15 @@
 
 use crate::LineSegment2D;
 use geo_contracts::Scalar;
-use geo_contracts::{ExtensionFoundation, PrimitiveKind};
+use geo_contracts::{MeasureFoundation, PrimitiveKind, PrimitiveMetadata};
 
-impl<T: Scalar> ExtensionFoundation<T> for LineSegment2D<T> {
+impl<T: Scalar> PrimitiveMetadata for LineSegment2D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::LineSegment
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for LineSegment2D<T> {
     fn measure(&self) -> Option<T> {
         // 線分の長さを測度として返す
         Some((self.end_param - self.start_param).abs())

--- a/model/geo_primitives/src/line_segment_3d_foundation.rs
+++ b/model/geo_primitives/src/line_segment_3d_foundation.rs
@@ -4,13 +4,15 @@
 
 use crate::LineSegment3D;
 use geo_contracts::Scalar;
-use geo_contracts::{ExtensionFoundation, PrimitiveKind};
+use geo_contracts::{MeasureFoundation, PrimitiveKind, PrimitiveMetadata};
 
-impl<T: Scalar> ExtensionFoundation<T> for LineSegment3D<T> {
+impl<T: Scalar> PrimitiveMetadata for LineSegment3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::LineSegment
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for LineSegment3D<T> {
     fn measure(&self) -> Option<T> {
         // 線分の長さを測度として返す
         Some(self.end_param - self.start_param)

--- a/model/geo_primitives/src/plane_3d_foundation.rs
+++ b/model/geo_primitives/src/plane_3d_foundation.rs
@@ -1,17 +1,19 @@
 //! Plane3D の Foundation トレイト実装
 
 use crate::Plane3D;
-use geo_contracts::{ExtensionFoundation, PrimitiveKind, Scalar, TolerantEq};
+use geo_contracts::{MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar, TolerantEq};
 
 // ============================================================================
 // Foundation Trait Implementation
 // ============================================================================
 
-impl<T: Scalar> ExtensionFoundation<T> for Plane3D<T> {
+impl<T: Scalar> PrimitiveMetadata for Plane3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::Plane
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for Plane3D<T> {
     fn measure(&self) -> Option<T> {
         // 無限平面の測度（面積）は無限大なので None を返す
         None
@@ -46,7 +48,7 @@ impl<T: Scalar> TolerantEq<T> for Plane3D<T> {
 mod tests {
     use super::*;
     use crate::{Point3D, Vector3D};
-    use geo_contracts::{ExtensionFoundation, TolerantEq};
+    use geo_contracts::TolerantEq;
 
     #[test]
     fn test_extension_foundation() {

--- a/model/geo_primitives/src/ray_2d_foundation.rs
+++ b/model/geo_primitives/src/ray_2d_foundation.rs
@@ -4,13 +4,15 @@
 
 use crate::Ray2D;
 use geo_contracts::Scalar;
-use geo_contracts::{ExtensionFoundation, PrimitiveKind};
+use geo_contracts::{MeasureFoundation, PrimitiveKind, PrimitiveMetadata};
 
-impl<T: Scalar> ExtensionFoundation<T> for Ray2D<T> {
+impl<T: Scalar> PrimitiveMetadata for Ray2D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::Ray
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for Ray2D<T> {
     fn measure(&self) -> Option<T> {
         None // 半無限直線の長さは定義されない
     }

--- a/model/geo_primitives/src/ray_3d_foundation.rs
+++ b/model/geo_primitives/src/ray_3d_foundation.rs
@@ -2,17 +2,19 @@
 
 use crate::Ray3D;
 use geo_contracts::Scalar;
-use geo_contracts::{ExtensionFoundation, PrimitiveKind, TolerantEq};
+use geo_contracts::{MeasureFoundation, PrimitiveKind, PrimitiveMetadata, TolerantEq};
 
 // ============================================================================
 // Foundation Trait Implementation
 // ============================================================================
 
-impl<T: Scalar> ExtensionFoundation<T> for Ray3D<T> {
+impl<T: Scalar> PrimitiveMetadata for Ray3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::Ray
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for Ray3D<T> {
     fn measure(&self) -> Option<T> {
         // レイの測度は無限大（長さがない）
         None // 無限大なので None を返す

--- a/model/geo_primitives/src/rectangle_2d_foundation.rs
+++ b/model/geo_primitives/src/rectangle_2d_foundation.rs
@@ -1,13 +1,15 @@
 //! Rect2D の Foundation トレイト実装
 
 use crate::Rect2D;
-use geo_contracts::{ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::{MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar};
 
-impl<T: Scalar> ExtensionFoundation<T> for Rect2D<T> {
+impl<T: Scalar> PrimitiveMetadata for Rect2D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::Rectangle
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for Rect2D<T> {
     fn measure(&self) -> Option<T> {
         Some(self.area())
     }

--- a/model/geo_primitives/src/rectangle_3d_foundation.rs
+++ b/model/geo_primitives/src/rectangle_3d_foundation.rs
@@ -1,13 +1,15 @@
 //! Rect3D の Foundation トレイト実装
 
 use crate::Rect3D;
-use geo_contracts::{ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::{MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar};
 
-impl<T: Scalar> ExtensionFoundation<T> for Rect3D<T> {
+impl<T: Scalar> PrimitiveMetadata for Rect3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::Rectangle
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for Rect3D<T> {
     fn measure(&self) -> Option<T> {
         Some(self.area())
     }

--- a/model/geo_primitives/src/spherical_solid_3d_foundation.rs
+++ b/model/geo_primitives/src/spherical_solid_3d_foundation.rs
@@ -6,14 +6,16 @@
 //! **最終更新: 2025年11月1日**
 
 use crate::SphericalSolid3D;
-use geo_contracts::{Bounded, ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::{Bounded, MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar};
 use geo_core::Aabb3D;
 
-impl<T: Scalar> ExtensionFoundation<T> for SphericalSolid3D<T> {
+impl<T: Scalar> PrimitiveMetadata for SphericalSolid3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::SphericalSolid
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for SphericalSolid3D<T> {
     fn measure(&self) -> Option<T> {
         Some(self.volume())
     }

--- a/model/geo_primitives/src/spherical_surface_3d_foundation.rs
+++ b/model/geo_primitives/src/spherical_surface_3d_foundation.rs
@@ -6,14 +6,16 @@
 //! **最終更新: 2025年11月1日**
 
 use crate::SphericalSurface3D;
-use geo_contracts::{Bounded, ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::{Bounded, MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar};
 use geo_core::Aabb3D;
 
-impl<T: Scalar> ExtensionFoundation<T> for SphericalSurface3D<T> {
+impl<T: Scalar> PrimitiveMetadata for SphericalSurface3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::SphericalSurface
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for SphericalSurface3D<T> {
     fn measure(&self) -> Option<T> {
         Some(self.surface_area())
     }

--- a/model/geo_primitives/src/torus_solid_3d_foundation.rs
+++ b/model/geo_primitives/src/torus_solid_3d_foundation.rs
@@ -5,14 +5,16 @@
 // 境界ボックス計算、測度（体積）、プリミティブ種別の分類を行います。
 
 use crate::TorusSolid3D;
-use geo_contracts::{Bounded, ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::{Bounded, MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar};
 use geo_core::Aabb3D;
 
-impl<T: Scalar> ExtensionFoundation<T> for TorusSolid3D<T> {
+impl<T: Scalar> PrimitiveMetadata for TorusSolid3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::TorusSolid
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for TorusSolid3D<T> {
     fn measure(&self) -> Option<T> {
         Some(self.volume_internal())
     }

--- a/model/geo_primitives/src/torus_surface_3d_foundation.rs
+++ b/model/geo_primitives/src/torus_surface_3d_foundation.rs
@@ -4,15 +4,17 @@
 // Foundation パターンに従い、統一されたプリミティブインターフェースを提供します。
 
 use crate::{Point3D, TorusSurface3D};
-use geo_contracts::{Bounded, ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::{Bounded, MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar};
 use geo_core::Aabb3D;
 
-impl<T: Scalar> ExtensionFoundation<T> for TorusSurface3D<T> {
+impl<T: Scalar> PrimitiveMetadata for TorusSurface3D<T> {
     /// プリミティブの種類を返す
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::TorusSurface
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for TorusSurface3D<T> {
     fn measure(&self) -> Option<T> {
         Some(self.surface_area())
     }

--- a/model/geo_primitives/src/triangle_2d_foundation.rs
+++ b/model/geo_primitives/src/triangle_2d_foundation.rs
@@ -3,13 +3,15 @@
 //! ExtensionFoundation トレイトの実装
 
 use crate::Triangle2D;
-use geo_contracts::{ExtensionFoundation, PrimitiveKind, Scalar};
+use geo_contracts::{MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar};
 
-impl<T: Scalar> ExtensionFoundation<T> for Triangle2D<T> {
+impl<T: Scalar> PrimitiveMetadata for Triangle2D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::Triangle
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for Triangle2D<T> {
     fn measure(&self) -> Option<T> {
         Some(self.area())
     }

--- a/model/geo_primitives/src/triangle_3d_foundation.rs
+++ b/model/geo_primitives/src/triangle_3d_foundation.rs
@@ -1,18 +1,22 @@
 //! Triangle3D の Foundation トレイト実装
 
 use crate::Triangle3D;
-use geo_contracts::{Bounded, ExtensionFoundation, PrimitiveKind, Scalar, TolerantEq};
+use geo_contracts::{
+    Bounded, MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar, TolerantEq,
+};
 use geo_core::Aabb3D;
 
 // ============================================================================
 // Foundation Trait Implementation
 // ============================================================================
 
-impl<T: Scalar> ExtensionFoundation<T> for Triangle3D<T> {
+impl<T: Scalar> PrimitiveMetadata for Triangle3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::Triangle
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for Triangle3D<T> {
     fn measure(&self) -> Option<T> {
         Some(self.area())
     }

--- a/model/geo_primitives/src/triangle_mesh_3d_foundation.rs
+++ b/model/geo_primitives/src/triangle_mesh_3d_foundation.rs
@@ -1,18 +1,22 @@
 //! TriangleMesh3D の Foundation トレイト実装
 
 use crate::TriangleMesh3D;
-use geo_contracts::{Bounded, ExtensionFoundation, PrimitiveKind, Scalar, TolerantEq};
+use geo_contracts::{
+    Bounded, MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar, TolerantEq,
+};
 use geo_core::Aabb3D;
 
 // ============================================================================
 // Foundation Trait Implementation
 // ============================================================================
 
-impl<T: Scalar> ExtensionFoundation<T> for TriangleMesh3D<T> {
+impl<T: Scalar> PrimitiveMetadata for TriangleMesh3D<T> {
     fn primitive_kind(&self) -> PrimitiveKind {
         PrimitiveKind::Mesh
     }
+}
 
+impl<T: Scalar> MeasureFoundation<T> for TriangleMesh3D<T> {
     fn measure(&self) -> Option<T> {
         // 三角形の面積の合計を計算
         let mut total_area = T::ZERO;

--- a/viewmodel/converter/src/shape_converter.rs
+++ b/viewmodel/converter/src/shape_converter.rs
@@ -18,7 +18,7 @@
 //!
 //! ## Foundation Patternとの統合
 //!
-//! `ExtensionFoundation` トレイトの `primitive_kind()` を活用して、
+//! `PrimitiveMetadata` trait の `primitive_kind()` を活用して、
 //! 型消去された形状オブジェクトを適切に変換します。
 
 use crate::mesh_converter::VertexData;


### PR DESCRIPTION
## 概要
- metadata capability と measure capability を分離
- `primitive_kind()` と `measure()` の所属を明確化
- `ExtensionFoundation` は metadata 向けの互換 surface に再定義

## 対応内容
- `geo_contracts` に `PrimitiveMetadata` と `MeasureFoundation` を追加
- `Bounded` の境界を metadata 側へ寄せて、`ExtensionFoundation` の責務を縮小
- `geo_primitives` / `geo_nurbs` の foundation 実装を `primitive_kind()` と `measure()` の別 trait 実装へ分離
- 利用側コメントと doc 例を新しい責務境界に合わせて更新
- foundation 配下の新規コメントを日本語へ統一

## 検証
- cargo clippy -- -D warnings
- cargo fmt
- cargo test --workspace

Closes #542