### PR TITLE
[Phase4] refactor: cross-shape と algorithm capability を operations へ移送

### DIFF
--- a/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
+++ b/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
@@ -277,6 +277,53 @@ Issue #535 では、`geo_contracts` の trait構造を次の最小構造へ再�
 
 - `geometry/core` から外し、operations 側へ寄せる
 
+### 12. #541 で優先して移す対象
+
+Issue #541 では、まず既存の `geometry::operations` trait に自然に載るものから移す。
+
+- deprecated な same-shape distance API
+- `LineSegment3D` と AABB の距離
+- `InfiniteLine3D` / `Plane3D` / `Ellipse3D` が持つ明示的な交点計算
+
+設計反映:
+
+- 距離は `CrossDistance`
+- 単一点交差は `BasicIntersection`
+- 複数交点は `MultipleIntersection`
+- concrete 型の convenience method は必要最小限だけ残し、trait定義の正本は `operations` 側に寄せる
+
+### 13. relation 系メソッドは独立に厳格判定する
+
+判定:
+
+- optional ではなく、責務分離の中核ルールとして扱う
+- 相手 shape の存在を前提にし、幾何学的な関係を返す API は relation 系として個別判定する
+
+relation 系の代表例:
+
+- `is_parallel_to`
+- `is_perpendicular_to`
+- `is_same_line`
+- `intersects`
+- `is_skew_to`
+- `is_same_direction`
+- `is_opposite_direction`
+- `angle_to`
+- `angle_between`
+- `closest_points`
+
+理由:
+
+- unary な measure / evaluation / metadata と、binary な relation が混在すると `core` と `minimal extension` の責務が再び曖昧になるから
+- 相手 shape を取る relation API を曖昧に残すと、same-shape distance や intersection と同様に `operations` へ寄せるべき責務が再流入するから
+- #541 の完了条件は、cross-shape の計算だけでなく relation API の所属も一貫して説明できる状態にすることだから
+
+設計反映:
+
+- relation 系メソッドは `measure` の残余として扱わない
+- `other: &Self` や他 shape 引数を取り、関係判定・角度・最近点対を返す API は relation 系候補として必ず棚卸しする
+- relation 系を `minimal extension` に残す場合でも、`operations` に寄せない理由を Issue / PR で明示する
+
 ## 採用する境界線
 
 最終的な境界線は次のとおりとする。
@@ -294,11 +341,17 @@ Issue #535 では、`geo_contracts` の trait構造を次の最小構造へ再�
 - sampling / evaluation / containment のような単一 shape capability
 - `primitive_kind()` のような lightweight metadata capability
 
+補足:
+
+- relation 系メソッドはこの層へ無批判に残さない
+- 相手 shape を取る API は、まず `operations` 候補として判定する
+
 ### operations
 
 - collision / distance / intersection
 - strategy / approximation / solver oriented capability
 - cross-shape specialized contracts
+- relation API
 
 ## 次段で必要な作業
 
@@ -338,6 +391,7 @@ Issue #535 では、`geo_contracts` の trait構造を次の最小構造へ再�
 - [ ] `Properties` の各メソッドが参照系に残せるか確認した
 - [ ] `Measure` 系 API を definition core に残していない
 - [ ] `contains_point` / `distance_to_point` / `point_at_parameter` / sampling 系を個別判定した
+- [ ] relation 系メソッド（平行・垂直・交差・同方向・角度・最近点対）を個別判定した
 
 ### 3. 配置変更
 
@@ -357,6 +411,7 @@ Issue #535 では、`geo_contracts` の trait構造を次の最小構造へ再�
 - [ ] extension と operations の境界が今回の変更で曖昧になっていない
 - [ ] metadata capability と measure capability を混在させていない
 - [ ] cross-shape 演算を definition core に持ち込んでいない
+- [ ] relation 系メソッドを "measure のついで" で残していない
 - [ ] shape 参照と capability の責務を文章で説明できる
 
 ### 6. 検証

--- a/model/geo_contracts/src/geometry/core/circle_traits.rs
+++ b/model/geo_contracts/src/geometry/core/circle_traits.rs
@@ -98,11 +98,6 @@ pub trait Circle2DMeasure<T: Scalar> {
     fn point_on_circumference(&self, point: (T, T)) -> bool;
     fn closest_point_to(&self, point: (T, T)) -> (T, T);
     fn point_at_parameter(&self, t: T) -> (T, T);
-    #[deprecated(
-        since = "0.1.0",
-        note = "cross-shape distance contracts are migrating to geometry::operations::CrossDistance"
-    )]
-    fn distance_to_circle(&self, other: &Self) -> T;
 }
 
 pub trait Circle3DMeasure<T: Scalar> {
@@ -113,11 +108,6 @@ pub trait Circle3DMeasure<T: Scalar> {
     fn point_on_circumference(&self, point: (T, T, T)) -> bool;
     fn closest_point_to(&self, point: (T, T, T)) -> (T, T, T);
     fn point_at_parameter(&self, t: T) -> (T, T, T);
-    #[deprecated(
-        since = "0.1.0",
-        note = "cross-shape distance contracts are migrating to geometry::operations::CrossDistance"
-    )]
-    fn distance_to_circle(&self, other: &Self) -> T;
 }
 
 pub trait Circle2DCore<T: Scalar>:

--- a/model/geo_contracts/src/geometry/core/cylindrical_solid_traits.rs
+++ b/model/geo_contracts/src/geometry/core/cylindrical_solid_traits.rs
@@ -62,7 +62,6 @@ pub trait CylindricalSolid3DMeasure<T: Scalar> {
     fn point_at_cylindrical(&self, r: T, theta: T, z: T) -> (T, T, T);
     fn bounding_box(&self) -> ((T, T, T), (T, T, T));
     fn closest_point_on_surface(&self, point: (T, T, T)) -> (T, T, T);
-    fn intersects_line(&self, line_point: (T, T, T), line_dir: (T, T, T)) -> Option<(T, T, T)>;
 }
 
 pub trait CylindricalSolid3DCore<T: Scalar>:

--- a/model/geo_contracts/src/geometry/core/ellipse_traits.rs
+++ b/model/geo_contracts/src/geometry/core/ellipse_traits.rs
@@ -178,20 +178,6 @@ pub trait Ellipse3DMeasure<T: Scalar> {
     /// 3D空間での点から楕円への最短距離を計算
     fn distance_to_point_3d(&self, point: (T, T, T)) -> T;
 
-    /// 3D空間での直線との交点を計算
-    fn intersection_with_line_3d(
-        &self,
-        line_point: (T, T, T),
-        line_direction: (T, T, T),
-    ) -> Vec<(T, T, T)>;
-
-    /// 平面との交点を計算
-    fn intersection_with_plane(
-        &self,
-        plane_point: (T, T, T),
-        plane_normal: (T, T, T),
-    ) -> Vec<(T, T, T)>;
-
     /// 楕円の面積を計算
     fn measure(&self) -> T;
 

--- a/model/geo_contracts/src/geometry/core/infinite_line_traits.rs
+++ b/model/geo_contracts/src/geometry/core/infinite_line_traits.rs
@@ -130,7 +130,6 @@ pub trait InfiniteLine3DProperties<T: Scalar> {
     fn passes_through_origin(&self) -> bool;
     fn dimension(&self) -> u32;
     fn xy_angle(&self) -> T;
-    fn is_on_plane(&self, plane_normal: (T, T, T), plane_point: (T, T, T)) -> bool;
     fn is_axis_aligned(&self) -> bool;
 }
 

--- a/model/geo_contracts/src/geometry/core/infinite_line_traits.rs
+++ b/model/geo_contracts/src/geometry/core/infinite_line_traits.rs
@@ -166,11 +166,6 @@ pub trait InfiniteLine3DMeasure<T: Scalar> {
     fn contains_point(&self, point: (T, T, T)) -> bool;
     fn project_point(&self, point: (T, T, T)) -> (T, T, T);
     fn parameter_for_point(&self, point: (T, T, T)) -> T;
-    #[deprecated(
-        since = "0.1.0",
-        note = "cross-shape distance contracts are migrating to geometry::operations::CrossDistance"
-    )]
-    fn distance_to_line(&self, other: &Self) -> T;
     fn closest_points(&self, other: &Self) -> Option<TwoPoints3D<T>>;
     fn is_parallel_to(&self, other: &Self) -> bool;
     fn is_perpendicular_to(&self, other: &Self) -> bool;
@@ -190,12 +185,6 @@ pub trait InfiniteLine3DMeasure<T: Scalar> {
     ) -> Option<Self>
     where
         Self: Sized;
-    fn intersection_with_plane(
-        &self,
-        plane_point: (T, T, T),
-        plane_normal: (T, T, T),
-    ) -> Option<(T, T, T)>;
-    fn intersection_with_line(&self, other: &Self) -> Option<(T, T, T)>;
 }
 
 pub trait InfiniteLine2DCore<T: Scalar>:

--- a/model/geo_contracts/src/geometry/core/infinite_line_traits.rs
+++ b/model/geo_contracts/src/geometry/core/infinite_line_traits.rs
@@ -140,11 +140,6 @@ pub trait InfiniteLine2DMeasure<T: Scalar> {
     fn contains_point(&self, point: (T, T)) -> bool;
     fn project_point(&self, point: (T, T)) -> (T, T);
     fn parameter_for_point(&self, point: (T, T)) -> T;
-    fn intersection(&self, other: &Self) -> Option<(T, T)>;
-    fn is_parallel_to(&self, other: &Self) -> bool;
-    fn is_perpendicular_to(&self, other: &Self) -> bool;
-    fn is_same_line(&self, other: &Self) -> bool;
-    fn angle_to(&self, other: &Self) -> T;
     fn reverse(&self) -> Self
     where
         Self: Sized;
@@ -166,13 +161,6 @@ pub trait InfiniteLine3DMeasure<T: Scalar> {
     fn contains_point(&self, point: (T, T, T)) -> bool;
     fn project_point(&self, point: (T, T, T)) -> (T, T, T);
     fn parameter_for_point(&self, point: (T, T, T)) -> T;
-    fn closest_points(&self, other: &Self) -> Option<TwoPoints3D<T>>;
-    fn is_parallel_to(&self, other: &Self) -> bool;
-    fn is_perpendicular_to(&self, other: &Self) -> bool;
-    fn is_same_line(&self, other: &Self) -> bool;
-    fn intersects(&self, other: &Self) -> bool;
-    fn is_skew_to(&self, other: &Self) -> bool;
-    fn angle_to(&self, other: &Self) -> T;
     fn reverse(&self) -> Self
     where
         Self: Sized;

--- a/model/geo_contracts/src/geometry/core/linesegment_traits.rs
+++ b/model/geo_contracts/src/geometry/core/linesegment_traits.rs
@@ -146,13 +146,6 @@ pub trait LineSegment2DMeasure<T: Scalar> {
     /// 点から線分への最近点を計算
     fn closest_point_to(&self, point: (T, T)) -> (T, T);
 
-    /// 2つの線分間の最短距離
-    #[deprecated(
-        since = "0.1.0",
-        note = "cross-shape distance contracts are migrating to geometry::operations::CrossDistance"
-    )]
-    fn distance_to_segment(&self, other: &Self) -> T;
-
     /// 方向ベクトルを取得
     fn direction_vector(&self) -> (T, T);
 
@@ -177,28 +170,11 @@ pub trait LineSegment3DMeasure<T: Scalar> {
     /// 点から線分への最近点を計算
     fn closest_point_to(&self, point: (T, T, T)) -> (T, T, T);
 
-    /// 2つの線分間の最短距離
-    #[deprecated(
-        since = "0.1.0",
-        note = "cross-shape distance contracts are migrating to geometry::operations::CrossDistance"
-    )]
-    fn distance_to_segment(&self, other: &Self) -> T;
-
     /// 方向ベクトルを取得
     fn direction_vector(&self) -> (T, T, T);
 
     /// 線分のベクトル表現（始点から終点）
     fn as_vector(&self) -> (T, T, T);
-}
-
-/// LineSegment3DとAxisAlignedBoundingBox（AABB）の衝突検出トレイト
-pub trait LineSegment3DCollisionDetection<T: Scalar> {
-    /// 線分と軸並行境界ボックス（AABB）の最短距離を計算
-    #[deprecated(
-        since = "0.1.0",
-        note = "cross-shape distance contracts are migrating to geometry::operations::CrossDistance"
-    )]
-    fn distance_to_aabb(&self, aabb_min: (T, T, T), aabb_max: (T, T, T)) -> T;
 }
 
 /// LineSegment2Dの3つのCore機能統合トレイト

