### PR TITLE
[Phase5] refactor: AABB trait を properties / derived / relation capability へ整理

### DIFF
--- a/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
+++ b/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
@@ -247,6 +247,8 @@ Issue #535 では、`geo_contracts` の trait構造を次の最小構造へ再�
 - `Aabb*Properties`: `min`, `max`
 - `Aabb*Derived`: `width`, `height`, `depth`, `center`, `area`, `volume`, `is_valid`
 - `contains_point`, `contains_bbox`, `intersects` は extension または operations へ移す
+- 既存 `Aabb2DTrait` / `Aabb3DTrait` の延命は前提にせず、新規 capability 群として再定義してよい
+- AABB 単体で参照系 / derived / relation の意味を再設計し、旧 trait 命名との互換維持より責務境界の明確化を優先する
 
 ### 10. `EllipseCalculation*` は extension か operations か
 

--- a/model/geo_contracts/src/geometry/core/aabb_traits.rs
+++ b/model/geo_contracts/src/geometry/core/aabb_traits.rs
@@ -3,32 +3,33 @@
 
 use crate::Scalar;
 
-pub trait Aabb2DTrait<T: Scalar> {
+pub trait Aabb2DProperties<T: Scalar> {
     type Point2D;
 
     fn min(&self) -> Self::Point2D;
     fn max(&self) -> Self::Point2D;
+}
+
+pub trait Aabb2DDerived<T: Scalar>: Aabb2DProperties<T> {
     fn width(&self) -> T;
     fn height(&self) -> T;
     fn area(&self) -> T;
     fn center(&self) -> Self::Point2D;
-    fn contains_point(&self, point: &Self::Point2D) -> bool;
-    fn contains_bbox(&self, other: &Self) -> bool;
     fn is_valid(&self) -> bool;
 }
 
-pub trait Aabb3DTrait<T: Scalar> {
+pub trait Aabb3DProperties<T: Scalar> {
     type Point3D;
 
     fn min(&self) -> Self::Point3D;
     fn max(&self) -> Self::Point3D;
+}
+
+pub trait Aabb3DDerived<T: Scalar>: Aabb3DProperties<T> {
     fn width(&self) -> T;
     fn height(&self) -> T;
     fn depth(&self) -> T;
     fn volume(&self) -> T;
     fn center(&self) -> Self::Point3D;
-    fn contains_point(&self, point: &Self::Point3D) -> bool;
-    fn contains_bbox(&self, other: &Self) -> bool;
-    fn intersects(&self, other: &Self) -> bool;
     fn is_valid(&self) -> bool;
 }

--- a/model/geo_contracts/src/geometry/core/mod.rs
+++ b/model/geo_contracts/src/geometry/core/mod.rs
@@ -29,7 +29,7 @@ pub mod torus_surface_traits;
 pub mod triangle_traits;
 pub mod vector_traits;
 
-pub use aabb_traits::{Aabb2DTrait, Aabb3DTrait};
+pub use aabb_traits::{Aabb2DDerived, Aabb2DProperties, Aabb3DDerived, Aabb3DProperties};
 pub use arc_traits::{
     Arc2DConstructor, Arc2DCore, Arc2DMeasure, Arc2DProperties, Arc3DConstructor, Arc3DCore,
     Arc3DMeasure, Arc3DProperties,

--- a/model/geo_contracts/src/geometry/operations/mod.rs
+++ b/model/geo_contracts/src/geometry/operations/mod.rs
@@ -1,9 +1,10 @@
-//! Geometry operation contracts (collision, intersection).
+//! Geometry operation contracts (collision, intersection, relation).
 
 pub mod collision;
 pub mod distance;
 pub mod ellipse_calculation_traits;
 pub mod intersection;
+pub mod relation;
 
 pub use collision::{AdvancedCollision, BBoxCollision, BasicCollision, PointDistance};
 pub use distance::{CrossDistance, DistanceConvergenceError, FallibleCrossDistance};
@@ -11,3 +12,4 @@ pub use ellipse_calculation_traits::{
     EllipseAccuracyAnalysis, EllipseAdaptiveCalculation, EllipseCalculation,
 };
 pub use intersection::{BasicIntersection, MultipleIntersection, SelfIntersection};
+pub use relation::{Aabb2DRelation, Aabb3DRelation};

--- a/model/geo_contracts/src/geometry/operations/relation.rs
+++ b/model/geo_contracts/src/geometry/operations/relation.rs
@@ -1,0 +1,19 @@
+//! Geometry relation contracts.
+
+use crate::Scalar;
+
+pub trait Aabb2DRelation<T: Scalar> {
+    type Point2D;
+
+    fn contains_point(&self, point: &Self::Point2D) -> bool;
+    fn contains_bbox(&self, other: &Self) -> bool;
+    fn intersects(&self, other: &Self) -> bool;
+}
+
+pub trait Aabb3DRelation<T: Scalar> {
+    type Point3D;
+
+    fn contains_point(&self, point: &Self::Point3D) -> bool;
+    fn contains_bbox(&self, other: &Self) -> bool;
+    fn intersects(&self, other: &Self) -> bool;
+}

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -15,7 +15,7 @@ pub use geometry::core::arc_traits::{Arc2DContainment, Arc2DSampling};
 pub use geometry::core::plane3d_traits::{
     Plane3DConstructor, Plane3DCore, Plane3DMeasure, Plane3DProperties,
 };
-pub use geometry::core::{Aabb2DTrait, Aabb3DTrait};
+pub use geometry::core::{Aabb2DDerived, Aabb2DProperties, Aabb3DDerived, Aabb3DProperties};
 pub use geometry::core::{
     Arc2DConstructor, Arc2DCore, Arc2DMeasure, Arc2DProperties, Arc3DConstructor, Arc3DCore,
     Arc3DMeasure, Arc3DProperties, Circle2DConstructor, Circle2DCore, Circle2DMeasure,
@@ -63,10 +63,10 @@ pub use geometry::foundation::{
     PrimitiveMetadata, Vector2DMeasure, Vector3DMeasure,
 };
 pub use geometry::operations::{
-    AdvancedCollision, BBoxCollision, BasicCollision, BasicIntersection, CrossDistance,
-    DistanceConvergenceError, EllipseAccuracyAnalysis, EllipseAdaptiveCalculation,
-    EllipseCalculation, FallibleCrossDistance, MultipleIntersection, PointDistance,
-    SelfIntersection,
+    Aabb2DRelation, Aabb3DRelation, AdvancedCollision, BBoxCollision, BasicCollision,
+    BasicIntersection, CrossDistance, DistanceConvergenceError, EllipseAccuracyAnalysis,
+    EllipseAdaptiveCalculation, EllipseCalculation, FallibleCrossDistance, MultipleIntersection,
+    PointDistance, SelfIntersection,
 };
 pub use tolerance::{
     default_angle_tolerance, default_distance_tolerance, default_kernel_numerical_zero_tolerance,

--- a/model/geo_core/src/aabb_2d.rs
+++ b/model/geo_core/src/aabb_2d.rs
@@ -3,7 +3,7 @@
 //! Foundation Pattern に基づく Aabb2D の実装。
 //! geo_primitives, geo_nurbs など全クレートから共通利用されます。
 
-use crate::aabb_traits::Aabb2DTrait;
+use crate::aabb_traits::{Aabb2DDerived, Aabb2DProperties, Aabb2DRelation};
 use crate::Point2D;
 use analysis::abstract_types::Scalar;
 
@@ -113,7 +113,7 @@ impl<T: Scalar> Aabb2D<T> {
 // Foundation Trait Implementation
 // ============================================================================
 
-impl<T: Scalar> Aabb2DTrait<T> for Aabb2D<T> {
+impl<T: Scalar> Aabb2DProperties<T> for Aabb2D<T> {
     type Point2D = Point2D<T>;
 
     fn min(&self) -> Self::Point2D {
@@ -123,7 +123,9 @@ impl<T: Scalar> Aabb2DTrait<T> for Aabb2D<T> {
     fn max(&self) -> Self::Point2D {
         self.max
     }
+}
 
+impl<T: Scalar> Aabb2DDerived<T> for Aabb2D<T> {
     fn width(&self) -> T {
         self.max.x() - self.min.x()
     }
@@ -144,6 +146,14 @@ impl<T: Scalar> Aabb2DTrait<T> for Aabb2D<T> {
         )
     }
 
+    fn is_valid(&self) -> bool {
+        !(self.min.x() > self.max.x() || self.min.y() > self.max.y())
+    }
+}
+
+impl<T: Scalar> Aabb2DRelation<T> for Aabb2D<T> {
+    type Point2D = Point2D<T>;
+
     fn contains_point(&self, point: &Self::Point2D) -> bool {
         point.x() >= self.min.x()
             && point.x() <= self.max.x()
@@ -158,14 +168,18 @@ impl<T: Scalar> Aabb2DTrait<T> for Aabb2D<T> {
             && self.max.y() >= other.max.y()
     }
 
-    fn is_valid(&self) -> bool {
-        !(self.min.x() > self.max.x() || self.min.y() > self.max.y())
+    fn intersects(&self, other: &Self) -> bool {
+        self.min.x() <= other.max.x()
+            && self.max.x() >= other.min.x()
+            && self.min.y() <= other.max.y()
+            && self.max.y() >= other.min.y()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::aabb_traits::{Aabb2DDerived, Aabb2DProperties, Aabb2DRelation};
 
     #[test]
     fn test_aabb2d_creation() {
@@ -260,5 +274,25 @@ mod tests {
     fn test_from_empty_points() {
         let points: Vec<Point2D<f64>> = vec![];
         assert!(Aabb2D::from_points(&points).is_none());
+    }
+
+    #[test]
+    fn test_aabb2d_capability_traits() {
+        let outer = Aabb2D::new(Point2D::new(0.0, 0.0), Point2D::new(4.0, 6.0));
+        let inner = Aabb2D::new(Point2D::new(1.0, 2.0), Point2D::new(3.0, 5.0));
+
+        assert_eq!(Aabb2DProperties::min(&outer), Point2D::new(0.0, 0.0));
+        assert_eq!(Aabb2DProperties::max(&outer), Point2D::new(4.0, 6.0));
+        assert_eq!(Aabb2DDerived::width(&outer), 4.0);
+        assert_eq!(Aabb2DDerived::height(&outer), 6.0);
+        assert_eq!(Aabb2DDerived::area(&outer), 24.0);
+        assert_eq!(Aabb2DDerived::center(&outer), Point2D::new(2.0, 3.0));
+        assert!(Aabb2DDerived::is_valid(&outer));
+        assert!(Aabb2DRelation::contains_point(
+            &outer,
+            &Point2D::new(2.0, 3.0)
+        ));
+        assert!(Aabb2DRelation::contains_bbox(&outer, &inner));
+        assert!(Aabb2DRelation::intersects(&outer, &inner));
     }
 }

--- a/model/geo_core/src/aabb_3d.rs
+++ b/model/geo_core/src/aabb_3d.rs
@@ -3,7 +3,7 @@
 //! Foundation Pattern に基づく Aabb3D の実装。
 //! geo_primitives, geo_nurbs など全クレートから共通利用されます。
 
-use crate::aabb_traits::Aabb3DTrait;
+use crate::aabb_traits::{Aabb3DDerived, Aabb3DProperties, Aabb3DRelation};
 use analysis::abstract_types::Scalar;
 
 use crate::Point3D;
@@ -124,7 +124,7 @@ impl<T: Scalar> Aabb3D<T> {
 // Foundation Trait Implementation
 // ============================================================================
 
-impl<T: Scalar> Aabb3DTrait<T> for Aabb3D<T> {
+impl<T: Scalar> Aabb3DProperties<T> for Aabb3D<T> {
     type Point3D = Point3D<T>;
 
     fn min(&self) -> Self::Point3D {
@@ -134,7 +134,9 @@ impl<T: Scalar> Aabb3DTrait<T> for Aabb3D<T> {
     fn max(&self) -> Self::Point3D {
         self.max
     }
+}
 
+impl<T: Scalar> Aabb3DDerived<T> for Aabb3D<T> {
     fn width(&self) -> T {
         self.max.x() - self.min.x()
     }
@@ -162,6 +164,14 @@ impl<T: Scalar> Aabb3DTrait<T> for Aabb3D<T> {
         )
     }
 
+    fn is_valid(&self) -> bool {
+        !(self.min.x() > self.max.x() || self.min.y() > self.max.y() || self.min.z() > self.max.z())
+    }
+}
+
+impl<T: Scalar> Aabb3DRelation<T> for Aabb3D<T> {
+    type Point3D = Point3D<T>;
+
     fn contains_point(&self, point: &Self::Point3D) -> bool {
         (self.min.x() <= point.x() && point.x() <= self.max.x())
             && (self.min.y() <= point.y() && point.y() <= self.max.y())
@@ -185,15 +195,12 @@ impl<T: Scalar> Aabb3DTrait<T> for Aabb3D<T> {
             && self.min.z() <= other.max.z()
             && self.max.z() >= other.min.z()
     }
-
-    fn is_valid(&self) -> bool {
-        !(self.min.x() > self.max.x() || self.min.y() > self.max.y() || self.min.z() > self.max.z())
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::aabb_traits::{Aabb3DDerived, Aabb3DProperties, Aabb3DRelation};
 
     #[test]
     fn test_aabb3d_creation() {
@@ -255,5 +262,26 @@ mod tests {
         let invalid = Aabb3D::new(Point3D::new(1.0, 0.0, 0.0), Point3D::new(0.0, 1.0, 1.0));
         assert!(!valid.is_empty());
         assert!(invalid.is_empty());
+    }
+
+    #[test]
+    fn test_aabb3d_capability_traits() {
+        let outer = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(4.0, 6.0, 8.0));
+        let inner = Aabb3D::new(Point3D::new(1.0, 2.0, 3.0), Point3D::new(3.0, 5.0, 7.0));
+
+        assert_eq!(Aabb3DProperties::min(&outer), Point3D::new(0.0, 0.0, 0.0));
+        assert_eq!(Aabb3DProperties::max(&outer), Point3D::new(4.0, 6.0, 8.0));
+        assert_eq!(Aabb3DDerived::width(&outer), 4.0);
+        assert_eq!(Aabb3DDerived::height(&outer), 6.0);
+        assert_eq!(Aabb3DDerived::depth(&outer), 8.0);
+        assert_eq!(Aabb3DDerived::volume(&outer), 192.0);
+        assert_eq!(Aabb3DDerived::center(&outer), Point3D::new(2.0, 3.0, 4.0));
+        assert!(Aabb3DDerived::is_valid(&outer));
+        assert!(Aabb3DRelation::contains_point(
+            &outer,
+            &Point3D::new(2.0, 3.0, 4.0)
+        ));
+        assert!(Aabb3DRelation::contains_bbox(&outer, &inner));
+        assert!(Aabb3DRelation::intersects(&outer, &inner));
     }
 }

--- a/model/geo_core/src/aabb_traits.rs
+++ b/model/geo_core/src/aabb_traits.rs
@@ -1,3 +1,6 @@
 //! Compatibility re-exports for AABB traits.
 
-pub use geo_contracts::{Aabb2DTrait, Aabb3DTrait};
+pub use geo_contracts::{
+    Aabb2DDerived, Aabb2DProperties, Aabb2DRelation, Aabb3DDerived, Aabb3DProperties,
+    Aabb3DRelation,
+};


### PR DESCRIPTION
Closes #540

## 概要

AABB を旧 `Aabb2DTrait` / `Aabb3DTrait` の延命対象として扱わず、参照系・derived capability・relation capability の 3 層へ再定義しました。

今回の方針では、個別 shape と歩調を合わせた旧定義の温存ではなく、AABB 単体で責務境界を明確にすることを優先しています。

## 実施内容

- `Aabb2DTrait` / `Aabb3DTrait` を廃止
- core 側に以下を新設
  - `Aabb2DProperties`
  - `Aabb2DDerived`
  - `Aabb3DProperties`
  - `Aabb3DDerived`
- operations 側に以下を新設
  - `Aabb2DRelation`
  - `Aabb3DRelation`
- `geo_contracts` の re-export を新しい trait 群へ更新
- `geo_core::Aabb2D` / `geo_core::Aabb3D` の impl を新しい trait 群へ追従
- AABB の capability trait を直接利用する回帰テストを追加
- 設計文書に「AABB は新規 capability 群として再定義してよい」前提を追記

## 完了条件との対応

- `min` / `max` の参照系
  - `Aabb2DProperties` / `Aabb3DProperties` へ整理済み
- `width` / `height` / `depth` / `center` / `area` / `volume` / `is_valid`
  - `Aabb2DDerived` / `Aabb3DDerived` へ整理済み
- `contains_point` / `contains_bbox` / `intersects`
  - `Aabb2DRelation` / `Aabb3DRelation` として operations 側へ整理済み
- AABB の境界線
  - definition core / derived / relation の説明軸で扱える状態へ整理済み

## 補足

- AABB は個別 shape と同時に古い責務境界を引きずって定義すると手戻りが大きいため、今回は意味合いも含めて再定義しています
- `geo_core` 側の inherent method として `contains_*` / `intersects` は残していますが、contract 上の責務は relation capability に分離済みです
- 追加棚卸しでは blocking な残件は確認できませんでした

## 検証

- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo test --workspace`