--- a/model/geo_contracts/src/geometry/core/mod.rs
+++ b/model/geo_contracts/src/geometry/core/mod.rs
@@ -79,8 +79,7 @@ pub use infinite_line_traits::{
 };
 pub use linesegment_traits::{
     LineSegment2DConstructor, LineSegment2DCore, LineSegment2DMeasure, LineSegment2DProperties,
-    LineSegment3DCollisionDetection, LineSegment3DConstructor, LineSegment3DCore,
-    LineSegment3DMeasure, LineSegment3DProperties,
+    LineSegment3DConstructor, LineSegment3DCore, LineSegment3DMeasure, LineSegment3DProperties,
 };
 pub use nurbs_curve_2d_traits::{
     NurbsCurve2DConstructor, NurbsCurve2DCore, NurbsCurve2DMeasure, NurbsCurve2DProperties,

--- a/model/geo_contracts/src/geometry/core/plane3d_traits.rs
+++ b/model/geo_contracts/src/geometry/core/plane3d_traits.rs
@@ -78,14 +78,6 @@ pub trait Plane3DMeasure<T: Scalar> {
 
     /// 点を平面に対して鏡面反射
     fn mirror_point(&self, point: (T, T, T)) -> (T, T, T);
-
-    /// 他の平面との交線を計算（方向ベクトルと通過点を返す）
-    #[allow(clippy::type_complexity)]
-    fn intersection_with_plane(
-        &self,
-        other_origin: (T, T, T),
-        other_normal: (T, T, T),
-    ) -> Option<((T, T, T), (T, T, T))>;
 }
 
 /// Plane3D Core トレイト（統合インターフェース）

--- a/model/geo_contracts/src/geometry/core/ray_traits.rs
+++ b/model/geo_contracts/src/geometry/core/ray_traits.rs
@@ -149,19 +149,13 @@ pub trait Ray2DMeasure<T: Scalar> {
     fn distance_to_point(&self, point: (T, T)) -> T;
     fn contains_point(&self, point: (T, T)) -> bool;
     fn parameter_for_point(&self, point: (T, T)) -> T;
-    fn points_towards(&self, direction: (T, T)) -> bool;
-    fn is_parallel_to(&self, other: &Self) -> bool;
-    fn is_same_direction(&self, other: &Self) -> bool;
-    fn is_opposite_direction(&self, other: &Self) -> bool;
     fn reverse(&self) -> Self
     where
         Self: Sized;
     fn translate(&self, offset: (T, T)) -> Self
     where
         Self: Sized;
-    fn intersection_with_ray(&self, other: &Self) -> Option<(T, T)>;
     fn point_at_distance(&self, distance: T) -> (T, T);
-    fn angle_between(&self, other: &Self) -> T;
     fn rotate_around_origin(&self, angle: T) -> Self
     where
         Self: Sized;
@@ -173,10 +167,6 @@ pub trait Ray3DMeasure<T: Scalar> {
     fn distance_to_point(&self, point: (T, T, T)) -> T;
     fn contains_point(&self, point: (T, T, T)) -> bool;
     fn parameter_for_point(&self, point: (T, T, T)) -> T;
-    fn points_towards(&self, direction: (T, T, T)) -> bool;
-    fn is_parallel_to(&self, other: &Self) -> bool;
-    fn is_same_direction(&self, other: &Self) -> bool;
-    fn is_opposite_direction(&self, other: &Self) -> bool;
     fn reverse(&self) -> Self
     where
         Self: Sized;
@@ -184,7 +174,6 @@ pub trait Ray3DMeasure<T: Scalar> {
     where
         Self: Sized;
     fn point_at_distance(&self, distance: T) -> (T, T, T);
-    fn angle_between(&self, other: &Self) -> T;
     fn rotate_around_axis(&self, axis: (T, T, T), angle: T) -> Option<Self>
     where
         Self: Sized;

--- a/model/geo_contracts/src/geometry/core/ray_traits.rs
+++ b/model/geo_contracts/src/geometry/core/ray_traits.rs
@@ -183,11 +183,6 @@ pub trait Ray3DMeasure<T: Scalar> {
     fn translate(&self, offset: (T, T, T)) -> Self
     where
         Self: Sized;
-    #[deprecated(
-        since = "0.1.0",
-        note = "cross-shape distance contracts are migrating to geometry::operations::CrossDistance"
-    )]
-    fn distance_to_ray(&self, other: &Self) -> T;
     fn point_at_distance(&self, distance: T) -> (T, T, T);
     fn angle_between(&self, other: &Self) -> T;
     fn rotate_around_axis(&self, axis: (T, T, T), angle: T) -> Option<Self>

--- a/model/geo_contracts/src/geometry/core/spherical_solid_traits.rs
+++ b/model/geo_contracts/src/geometry/core/spherical_solid_traits.rs
@@ -51,7 +51,6 @@ pub trait SphericalSolid3DMeasure<T: Scalar> {
     fn point_at_latlong(&self, latitude: T, longitude: T) -> (T, T, T);
     fn bounding_box(&self) -> ((T, T, T), (T, T, T));
     fn closest_point_on_surface(&self, point: (T, T, T)) -> (T, T, T);
-    fn intersects_sphere(&self, other_center: (T, T, T), other_radius: T) -> bool;
 }
 
 pub trait SphericalSolid3DCore<T: Scalar>:

--- a/model/geo_contracts/src/geometry/operations/mod.rs
+++ b/model/geo_contracts/src/geometry/operations/mod.rs
@@ -4,6 +4,7 @@ pub mod collision;
 pub mod distance;
 pub mod ellipse_calculation_traits;
 pub mod intersection;
+pub mod relation;
 
 pub use collision::{AdvancedCollision, BBoxCollision, BasicCollision, PointDistance};
 pub use distance::{CrossDistance, DistanceConvergenceError, FallibleCrossDistance};
@@ -11,3 +12,7 @@ pub use ellipse_calculation_traits::{
     EllipseAccuracyAnalysis, EllipseAdaptiveCalculation, EllipseCalculation,
 };
 pub use intersection::{BasicIntersection, MultipleIntersection, SelfIntersection};
+pub use relation::{
+    AngleBetween, AngularRelation, ClosestPointPair, DirectionalRelation, IntersectsRelation,
+    ParallelRelation, PerpendicularRelation, PointsTowards, SameLineRelation, SkewRelation,
+};

--- a/model/geo_contracts/src/geometry/operations/mod.rs
+++ b/model/geo_contracts/src/geometry/operations/mod.rs
@@ -14,5 +14,6 @@ pub use ellipse_calculation_traits::{
 pub use intersection::{BasicIntersection, MultipleIntersection, SelfIntersection};
 pub use relation::{
     AngleBetween, AngularRelation, ClosestPointPair, DirectionalRelation, IntersectsRelation,
-    ParallelRelation, PerpendicularRelation, PointsTowards, SameLineRelation, SkewRelation,
+    OnPlaneRelation, ParallelRelation, PerpendicularRelation, PointsTowards, SameLineRelation,
+    SkewRelation,
 };

--- a/model/geo_contracts/src/geometry/operations/relation.rs
+++ b/model/geo_contracts/src/geometry/operations/relation.rs
@@ -1,0 +1,71 @@
+//! 幾何 relation のtrait定義
+//!
+//! 平行・垂直・同一直線・向き一致のような、相手との関係を返す契約を集約する。
+
+use analysis::abstract_types::Scalar;
+
+/// 最近点対を返す relation
+pub trait ClosestPointPair<Other> {
+    /// 最近点対の型
+    type PointPair;
+
+    /// 最近点対を返す
+    fn closest_points(&self, other: &Other) -> Option<Self::PointPair>;
+}
+
+/// 平行関係
+pub trait ParallelRelation<Other> {
+    /// 相手と平行かを返す
+    fn is_parallel_to(&self, other: &Other) -> bool;
+}
+
+/// 垂直関係
+pub trait PerpendicularRelation<Other> {
+    /// 相手と垂直かを返す
+    fn is_perpendicular_to(&self, other: &Other) -> bool;
+}
+
+/// 同一直線関係
+pub trait SameLineRelation<Other> {
+    /// 相手と同一直線かを返す
+    fn is_same_line(&self, other: &Other) -> bool;
+}
+
+/// 交差関係
+pub trait IntersectsRelation<Other> {
+    /// 相手と交差するかを返す
+    fn intersects(&self, other: &Other) -> bool;
+}
+
+/// ねじれ関係
+pub trait SkewRelation<Other> {
+    /// 相手とスキュー関係かを返す
+    fn is_skew_to(&self, other: &Other) -> bool;
+}
+
+/// 角度 relation
+pub trait AngularRelation<T: Scalar, Other> {
+    /// 相手との角度を返す
+    fn angle_to(&self, other: &Other) -> T;
+}
+
+/// 向き relation
+pub trait DirectionalRelation<Other> {
+    /// 相手と同方向かを返す
+    fn is_same_direction(&self, other: &Other) -> bool;
+
+    /// 相手と逆方向かを返す
+    fn is_opposite_direction(&self, other: &Other) -> bool;
+}
+
+/// 指定方向を向くかを判定する relation
+pub trait PointsTowards<Target> {
+    /// 指定対象を向くかを返す
+    fn points_towards(&self, target: Target) -> bool;
+}
+
+/// 相手との角度を返す relation
+pub trait AngleBetween<T: Scalar, Other> {
+    /// 相手との角度を返す
+    fn angle_between(&self, other: &Other) -> T;
+}

--- a/model/geo_contracts/src/geometry/operations/relation.rs
+++ b/model/geo_contracts/src/geometry/operations/relation.rs
@@ -64,6 +64,12 @@ pub trait PointsTowards<Target> {
     fn points_towards(&self, target: Target) -> bool;
 }
 
+/// 平面上に存在するかを判定する relation
+pub trait OnPlaneRelation<Other> {
+    /// 相手の平面上にあるかを返す
+    fn is_on_plane(&self, other: &Other) -> bool;
+}
+
 /// 相手との角度を返す relation
 pub trait AngleBetween<T: Scalar, Other> {
     /// 相手との角度を返す

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -47,9 +47,9 @@ pub use geometry::core::{
     InfiniteLine2DConstructor, InfiniteLine2DCore, InfiniteLine2DMeasure, InfiniteLine2DProperties,
     InfiniteLine3DConstructor, InfiniteLine3DCore, InfiniteLine3DMeasure, InfiniteLine3DProperties,
     LineSegment2DConstructor, LineSegment2DCore, LineSegment2DMeasure, LineSegment2DProperties,
-    LineSegment3DCollisionDetection, LineSegment3DConstructor, LineSegment3DCore,
-    LineSegment3DMeasure, LineSegment3DProperties, Ray2DConstructor, Ray2DCore, Ray2DMeasure,
-    Ray2DProperties, Ray3DConstructor, Ray3DCore, Ray3DMeasure, Ray3DProperties,
+    LineSegment3DConstructor, LineSegment3DCore, LineSegment3DMeasure, LineSegment3DProperties,
+    Ray2DConstructor, Ray2DCore, Ray2DMeasure, Ray2DProperties, Ray3DConstructor, Ray3DCore,
+    Ray3DMeasure, Ray3DProperties,
 };
 pub use geometry::core::{
     NurbsCurve2DConstructor, NurbsCurve2DCore, NurbsCurve2DMeasure, NurbsCurve2DProperties,

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -67,8 +67,8 @@ pub use geometry::operations::{
     BasicIntersection, ClosestPointPair, CrossDistance, DirectionalRelation,
     DistanceConvergenceError, EllipseAccuracyAnalysis, EllipseAdaptiveCalculation,
     EllipseCalculation, FallibleCrossDistance, IntersectsRelation, MultipleIntersection,
-    ParallelRelation, PerpendicularRelation, PointDistance, PointsTowards, SameLineRelation,
-    SelfIntersection, SkewRelation,
+    OnPlaneRelation, ParallelRelation, PerpendicularRelation, PointDistance, PointsTowards,
+    SameLineRelation, SelfIntersection, SkewRelation,
 };
 pub use tolerance::{
     default_angle_tolerance, default_distance_tolerance, default_kernel_numerical_zero_tolerance,

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -63,10 +63,12 @@ pub use geometry::foundation::{
     PrimitiveMetadata, Vector2DMeasure, Vector3DMeasure,
 };
 pub use geometry::operations::{
-    AdvancedCollision, BBoxCollision, BasicCollision, BasicIntersection, CrossDistance,
+    AdvancedCollision, AngleBetween, AngularRelation, BBoxCollision, BasicCollision,
+    BasicIntersection, ClosestPointPair, CrossDistance, DirectionalRelation,
     DistanceConvergenceError, EllipseAccuracyAnalysis, EllipseAdaptiveCalculation,
-    EllipseCalculation, FallibleCrossDistance, MultipleIntersection, PointDistance,
-    SelfIntersection,
+    EllipseCalculation, FallibleCrossDistance, IntersectsRelation, MultipleIntersection,
+    ParallelRelation, PerpendicularRelation, PointDistance, PointsTowards, SameLineRelation,
+    SelfIntersection, SkewRelation,
 };
 pub use tolerance::{
     default_angle_tolerance, default_distance_tolerance, default_kernel_numerical_zero_tolerance,

--- a/model/geo_primitives/src/circle_2d.rs
+++ b/model/geo_primitives/src/circle_2d.rs
@@ -5,7 +5,9 @@
 
 use crate::{Direction2D, Point2D};
 use geo_contracts::{default_distance_tolerance, default_kernel_numerical_zero_tolerance};
-use geo_contracts::{Circle2DConstructor, Circle2DMeasure, Circle2DProperties, Scalar};
+use geo_contracts::{
+    Circle2DConstructor, Circle2DMeasure, Circle2DProperties, CrossDistance, Scalar,
+};
 
 /// 2次元円
 ///
@@ -335,8 +337,10 @@ impl<T: Scalar> Circle2DMeasure<T> for Circle2D<T> {
         let point = self.point_at_parameter(t);
         (point.x(), point.y())
     }
+}
 
-    fn distance_to_circle(&self, other: &Self) -> T {
-        self.distance_to_circle(other)
+impl<T: Scalar> CrossDistance<T, Self> for Circle2D<T> {
+    fn distance_to(&self, other: &Self) -> T {
+        Circle2D::distance_to_circle(self, other)
     }
 }

--- a/model/geo_primitives/src/circle_3d.rs
+++ b/model/geo_primitives/src/circle_3d.rs
@@ -6,7 +6,9 @@
 use crate::{Direction3D, Point3D, Vector3D};
 use geo_contracts::default_angle_tolerance;
 use geo_contracts::{default_distance_tolerance, default_kernel_numerical_zero_tolerance};
-use geo_contracts::{Circle3DConstructor, Circle3DMeasure, Circle3DProperties, Scalar};
+use geo_contracts::{
+    Circle3DConstructor, Circle3DMeasure, Circle3DProperties, CrossDistance, Scalar,
+};
 
 /// 3次元空間の円
 ///
@@ -470,17 +472,17 @@ impl<T: Scalar> Circle3DMeasure<T> for Circle3D<T> {
 
         (point.x(), point.y(), point.z())
     }
+}
 
-    fn distance_to_circle(&self, other: &Self) -> T {
-        // 簡易実装：中心間距離から半径を考慮
+impl<T: Scalar> CrossDistance<T, Self> for Circle3D<T> {
+    fn distance_to(&self, other: &Self) -> T {
         let center_distance = self.center.distance_to(&other.center);
-
         let radii_sum = self.radius + other.radius;
 
         if center_distance >= radii_sum {
             center_distance - radii_sum
         } else {
-            T::ZERO // 交差または包含
+            T::ZERO
         }
     }
 }

--- a/model/geo_primitives/src/cylindrical_solid_3d.rs
+++ b/model/geo_primitives/src/cylindrical_solid_3d.rs
@@ -15,8 +15,8 @@
 //! - radius: 円柱半径
 //! - height: 円柱高さ
 
-use crate::{Direction3D, Point3D, Vector3D};
-use geo_contracts::Scalar;
+use crate::{Direction3D, InfiniteLine3D, Point3D, Vector3D};
+use geo_contracts::{BasicIntersection, Scalar};
 
 /// 3次元円柱ソリッド（STEP準拠のCore実装）
 ///
@@ -607,13 +607,17 @@ impl<T: Scalar> CylindricalSolid3DMeasure<T> for CylindricalSolid3D<T> {
             )
         }
     }
-
-    fn intersects_line(&self, _line_point: (T, T, T), _line_dir: (T, T, T)) -> Option<(T, T, T)> {
-        None
-    }
 }
 
 impl<T: Scalar> CylindricalSolid3DCore<T> for CylindricalSolid3D<T> {}
+
+impl<T: Scalar> BasicIntersection<T, InfiniteLine3D<T>> for CylindricalSolid3D<T> {
+    type Point = (T, T, T);
+
+    fn intersection_with(&self, _other: &InfiniteLine3D<T>, _tolerance: T) -> Option<Self::Point> {
+        None
+    }
+}
 
 // ============================================================================
 // Backward Compatibility (移行期間中のみ)

--- a/model/geo_primitives/src/cylindrical_solid_3d_tests.rs
+++ b/model/geo_primitives/src/cylindrical_solid_3d_tests.rs
@@ -3,8 +3,10 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::{CylindricalSolid3D, Direction3D, Point3D, Vector3D};
-    use geo_contracts::{CylindricalSolid3DMeasure, CylindricalSolid3DProperties};
+    use crate::{CylindricalSolid3D, Direction3D, InfiniteLine3D, Point3D, Vector3D};
+    use geo_contracts::{
+        BasicIntersection, CylindricalSolid3DMeasure, CylindricalSolid3DProperties,
+    };
 
     #[test]
     fn test_cylindrical_solid_creation() {
@@ -278,5 +280,22 @@ mod tests {
         let actual_distance =
             CylindricalSolid3DMeasure::distance_to_point(&cylindrical_solid, external_point);
         assert!((actual_distance - expected_distance).abs() < 1e-10_f64);
+    }
+
+    #[test]
+    fn test_cylindrical_solid_line_intersection_is_exposed_via_basic_intersection() {
+        let cylindrical_solid = CylindricalSolid3D::new(
+            Point3D::new(0.0, 0.0, 0.0),
+            Vector3D::new(0.0, 0.0, 1.0),
+            Vector3D::new(1.0, 0.0, 0.0),
+            5.0,
+            10.0,
+        )
+        .unwrap();
+        let line = InfiniteLine3D::new(Point3D::new(-10.0, 0.0, 5.0), Vector3D::unit_x()).unwrap();
+
+        let intersection = BasicIntersection::intersection_with(&cylindrical_solid, &line, 1e-10);
+
+        assert!(intersection.is_none());
     }
 }

--- a/model/geo_primitives/src/ellipse_3d.rs
+++ b/model/geo_primitives/src/ellipse_3d.rs
@@ -2,7 +2,8 @@
 //!
 //! Foundation統一システムに基づくEllipse3Dの必須機能のみ
 
-use crate::{Angle, Circle3D, Direction3D, Point3D, Vector3D};
+use crate::{Angle, Circle3D, Direction3D, InfiniteLine3D, Plane3D, Point3D, Vector3D};
+use geo_contracts::MultipleIntersection;
 use geo_contracts::{default_angle_tolerance, default_distance_tolerance};
 use geo_contracts::{Ellipse3DConstructor, Ellipse3DMeasure, Ellipse3DProperties, Scalar};
 use geo_contracts::{EllipseAccuracyAnalysis, EllipseAdaptiveCalculation, EllipseCalculation};
@@ -412,25 +413,6 @@ impl<T: Scalar + From<f64>> Ellipse3DMeasure<T> for Ellipse3D<T> {
         self.distance_to_point_3d_internal(point)
     }
 
-    /// 3D空間での直線との交点を計算（未実装）
-    fn intersection_with_line_3d(
-        &self,
-        _line_point: (T, T, T),
-        _line_direction: (T, T, T),
-    ) -> Vec<(T, T, T)> {
-        // 3D楕円と3D直線の交点計算は複雑
-        Vec::new()
-    }
-
-    /// 平面との交点を計算（未実装）
-    fn intersection_with_plane(
-        &self,
-        _plane_point: (T, T, T),
-        _plane_normal: (T, T, T),
-    ) -> Vec<(T, T, T)> {
-        // 3D楕円と平面の交点計算は複雑
-        Vec::new()
-    }
     /// 楕円の面積を計算
     fn measure(&self) -> T {
         self.area()
@@ -451,6 +433,22 @@ impl<T: Scalar + From<f64>> Ellipse3DMeasure<T> for Ellipse3D<T> {
     fn is_circle(&self) -> bool {
         let tolerance = default_distance_tolerance::<T>();
         (self.semi_major_axis - self.semi_minor_axis).abs() <= tolerance
+    }
+}
+
+impl<T: Scalar + From<f64>> MultipleIntersection<T, InfiniteLine3D<T>> for Ellipse3D<T> {
+    type Point = (T, T, T);
+
+    fn intersections_with(&self, _other: &InfiniteLine3D<T>, _tolerance: T) -> Vec<Self::Point> {
+        Vec::new()
+    }
+}
+
+impl<T: Scalar + From<f64>> MultipleIntersection<T, Plane3D<T>> for Ellipse3D<T> {
+    type Point = (T, T, T);
+
+    fn intersections_with(&self, _other: &Plane3D<T>, _tolerance: T) -> Vec<Self::Point> {
+        Vec::new()
     }
 }
 

--- a/model/geo_primitives/src/infinite_line_2d.rs
+++ b/model/geo_primitives/src/infinite_line_2d.rs
@@ -3,7 +3,10 @@
 //! Foundation統一システムに基づくInfiniteLine2Dの必須機能のみ
 
 use crate::{Direction2D, Point2D, Vector2D};
-use geo_contracts::Scalar;
+use geo_contracts::{
+    AngularRelation, BasicIntersection, ParallelRelation, PerpendicularRelation, SameLineRelation,
+    Scalar,
+};
 
 /// 2次元無限直線（Core実装）
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -327,34 +330,6 @@ impl<T: Scalar> InfiniteLine2DMeasure<T> for InfiniteLine2D<T> {
         self.parameter_for_point(&p)
     }
 
-    fn intersection(&self, other: &Self) -> Option<(T, T)> {
-        self.intersection(other)
-            .map(|intersection_point| (intersection_point.x(), intersection_point.y()))
-    }
-
-    fn is_parallel_to(&self, other: &Self) -> bool {
-        self.direction_internal()
-            .is_parallel_to(&other.direction_internal())
-    }
-
-    fn is_perpendicular_to(&self, other: &Self) -> bool {
-        self.direction.is_perpendicular_to(&other.direction)
-    }
-
-    fn is_same_line(&self, other: &Self) -> bool {
-        // 平行かつ同じ点を含む場合
-        self.is_parallel_to(other) && {
-            use geo_contracts::default_distance_tolerance;
-            self.contains_point(&other.point, default_distance_tolerance::<T>())
-        }
-    }
-
-    fn angle_to(&self, other: &Self) -> T {
-        let dot = self.direction.dot(&other.direction);
-        let clamped = dot.max(-T::ONE).min(T::ONE);
-        clamped.acos()
-    }
-
     fn reverse(&self) -> Self {
         Self::new(self.point, -(*self.direction)).unwrap()
     }
@@ -415,5 +390,45 @@ impl<T: Scalar> InfiniteLine2DMeasure<T> for InfiniteLine2D<T> {
         );
 
         Self::new(rotated_point, rotated_dir).unwrap()
+    }
+}
+
+impl<T: Scalar> BasicIntersection<T, Self> for InfiniteLine2D<T> {
+    type Point = (T, T);
+
+    fn intersection_with(&self, other: &Self, _tolerance: T) -> Option<Self::Point> {
+        InfiniteLine2D::intersection(self, other).map(|point| (point.x(), point.y()))
+    }
+}
+
+impl<T: Scalar> ParallelRelation<Self> for InfiniteLine2D<T> {
+    fn is_parallel_to(&self, other: &Self) -> bool {
+        self.direction_internal()
+            .is_parallel_to(&other.direction_internal())
+    }
+}
+
+impl<T: Scalar> PerpendicularRelation<Self> for InfiniteLine2D<T> {
+    fn is_perpendicular_to(&self, other: &Self) -> bool {
+        self.direction.is_perpendicular_to(&other.direction)
+    }
+}
+
+impl<T: Scalar> SameLineRelation<Self> for InfiniteLine2D<T> {
+    fn is_same_line(&self, other: &Self) -> bool {
+        self.direction_internal()
+            .is_parallel_to(&other.direction_internal())
+            && {
+                use geo_contracts::default_distance_tolerance;
+                self.contains_point(&other.point, default_distance_tolerance::<T>())
+            }
+    }
+}
+
+impl<T: Scalar> AngularRelation<T, Self> for InfiniteLine2D<T> {
+    fn angle_to(&self, other: &Self) -> T {
+        let dot = self.direction.dot(&other.direction);
+        let clamped = dot.max(-T::ONE).min(T::ONE);
+        clamped.acos()
     }
 }

--- a/model/geo_primitives/src/infinite_line_3d.rs
+++ b/model/geo_primitives/src/infinite_line_3d.rs
@@ -3,10 +3,10 @@
 //! Foundation統一システムに基づくInfiniteLine3Dの必須機能のみ
 //! Foundation Pattern: Constructor/Properties/Measure の3つのCore Traits実装
 
-use crate::{Direction3D, Point3D, Vector3D};
+use crate::{Direction3D, Plane3D, Point3D, Vector3D};
 use geo_contracts::{
-    default_angle_tolerance, default_distance_tolerance, InfiniteLine3DConstructor,
-    InfiniteLine3DMeasure, InfiniteLine3DProperties, Scalar,
+    default_angle_tolerance, default_distance_tolerance, BasicIntersection, CrossDistance,
+    InfiniteLine3DConstructor, InfiniteLine3DMeasure, InfiniteLine3DProperties, Scalar,
 };
 
 /// 3次元空間の無限直線（Core実装）
@@ -491,10 +491,6 @@ impl<T: Scalar> InfiniteLine3DMeasure<T> for InfiniteLine3D<T> {
         InfiniteLine3D::parameter_for_point(self, &p)
     }
 
-    fn distance_to_line(&self, other: &Self) -> T {
-        InfiniteLine3D::distance_to_line(self, other)
-    }
-
     fn closest_points(&self, other: &Self) -> Option<((T, T, T), (T, T, T))> {
         if self.is_parallel_to(other) {
             None
@@ -547,7 +543,7 @@ impl<T: Scalar> InfiniteLine3DMeasure<T> for InfiniteLine3D<T> {
     }
 
     fn intersects(&self, other: &Self) -> bool {
-        self.distance_to_line(other) <= default_distance_tolerance::<T>()
+        InfiniteLine3D::distance_to_line(self, other) <= default_distance_tolerance::<T>()
     }
 
     fn is_skew_to(&self, other: &Self) -> bool {
@@ -612,38 +608,28 @@ impl<T: Scalar> InfiniteLine3DMeasure<T> for InfiniteLine3D<T> {
 
         InfiniteLine3D::new(rotated_point, rotated_dir)
     }
+}
 
-    fn intersection_with_plane(
-        &self,
-        plane_point: (T, T, T),
-        plane_normal: (T, T, T),
-    ) -> Option<(T, T, T)> {
-        let dir_vec = Vector3D::new(self.direction.x(), self.direction.y(), self.direction.z());
-        let normal = Vector3D::new(plane_normal.0, plane_normal.1, plane_normal.2);
-
-        let denom = dir_vec.dot(&normal);
-        if denom.abs() <= T::ORTHOGONALITY_DOT_ERROR_TOLERANCE {
-            return None; // 平行または平面内
-        }
-
-        let plane_pt = Point3D::new(plane_point.0, plane_point.1, plane_point.2);
-        let to_plane = Vector3D::from_points(&self.point, &plane_pt);
-
-        let t = to_plane.dot(&normal) / denom;
-        let intersection = <Self as InfiniteLine3DMeasure<T>>::point_at_parameter(self, t);
-        Some(intersection)
+impl<T: Scalar> CrossDistance<T, Self> for InfiniteLine3D<T> {
+    fn distance_to(&self, other: &Self) -> T {
+        InfiniteLine3D::distance_to_line(self, other)
     }
+}
 
-    fn intersection_with_line(&self, other: &Self) -> Option<(T, T, T)> {
-        if self.is_parallel_to(other) {
-            return None;
-        }
+impl<T: Scalar> BasicIntersection<T, Self> for InfiniteLine3D<T> {
+    type Point = (T, T, T);
 
-        if !self.intersects(other) {
-            return None; // スキュー線
-        }
+    fn intersection_with(&self, other: &Self, _tolerance: T) -> Option<Self::Point> {
+        InfiniteLine3D::intersection_with_line(self, other)
+            .map(|point| (point.x(), point.y(), point.z()))
+    }
+}
 
-        // 交差する場合、最接近点が交点
-        self.closest_points(other).map(|(p1, _)| p1)
+impl<T: Scalar> BasicIntersection<T, Plane3D<T>> for InfiniteLine3D<T> {
+    type Point = (T, T, T);
+
+    fn intersection_with(&self, other: &Plane3D<T>, _tolerance: T) -> Option<Self::Point> {
+        InfiniteLine3D::intersection_with_plane(self, &other.origin(), &other.normal().as_vector())
+            .map(|point| (point.x(), point.y(), point.z()))
     }
 }

--- a/model/geo_primitives/src/infinite_line_3d.rs
+++ b/model/geo_primitives/src/infinite_line_3d.rs
@@ -5,10 +5,10 @@
 
 use crate::{Direction3D, Plane3D, Point3D, Vector3D};
 use geo_contracts::{
-    default_angle_tolerance, default_distance_tolerance, AngularRelation, BasicIntersection,
-    ClosestPointPair, CrossDistance, InfiniteLine3DConstructor, InfiniteLine3DMeasure,
-    InfiniteLine3DProperties, IntersectsRelation, ParallelRelation, PerpendicularRelation,
-    SameLineRelation, Scalar, SkewRelation,
+    default_distance_tolerance, default_orthogonality_dot_error_tolerance, AngularRelation,
+    BasicIntersection, ClosestPointPair, CrossDistance, InfiniteLine3DConstructor,
+    InfiniteLine3DMeasure, InfiniteLine3DProperties, IntersectsRelation, OnPlaneRelation,
+    ParallelRelation, PerpendicularRelation, SameLineRelation, Scalar, SkewRelation,
 };
 
 type LinePointPair3D<T> = ((T, T, T), (T, T, T));
@@ -500,21 +500,6 @@ impl<T: Scalar> InfiniteLine3DProperties<T> for InfiniteLine3D<T> {
         self.direction.y().atan2(self.direction.x())
     }
 
-    fn is_on_plane(&self, plane_normal: (T, T, T), plane_point: (T, T, T)) -> bool {
-        let normal = Vector3D::new(plane_normal.0, plane_normal.1, plane_normal.2);
-        let dir_vec = Vector3D::new(self.direction.x(), self.direction.y(), self.direction.z());
-
-        // 方向ベクトルが法線に垂直かつ、直線上の点が平面上にある
-        let dot = dir_vec.dot(&normal);
-        if dot.abs() > default_angle_tolerance::<T>() {
-            return false;
-        }
-
-        let plane_pt = Point3D::new(plane_point.0, plane_point.1, plane_point.2);
-        let to_line = Vector3D::from_points(&plane_pt, &self.point);
-        to_line.dot(&normal).abs() <= default_distance_tolerance::<T>()
-    }
-
     fn is_axis_aligned(&self) -> bool {
         self.is_x_parallel() || self.is_y_parallel() || self.is_z_parallel()
     }
@@ -672,5 +657,20 @@ impl<T: Scalar> SkewRelation<Self> for InfiniteLine3D<T> {
 impl<T: Scalar> AngularRelation<T, Self> for InfiniteLine3D<T> {
     fn angle_to(&self, other: &Self) -> T {
         InfiniteLine3D::angle_to(self, other)
+    }
+}
+
+impl<T: Scalar> OnPlaneRelation<Plane3D<T>> for InfiniteLine3D<T> {
+    fn is_on_plane(&self, other: &Plane3D<T>) -> bool {
+        let normal = other.normal().as_vector();
+        let dir_vec = Vector3D::new(self.direction.x(), self.direction.y(), self.direction.z());
+
+        if dir_vec.dot(&normal).abs() > default_orthogonality_dot_error_tolerance::<T>() {
+            return false;
+        }
+
+        let plane_pt = other.origin();
+        let to_line = Vector3D::from_points(&plane_pt, &self.point);
+        to_line.dot(&normal).abs() <= default_distance_tolerance::<T>()
     }
 }

--- a/model/geo_primitives/src/infinite_line_3d.rs
+++ b/model/geo_primitives/src/infinite_line_3d.rs
@@ -5,9 +5,13 @@
 
 use crate::{Direction3D, Plane3D, Point3D, Vector3D};
 use geo_contracts::{
-    default_angle_tolerance, default_distance_tolerance, BasicIntersection, CrossDistance,
-    InfiniteLine3DConstructor, InfiniteLine3DMeasure, InfiniteLine3DProperties, Scalar,
+    default_angle_tolerance, default_distance_tolerance, AngularRelation, BasicIntersection,
+    ClosestPointPair, CrossDistance, InfiniteLine3DConstructor, InfiniteLine3DMeasure,
+    InfiniteLine3DProperties, IntersectsRelation, ParallelRelation, PerpendicularRelation,
+    SameLineRelation, Scalar, SkewRelation,
 };
+
+type LinePointPair3D<T> = ((T, T, T), (T, T, T));
 
 /// 3次元空間の無限直線（Core実装）
 ///
@@ -135,6 +139,62 @@ impl<T: Scalar> InfiniteLine3D<T> {
     /// 他の直線とスキュー（ねじれ）関係にあるかを判定
     pub fn is_skew_to(&self, other: &Self) -> bool {
         !self.is_parallel_to(other) && !self.is_coplanar_with(other)
+    }
+
+    /// 他の直線との最近点対を取得
+    pub fn closest_points(&self, other: &Self) -> Option<LinePointPair3D<T>> {
+        if self.is_parallel_to(other) {
+            return None;
+        }
+
+        let self_dir = <Self as InfiniteLine3DProperties<T>>::direction(self);
+        let other_dir = <Self as InfiniteLine3DProperties<T>>::direction(other);
+        let self_point = <Self as InfiniteLine3DProperties<T>>::point(self);
+        let other_point = <Self as InfiniteLine3DProperties<T>>::point(other);
+
+        let d1 = Vector3D::new(self_dir.0, self_dir.1, self_dir.2);
+        let d2 = Vector3D::new(other_dir.0, other_dir.1, other_dir.2);
+        let p1 = Point3D::new(self_point.0, self_point.1, self_point.2);
+        let p2 = Point3D::new(other_point.0, other_point.1, other_point.2);
+        let w = Vector3D::from_points(&p2, &p1);
+
+        let a = d1.dot(&d1);
+        let b = d1.dot(&d2);
+        let c = d2.dot(&d2);
+        let d = d1.dot(&w);
+        let e = d2.dot(&w);
+
+        let denom = a * c - b * b;
+        if denom.abs() <= T::PARALLEL_CROSS_ERROR_TOLERANCE {
+            return None;
+        }
+
+        let t1 = (b * e - c * d) / denom;
+        let t2 = (a * e - b * d) / denom;
+        let closest1 = self.point_at_parameter(t1);
+        let closest2 = other.point_at_parameter(t2);
+        Some((
+            (closest1.x(), closest1.y(), closest1.z()),
+            (closest2.x(), closest2.y(), closest2.z()),
+        ))
+    }
+
+    /// 他の直線と同一直線かを判定
+    pub fn is_same_line(&self, other: &Self) -> bool {
+        self.is_parallel_to(other) && {
+            let other_point = <Self as InfiniteLine3DProperties<T>>::point(other);
+            <Self as InfiniteLine3DMeasure<T>>::contains_point(self, other_point)
+        }
+    }
+
+    /// 他の直線と交差するかを判定
+    pub fn intersects(&self, other: &Self) -> bool {
+        InfiniteLine3D::distance_to_line(self, other) <= default_distance_tolerance::<T>()
+    }
+
+    /// 他の直線との角度を返す
+    pub fn angle_to(&self, other: &Self) -> T {
+        InfiniteLine3D::angle_with_line(self, other)
     }
 
     /// 他の直線と同一平面上にあるかを判定
@@ -491,69 +551,6 @@ impl<T: Scalar> InfiniteLine3DMeasure<T> for InfiniteLine3D<T> {
         InfiniteLine3D::parameter_for_point(self, &p)
     }
 
-    fn closest_points(&self, other: &Self) -> Option<((T, T, T), (T, T, T))> {
-        if self.is_parallel_to(other) {
-            None
-        } else {
-            // 実装：最接近点の計算
-            let self_dir = <Self as InfiniteLine3DProperties<T>>::direction(self);
-            let other_dir = <Self as InfiniteLine3DProperties<T>>::direction(other);
-            let self_point = <Self as InfiniteLine3DProperties<T>>::point(self);
-            let other_point = <Self as InfiniteLine3DProperties<T>>::point(other);
-
-            let d1 = Vector3D::new(self_dir.0, self_dir.1, self_dir.2);
-            let d2 = Vector3D::new(other_dir.0, other_dir.1, other_dir.2);
-            let p1 = Point3D::new(self_point.0, self_point.1, self_point.2);
-            let p2 = Point3D::new(other_point.0, other_point.1, other_point.2);
-            let w = Vector3D::from_points(&p2, &p1);
-
-            let a = d1.dot(&d1);
-            let b = d1.dot(&d2);
-            let c = d2.dot(&d2);
-            let d = d1.dot(&w);
-            let e = d2.dot(&w);
-
-            let denom = a * c - b * b;
-            if denom.abs() <= T::PARALLEL_CROSS_ERROR_TOLERANCE {
-                None
-            } else {
-                let t1 = (b * e - c * d) / denom;
-                let t2 = (a * e - b * d) / denom;
-
-                let closest1 = <Self as InfiniteLine3DMeasure<T>>::point_at_parameter(self, t1);
-                let closest2 = <Self as InfiniteLine3DMeasure<T>>::point_at_parameter(other, t2);
-                Some((closest1, closest2))
-            }
-        }
-    }
-
-    fn is_parallel_to(&self, other: &Self) -> bool {
-        InfiniteLine3D::is_parallel_to(self, other)
-    }
-
-    fn is_perpendicular_to(&self, other: &Self) -> bool {
-        InfiniteLine3D::is_perpendicular_to(self, other)
-    }
-
-    fn is_same_line(&self, other: &Self) -> bool {
-        self.is_parallel_to(other) && {
-            let other_point = <Self as InfiniteLine3DProperties<T>>::point(other);
-            <Self as InfiniteLine3DMeasure<T>>::contains_point(self, other_point)
-        }
-    }
-
-    fn intersects(&self, other: &Self) -> bool {
-        InfiniteLine3D::distance_to_line(self, other) <= default_distance_tolerance::<T>()
-    }
-
-    fn is_skew_to(&self, other: &Self) -> bool {
-        InfiniteLine3D::is_skew_to(self, other)
-    }
-
-    fn angle_to(&self, other: &Self) -> T {
-        InfiniteLine3D::angle_with_line(self, other)
-    }
-
     fn reverse(&self) -> Self {
         let self_dir = <Self as InfiniteLine3DProperties<T>>::direction(self);
         let self_point = <Self as InfiniteLine3DProperties<T>>::point(self);
@@ -631,5 +628,49 @@ impl<T: Scalar> BasicIntersection<T, Plane3D<T>> for InfiniteLine3D<T> {
     fn intersection_with(&self, other: &Plane3D<T>, _tolerance: T) -> Option<Self::Point> {
         InfiniteLine3D::intersection_with_plane(self, &other.origin(), &other.normal().as_vector())
             .map(|point| (point.x(), point.y(), point.z()))
+    }
+}
+
+impl<T: Scalar> ClosestPointPair<Self> for InfiniteLine3D<T> {
+    type PointPair = ((T, T, T), (T, T, T));
+
+    fn closest_points(&self, other: &Self) -> Option<Self::PointPair> {
+        InfiniteLine3D::closest_points(self, other)
+    }
+}
+
+impl<T: Scalar> ParallelRelation<Self> for InfiniteLine3D<T> {
+    fn is_parallel_to(&self, other: &Self) -> bool {
+        InfiniteLine3D::is_parallel_to(self, other)
+    }
+}
+
+impl<T: Scalar> PerpendicularRelation<Self> for InfiniteLine3D<T> {
+    fn is_perpendicular_to(&self, other: &Self) -> bool {
+        InfiniteLine3D::is_perpendicular_to(self, other)
+    }
+}
+
+impl<T: Scalar> SameLineRelation<Self> for InfiniteLine3D<T> {
+    fn is_same_line(&self, other: &Self) -> bool {
+        InfiniteLine3D::is_same_line(self, other)
+    }
+}
+
+impl<T: Scalar> IntersectsRelation<Self> for InfiniteLine3D<T> {
+    fn intersects(&self, other: &Self) -> bool {
+        InfiniteLine3D::intersects(self, other)
+    }
+}
+
+impl<T: Scalar> SkewRelation<Self> for InfiniteLine3D<T> {
+    fn is_skew_to(&self, other: &Self) -> bool {
+        InfiniteLine3D::is_skew_to(self, other)
+    }
+}
+
+impl<T: Scalar> AngularRelation<T, Self> for InfiniteLine3D<T> {
+    fn angle_to(&self, other: &Self) -> T {
+        InfiniteLine3D::angle_to(self, other)
     }
 }

--- a/model/geo_primitives/src/infinite_line_3d_tests.rs
+++ b/model/geo_primitives/src/infinite_line_3d_tests.rs
@@ -1,0 +1,58 @@
+//! InfiniteLine3D テストモジュール
+
+use crate::{InfiniteLine3D, Plane3D, Point3D, Vector3D};
+use geo_contracts::{
+    default_distance_tolerance, default_orthogonality_dot_error_tolerance, OnPlaneRelation,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_on_plane_relation_true_when_line_lies_on_plane() {
+        let plane = Plane3D::xy_plane(0.0);
+        let line = InfiniteLine3D::new(Point3D::new(1.0, 2.0, 0.0), Vector3D::unit_x()).unwrap();
+
+        assert!(OnPlaneRelation::is_on_plane(&line, &plane));
+    }
+
+    #[test]
+    fn test_on_plane_relation_false_when_direction_is_not_orthogonal_to_plane_normal() {
+        let plane = Plane3D::xy_plane(0.0);
+        let orthogonality_tolerance = default_orthogonality_dot_error_tolerance::<f64>();
+        let line = InfiniteLine3D::new(
+            Point3D::new(0.0, 0.0, 0.0),
+            Vector3D::new(1.0, 0.0, orthogonality_tolerance * 10.0),
+        )
+        .unwrap();
+
+        assert!(!OnPlaneRelation::is_on_plane(&line, &plane));
+    }
+
+    #[test]
+    fn test_on_plane_relation_true_when_point_offset_is_within_distance_tolerance() {
+        let plane = Plane3D::xy_plane(0.0);
+        let distance_tolerance = default_distance_tolerance::<f64>();
+        let line = InfiniteLine3D::new(
+            Point3D::new(0.0, 0.0, distance_tolerance * 0.5),
+            Vector3D::unit_x(),
+        )
+        .unwrap();
+
+        assert!(OnPlaneRelation::is_on_plane(&line, &plane));
+    }
+
+    #[test]
+    fn test_on_plane_relation_false_when_point_offset_exceeds_distance_tolerance() {
+        let plane = Plane3D::xy_plane(0.0);
+        let distance_tolerance = default_distance_tolerance::<f64>();
+        let line = InfiniteLine3D::new(
+            Point3D::new(0.0, 0.0, distance_tolerance * 2.0),
+            Vector3D::unit_x(),
+        )
+        .unwrap();
+
+        assert!(!OnPlaneRelation::is_on_plane(&line, &plane));
+    }
+}

--- a/model/geo_primitives/src/lib.rs
+++ b/model/geo_primitives/src/lib.rs
@@ -67,6 +67,8 @@ pub mod rectangle_3d_foundation;
 pub mod rectangle_3d_transform;
 pub mod spherical_solid_3d;
 pub mod spherical_solid_3d_foundation;
+#[cfg(test)]
+pub mod spherical_solid_3d_tests;
 pub mod spherical_surface_3d;
 pub mod spherical_surface_3d_foundation;
 pub mod torus_solid_3d;

--- a/model/geo_primitives/src/lib.rs
+++ b/model/geo_primitives/src/lib.rs
@@ -112,14 +112,16 @@ pub use geo_contracts::{Direction3DConstructor, Direction3DMeasure, Direction3DP
 
 // InfiniteLine の Core trait定義 再公開
 pub use geo_contracts::{
-    InfiniteLine2DConstructor, InfiniteLine2DMeasure, InfiniteLine2DProperties,
-    InfiniteLine3DConstructor, InfiniteLine3DMeasure, InfiniteLine3DProperties,
+    AngularRelation, ClosestPointPair, InfiniteLine2DConstructor, InfiniteLine2DMeasure,
+    InfiniteLine2DProperties, InfiniteLine3DConstructor, InfiniteLine3DMeasure,
+    InfiniteLine3DProperties, IntersectsRelation, ParallelRelation, PerpendicularRelation,
+    SameLineRelation, SkewRelation,
 };
 
 // Ray の Core trait定義 再公開
 pub use geo_contracts::{
-    Ray2DConstructor, Ray2DMeasure, Ray2DProperties, Ray3DConstructor, Ray3DMeasure,
-    Ray3DProperties,
+    AngleBetween, DirectionalRelation, PointsTowards, Ray2DConstructor, Ray2DMeasure,
+    Ray2DProperties, Ray3DConstructor, Ray3DMeasure, Ray3DProperties,
 };
 pub mod ellipse_2d;
 pub mod ellipse_2d_foundation;

--- a/model/geo_primitives/src/lib.rs
+++ b/model/geo_primitives/src/lib.rs
@@ -46,6 +46,8 @@ pub mod ellipsoidal_surface_3d;
 pub mod infinite_line_3d;
 pub mod infinite_line_3d_extensions;
 pub mod infinite_line_3d_foundation;
+#[cfg(test)]
+pub mod infinite_line_3d_tests;
 pub mod line_segment_3d;
 pub mod line_segment_3d_extensions;
 pub mod line_segment_3d_foundation;
@@ -114,8 +116,8 @@ pub use geo_contracts::{Direction3DConstructor, Direction3DMeasure, Direction3DP
 pub use geo_contracts::{
     AngularRelation, ClosestPointPair, InfiniteLine2DConstructor, InfiniteLine2DMeasure,
     InfiniteLine2DProperties, InfiniteLine3DConstructor, InfiniteLine3DMeasure,
-    InfiniteLine3DProperties, IntersectsRelation, ParallelRelation, PerpendicularRelation,
-    SameLineRelation, SkewRelation,
+    InfiniteLine3DProperties, IntersectsRelation, OnPlaneRelation, ParallelRelation,
+    PerpendicularRelation, SameLineRelation, SkewRelation,
 };
 
 // Ray の Core trait定義 再公開

--- a/model/geo_primitives/src/line_segment_2d.rs
+++ b/model/geo_primitives/src/line_segment_2d.rs
@@ -5,7 +5,7 @@
 
 use crate::{InfiniteLine2D, Point2D, Vector2D};
 use geo_contracts::{
-    default_distance_tolerance, LineSegment2DConstructor, LineSegment2DMeasure,
+    default_distance_tolerance, CrossDistance, LineSegment2DConstructor, LineSegment2DMeasure,
     LineSegment2DProperties, Scalar,
 };
 
@@ -229,6 +229,27 @@ impl<T: Scalar> LineSegment2D<T> {
     pub fn on_boundary(&self, point: &Point2D<T>, tolerance: T) -> bool {
         self.contains_point(point, tolerance)
     }
+
+    /// 他の線分との最短距離を計算
+    pub fn distance_to_segment(&self, other: &Self) -> T {
+        let other_start_pt = other.start_point();
+        let other_end_pt = other.end_point();
+        let self_start_pt = self.start_point();
+        let self_end_pt = self.end_point();
+
+        let d1 = self.distance_to_point(&other_start_pt);
+        let d2 = self.distance_to_point(&other_end_pt);
+        let d3 = other.distance_to_point(&self_start_pt);
+        let d4 = other.distance_to_point(&self_end_pt);
+
+        let min1 = if d1 < d2 { d1 } else { d2 };
+        let min2 = if d3 < d4 { d3 } else { d4 };
+        if min1 < min2 {
+            min1
+        } else {
+            min2
+        }
+    }
 }
 
 // ============================================================================
@@ -361,27 +382,6 @@ impl<T: Scalar> LineSegment2DMeasure<T> for LineSegment2D<T> {
         self.point_at_parameter(clamped_t)
     }
 
-    fn distance_to_segment(&self, other: &Self) -> T {
-        // 簡易実装: 各端点から他方の線分への最短距離の最小値
-        let other_start_pt = other.start_point();
-        let other_end_pt = other.end_point();
-        let self_start_pt = self.start_point();
-        let self_end_pt = self.end_point();
-
-        let d1 = self.distance_to_point(&other_start_pt);
-        let d2 = self.distance_to_point(&other_end_pt);
-        let d3 = other.distance_to_point(&self_start_pt);
-        let d4 = other.distance_to_point(&self_end_pt);
-
-        let min1 = if d1 < d2 { d1 } else { d2 };
-        let min2 = if d3 < d4 { d3 } else { d4 };
-        if min1 < min2 {
-            min1
-        } else {
-            min2
-        }
-    }
-
     fn direction_vector(&self) -> (T, T) {
         let dir = self.direction();
         (dir.x(), dir.y())
@@ -390,5 +390,11 @@ impl<T: Scalar> LineSegment2DMeasure<T> for LineSegment2D<T> {
     fn as_vector(&self) -> (T, T) {
         let v = self.vector();
         (v.x(), v.y())
+    }
+}
+
+impl<T: Scalar> CrossDistance<T, Self> for LineSegment2D<T> {
+    fn distance_to(&self, other: &Self) -> T {
+        LineSegment2D::distance_to_segment(self, other)
     }
 }

--- a/model/geo_primitives/src/line_segment_3d.rs
+++ b/model/geo_primitives/src/line_segment_3d.rs
@@ -5,8 +5,8 @@
 
 use crate::{InfiniteLine3D, Point3D, Vector3D};
 use geo_contracts::{
-    default_distance_tolerance, CrossDistance, LineSegment3DCollisionDetection,
-    LineSegment3DConstructor, LineSegment3DMeasure, LineSegment3DProperties, Scalar,
+    default_distance_tolerance, CrossDistance, LineSegment3DConstructor, LineSegment3DMeasure,
+    LineSegment3DProperties, Scalar,
 };
 
 /// 3次元空間の線分
@@ -278,8 +278,21 @@ impl<T: Scalar> LineSegment3DMeasure<T> for LineSegment3D<T> {
         (result.x(), result.y(), result.z())
     }
 
-    fn distance_to_segment(&self, other: &Self) -> T {
-        // 簡易実装: 各端点から他方の線分への最短距離の最小値
+    fn direction_vector(&self) -> (T, T, T) {
+        let dir = self.direction();
+        (dir.x(), dir.y(), dir.z())
+    }
+
+    fn as_vector(&self) -> (T, T, T) {
+        let start = self.start();
+        let end = self.end();
+        let v = Vector3D::from_points(&start, &end);
+        (v.x(), v.y(), v.z())
+    }
+}
+
+impl<T: Scalar> CrossDistance<T, Self> for LineSegment3D<T> {
+    fn distance_to(&self, other: &Self) -> T {
         let other_start_pt = other.start();
         let other_end_pt = other.end();
         let self_start_pt = self.start();
@@ -297,29 +310,6 @@ impl<T: Scalar> LineSegment3DMeasure<T> for LineSegment3D<T> {
         } else {
             min2
         }
-    }
-
-    fn direction_vector(&self) -> (T, T, T) {
-        let dir = self.direction();
-        (dir.x(), dir.y(), dir.z())
-    }
-
-    fn as_vector(&self) -> (T, T, T) {
-        let start = self.start();
-        let end = self.end();
-        let v = Vector3D::from_points(&start, &end);
-        (v.x(), v.y(), v.z())
-    }
-}
-
-impl<T: Scalar> LineSegment3DCollisionDetection<T> for LineSegment3D<T> {
-    fn distance_to_aabb(&self, aabb_min: (T, T, T), aabb_max: (T, T, T)) -> T {
-        use geo_commons::line_segment_to_aabb_distance;
-        let start_point = self.start();
-        let end_point = self.end();
-        let start = (start_point.x(), start_point.y(), start_point.z());
-        let end = (end_point.x(), end_point.y(), end_point.z());
-        line_segment_to_aabb_distance(start, end, aabb_min, aabb_max)
     }
 }
 

--- a/model/geo_primitives/src/plane_3d.rs
+++ b/model/geo_primitives/src/plane_3d.rs
@@ -5,7 +5,8 @@
 
 use crate::{Direction3D, Point3D, Vector3D};
 use geo_contracts::{
-    default_distance_tolerance, Plane3DConstructor, Plane3DMeasure, Plane3DProperties, Scalar,
+    default_distance_tolerance, BasicIntersection, Plane3DConstructor, Plane3DMeasure,
+    Plane3DProperties, Scalar,
 };
 
 /// CAD用3次元平面（座標系付き）
@@ -484,14 +485,14 @@ impl<T: Scalar + From<f64>> Plane3DMeasure<T> for Plane3D<T> {
             projected_z + projected_z - point.2,
         )
     }
+}
 
-    fn intersection_with_plane(
-        &self,
-        other_origin: (T, T, T),
-        other_normal: (T, T, T),
-    ) -> Option<((T, T, T), (T, T, T))> {
+impl<T: Scalar + From<f64>> BasicIntersection<T, Self> for Plane3D<T> {
+    type Point = ((T, T, T), (T, T, T));
+
+    fn intersection_with(&self, other: &Self, _tolerance: T) -> Option<Self::Point> {
         let n1 = self.normal.as_vector();
-        let n2 = Vector3D::new(other_normal.0, other_normal.1, other_normal.2);
+        let n2 = other.normal.as_vector();
 
         // 交線の方向 = n1 × n2
         let direction = n1.cross(&n2);
@@ -507,7 +508,8 @@ impl<T: Scalar + From<f64>> Plane3DMeasure<T> for Plane3D<T> {
         let c1 = self.normal.z();
         let d1 = -(a1 * self.origin.x() + b1 * self.origin.y() + c1 * self.origin.z());
 
-        let d2 = -(n2.x() * other_origin.0 + n2.y() * other_origin.1 + n2.z() * other_origin.2);
+        let d2 =
+            -(n2.x() * other.origin.x() + n2.y() * other.origin.y() + n2.z() * other.origin.z());
 
         // 適当な座標を固定して解く（z=0として解く）
         let det = n1.x() * n2.y() - n1.y() * n2.x();

--- a/model/geo_primitives/src/ray_2d.rs
+++ b/model/geo_primitives/src/ray_2d.rs
@@ -14,7 +14,10 @@
 //! - Core Traits実装（Constructor, Properties, Measure）
 
 use crate::{Direction2D, InfiniteLine2D, Point2D, Vector2D};
-use geo_contracts::{Ray2DConstructor, Ray2DMeasure, Ray2DProperties, Scalar};
+use geo_contracts::{
+    AngleBetween, BasicIntersection, DirectionalRelation, ParallelRelation, PointsTowards,
+    Ray2DConstructor, Ray2DMeasure, Ray2DProperties, Scalar,
+};
 
 /// 2次元半無限直線
 ///
@@ -113,6 +116,24 @@ impl<T: Scalar> Ray2D<T> {
     pub fn parameter_for_point(&self, point: &Point2D<T>) -> T {
         let to_point = *point - self.origin;
         to_point.dot(&self.direction)
+    }
+
+    /// 指定方向を向いているかを判定
+    pub fn points_towards_direction(&self, direction: (T, T)) -> bool {
+        let target_direction = Vector2D::new(direction.0, direction.1);
+        let self_direction =
+            Vector2D::new(self.direction_internal().x(), self.direction_internal().y());
+        self_direction.dot(&target_direction) > T::ZERO
+    }
+
+    /// 他の Ray との角度を返す
+    pub fn angle_between(&self, other: &Self) -> T {
+        let this_dir = Vector2D::new(self.direction_internal().x(), self.direction_internal().y());
+        let other_dir = Vector2D::new(
+            other.direction_internal().x(),
+            other.direction_internal().y(),
+        );
+        this_dir.dot(&other_dir).acos()
     }
 }
 
@@ -351,60 +372,6 @@ impl<T: Scalar> Ray2DMeasure<T> for Ray2D<T> {
         self.parameter_for_point(&target_point)
     }
 
-    fn points_towards(&self, direction: (T, T)) -> bool {
-        let target_direction = Vector2D::new(direction.0, direction.1);
-        let self_direction =
-            Vector2D::new(self.direction_internal().x(), self.direction_internal().y());
-        let dot = self_direction.dot(&target_direction);
-        dot > T::ZERO
-    }
-
-    fn is_parallel_to(&self, other: &Self) -> bool {
-        let this_dir = Vector2D::new(self.direction_internal().x(), self.direction_internal().y());
-        let other_dir = Vector2D::new(
-            other.direction_internal().x(),
-            other.direction_internal().y(),
-        );
-
-        let cross = this_dir.cross(&other_dir);
-        use geo_contracts::default_distance_tolerance;
-        cross.abs() < default_distance_tolerance::<T>()
-    }
-
-    fn is_same_direction(&self, other: &Self) -> bool {
-        let this_dir = Vector2D::new(self.direction_internal().x(), self.direction_internal().y());
-        let other_dir = Vector2D::new(
-            other.direction_internal().x(),
-            other.direction_internal().y(),
-        );
-
-        let cross = this_dir.cross(&other_dir);
-        use geo_contracts::default_distance_tolerance;
-        if cross.abs() >= default_distance_tolerance::<T>() {
-            return false;
-        }
-
-        let dot = this_dir.dot(&other_dir);
-        dot > T::ZERO
-    }
-
-    fn is_opposite_direction(&self, other: &Self) -> bool {
-        let this_dir = Vector2D::new(self.direction_internal().x(), self.direction_internal().y());
-        let other_dir = Vector2D::new(
-            other.direction_internal().x(),
-            other.direction_internal().y(),
-        );
-
-        let cross = this_dir.cross(&other_dir);
-        use geo_contracts::default_distance_tolerance;
-        if cross.abs() >= default_distance_tolerance::<T>() {
-            return false;
-        }
-
-        let dot = this_dir.dot(&other_dir);
-        dot < T::ZERO
-    }
-
     fn reverse(&self) -> Self
     where
         Self: Sized,
@@ -427,47 +394,10 @@ impl<T: Scalar> Ray2DMeasure<T> for Ray2D<T> {
         Ray2D::new(new_origin, direction_vec).unwrap()
     }
 
-    // ========== Phase 2 実装 ==========
-
-    fn intersection_with_ray(&self, other: &Self) -> Option<(T, T)> {
-        let this_dir = Vector2D::new(self.direction_internal().x(), self.direction_internal().y());
-        let other_dir = Vector2D::new(
-            other.direction_internal().x(),
-            other.direction_internal().y(),
-        );
-
-        let cross = this_dir.cross(&other_dir);
-        use geo_contracts::default_distance_tolerance;
-        if cross.abs() < default_distance_tolerance::<T>() {
-            return None; // 平行または一致
-        }
-
-        let diff = other.origin_internal() - self.origin_internal();
-        let diff_vec = Vector2D::new(diff.x(), diff.y());
-        let t = diff_vec.cross(&other_dir) / cross;
-
-        if t < T::ZERO {
-            return None; // Rayの逆方向
-        }
-
-        let intersection = self.point_at_parameter(t);
-        Some((intersection.x(), intersection.y()))
-    }
-
     fn point_at_distance(&self, distance: T) -> (T, T) {
         // 方向ベクトルは正規化済みなので、パラメータ = 距離
         let point = self.point_at_parameter(distance);
         (point.x(), point.y())
-    }
-
-    fn angle_between(&self, other: &Self) -> T {
-        let this_dir = Vector2D::new(self.direction_internal().x(), self.direction_internal().y());
-        let other_dir = Vector2D::new(
-            other.direction_internal().x(),
-            other.direction_internal().y(),
-        );
-        let dot = this_dir.dot(&other_dir);
-        dot.acos()
     }
 
     fn rotate_around_origin(&self, angle: T) -> Self
@@ -492,5 +422,86 @@ impl<T: Scalar> Ray2DMeasure<T> for Ray2D<T> {
         let new_direction = Vector2D::new(new_dx, new_dy);
 
         Ray2D::new(new_origin, new_direction).unwrap()
+    }
+}
+
+impl<T: Scalar> BasicIntersection<T, Self> for Ray2D<T> {
+    type Point = (T, T);
+
+    fn intersection_with(&self, other: &Self, _tolerance: T) -> Option<Self::Point> {
+        let this_dir = Vector2D::new(self.direction_internal().x(), self.direction_internal().y());
+        let other_dir = Vector2D::new(
+            other.direction_internal().x(),
+            other.direction_internal().y(),
+        );
+
+        let cross = this_dir.cross(&other_dir);
+        use geo_contracts::default_distance_tolerance;
+        if cross.abs() < default_distance_tolerance::<T>() {
+            return None;
+        }
+
+        let diff = other.origin_internal() - self.origin_internal();
+        let diff_vec = Vector2D::new(diff.x(), diff.y());
+        let t = diff_vec.cross(&other_dir) / cross;
+
+        if t < T::ZERO {
+            return None;
+        }
+
+        let intersection = self.point_at_parameter(t);
+        Some((intersection.x(), intersection.y()))
+    }
+}
+
+impl<T: Scalar> PointsTowards<(T, T)> for Ray2D<T> {
+    fn points_towards(&self, target: (T, T)) -> bool {
+        Ray2D::points_towards_direction(self, target)
+    }
+}
+
+impl<T: Scalar> ParallelRelation<Self> for Ray2D<T> {
+    fn is_parallel_to(&self, other: &Self) -> bool {
+        let this_dir = Vector2D::new(self.direction_internal().x(), self.direction_internal().y());
+        let other_dir = Vector2D::new(
+            other.direction_internal().x(),
+            other.direction_internal().y(),
+        );
+        let cross = this_dir.cross(&other_dir);
+        cross.abs() < geo_contracts::default_distance_tolerance::<T>()
+    }
+}
+
+impl<T: Scalar> DirectionalRelation<Self> for Ray2D<T> {
+    fn is_same_direction(&self, other: &Self) -> bool {
+        let this_dir = Vector2D::new(self.direction_internal().x(), self.direction_internal().y());
+        let other_dir = Vector2D::new(
+            other.direction_internal().x(),
+            other.direction_internal().y(),
+        );
+        let cross = this_dir.cross(&other_dir);
+        if cross.abs() >= geo_contracts::default_distance_tolerance::<T>() {
+            return false;
+        }
+        this_dir.dot(&other_dir) > T::ZERO
+    }
+
+    fn is_opposite_direction(&self, other: &Self) -> bool {
+        let this_dir = Vector2D::new(self.direction_internal().x(), self.direction_internal().y());
+        let other_dir = Vector2D::new(
+            other.direction_internal().x(),
+            other.direction_internal().y(),
+        );
+        let cross = this_dir.cross(&other_dir);
+        if cross.abs() >= geo_contracts::default_distance_tolerance::<T>() {
+            return false;
+        }
+        this_dir.dot(&other_dir) < T::ZERO
+    }
+}
+
+impl<T: Scalar> AngleBetween<T, Self> for Ray2D<T> {
+    fn angle_between(&self, other: &Self) -> T {
+        Ray2D::angle_between(self, other)
     }
 }

--- a/model/geo_primitives/src/ray_3d.rs
+++ b/model/geo_primitives/src/ray_3d.rs
@@ -5,7 +5,7 @@
 //! Core Traits実装（Constructor, Properties, Measure）も含む
 
 use crate::{Direction3D, Point3D, Vector3D};
-use geo_contracts::{Ray3DConstructor, Ray3DMeasure, Ray3DProperties, Scalar};
+use geo_contracts::{CrossDistance, Ray3DConstructor, Ray3DMeasure, Ray3DProperties, Scalar};
 
 /// 3次元半無限直線
 ///
@@ -442,41 +442,6 @@ impl<T: Scalar> Ray3DMeasure<T> for Ray3D<T> {
         Ray3D::new(new_origin, self.direction).unwrap()
     }
 
-    // ========== Phase 2 実装 ==========
-
-    fn distance_to_ray(&self, other: &Self) -> T {
-        let w = self.origin - other.origin;
-        let a = self.direction.dot(&self.direction);
-        let b = self.direction.dot(&other.direction);
-        let c = other.direction.dot(&other.direction);
-        let d = self.direction.dot(&w);
-        let e = other.direction.dot(&w);
-
-        let denom = a * c - b * b;
-        use geo_contracts::default_kernel_numerical_zero_tolerance;
-        if denom.abs() < default_kernel_numerical_zero_tolerance::<T>() {
-            // 平行: 片方の起点から他方への距離
-            let other_origin = other.origin;
-            return self.distance_to_point(&Point3D::new(
-                other_origin.x(),
-                other_origin.y(),
-                other_origin.z(),
-            ));
-        }
-
-        let sc = (b * e - c * d) / denom;
-        let tc = (a * e - b * d) / denom;
-
-        let sc_clamped = if sc < T::ZERO { T::ZERO } else { sc };
-        let tc_clamped = if tc < T::ZERO { T::ZERO } else { tc };
-
-        let p1 = self.point_at_parameter(sc_clamped);
-        let p2 = other.point_at_parameter(tc_clamped);
-
-        let diff = Vector3D::new(p1.x() - p2.x(), p1.y() - p2.y(), p1.z() - p2.z());
-        diff.length()
-    }
-
     fn point_at_distance(&self, distance: T) -> (T, T, T) {
         // 方向ベクトルは正規化済みなので、パラメータ = 距離
         let point = self.point_at_parameter(distance);
@@ -532,5 +497,39 @@ impl<T: Scalar> Ray3DMeasure<T> for Ray3D<T> {
         );
 
         Ray3D::new(rotated_origin, rotated_dir)
+    }
+}
+
+impl<T: Scalar> CrossDistance<T, Self> for Ray3D<T> {
+    fn distance_to(&self, other: &Self) -> T {
+        let w = self.origin - other.origin;
+        let a = self.direction.dot(&self.direction);
+        let b = self.direction.dot(&other.direction);
+        let c = other.direction.dot(&other.direction);
+        let d = self.direction.dot(&w);
+        let e = other.direction.dot(&w);
+
+        let denom = a * c - b * b;
+        use geo_contracts::default_kernel_numerical_zero_tolerance;
+        if denom.abs() < default_kernel_numerical_zero_tolerance::<T>() {
+            let other_origin = other.origin;
+            return self.distance_to_point(&Point3D::new(
+                other_origin.x(),
+                other_origin.y(),
+                other_origin.z(),
+            ));
+        }
+
+        let sc = (b * e - c * d) / denom;
+        let tc = (a * e - b * d) / denom;
+
+        let sc_clamped = if sc < T::ZERO { T::ZERO } else { sc };
+        let tc_clamped = if tc < T::ZERO { T::ZERO } else { tc };
+
+        let p1 = self.point_at_parameter(sc_clamped);
+        let p2 = other.point_at_parameter(tc_clamped);
+
+        let diff = Vector3D::new(p1.x() - p2.x(), p1.y() - p2.y(), p1.z() - p2.z());
+        diff.length()
     }
 }

--- a/model/geo_primitives/src/ray_3d.rs
+++ b/model/geo_primitives/src/ray_3d.rs
@@ -5,7 +5,10 @@
 //! Core Traits実装（Constructor, Properties, Measure）も含む
 
 use crate::{Direction3D, Point3D, Vector3D};
-use geo_contracts::{CrossDistance, Ray3DConstructor, Ray3DMeasure, Ray3DProperties, Scalar};
+use geo_contracts::{
+    AngleBetween, CrossDistance, DirectionalRelation, ParallelRelation, PointsTowards,
+    Ray3DConstructor, Ray3DMeasure, Ray3DProperties, Scalar,
+};
 
 /// 3次元半無限直線
 ///
@@ -139,6 +142,35 @@ impl<T: Scalar> Ray3D<T> {
             origin: self.origin,
             direction: -self.direction,
         }
+    }
+
+    /// 他の Ray と平行かを判定
+    pub fn is_parallel_to(&self, other: &Self) -> bool {
+        let cross = self.direction.cross(&other.direction);
+        cross.length() < geo_contracts::default_distance_tolerance::<T>()
+    }
+
+    /// 他の Ray と同方向かを判定
+    pub fn is_same_direction(&self, other: &Self) -> bool {
+        self.is_parallel_to(other) && self.direction.dot(&other.direction) > T::ZERO
+    }
+
+    /// 他の Ray と逆方向かを判定
+    pub fn is_opposite_direction(&self, other: &Self) -> bool {
+        self.is_parallel_to(other) && self.direction.dot(&other.direction) < T::ZERO
+    }
+
+    /// 他の Ray との角度を返す
+    pub fn angle_between(&self, other: &Self) -> T {
+        let dot = self.direction.dot(&other.direction);
+        let clamped = if dot > T::ONE {
+            T::ONE
+        } else if dot < -T::ONE {
+            -T::ONE
+        } else {
+            dot
+        };
+        clamped.acos()
     }
 
     // ========================================================================
@@ -395,36 +427,6 @@ impl<T: Scalar> Ray3DMeasure<T> for Ray3D<T> {
         self.parameter_for_point(&target_point)
     }
 
-    fn points_towards(&self, direction: (T, T, T)) -> bool {
-        let target_direction = Vector3D::new(direction.0, direction.1, direction.2);
-        let dot = self.direction.dot(&target_direction);
-        dot > T::ZERO
-    }
-
-    fn is_parallel_to(&self, other: &Self) -> bool {
-        let cross = self.direction.cross(&other.direction);
-        use geo_contracts::default_distance_tolerance;
-        cross.length() < default_distance_tolerance::<T>()
-    }
-
-    fn is_same_direction(&self, other: &Self) -> bool {
-        if !self.is_parallel_to(other) {
-            return false;
-        }
-
-        let dot = self.direction.dot(&other.direction);
-        dot > T::ZERO
-    }
-
-    fn is_opposite_direction(&self, other: &Self) -> bool {
-        if !self.is_parallel_to(other) {
-            return false;
-        }
-
-        let dot = self.direction.dot(&other.direction);
-        dot < T::ZERO
-    }
-
     fn reverse(&self) -> Self
     where
         Self: Sized,
@@ -446,18 +448,6 @@ impl<T: Scalar> Ray3DMeasure<T> for Ray3D<T> {
         // 方向ベクトルは正規化済みなので、パラメータ = 距離
         let point = self.point_at_parameter(distance);
         (point.x(), point.y(), point.z())
-    }
-
-    fn angle_between(&self, other: &Self) -> T {
-        let dot = self.direction.dot(&other.direction);
-        let clamped = if dot > T::ONE {
-            T::ONE
-        } else if dot < -T::ONE {
-            -T::ONE
-        } else {
-            dot
-        };
-        clamped.acos()
     }
 
     fn rotate_around_axis(&self, axis: (T, T, T), angle: T) -> Option<Self>
@@ -531,5 +521,34 @@ impl<T: Scalar> CrossDistance<T, Self> for Ray3D<T> {
 
         let diff = Vector3D::new(p1.x() - p2.x(), p1.y() - p2.y(), p1.z() - p2.z());
         diff.length()
+    }
+}
+
+impl<T: Scalar> PointsTowards<(T, T, T)> for Ray3D<T> {
+    fn points_towards(&self, target: (T, T, T)) -> bool {
+        let target_direction = Vector3D::new(target.0, target.1, target.2);
+        self.direction.dot(&target_direction) > T::ZERO
+    }
+}
+
+impl<T: Scalar> ParallelRelation<Self> for Ray3D<T> {
+    fn is_parallel_to(&self, other: &Self) -> bool {
+        Ray3D::is_parallel_to(self, other)
+    }
+}
+
+impl<T: Scalar> DirectionalRelation<Self> for Ray3D<T> {
+    fn is_same_direction(&self, other: &Self) -> bool {
+        Ray3D::is_same_direction(self, other)
+    }
+
+    fn is_opposite_direction(&self, other: &Self) -> bool {
+        Ray3D::is_opposite_direction(self, other)
+    }
+}
+
+impl<T: Scalar> AngleBetween<T, Self> for Ray3D<T> {
+    fn angle_between(&self, other: &Self) -> T {
+        Ray3D::angle_between(self, other)
     }
 }

--- a/model/geo_primitives/src/spherical_solid_3d.rs
+++ b/model/geo_primitives/src/spherical_solid_3d.rs
@@ -1,61 +1,25 @@
-//! 3次元球ソリッド（SphericalSolid3D）のCore実装
+//! 3次元球ソリッドのCore実装
 //!
-//! STEP準拠のSOLID_SPHERE + AXIS2_PLACEMENT_3Dに対応
-//! 完全ハイブリッドモデラー対応：ソリッド（立体）として明確に定義
+//! STEP の SOLID_SPHERE と AXIS2_PLACEMENT_3D への対応
 //! 拡張機能は spherical_solid_3d_extensions.rs を参照
-//!
-//! ## STEP標準対応
-//! ```step
-//! SOLID_SPHERE('', AXIS2_PLACEMENT_3D('', POINT, AXIS, REF_DIRECTION), RADIUS);
-//! ```
-//! - location: 球の中心点（center）
-//! - axis: Z軸方向（参照軸）- 正規化済み
-//! - ref_direction: X軸方向（参照方向）- 正規化済み
-//! - derived Y軸: axis × ref_direction で自動計算
-//! - radius: 球の半径
-//!
-//! **作成日: 2025年11月1日**
-//! **最終更新: 2025年11月1日**
 
 // use crate::{BBox3D, Direction3D, Plane3DCoordinateSystem, Point3D, Vector3D}; // 一時的にコメントアウト
 use crate::{Direction3D, Point3D, Vector3D};
 use geo_contracts::{IntersectsRelation, Scalar};
 
-/// 3次元球ソリッド（STEP準拠のCore実装）
+/// STEP 準拠の 3 次元球ソリッド
 ///
-/// STEP AP214の SOLID_SPHERE + AXIS2_PLACEMENT_3D エンティティに対応
-/// 完全ハイブリッドモデラー：立体として体積・内部判定を持つ
-///
-/// ## 座標系定義（STEP準拠）
-/// - center: 球の中心点（STEP: location）
-/// - axis: Z軸方向（STEP: axis）- 参照軸、正規化済み
-/// - ref_direction: X軸方向（STEP: ref_direction）- 参照方向、正規化済み
-/// - derived Y軸: axis × ref_direction で自動計算
-/// - radius: 球の半径
-///
-/// ## ソリッド特性
-/// - 体積計算：V = (4/3)π × r³
-/// - 内部判定：点の包含テスト
-/// - 表面積計算：S = 4π × r²
-/// - 境界ボックス：中心を基準とした立方体
-///
-/// ## CAD用途
-/// - パラメトリック球ソリッドの基準座標系
-/// - ブーリアン演算（和・差・積）
-/// - STEPファイルとの相互変換
-/// - 体積・質量特性計算
+/// 中心、参照軸、参照方向、半径を保持
+/// 体積、表面積、包含判定を提供
 #[derive(Debug, Clone, PartialEq)]
 pub struct SphericalSolid3D<T: Scalar> {
-    /// 球の中心点（STEP: location）
+    /// 球の中心点
     center: Point3D<T>,
 
-    /// 参照軸方向（STEP: axis）- Z軸、正規化済み
-    /// Direction3D<T>により正規化が保証される
+    /// 参照軸方向
     axis: Direction3D<T>,
 
-    /// 参照方向（STEP: ref_direction）- X軸、正規化済み
-    /// Direction3D<T>により正規化が保証される
-    /// axis と直交していなくても自動調整
+    /// 参照方向
     ref_direction: Direction3D<T>,
 
     /// 球の半径
@@ -67,45 +31,24 @@ pub struct SphericalSolid3D<T: Scalar> {
 // ============================================================================
 
 impl<T: Scalar> SphericalSolid3D<T> {
-    // ========================================================================
-    // STEP準拠のコンストラクタ
-    // ========================================================================
-
-    /// STEP AXIS2_PLACEMENT_3D 形式で球ソリッドを作成
+    /// STEP 配置情報からの球ソリッド生成
     ///
-    /// # Arguments
-    /// * `center` - 球の中心点
-    /// * `axis` - 参照軸ベクトル（Z軸）
-    /// * `ref_direction` - 参照方向ベクトル（X軸）、軸と直交していなくても自動調整
-    /// * `radius` - 半径（正の値）
-    ///
-    /// # Returns
-    /// 有効な球ソリッドが作成できた場合は `Some(SphericalSolid3D)`、
-    /// 無効なパラメータの場合は `None`
-    ///
-    /// # アルゴリズム
-    /// 1. 軸を正規化してZ軸とする
-    /// 2. 参照方向から軸成分を除去（グラム・シュミット正規直交化）
-    /// 3. 正規化して参照方向とする
+    /// 軸の正規化と参照方向の直交補正を実施
     pub fn new(
         center: Point3D<T>,
         axis: Vector3D<T>,
         ref_direction: Vector3D<T>,
         radius: T,
     ) -> Option<Self> {
-        // 半径の検証
         if radius <= T::ZERO {
             return None;
         }
 
-        // 軸の正規化
         let z_axis = Direction3D::from_vector(axis)?;
 
-        // 参照方向の軸成分を除去して正規化（グラム・シュミット正規直交化）
         let axis_component = ref_direction.dot(&z_axis.as_vector());
         let orthogonal_ref = ref_direction - z_axis.as_vector() * axis_component;
 
-        // 参照方向の正規化
         let x_axis = Direction3D::from_vector(orthogonal_ref)?;
 
         Some(Self {
@@ -116,7 +59,7 @@ impl<T: Scalar> SphericalSolid3D<T> {
         })
     }
 
-    /// Z軸標準の球ソリッドを作成（簡易コンストラクタ）
+    /// 標準軸での球ソリッド生成
     pub fn new_standard(center: Point3D<T>, radius: T) -> Option<Self> {
         Self::new(
             center,
@@ -126,12 +69,12 @@ impl<T: Scalar> SphericalSolid3D<T> {
         )
     }
 
-    /// 原点中心の球ソリッドを作成（簡易コンストラクタ）
+    /// 原点中心の球ソリッド生成
     pub fn new_at_origin(radius: T) -> Option<Self> {
         Self::new_standard(Point3D::new(T::ZERO, T::ZERO, T::ZERO), radius)
     }
 
-    /// 直径から球ソリッドを作成
+    /// 直径からの球ソリッド生成
     pub fn from_diameter(
         center: Point3D<T>,
         axis: Vector3D<T>,
@@ -148,22 +91,22 @@ impl<T: Scalar> SphericalSolid3D<T> {
     // Core Accessor Methods
     // ========================================================================
 
-    /// 球の中心点を取得
+    /// 球の中心点の取得
     pub(crate) fn center_internal(&self) -> Point3D<T> {
         self.center
     }
 
-    /// 参照軸方向を取得（正規化済み）
+    /// 参照軸方向の取得
     pub(crate) fn axis_internal(&self) -> Direction3D<T> {
         self.axis
     }
 
-    /// 参照方向を取得（正規化済み、X軸相当）
+    /// 参照方向の取得
     pub(crate) fn ref_direction_internal(&self) -> Direction3D<T> {
         self.ref_direction
     }
 
-    /// Y軸方向を計算（axis × ref_direction）
+    /// Y 軸相当方向の計算
     #[allow(dead_code)]
     pub(crate) fn y_axis_internal(&self) -> Direction3D<T> {
         let y_vector = self.axis.as_vector().cross(&self.ref_direction.as_vector());
@@ -171,12 +114,11 @@ impl<T: Scalar> SphericalSolid3D<T> {
             .expect("Y-axis calculation should always succeed with orthogonal axes")
     }
 
-    /// 球ソリッドの半径を取得
+    /// 半径の取得
     pub(crate) fn radius_internal(&self) -> T {
         self.radius
     }
 
-    /// 球ソリッドの位置（座標系）を取得
     // 一時的にコメントアウト: Plane3DCoordinateSystemが未定義
     // pub fn position(&self) -> Plane3DCoordinateSystem<T> {
     //     // Plane3DCoordinateSystemを原点と軸から構築
@@ -187,30 +129,22 @@ impl<T: Scalar> SphericalSolid3D<T> {
     //     )
     //     .expect("Coordinate system creation should succeed with valid sphere parameters")
     // }
-    /// 球の直径を取得
+    /// 直径の取得
     pub fn diameter(&self) -> T {
         self.radius * T::from_f64(2.0)
     }
 
-    // ========================================================================
-    // Core Geometric Properties (ソリッド特性)
-    // ========================================================================
-
-    /// 球ソリッドの体積を計算
-    ///
-    /// 体積 = (4/3)π × r³
+    /// 体積の計算
     pub fn volume(&self) -> T {
         T::from_f64(4.0) * T::PI * self.radius * self.radius * self.radius / T::from_f64(3.0)
     }
 
-    /// 球ソリッドの表面積を計算
-    ///
-    /// 表面積 = 4π × r²
+    /// 表面積の計算
     pub fn surface_area(&self) -> T {
         T::from_f64(4.0) * T::PI * self.radius * self.radius
     }
 
-    /// 球ソリッドの境界ボックスを計算
+    /// 境界ボックスの計算
     pub fn bounding_box(&self) -> geo_core::Aabb3D<T> {
         let min_point = geo_core::Point3D::new(
             self.center.x() - self.radius,
@@ -225,40 +159,24 @@ impl<T: Scalar> SphericalSolid3D<T> {
         geo_core::Aabb3D::new(min_point, max_point)
     }
 
-    // ========================================================================
-    // Core Containment and Distance Methods (ソリッド特性)
-    // ========================================================================
-
-    /// 点が球ソリッド内部に含まれるかを判定
+    /// 点の内部包含判定
     pub fn contains_point(&self, point: Point3D<T>) -> bool {
         let distance_squared = self.center.distance_squared_to(&point);
         distance_squared <= self.radius * self.radius
     }
 
-    /// 点から球ソリッド表面までの距離を計算
-    /// 内部の点の場合は負の値を返す
+    /// 点から表面までの符号付き距離の返却
     pub fn distance_to_surface(&self, point: Point3D<T>) -> T {
         let distance_to_center = self.center.distance_to(&point);
         distance_to_center - self.radius
     }
 
-    /// 球ソリッドが退化しているかどうかを判定
+    /// 退化判定
     pub fn is_degenerate(&self) -> bool {
         self.radius <= T::EPSILON
     }
 
-    // ========================================================================
-    // 距離計算メソッド（sphere_metricsから移動）
-    // ========================================================================
-
-    /// 球ソリッドから無限直線までの最短距離を計算
-    ///
-    /// # Arguments
-    /// * `line_point` - 直線上の任意の点
-    /// * `line_direction` - 直線の方向ベクトル（正規化不要）
-    ///
-    /// # Returns
-    /// 球ソリッドから無限直線までの最短距離（内部なら0）
+    /// 無限直線までの最短距離の返却
     pub fn distance_to_infinite_line(
         &self,
         line_point: &Point3D<T>,
@@ -277,21 +195,13 @@ impl<T: Scalar> SphericalSolid3D<T> {
         }
     }
 
-    /// 球ソリッドから光線（Ray）までの最短距離を計算
-    ///
-    /// # Arguments
-    /// * `ray_origin` - 光線の始点
-    /// * `ray_direction` - 光線の方向ベクトル（正規化不要）
-    ///
-    /// # Returns
-    /// 球ソリッドから光線までの最短距離（内部なら0）
+    /// 光線までの最短距離の返却
     pub fn distance_to_ray(&self, ray_origin: &Point3D<T>, ray_direction: &Vector3D<T>) -> T {
         let to_center = self.center - *ray_origin;
         let dir_dot = ray_direction.dot(ray_direction);
         let t = to_center.dot(ray_direction) / dir_dot;
 
         if t < T::ZERO {
-            // 光線の始点が最近点
             let dist_to_origin = to_center.length();
             if dist_to_origin <= self.radius {
                 T::ZERO
@@ -299,7 +209,6 @@ impl<T: Scalar> SphericalSolid3D<T> {
                 dist_to_origin - self.radius
             }
         } else {
-            // t ≥ 0: 無限直線と同じ処理
             let closest = *ray_origin + *ray_direction * t;
             let distance_from_center = (self.center - closest).length();
             if distance_from_center <= self.radius {
@@ -310,14 +219,7 @@ impl<T: Scalar> SphericalSolid3D<T> {
         }
     }
 
-    /// 球ソリッドから線分までの最短距離を計算
-    ///
-    /// # Arguments
-    /// * `segment_start` - 線分の始点
-    /// * `segment_end` - 線分の終点
-    ///
-    /// # Returns
-    /// 球ソリッドから線分までの最短距離（内部なら0）
+    /// 線分までの最短距離の返却
     pub fn distance_to_line_segment(
         &self,
         segment_start: &Point3D<T>,
@@ -344,12 +246,7 @@ impl<T: Scalar> SphericalSolid3D<T> {
         }
     }
 
-    // ========================================================================
-    // Surface Operations
-    // ========================================================================
-
-    /// 指定された方向ベクトルで球表面上の点を取得
-    /// 方向ベクトルは正規化される
+    /// 指定方向の表面点の返却
     pub fn point_on_surface_in_direction(&self, direction: Vector3D<T>) -> Option<Point3D<T>> {
         let normalized = direction.normalize();
         if normalized == Vector3D::new(T::ZERO, T::ZERO, T::ZERO) {
@@ -363,7 +260,7 @@ impl<T: Scalar> SphericalSolid3D<T> {
         ))
     }
 
-    /// 球の中心から指定された点への方向の表面点を取得
+    /// 指定点方向の表面点の返却
     pub fn point_on_surface_towards(&self, target: Point3D<T>) -> Option<Point3D<T>> {
         let direction = Vector3D::new(
             target.x() - self.center.x(),
@@ -405,8 +302,6 @@ impl<T: Scalar> SphericalSolid3DConstructor<T> for SphericalSolid3D<T> {
         Self::new_at_origin(T::ONE).expect("Unit sphere creation should always succeed")
     }
 
-    // Phase 2: 追加コンストラクタ
-
     fn from_diameter(center: (T, T, T), diameter: T) -> Option<Self> {
         let radius = diameter / (T::ONE + T::ONE);
         let center_point = Point3D::new(center.0, center.1, center.2);
@@ -433,8 +328,7 @@ impl<T: Scalar> SphericalSolid3DConstructor<T> for SphericalSolid3D<T> {
         p3: (T, T, T),
         p4: (T, T, T),
     ) -> Option<Self> {
-        // 4点を通る球の中心と半径を計算（外接球）
-        // 簡易実装：重心を中心として最も遠い点までの距離を半径とする
+        // 厳密外接球ではなく重心ベースの近似生成
         let center_x = (p1.0 + p2.0 + p3.0 + p4.0) / T::from_f64(4.0);
         let center_y = (p1.1 + p2.1 + p3.1 + p4.1) / T::from_f64(4.0);
         let center_z = (p1.2 + p2.2 + p3.2 + p4.2) / T::from_f64(4.0);
@@ -515,8 +409,6 @@ impl<T: Scalar> SphericalSolid3DMeasure<T> for SphericalSolid3D<T> {
         self.distance_to_surface(point_3d).abs()
     }
 
-    // Phase 2: 追加測定
-
     fn point_at_latlong(&self, latitude: T, longitude: T) -> (T, T, T) {
         let c = self.center_internal();
         let r = self.radius_internal();
@@ -552,7 +444,6 @@ impl<T: Scalar> SphericalSolid3DMeasure<T> for SphericalSolid3D<T> {
         let len = dir.length();
 
         if len < T::EPSILON {
-            // 点が中心にある場合は任意の表面点を返す
             return (c.x() + r, c.y(), c.z());
         }
 

--- a/model/geo_primitives/src/spherical_solid_3d.rs
+++ b/model/geo_primitives/src/spherical_solid_3d.rs
@@ -19,7 +19,7 @@
 
 // use crate::{BBox3D, Direction3D, Plane3DCoordinateSystem, Point3D, Vector3D}; // 一時的にコメントアウト
 use crate::{Direction3D, Point3D, Vector3D};
-use geo_contracts::Scalar;
+use geo_contracts::{IntersectsRelation, Scalar};
 
 /// 3次元球ソリッド（STEP準拠のCore実装）
 ///
@@ -565,19 +565,17 @@ impl<T: Scalar> SphericalSolid3DMeasure<T> for SphericalSolid3D<T> {
 
         (surface_point.x(), surface_point.y(), surface_point.z())
     }
-
-    fn intersects_sphere(&self, other_center: (T, T, T), other_radius: T) -> bool {
-        let c1 = self.center_internal();
-        let c2 = Point3D::new(other_center.0, other_center.1, other_center.2);
-        let r1 = self.radius_internal();
-        let r2 = other_radius;
-
-        let distance = c1.distance_to(&c2);
-        distance <= (r1 + r2)
-    }
 }
 
 impl<T: Scalar> SphericalSolid3DCore<T> for SphericalSolid3D<T> {}
+
+impl<T: Scalar> IntersectsRelation<Self> for SphericalSolid3D<T> {
+    fn intersects(&self, other: &Self) -> bool {
+        let center = other.center_internal();
+        let radius = other.radius_internal();
+        self.center_internal().distance_to(&center) <= (self.radius_internal() + radius)
+    }
+}
 
 // ============================================================================
 // Display Implementation

--- a/model/geo_primitives/src/spherical_solid_3d_foundation.rs
+++ b/model/geo_primitives/src/spherical_solid_3d_foundation.rs
@@ -1,9 +1,6 @@
-//! SphericalSolid3D Foundation Implementation
+//! SphericalSolid3D の Foundation 実装
 //!
-//! ExtensionFoundation トレイトによる統一インターフェースの実装
-//!
-//! **作成日: 2025年11月1日**
-//! **最終更新: 2025年11月1日**
+//! Foundation 系 trait への適合
 
 use crate::SphericalSolid3D;
 use geo_contracts::{Bounded, MeasureFoundation, PrimitiveKind, PrimitiveMetadata, Scalar};
@@ -39,7 +36,6 @@ mod tests {
         let center = Point3D::new(1.0, 2.0, 3.0);
         let solid = SphericalSolid3D::new_standard(center, 2.0).unwrap();
 
-        // Foundation トレイトのテスト
         assert_eq!(solid.primitive_kind(), PrimitiveKind::SphericalSolid);
 
         let bbox = solid.aabb().expect("should have aabb");
@@ -47,7 +43,7 @@ mod tests {
         assert_eq!(bbox.max(), Point3D::new(3.0, 4.0, 5.0));
 
         let volume = solid.measure().unwrap();
-        let expected_volume = 4.0 * std::f64::consts::PI * 8.0 / 3.0; // 4/3 * π * r³
+        let expected_volume = 4.0 * std::f64::consts::PI * 8.0 / 3.0;
         assert!((volume - expected_volume).abs() < 1e-10);
     }
 

--- a/model/geo_primitives/src/spherical_solid_3d_tests.rs
+++ b/model/geo_primitives/src/spherical_solid_3d_tests.rs
@@ -1,0 +1,25 @@
+//! SphericalSolid3D の relation 回帰テスト
+
+#[cfg(test)]
+mod tests {
+    use crate::{Point3D, SphericalSolid3D};
+    use geo_contracts::IntersectsRelation;
+
+    #[test]
+    fn test_spherical_solid_intersection_is_exposed_via_relation_trait() {
+        let sphere_a = SphericalSolid3D::new_standard(Point3D::new(0.0, 0.0, 0.0), 5.0).unwrap();
+        let sphere_b = SphericalSolid3D::new_standard(Point3D::new(9.0, 0.0, 0.0), 5.0).unwrap();
+        let sphere_c = SphericalSolid3D::new_standard(Point3D::new(11.0, 0.0, 0.0), 5.0).unwrap();
+
+        assert!(IntersectsRelation::intersects(&sphere_a, &sphere_b));
+        assert!(!IntersectsRelation::intersects(&sphere_a, &sphere_c));
+    }
+
+    #[test]
+    fn test_spherical_solid_intersection_tangent_counts_as_intersecting() {
+        let sphere_a = SphericalSolid3D::new_standard(Point3D::new(0.0, 0.0, 0.0), 5.0).unwrap();
+        let sphere_b = SphericalSolid3D::new_standard(Point3D::new(10.0, 0.0, 0.0), 5.0).unwrap();
+
+        assert!(IntersectsRelation::intersects(&sphere_a, &sphere_b));
+    }
+}


### PR DESCRIPTION
Closes #541

## 概要

shape 定義層に残っていた cross-shape / relation / intersection 系 capability を `operations` 側へ移送し、definition core から横断責務を外しました。

あわせて、今回の仕上げとして球ソリッド関連ファイルのコメントを簡潔化し、現在の記述ルールに合わせて整理しています。

## 実施内容

- `InfiniteLine2DMeasure::intersection` を core から除去し、`BasicIntersection<T, Self>` へ移送
- `Ray2DMeasure::intersection_with_ray` を core から除去し、`BasicIntersection<T, Self>` へ移送
- `InfiniteLine3DProperties::is_on_plane` を core から除去し、`OnPlaneRelation<Plane3D<T>>` を追加
- `SphericalSolid3DMeasure::intersects_sphere` を core から除去し、`IntersectsRelation<Self>` へ移送
- `CylindricalSolid3DMeasure::intersects_line` を core から除去し、`BasicIntersection<T, InfiniteLine3D<T>>` へ移送
- 上記移送に対応する relation / regression test を追加
- `spherical_solid_3d.rs` と `spherical_solid_3d_foundation.rs` のコメントを簡潔な文体へ整理

## 完了条件との対応

- cross-shape 演算の core 残置
  - AABB のみ非対象として据え置き
  - それ以外の cross-shape / relation / intersection 系残件は整理済み
- algorithm / approximation / solver capability の残置
  - `geometry/core` 配下に blocking な残件なし
- `operations` 側の公開面
  - `BasicIntersection` / `IntersectsRelation` / `OnPlaneRelation` に寄せて統一
- 後続 shape への適用可能性
  - line / ray / sphere / cylinder で同じ分離パターンを適用済み

## 補足

`direction_traits.rs` には自己関係の relation API が残っていますが、これは cross-shape capability ではないため、本 PR では #541 の対象外として扱っています。

## 検証

- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo test --workspace`