### PR TITLE
[Phase7] refactor: Rect と linear shape の capability taxonomy を統一適用

### DIFF
--- a/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
+++ b/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
@@ -258,6 +258,37 @@ Issue #535 では、`geo_contracts` の trait構造を次の最小構造へ再�
 
 理由:
 
+### 14. Rect と linear shape への適用方針
+
+判定:
+
+- #540 の AABB で使った `properties / derived / relation` の説明軸を、そのまま Rect と linear shape 群へ拡張する
+- ただし linear shape 群では `evaluation / projection / transform` も明示的に分離する
+
+対象:
+
+- `Rect2D/3D`
+- `InfiniteLine2D/3D`
+- `Ray2D/3D`
+- `LineSegment2D/3D`
+- `Plane3D`
+
+設計反映:
+
+- `*Core` は `Constructor + Properties` の統合 alias に縮小する
+- 旧 `*Measure` は後方互換のために集約 trait として残してよいが、新規実装の責務配置はそこで説明しない
+- `contains_point` は `Containment`
+- `point_at_parameter` / `parameter_for_point` / `point_to_uv` / `uv_to_point` は `Evaluation`
+- `closest_point` / `project_point` は `Projection`
+- `mirror_point` / `rotate_*` / `translate` / `reverse` / `offset` は `Transform`
+- `area` / `perimeter` / `corners` / `direction_vector` / `as_vector` / `equation_coefficients` は `Derived`
+- `distance_to_point` のような単一点相手の距離は unary capability として `Distance` に分ける
+
+理由:
+
+- `Measure` という名前のまま unary measure, relation, projection, transform を混在させると、AABB 後に採用した taxonomy と説明軸が揃わないから
+- 先行対象で capability taxonomy を分けておくと、後続の `Circle` / `Triangle` / solid / surface にも同じ軸で横展開できるから
+
 - これは shape の定義でも一般的な単一 shape metadata でもなく、近似式・数値計算戦略の選択そのものだから
 - capability としても algorithm 寄りであり、他の operations 群と同じ層に置く方が自然だから
 

--- a/model/geo_contracts/src/geometry/core/infinite_line_traits.rs
+++ b/model/geo_contracts/src/geometry/core/infinite_line_traits.rs
@@ -133,16 +133,88 @@ pub trait InfiniteLine3DProperties<T: Scalar> {
     fn is_axis_aligned(&self) -> bool;
 }
 
-pub trait InfiniteLine2DMeasure<T: Scalar> {
+pub trait InfiniteLine2DMeasure<T: Scalar>:
+    InfiniteLine2DEvaluation<T>
+    + InfiniteLine2DDistance<T>
+    + InfiniteLine2DContainment<T>
+    + InfiniteLine2DProjection<T>
+    + InfiniteLine2DTransform<T>
+{
+    fn point_at_parameter(&self, t: T) -> (T, T) {
+        <Self as InfiniteLine2DEvaluation<T>>::point_at_parameter(self, t)
+    }
+
+    fn distance_to_point(&self, point: (T, T)) -> T {
+        <Self as InfiniteLine2DDistance<T>>::distance_to_point(self, point)
+    }
+
+    fn contains_point(&self, point: (T, T)) -> bool {
+        <Self as InfiniteLine2DContainment<T>>::contains_point(self, point)
+    }
+
+    fn project_point(&self, point: (T, T)) -> (T, T) {
+        <Self as InfiniteLine2DProjection<T>>::project_point(self, point)
+    }
+
+    fn parameter_for_point(&self, point: (T, T)) -> T {
+        <Self as InfiniteLine2DEvaluation<T>>::parameter_for_point(self, point)
+    }
+
+    fn reverse(&self) -> Self
+    where
+        Self: Sized,
+    {
+        <Self as InfiniteLine2DTransform<T>>::reverse(self)
+    }
+
+    fn mirror_point(&self, point: (T, T)) -> (T, T) {
+        <Self as InfiniteLine2DProjection<T>>::mirror_point(self, point)
+    }
+
+    fn offset(&self, distance: T) -> Self
+    where
+        Self: Sized,
+    {
+        <Self as InfiniteLine2DTransform<T>>::offset(self, distance)
+    }
+
+    fn rotate_around_origin(&self, angle: T) -> Self
+    where
+        Self: Sized,
+    {
+        <Self as InfiniteLine2DTransform<T>>::rotate_around_origin(self, angle)
+    }
+
+    fn rotate_around_point(&self, center: (T, T), angle: T) -> Self
+    where
+        Self: Sized,
+    {
+        <Self as InfiniteLine2DTransform<T>>::rotate_around_point(self, center, angle)
+    }
+}
+
+pub trait InfiniteLine2DEvaluation<T: Scalar> {
     fn point_at_parameter(&self, t: T) -> (T, T);
-    fn distance_to_point(&self, point: (T, T)) -> T;
-    fn contains_point(&self, point: (T, T)) -> bool;
-    fn project_point(&self, point: (T, T)) -> (T, T);
     fn parameter_for_point(&self, point: (T, T)) -> T;
+}
+
+pub trait InfiniteLine2DDistance<T: Scalar> {
+    fn distance_to_point(&self, point: (T, T)) -> T;
+}
+
+pub trait InfiniteLine2DContainment<T: Scalar> {
+    fn contains_point(&self, point: (T, T)) -> bool;
+}
+
+pub trait InfiniteLine2DProjection<T: Scalar> {
+    fn project_point(&self, point: (T, T)) -> (T, T);
+    fn mirror_point(&self, point: (T, T)) -> (T, T);
+}
+
+pub trait InfiniteLine2DTransform<T: Scalar> {
     fn reverse(&self) -> Self
     where
         Self: Sized;
-    fn mirror_point(&self, point: (T, T)) -> (T, T);
     fn offset(&self, distance: T) -> Self
     where
         Self: Sized;
@@ -154,16 +226,93 @@ pub trait InfiniteLine2DMeasure<T: Scalar> {
         Self: Sized;
 }
 
-pub trait InfiniteLine3DMeasure<T: Scalar> {
+impl<T: Scalar, L> InfiniteLine2DMeasure<T> for L where
+    L: InfiniteLine2DEvaluation<T>
+        + InfiniteLine2DDistance<T>
+        + InfiniteLine2DContainment<T>
+        + InfiniteLine2DProjection<T>
+        + InfiniteLine2DTransform<T>
+{
+}
+
+pub trait InfiniteLine3DMeasure<T: Scalar>:
+    InfiniteLine3DEvaluation<T>
+    + InfiniteLine3DDistance<T>
+    + InfiniteLine3DContainment<T>
+    + InfiniteLine3DProjection<T>
+    + InfiniteLine3DTransform<T>
+{
+    fn point_at_parameter(&self, t: T) -> (T, T, T) {
+        <Self as InfiniteLine3DEvaluation<T>>::point_at_parameter(self, t)
+    }
+
+    fn distance_to_point(&self, point: (T, T, T)) -> T {
+        <Self as InfiniteLine3DDistance<T>>::distance_to_point(self, point)
+    }
+
+    fn contains_point(&self, point: (T, T, T)) -> bool {
+        <Self as InfiniteLine3DContainment<T>>::contains_point(self, point)
+    }
+
+    fn project_point(&self, point: (T, T, T)) -> (T, T, T) {
+        <Self as InfiniteLine3DProjection<T>>::project_point(self, point)
+    }
+
+    fn parameter_for_point(&self, point: (T, T, T)) -> T {
+        <Self as InfiniteLine3DEvaluation<T>>::parameter_for_point(self, point)
+    }
+
+    fn reverse(&self) -> Self
+    where
+        Self: Sized,
+    {
+        <Self as InfiniteLine3DTransform<T>>::reverse(self)
+    }
+
+    fn mirror_point(&self, point: (T, T, T)) -> (T, T, T) {
+        <Self as InfiniteLine3DProjection<T>>::mirror_point(self, point)
+    }
+
+    fn rotate_around_axis(
+        &self,
+        axis_point: (T, T, T),
+        axis_direction: (T, T, T),
+        angle: T,
+    ) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        <Self as InfiniteLine3DTransform<T>>::rotate_around_axis(
+            self,
+            axis_point,
+            axis_direction,
+            angle,
+        )
+    }
+}
+
+pub trait InfiniteLine3DEvaluation<T: Scalar> {
     fn point_at_parameter(&self, t: T) -> (T, T, T);
-    fn distance_to_point(&self, point: (T, T, T)) -> T;
-    fn contains_point(&self, point: (T, T, T)) -> bool;
-    fn project_point(&self, point: (T, T, T)) -> (T, T, T);
     fn parameter_for_point(&self, point: (T, T, T)) -> T;
+}
+
+pub trait InfiniteLine3DDistance<T: Scalar> {
+    fn distance_to_point(&self, point: (T, T, T)) -> T;
+}
+
+pub trait InfiniteLine3DContainment<T: Scalar> {
+    fn contains_point(&self, point: (T, T, T)) -> bool;
+}
+
+pub trait InfiniteLine3DProjection<T: Scalar> {
+    fn project_point(&self, point: (T, T, T)) -> (T, T, T);
+    fn mirror_point(&self, point: (T, T, T)) -> (T, T, T);
+}
+
+pub trait InfiniteLine3DTransform<T: Scalar> {
     fn reverse(&self) -> Self
     where
         Self: Sized;
-    fn mirror_point(&self, point: (T, T, T)) -> (T, T, T);
     fn rotate_around_axis(
         &self,
         axis_point: (T, T, T),
@@ -174,22 +323,31 @@ pub trait InfiniteLine3DMeasure<T: Scalar> {
         Self: Sized;
 }
 
+impl<T: Scalar, L> InfiniteLine3DMeasure<T> for L where
+    L: InfiniteLine3DEvaluation<T>
+        + InfiniteLine3DDistance<T>
+        + InfiniteLine3DContainment<T>
+        + InfiniteLine3DProjection<T>
+        + InfiniteLine3DTransform<T>
+{
+}
+
 pub trait InfiniteLine2DCore<T: Scalar>:
-    InfiniteLine2DConstructor<T> + InfiniteLine2DProperties<T> + InfiniteLine2DMeasure<T>
+    InfiniteLine2DConstructor<T> + InfiniteLine2DProperties<T>
 {
 }
 
 pub trait InfiniteLine3DCore<T: Scalar>:
-    InfiniteLine3DConstructor<T> + InfiniteLine3DProperties<T> + InfiniteLine3DMeasure<T>
+    InfiniteLine3DConstructor<T> + InfiniteLine3DProperties<T>
 {
 }
 
 impl<T: Scalar, L> InfiniteLine2DCore<T> for L where
-    L: InfiniteLine2DConstructor<T> + InfiniteLine2DProperties<T> + InfiniteLine2DMeasure<T>
+    L: InfiniteLine2DConstructor<T> + InfiniteLine2DProperties<T>
 {
 }
 
 impl<T: Scalar, L> InfiniteLine3DCore<T> for L where
-    L: InfiniteLine3DConstructor<T> + InfiniteLine3DProperties<T> + InfiniteLine3DMeasure<T>
+    L: InfiniteLine3DConstructor<T> + InfiniteLine3DProperties<T>
 {
 }

--- a/model/geo_contracts/src/geometry/core/linesegment_traits.rs
+++ b/model/geo_contracts/src/geometry/core/linesegment_traits.rs
@@ -130,21 +130,52 @@ pub trait LineSegment3DProperties<T: Scalar> {
 }
 
 /// LineSegment2D計量・関係演算機能トレイト
-pub trait LineSegment2DMeasure<T: Scalar> {
+pub trait LineSegment2DMeasure<T: Scalar>:
+    LineSegment2DDerived<T>
+    + LineSegment2DDistance<T>
+    + LineSegment2DContainment<T>
+    + LineSegment2DEvaluation<T>
+    + LineSegment2DProjection<T>
+{
     /// 線分の長さ（測度）
-    fn measure(&self) -> T;
+    fn measure(&self) -> T {
+        <Self as LineSegment2DDerived<T>>::measure(self)
+    }
 
     /// 点から線分への最短距離を計算
-    fn distance_to_point(&self, point: (T, T)) -> T;
+    fn distance_to_point(&self, point: (T, T)) -> T {
+        <Self as LineSegment2DDistance<T>>::distance_to_point(self, point)
+    }
 
     /// 点が線分上にあるかを判定
-    fn contains_point(&self, point: (T, T)) -> bool;
+    fn contains_point(&self, point: (T, T)) -> bool {
+        <Self as LineSegment2DContainment<T>>::contains_point(self, point)
+    }
 
     /// パラメータt（0<=t<=1）での点を取得
-    fn point_at_parameter(&self, t: T) -> (T, T);
+    fn point_at_parameter(&self, t: T) -> (T, T) {
+        <Self as LineSegment2DEvaluation<T>>::point_at_parameter(self, t)
+    }
 
     /// 点から線分への最近点を計算
-    fn closest_point_to(&self, point: (T, T)) -> (T, T);
+    fn closest_point_to(&self, point: (T, T)) -> (T, T) {
+        <Self as LineSegment2DProjection<T>>::closest_point_to(self, point)
+    }
+
+    /// 方向ベクトルを取得
+    fn direction_vector(&self) -> (T, T) {
+        <Self as LineSegment2DDerived<T>>::direction_vector(self)
+    }
+
+    /// 線分のベクトル表現（始点から終点）
+    fn as_vector(&self) -> (T, T) {
+        <Self as LineSegment2DDerived<T>>::as_vector(self)
+    }
+}
+
+pub trait LineSegment2DDerived<T: Scalar> {
+    /// 線分の長さ（測度）
+    fn measure(&self) -> T;
 
     /// 方向ベクトルを取得
     fn direction_vector(&self) -> (T, T);
@@ -153,22 +184,82 @@ pub trait LineSegment2DMeasure<T: Scalar> {
     fn as_vector(&self) -> (T, T);
 }
 
+pub trait LineSegment2DDistance<T: Scalar> {
+    /// 点から線分への最短距離を計算
+    fn distance_to_point(&self, point: (T, T)) -> T;
+}
+
+pub trait LineSegment2DContainment<T: Scalar> {
+    /// 点が線分上にあるかを判定
+    fn contains_point(&self, point: (T, T)) -> bool;
+}
+
+pub trait LineSegment2DEvaluation<T: Scalar> {
+    /// パラメータt（0<=t<=1）での点を取得
+    fn point_at_parameter(&self, t: T) -> (T, T);
+}
+
+pub trait LineSegment2DProjection<T: Scalar> {
+    /// 点から線分への最近点を計算
+    fn closest_point_to(&self, point: (T, T)) -> (T, T);
+}
+
+impl<T: Scalar, L> LineSegment2DMeasure<T> for L where
+    L: LineSegment2DDerived<T>
+        + LineSegment2DDistance<T>
+        + LineSegment2DContainment<T>
+        + LineSegment2DEvaluation<T>
+        + LineSegment2DProjection<T>
+{
+}
+
 /// LineSegment3D計量・関係演算機能トレイト
-pub trait LineSegment3DMeasure<T: Scalar> {
+pub trait LineSegment3DMeasure<T: Scalar>:
+    LineSegment3DDerived<T>
+    + LineSegment3DDistance<T>
+    + LineSegment3DContainment<T>
+    + LineSegment3DEvaluation<T>
+    + LineSegment3DProjection<T>
+{
     /// 線分の長さ（測度）
-    fn measure(&self) -> T;
+    fn measure(&self) -> T {
+        <Self as LineSegment3DDerived<T>>::measure(self)
+    }
 
     /// 点から線分への最短距離を計算
-    fn distance_to_point(&self, point: (T, T, T)) -> T;
+    fn distance_to_point(&self, point: (T, T, T)) -> T {
+        <Self as LineSegment3DDistance<T>>::distance_to_point(self, point)
+    }
 
     /// 点が線分上にあるかを判定
-    fn contains_point(&self, point: (T, T, T)) -> bool;
+    fn contains_point(&self, point: (T, T, T)) -> bool {
+        <Self as LineSegment3DContainment<T>>::contains_point(self, point)
+    }
 
     /// パラメータt（0<=t<=1）での点を取得
-    fn point_at_parameter(&self, t: T) -> (T, T, T);
+    fn point_at_parameter(&self, t: T) -> (T, T, T) {
+        <Self as LineSegment3DEvaluation<T>>::point_at_parameter(self, t)
+    }
 
     /// 点から線分への最近点を計算
-    fn closest_point_to(&self, point: (T, T, T)) -> (T, T, T);
+    fn closest_point_to(&self, point: (T, T, T)) -> (T, T, T) {
+        <Self as LineSegment3DProjection<T>>::closest_point_to(self, point)
+    }
+
+    /// 方向ベクトルを取得
+    fn direction_vector(&self) -> (T, T, T) {
+        <Self as LineSegment3DDerived<T>>::direction_vector(self)
+    }
+
+    /// 線分のベクトル表現（始点から終点）
+    fn as_vector(&self) -> (T, T, T) {
+        <Self as LineSegment3DDerived<T>>::as_vector(self)
+    }
+}
+
+pub trait LineSegment3DDerived<T: Scalar> {
+    /// 線分の長さ（測度）
+    fn measure(&self) -> T;
 
     /// 方向ベクトルを取得
     fn direction_vector(&self) -> (T, T, T);
@@ -177,24 +268,53 @@ pub trait LineSegment3DMeasure<T: Scalar> {
     fn as_vector(&self) -> (T, T, T);
 }
 
+pub trait LineSegment3DDistance<T: Scalar> {
+    /// 点から線分への最短距離を計算
+    fn distance_to_point(&self, point: (T, T, T)) -> T;
+}
+
+pub trait LineSegment3DContainment<T: Scalar> {
+    /// 点が線分上にあるかを判定
+    fn contains_point(&self, point: (T, T, T)) -> bool;
+}
+
+pub trait LineSegment3DEvaluation<T: Scalar> {
+    /// パラメータt（0<=t<=1）での点を取得
+    fn point_at_parameter(&self, t: T) -> (T, T, T);
+}
+
+pub trait LineSegment3DProjection<T: Scalar> {
+    /// 点から線分への最近点を計算
+    fn closest_point_to(&self, point: (T, T, T)) -> (T, T, T);
+}
+
+impl<T: Scalar, L> LineSegment3DMeasure<T> for L where
+    L: LineSegment3DDerived<T>
+        + LineSegment3DDistance<T>
+        + LineSegment3DContainment<T>
+        + LineSegment3DEvaluation<T>
+        + LineSegment3DProjection<T>
+{
+}
+
 /// LineSegment2Dの3つのCore機能統合トレイト
 pub trait LineSegment2DCore<T: Scalar>:
-    LineSegment2DConstructor<T> + LineSegment2DProperties<T> + LineSegment2DMeasure<T>
+    LineSegment2DConstructor<T> + LineSegment2DProperties<T>
 {
 }
 
 /// LineSegment3Dの3つのCore機能統合トレイト
 pub trait LineSegment3DCore<T: Scalar>:
-    LineSegment3DConstructor<T> + LineSegment3DProperties<T> + LineSegment3DMeasure<T>
+    LineSegment3DConstructor<T> + LineSegment3DProperties<T>
 {
 }
 
 impl<T: Scalar, L> LineSegment2DCore<T> for L where
-    L: LineSegment2DConstructor<T> + LineSegment2DProperties<T> + LineSegment2DMeasure<T>
+    L: LineSegment2DConstructor<T> + LineSegment2DProperties<T>
 {
 }
 
 impl<T: Scalar, L> LineSegment3DCore<T> for L where
-    L: LineSegment3DConstructor<T> + LineSegment3DProperties<T> + LineSegment3DMeasure<T>
+    L: LineSegment3DConstructor<T> + LineSegment3DProperties<T>
 {
 }

--- a/model/geo_contracts/src/geometry/core/mod.rs
+++ b/model/geo_contracts/src/geometry/core/mod.rs
@@ -74,12 +74,19 @@ pub use ellipsoidal_surface_traits::{
     EllipsoidalSurface3DProperties,
 };
 pub use infinite_line_traits::{
-    InfiniteLine2DConstructor, InfiniteLine2DCore, InfiniteLine2DMeasure, InfiniteLine2DProperties,
-    InfiniteLine3DConstructor, InfiniteLine3DCore, InfiniteLine3DMeasure, InfiniteLine3DProperties,
+    InfiniteLine2DConstructor, InfiniteLine2DContainment, InfiniteLine2DCore,
+    InfiniteLine2DDistance, InfiniteLine2DEvaluation, InfiniteLine2DMeasure,
+    InfiniteLine2DProjection, InfiniteLine2DProperties, InfiniteLine2DTransform,
+    InfiniteLine3DConstructor, InfiniteLine3DContainment, InfiniteLine3DCore,
+    InfiniteLine3DDistance, InfiniteLine3DEvaluation, InfiniteLine3DMeasure,
+    InfiniteLine3DProjection, InfiniteLine3DProperties, InfiniteLine3DTransform,
 };
 pub use linesegment_traits::{
-    LineSegment2DConstructor, LineSegment2DCore, LineSegment2DMeasure, LineSegment2DProperties,
-    LineSegment3DConstructor, LineSegment3DCore, LineSegment3DMeasure, LineSegment3DProperties,
+    LineSegment2DConstructor, LineSegment2DContainment, LineSegment2DCore, LineSegment2DDerived,
+    LineSegment2DDistance, LineSegment2DEvaluation, LineSegment2DMeasure, LineSegment2DProjection,
+    LineSegment2DProperties, LineSegment3DConstructor, LineSegment3DContainment, LineSegment3DCore,
+    LineSegment3DDerived, LineSegment3DDistance, LineSegment3DEvaluation, LineSegment3DMeasure,
+    LineSegment3DProjection, LineSegment3DProperties,
 };
 pub use nurbs_curve_2d_traits::{
     NurbsCurve2DConstructor, NurbsCurve2DCore, NurbsCurve2DMeasure, NurbsCurve2DProperties,
@@ -90,18 +97,24 @@ pub use nurbs_curve_3d_traits::{
 pub use nurbs_surface_3d_traits::{
     NurbsSurface3DConstructor, NurbsSurface3DCore, NurbsSurface3DMeasure, NurbsSurface3DProperties,
 };
-pub use plane3d_traits::Plane3DProperties;
+pub use plane3d_traits::{
+    Plane3DConstructor, Plane3DContainment, Plane3DCore, Plane3DDerived, Plane3DDistance,
+    Plane3DEvaluation, Plane3DMeasure, Plane3DProjection, Plane3DProperties, Plane3DTransform,
+};
 pub use point_traits::{
     Point2DConstructor, Point2DCore, Point2DProperties, Point3DConstructor, Point3DCore,
     Point3DProperties,
 };
 pub use ray_traits::{
-    Ray2DConstructor, Ray2DCore, Ray2DMeasure, Ray2DProperties, Ray3DConstructor, Ray3DCore,
-    Ray3DMeasure, Ray3DProperties,
+    Ray2DConstructor, Ray2DContainment, Ray2DCore, Ray2DDistance, Ray2DEvaluation, Ray2DMeasure,
+    Ray2DProjection, Ray2DProperties, Ray2DTransform, Ray3DConstructor, Ray3DContainment,
+    Ray3DCore, Ray3DDistance, Ray3DEvaluation, Ray3DMeasure, Ray3DProjection, Ray3DProperties,
+    Ray3DTransform,
 };
 pub use rectangle_traits::{
-    Rect2DConstructor, Rect2DCore, Rect2DMeasure, Rect2DProperties, Rect3DConstructor, Rect3DCore,
-    Rect3DMeasure, Rect3DProperties,
+    Rect2DConstructor, Rect2DContainment, Rect2DCore, Rect2DDerived, Rect2DMeasure,
+    Rect2DProperties, Rect3DConstructor, Rect3DContainment, Rect3DCore, Rect3DDerived,
+    Rect3DEvaluation, Rect3DMeasure, Rect3DProperties,
 };
 pub use spherical_solid_traits::{
     SphericalSolid3DConstructor, SphericalSolid3DCore, SphericalSolid3DMeasure,

--- a/model/geo_contracts/src/geometry/core/plane3d_traits.rs
+++ b/model/geo_contracts/src/geometry/core/plane3d_traits.rs
@@ -57,31 +57,92 @@ pub trait Plane3DProperties<T: Scalar> {
 }
 
 /// Plane3D Measure トレイト
-pub trait Plane3DMeasure<T: Scalar> {
+pub trait Plane3DMeasure<T: Scalar>:
+    Plane3DContainment<T>
+    + Plane3DDistance<T>
+    + Plane3DProjection<T>
+    + Plane3DDerived<T>
+    + Plane3DEvaluation<T>
+    + Plane3DTransform<T>
+{
     /// 点が平面上にあるか判定
-    fn contains_point(&self, point: (T, T, T)) -> bool;
+    fn contains_point(&self, point: (T, T, T)) -> bool {
+        <Self as Plane3DContainment<T>>::contains_point(self, point)
+    }
 
     /// 点から平面への距離
-    fn distance_to_point(&self, point: (T, T, T)) -> T;
+    fn distance_to_point(&self, point: (T, T, T)) -> T {
+        <Self as Plane3DDistance<T>>::distance_to_point(self, point)
+    }
 
     /// 点を平面に投影
-    fn project_point(&self, point: (T, T, T)) -> (T, T, T);
+    fn project_point(&self, point: (T, T, T)) -> (T, T, T) {
+        <Self as Plane3DProjection<T>>::project_point(self, point)
+    }
 
     /// 平面の方程式係数を取得（Ax + By + Cz + D = 0）
-    fn equation_coefficients(&self) -> (T, T, T, T);
+    fn equation_coefficients(&self) -> (T, T, T, T) {
+        <Self as Plane3DDerived<T>>::equation_coefficients(self)
+    }
 
+    /// 点の平面座標（UV座標）を取得
+    fn point_to_uv(&self, point: (T, T, T)) -> (T, T) {
+        <Self as Plane3DEvaluation<T>>::point_to_uv(self, point)
+    }
+
+    /// UV座標から3D点を取得
+    fn uv_to_point(&self, u: T, v: T) -> (T, T, T) {
+        <Self as Plane3DEvaluation<T>>::uv_to_point(self, u, v)
+    }
+
+    /// 点を平面に対して鏡面反射
+    fn mirror_point(&self, point: (T, T, T)) -> (T, T, T) {
+        <Self as Plane3DTransform<T>>::mirror_point(self, point)
+    }
+}
+
+pub trait Plane3DContainment<T: Scalar> {
+    /// 点が平面上にあるか判定
+    fn contains_point(&self, point: (T, T, T)) -> bool;
+}
+
+pub trait Plane3DDistance<T: Scalar> {
+    /// 点から平面への距離
+    fn distance_to_point(&self, point: (T, T, T)) -> T;
+}
+
+pub trait Plane3DProjection<T: Scalar> {
+    /// 点を平面に投影
+    fn project_point(&self, point: (T, T, T)) -> (T, T, T);
+}
+
+pub trait Plane3DDerived<T: Scalar> {
+    /// 平面の方程式係数を取得（Ax + By + Cz + D = 0）
+    fn equation_coefficients(&self) -> (T, T, T, T);
+}
+
+pub trait Plane3DEvaluation<T: Scalar> {
     /// 点の平面座標（UV座標）を取得
     fn point_to_uv(&self, point: (T, T, T)) -> (T, T);
 
     /// UV座標から3D点を取得
     fn uv_to_point(&self, u: T, v: T) -> (T, T, T);
+}
 
+pub trait Plane3DTransform<T: Scalar> {
     /// 点を平面に対して鏡面反射
     fn mirror_point(&self, point: (T, T, T)) -> (T, T, T);
 }
 
-/// Plane3D Core トレイト（統合インターフェース）
-pub trait Plane3DCore<T: Scalar>:
-    Plane3DConstructor<T> + Plane3DProperties<T> + Plane3DMeasure<T>
+impl<T: Scalar, P> Plane3DMeasure<T> for P where
+    P: Plane3DContainment<T>
+        + Plane3DDistance<T>
+        + Plane3DProjection<T>
+        + Plane3DDerived<T>
+        + Plane3DEvaluation<T>
+        + Plane3DTransform<T>
 {
 }
+
+/// Plane3D Core トレイト（統合インターフェース）
+pub trait Plane3DCore<T: Scalar>: Plane3DConstructor<T> + Plane3DProperties<T> {}

--- a/model/geo_contracts/src/geometry/core/ray_traits.rs
+++ b/model/geo_contracts/src/geometry/core/ray_traits.rs
@@ -143,52 +143,186 @@ pub trait Ray3DProperties<T: Scalar> {
     fn is_on_xy_plane(&self) -> bool;
 }
 
-pub trait Ray2DMeasure<T: Scalar> {
+pub trait Ray2DMeasure<T: Scalar>:
+    Ray2DEvaluation<T> + Ray2DProjection<T> + Ray2DDistance<T> + Ray2DContainment<T> + Ray2DTransform<T>
+{
+    fn point_at_parameter(&self, t: T) -> (T, T) {
+        <Self as Ray2DEvaluation<T>>::point_at_parameter(self, t)
+    }
+
+    fn closest_point(&self, point: (T, T)) -> (T, T) {
+        <Self as Ray2DProjection<T>>::closest_point(self, point)
+    }
+
+    fn distance_to_point(&self, point: (T, T)) -> T {
+        <Self as Ray2DDistance<T>>::distance_to_point(self, point)
+    }
+
+    fn contains_point(&self, point: (T, T)) -> bool {
+        <Self as Ray2DContainment<T>>::contains_point(self, point)
+    }
+
+    fn parameter_for_point(&self, point: (T, T)) -> T {
+        <Self as Ray2DEvaluation<T>>::parameter_for_point(self, point)
+    }
+
+    fn reverse(&self) -> Self
+    where
+        Self: Sized,
+    {
+        <Self as Ray2DTransform<T>>::reverse(self)
+    }
+
+    fn translate(&self, offset: (T, T)) -> Self
+    where
+        Self: Sized,
+    {
+        <Self as Ray2DTransform<T>>::translate(self, offset)
+    }
+
+    fn point_at_distance(&self, distance: T) -> (T, T) {
+        <Self as Ray2DEvaluation<T>>::point_at_distance(self, distance)
+    }
+
+    fn rotate_around_origin(&self, angle: T) -> Self
+    where
+        Self: Sized,
+    {
+        <Self as Ray2DTransform<T>>::rotate_around_origin(self, angle)
+    }
+}
+
+pub trait Ray2DEvaluation<T: Scalar> {
     fn point_at_parameter(&self, t: T) -> (T, T);
-    fn closest_point(&self, point: (T, T)) -> (T, T);
-    fn distance_to_point(&self, point: (T, T)) -> T;
-    fn contains_point(&self, point: (T, T)) -> bool;
     fn parameter_for_point(&self, point: (T, T)) -> T;
+    fn point_at_distance(&self, distance: T) -> (T, T);
+}
+
+pub trait Ray2DProjection<T: Scalar> {
+    fn closest_point(&self, point: (T, T)) -> (T, T);
+}
+
+pub trait Ray2DDistance<T: Scalar> {
+    fn distance_to_point(&self, point: (T, T)) -> T;
+}
+
+pub trait Ray2DContainment<T: Scalar> {
+    fn contains_point(&self, point: (T, T)) -> bool;
+}
+
+pub trait Ray2DTransform<T: Scalar> {
     fn reverse(&self) -> Self
     where
         Self: Sized;
     fn translate(&self, offset: (T, T)) -> Self
     where
         Self: Sized;
-    fn point_at_distance(&self, distance: T) -> (T, T);
     fn rotate_around_origin(&self, angle: T) -> Self
     where
         Self: Sized;
 }
 
-pub trait Ray3DMeasure<T: Scalar> {
+impl<T: Scalar, R> Ray2DMeasure<T> for R where
+    R: Ray2DEvaluation<T>
+        + Ray2DProjection<T>
+        + Ray2DDistance<T>
+        + Ray2DContainment<T>
+        + Ray2DTransform<T>
+{
+}
+
+pub trait Ray3DMeasure<T: Scalar>:
+    Ray3DEvaluation<T> + Ray3DProjection<T> + Ray3DDistance<T> + Ray3DContainment<T> + Ray3DTransform<T>
+{
+    fn point_at_parameter(&self, t: T) -> (T, T, T) {
+        <Self as Ray3DEvaluation<T>>::point_at_parameter(self, t)
+    }
+
+    fn closest_point(&self, point: (T, T, T)) -> (T, T, T) {
+        <Self as Ray3DProjection<T>>::closest_point(self, point)
+    }
+
+    fn distance_to_point(&self, point: (T, T, T)) -> T {
+        <Self as Ray3DDistance<T>>::distance_to_point(self, point)
+    }
+
+    fn contains_point(&self, point: (T, T, T)) -> bool {
+        <Self as Ray3DContainment<T>>::contains_point(self, point)
+    }
+
+    fn parameter_for_point(&self, point: (T, T, T)) -> T {
+        <Self as Ray3DEvaluation<T>>::parameter_for_point(self, point)
+    }
+
+    fn reverse(&self) -> Self
+    where
+        Self: Sized,
+    {
+        <Self as Ray3DTransform<T>>::reverse(self)
+    }
+
+    fn translate(&self, offset: (T, T, T)) -> Self
+    where
+        Self: Sized,
+    {
+        <Self as Ray3DTransform<T>>::translate(self, offset)
+    }
+
+    fn point_at_distance(&self, distance: T) -> (T, T, T) {
+        <Self as Ray3DEvaluation<T>>::point_at_distance(self, distance)
+    }
+
+    fn rotate_around_axis(&self, axis: (T, T, T), angle: T) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        <Self as Ray3DTransform<T>>::rotate_around_axis(self, axis, angle)
+    }
+}
+
+pub trait Ray3DEvaluation<T: Scalar> {
     fn point_at_parameter(&self, t: T) -> (T, T, T);
-    fn closest_point(&self, point: (T, T, T)) -> (T, T, T);
-    fn distance_to_point(&self, point: (T, T, T)) -> T;
-    fn contains_point(&self, point: (T, T, T)) -> bool;
     fn parameter_for_point(&self, point: (T, T, T)) -> T;
+    fn point_at_distance(&self, distance: T) -> (T, T, T);
+}
+
+pub trait Ray3DProjection<T: Scalar> {
+    fn closest_point(&self, point: (T, T, T)) -> (T, T, T);
+}
+
+pub trait Ray3DDistance<T: Scalar> {
+    fn distance_to_point(&self, point: (T, T, T)) -> T;
+}
+
+pub trait Ray3DContainment<T: Scalar> {
+    fn contains_point(&self, point: (T, T, T)) -> bool;
+}
+
+pub trait Ray3DTransform<T: Scalar> {
     fn reverse(&self) -> Self
     where
         Self: Sized;
     fn translate(&self, offset: (T, T, T)) -> Self
     where
         Self: Sized;
-    fn point_at_distance(&self, distance: T) -> (T, T, T);
     fn rotate_around_axis(&self, axis: (T, T, T), angle: T) -> Option<Self>
     where
         Self: Sized;
 }
 
-pub trait Ray2DCore<T: Scalar>: Ray2DConstructor<T> + Ray2DProperties<T> + Ray2DMeasure<T> {}
-
-pub trait Ray3DCore<T: Scalar>: Ray3DConstructor<T> + Ray3DProperties<T> + Ray3DMeasure<T> {}
-
-impl<T: Scalar, R> Ray2DCore<T> for R where
-    R: Ray2DConstructor<T> + Ray2DProperties<T> + Ray2DMeasure<T>
+impl<T: Scalar, R> Ray3DMeasure<T> for R where
+    R: Ray3DEvaluation<T>
+        + Ray3DProjection<T>
+        + Ray3DDistance<T>
+        + Ray3DContainment<T>
+        + Ray3DTransform<T>
 {
 }
 
-impl<T: Scalar, R> Ray3DCore<T> for R where
-    R: Ray3DConstructor<T> + Ray3DProperties<T> + Ray3DMeasure<T>
-{
-}
+pub trait Ray2DCore<T: Scalar>: Ray2DConstructor<T> + Ray2DProperties<T> {}
+
+pub trait Ray3DCore<T: Scalar>: Ray3DConstructor<T> + Ray3DProperties<T> {}
+
+impl<T: Scalar, R> Ray2DCore<T> for R where R: Ray2DConstructor<T> + Ray2DProperties<T> {}
+
+impl<T: Scalar, R> Ray3DCore<T> for R where R: Ray3DConstructor<T> + Ray3DProperties<T> {}

--- a/model/geo_contracts/src/geometry/core/rectangle_traits.rs
+++ b/model/geo_contracts/src/geometry/core/rectangle_traits.rs
@@ -18,17 +18,37 @@ pub trait Rect2DProperties<T: Scalar> {
     fn center(&self) -> (T, T);
 }
 
-pub trait Rect2DMeasure<T: Scalar> {
+pub trait Rect2DMeasure<T: Scalar>: Rect2DContainment<T> + Rect2DDerived<T> {
+    fn contains_point(&self, point: (T, T)) -> bool {
+        <Self as Rect2DContainment<T>>::contains_point(self, point)
+    }
+
+    fn area(&self) -> T {
+        <Self as Rect2DDerived<T>>::area(self)
+    }
+
+    fn perimeter(&self) -> T {
+        <Self as Rect2DDerived<T>>::perimeter(self)
+    }
+
+    fn is_valid(&self) -> bool {
+        <Self as Rect2DDerived<T>>::is_valid(self)
+    }
+}
+
+pub trait Rect2DContainment<T: Scalar> {
     fn contains_point(&self, point: (T, T)) -> bool;
+}
+
+pub trait Rect2DDerived<T: Scalar> {
     fn area(&self) -> T;
     fn perimeter(&self) -> T;
     fn is_valid(&self) -> bool;
 }
 
-pub trait Rect2DCore<T: Scalar>:
-    Rect2DConstructor<T> + Rect2DProperties<T> + Rect2DMeasure<T>
-{
-}
+impl<T: Scalar, R> Rect2DMeasure<T> for R where R: Rect2DContainment<T> + Rect2DDerived<T> {}
+
+pub trait Rect2DCore<T: Scalar>: Rect2DConstructor<T> + Rect2DProperties<T> {}
 
 pub trait Rect3DConstructor<T: Scalar>: Sized {
     fn new(
@@ -51,15 +71,47 @@ pub trait Rect3DProperties<T: Scalar> {
     fn center(&self) -> (T, T, T);
 }
 
-pub trait Rect3DMeasure<T: Scalar> {
+pub trait Rect3DMeasure<T: Scalar>:
+    Rect3DContainment<T> + Rect3DDerived<T> + Rect3DEvaluation<T>
+{
+    fn contains_point(&self, point: (T, T, T), tolerance: T) -> bool {
+        <Self as Rect3DContainment<T>>::contains_point(self, point, tolerance)
+    }
+
+    fn area(&self) -> T {
+        <Self as Rect3DDerived<T>>::area(self)
+    }
+
+    fn corners(&self) -> [(T, T, T); 4] {
+        <Self as Rect3DDerived<T>>::corners(self)
+    }
+
+    fn distance_to_plane(&self, point: (T, T, T)) -> T {
+        <Self as Rect3DEvaluation<T>>::distance_to_plane(self, point)
+    }
+
+    fn is_valid(&self) -> bool {
+        <Self as Rect3DDerived<T>>::is_valid(self)
+    }
+}
+
+pub trait Rect3DContainment<T: Scalar> {
     fn contains_point(&self, point: (T, T, T), tolerance: T) -> bool;
+}
+
+pub trait Rect3DDerived<T: Scalar> {
     fn area(&self) -> T;
     fn corners(&self) -> [(T, T, T); 4];
-    fn distance_to_plane(&self, point: (T, T, T)) -> T;
     fn is_valid(&self) -> bool;
 }
 
-pub trait Rect3DCore<T: Scalar>:
-    Rect3DConstructor<T> + Rect3DProperties<T> + Rect3DMeasure<T>
+pub trait Rect3DEvaluation<T: Scalar> {
+    fn distance_to_plane(&self, point: (T, T, T)) -> T;
+}
+
+impl<T: Scalar, R> Rect3DMeasure<T> for R where
+    R: Rect3DContainment<T> + Rect3DDerived<T> + Rect3DEvaluation<T>
 {
 }
+
+pub trait Rect3DCore<T: Scalar>: Rect3DConstructor<T> + Rect3DProperties<T> {}

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -13,7 +13,8 @@ pub use classification::{DimensionClass, GeometryPrimitive, PrimitiveKind};
 pub use entity::{EntityDisplayProperties, EntityIdentity, LineEntity3DProperties};
 pub use geometry::core::arc_traits::{Arc2DContainment, Arc2DSampling};
 pub use geometry::core::plane3d_traits::{
-    Plane3DConstructor, Plane3DCore, Plane3DMeasure, Plane3DProperties,
+    Plane3DConstructor, Plane3DContainment, Plane3DCore, Plane3DDerived, Plane3DDistance,
+    Plane3DEvaluation, Plane3DMeasure, Plane3DProjection, Plane3DProperties, Plane3DTransform,
 };
 pub use geometry::core::{Aabb2DDerived, Aabb2DProperties, Aabb3DDerived, Aabb3DProperties};
 pub use geometry::core::{
@@ -35,21 +36,31 @@ pub use geometry::core::{
     EllipsoidalSolid3DProperties, EllipsoidalSurface3DConstructor, EllipsoidalSurface3DCore,
     EllipsoidalSurface3DMeasure, EllipsoidalSurface3DProperties, Point2DConstructor, Point2DCore,
     Point2DProperties, Point3DConstructor, Point3DCore, Point3DProperties, Rect2DConstructor,
-    Rect2DCore, Rect2DMeasure, Rect2DProperties, Rect3DConstructor, Rect3DCore, Rect3DMeasure,
-    Rect3DProperties, SphericalSolid3DConstructor, SphericalSolid3DCore, SphericalSolid3DMeasure,
-    SphericalSolid3DProperties, SphericalSurface3DConstructor, SphericalSurface3DCore,
-    SphericalSurface3DMeasure, SphericalSurface3DProperties, TorusSolid3DConstructor,
-    TorusSolid3DCore, TorusSolid3DMeasure, TorusSolid3DProperties, TorusSurface3DConstructor,
-    TorusSurface3DCore, TorusSurface3DMeasure, TorusSurface3DProperties, Vector2DConstructor,
-    Vector2DCore, Vector2DProperties, Vector3DConstructor, Vector3DCore, Vector3DProperties,
+    Rect2DContainment, Rect2DCore, Rect2DDerived, Rect2DMeasure, Rect2DProperties,
+    Rect3DConstructor, Rect3DContainment, Rect3DCore, Rect3DDerived, Rect3DEvaluation,
+    Rect3DMeasure, Rect3DProperties, SphericalSolid3DConstructor, SphericalSolid3DCore,
+    SphericalSolid3DMeasure, SphericalSolid3DProperties, SphericalSurface3DConstructor,
+    SphericalSurface3DCore, SphericalSurface3DMeasure, SphericalSurface3DProperties,
+    TorusSolid3DConstructor, TorusSolid3DCore, TorusSolid3DMeasure, TorusSolid3DProperties,
+    TorusSurface3DConstructor, TorusSurface3DCore, TorusSurface3DMeasure, TorusSurface3DProperties,
+    Vector2DConstructor, Vector2DCore, Vector2DProperties, Vector3DConstructor, Vector3DCore,
+    Vector3DProperties,
 };
 pub use geometry::core::{
-    InfiniteLine2DConstructor, InfiniteLine2DCore, InfiniteLine2DMeasure, InfiniteLine2DProperties,
-    InfiniteLine3DConstructor, InfiniteLine3DCore, InfiniteLine3DMeasure, InfiniteLine3DProperties,
-    LineSegment2DConstructor, LineSegment2DCore, LineSegment2DMeasure, LineSegment2DProperties,
-    LineSegment3DConstructor, LineSegment3DCore, LineSegment3DMeasure, LineSegment3DProperties,
-    Ray2DConstructor, Ray2DCore, Ray2DMeasure, Ray2DProperties, Ray3DConstructor, Ray3DCore,
-    Ray3DMeasure, Ray3DProperties,
+    InfiniteLine2DConstructor, InfiniteLine2DContainment, InfiniteLine2DCore,
+    InfiniteLine2DDistance, InfiniteLine2DEvaluation, InfiniteLine2DMeasure,
+    InfiniteLine2DProjection, InfiniteLine2DProperties, InfiniteLine2DTransform,
+    InfiniteLine3DConstructor, InfiniteLine3DContainment, InfiniteLine3DCore,
+    InfiniteLine3DDistance, InfiniteLine3DEvaluation, InfiniteLine3DMeasure,
+    InfiniteLine3DProjection, InfiniteLine3DProperties, InfiniteLine3DTransform,
+    LineSegment2DConstructor, LineSegment2DContainment, LineSegment2DCore, LineSegment2DDerived,
+    LineSegment2DDistance, LineSegment2DEvaluation, LineSegment2DMeasure, LineSegment2DProjection,
+    LineSegment2DProperties, LineSegment3DConstructor, LineSegment3DContainment, LineSegment3DCore,
+    LineSegment3DDerived, LineSegment3DDistance, LineSegment3DEvaluation, LineSegment3DMeasure,
+    LineSegment3DProjection, LineSegment3DProperties, Ray2DConstructor, Ray2DContainment,
+    Ray2DCore, Ray2DDistance, Ray2DEvaluation, Ray2DMeasure, Ray2DProjection, Ray2DProperties,
+    Ray2DTransform, Ray3DConstructor, Ray3DContainment, Ray3DCore, Ray3DDistance, Ray3DEvaluation,
+    Ray3DMeasure, Ray3DProjection, Ray3DProperties, Ray3DTransform,
 };
 pub use geometry::core::{
     NurbsCurve2DConstructor, NurbsCurve2DCore, NurbsCurve2DMeasure, NurbsCurve2DProperties,

--- a/model/geo_primitives/src/ellipse_2d.rs
+++ b/model/geo_primitives/src/ellipse_2d.rs
@@ -22,15 +22,7 @@ pub struct Ellipse2D<T: Scalar> {
     rotation: T,        // 回転角（ラジアン、X軸からの回転）
 }
 
-// ============================================================================
-// Core Implementation (必須機能のみ)
-// ============================================================================
-
 impl<T: Scalar> Ellipse2D<T> {
-    // ========================================================================
-    // Core Construction Methods
-    // ========================================================================
-
     /// 新しい楕円を作成
     ///
     /// # 引数
@@ -65,10 +57,6 @@ impl<T: Scalar> Ellipse2D<T> {
     pub fn axis_aligned(center: Point2D<T>, semi_major: T, semi_minor: T) -> Option<Self> {
         Self::new(center, semi_major, semi_minor, T::ZERO)
     }
-
-    // ========================================================================
-    // Core Accessor Methods
-    // ========================================================================
 
     /// 中心点を取得（内部使用）
     pub(crate) fn center_internal(&self) -> Point2D<T> {
@@ -133,10 +121,6 @@ impl<T: Scalar> Ellipse2D<T> {
 
         T::PI * (a + b) * (T::ONE + (three * h) / (ten + (four - three * h).sqrt()))
     }
-
-    // ========================================================================
-    // Core Geometric Methods
-    // ========================================================================
 
     /// 点が楕円内に含まれるかを判定
     pub fn contains_point(&self, point: &Point2D<T>, tolerance: T) -> bool {
@@ -219,10 +203,6 @@ impl<T: Scalar> Ellipse2D<T> {
         )
     }
 
-    // ========================================================================
-    // Conversion Methods
-    // ========================================================================
-
     /// 円に変換（可能な場合）
     pub fn to_circle(&self) -> Option<Circle2D<T>> {
         if (self.semi_major_internal() - self.semi_minor_internal()).abs() <= T::EPSILON {
@@ -237,10 +217,6 @@ impl<T: Scalar> Ellipse2D<T> {
         (self.semi_major - self.semi_minor).abs() <= tolerance
     }
 }
-
-// ============================================================================
-// Helper Methods
-// ============================================================================
 
 impl<T: Scalar> Ellipse2D<T> {
     /// 境界上の点かどうかを判定
@@ -264,10 +240,6 @@ impl<T: Scalar> Ellipse2D<T> {
         Vector2D::new(-self.rotation.sin(), self.rotation.cos())
     }
 }
-
-// ============================================================================
-// Advanced Calculation Traits Implementation
-// ============================================================================
 
 impl<T: Scalar> EllipseCalculation<T> for Ellipse2D<T> {
     type Point = Point2D<T>;
@@ -386,13 +358,7 @@ impl<T: Scalar> EllipseAccuracyAnalysis<T> for Ellipse2D<T> {
     }
 }
 
-// ============================================================================
-// Core Traits Implementation (Phase 1)
-// ============================================================================
-
 impl<T: Scalar> Ellipse2DConstructor<T> for Ellipse2D<T> {
-    // ========== Phase 1 実装 ==========
-
     fn new(center: (T, T), semi_major: T, semi_minor: T, rotation: T) -> Option<Self> {
         let center_point = Point2D::new(center.0, center.1);
         Self::new(center_point, semi_major, semi_minor, rotation)
@@ -407,8 +373,6 @@ impl<T: Scalar> Ellipse2DConstructor<T> for Ellipse2D<T> {
         let c = Point2D::new(center.0, center.1);
         Self::new(c, semi_major, semi_minor, T::ZERO)
     }
-
-    // ========== Phase 2 実装 ==========
 
     fn from_circle(center: (T, T), radius: T) -> Self {
         let c = Point2D::new(center.0, center.1);
@@ -448,8 +412,6 @@ impl<T: Scalar> Ellipse2DConstructor<T> for Ellipse2D<T> {
 }
 
 impl<T: Scalar> Ellipse2DProperties<T> for Ellipse2D<T> {
-    // ========== Phase 1 実装 ==========
-
     fn center(&self) -> (T, T) {
         (self.center.x(), self.center.y())
     }
@@ -470,8 +432,6 @@ impl<T: Scalar> Ellipse2DProperties<T> for Ellipse2D<T> {
         self.eccentricity()
     }
 
-    // ========== Phase 2 実装 ==========
-
     fn focal_distance(&self) -> T {
         geo_contracts::EllipseCalculation::focal_distance(self)
     }
@@ -488,8 +448,6 @@ impl<T: Scalar> Ellipse2DProperties<T> for Ellipse2D<T> {
 }
 
 impl<T: Scalar + From<f64>> Ellipse2DMeasure<T> for Ellipse2D<T> {
-    // ========== Phase 1 実装 ==========
-
     fn measure(&self) -> T {
         self.area()
     }
@@ -508,8 +466,6 @@ impl<T: Scalar + From<f64>> Ellipse2DMeasure<T> for Ellipse2D<T> {
         let tolerance = default_distance_tolerance::<T>();
         self.is_circle(tolerance)
     }
-
-    // ========== Phase 2 実装 ==========
 
     fn point_at_parameter(&self, t: T) -> (T, T) {
         // パラメトリック方程式で楕円上の点を計算

--- a/model/geo_primitives/src/infinite_line_2d.rs
+++ b/model/geo_primitives/src/infinite_line_2d.rs
@@ -159,7 +159,11 @@ impl<T: Scalar> InfiniteLine2D<T> {
 // Foundation Pattern Core Traits Implementation
 // ============================================================================
 
-use geo_contracts::{InfiniteLine2DConstructor, InfiniteLine2DMeasure, InfiniteLine2DProperties};
+use geo_contracts::{
+    InfiniteLine2DConstructor, InfiniteLine2DContainment, InfiniteLine2DDistance,
+    InfiniteLine2DEvaluation, InfiniteLine2DProjection, InfiniteLine2DProperties,
+    InfiniteLine2DTransform,
+};
 
 /// InfiniteLine2D Constructor Trait Implementation
 impl<T: Scalar> InfiniteLine2DConstructor<T> for InfiniteLine2D<T> {
@@ -301,37 +305,38 @@ impl<T: Scalar> InfiniteLine2DProperties<T> for InfiniteLine2D<T> {
     }
 }
 
-/// InfiniteLine2D Measure Trait Implementation
-impl<T: Scalar> InfiniteLine2DMeasure<T> for InfiniteLine2D<T> {
+impl<T: Scalar> InfiniteLine2DEvaluation<T> for InfiniteLine2D<T> {
     fn point_at_parameter(&self, t: T) -> (T, T) {
         let p = self.point_at_parameter(t);
         (p.x(), p.y())
-    }
-
-    fn distance_to_point(&self, point: (T, T)) -> T {
-        let p = Point2D::new(point.0, point.1);
-        self.distance_to_point(&p)
-    }
-
-    fn contains_point(&self, point: (T, T)) -> bool {
-        let p = Point2D::new(point.0, point.1);
-        use geo_contracts::default_distance_tolerance;
-        self.contains_point(&p, default_distance_tolerance::<T>())
-    }
-
-    fn project_point(&self, point: (T, T)) -> (T, T) {
-        let p = Point2D::new(point.0, point.1);
-        let projected = self.project_point(&p);
-        (projected.x(), projected.y())
     }
 
     fn parameter_for_point(&self, point: (T, T)) -> T {
         let p = Point2D::new(point.0, point.1);
         self.parameter_for_point(&p)
     }
+}
 
-    fn reverse(&self) -> Self {
-        Self::new(self.point, -(*self.direction)).unwrap()
+impl<T: Scalar> InfiniteLine2DDistance<T> for InfiniteLine2D<T> {
+    fn distance_to_point(&self, point: (T, T)) -> T {
+        let p = Point2D::new(point.0, point.1);
+        self.distance_to_point(&p)
+    }
+}
+
+impl<T: Scalar> InfiniteLine2DContainment<T> for InfiniteLine2D<T> {
+    fn contains_point(&self, point: (T, T)) -> bool {
+        let p = Point2D::new(point.0, point.1);
+        use geo_contracts::default_distance_tolerance;
+        self.contains_point(&p, default_distance_tolerance::<T>())
+    }
+}
+
+impl<T: Scalar> InfiniteLine2DProjection<T> for InfiniteLine2D<T> {
+    fn project_point(&self, point: (T, T)) -> (T, T) {
+        let p = Point2D::new(point.0, point.1);
+        let projected = self.project_point(&p);
+        (projected.x(), projected.y())
     }
 
     // ========== Phase 2 実装 ==========
@@ -342,6 +347,12 @@ impl<T: Scalar> InfiniteLine2DMeasure<T> for InfiniteLine2D<T> {
         // 鏡面点 = 2 * 投影点 - 元の点
         let mirrored = projected + (projected - p);
         (mirrored.x(), mirrored.y())
+    }
+}
+
+impl<T: Scalar> InfiniteLine2DTransform<T> for InfiniteLine2D<T> {
+    fn reverse(&self) -> Self {
+        Self::new(self.point, -(*self.direction)).unwrap()
     }
 
     fn offset(&self, distance: T) -> Self {

--- a/model/geo_primitives/src/infinite_line_2d.rs
+++ b/model/geo_primitives/src/infinite_line_2d.rs
@@ -15,14 +15,7 @@ pub struct InfiniteLine2D<T: Scalar> {
     pub(crate) direction: Direction2D<T>, // 正規化された方向ベクトル
 }
 
-// ============================================================================
-// Core Implementation (必須機能のみ)
-// ============================================================================
-
 impl<T: Scalar> InfiniteLine2D<T> {
-    // ========================================================================
-    // Core Construction Methods
-    // ========================================================================
     /// 点と方向ベクトルから無限直線を作成
     pub fn new(point: Point2D<T>, direction: Vector2D<T>) -> Option<Self> {
         Direction2D::from_vector(direction).map(|dir| Self {
@@ -36,14 +29,6 @@ impl<T: Scalar> InfiniteLine2D<T> {
         let direction = Vector2D::from_points(p1, p2);
         Self::new(p1, direction)
     }
-
-    // ========================================================================
-    // Core Accessor Methods
-    // ========================================================================
-
-    // ========================================================================
-    // Core Accessor Methods
-    // ========================================================================
 
     /// 直線上の点を取得（内部用）
     pub(crate) fn point_internal(&self) -> Point2D<T> {
@@ -60,10 +45,6 @@ impl<T: Scalar> InfiniteLine2D<T> {
         Direction2D::from_vector(self.direction.rotate_neg_90())
             .expect("Rotated direction should be valid")
     }
-
-    // ========================================================================
-    // Core Geometric Methods
-    // ========================================================================
 
     /// 指定パラメータでの点を取得（point + t * direction）
     pub fn point_at_parameter(&self, t: T) -> Point2D<T> {
@@ -119,10 +100,6 @@ impl<T: Scalar> InfiniteLine2D<T> {
         Some(other.point_at_parameter(t1))
     }
 
-    // ========================================================================
-    // Core Helper Methods
-    // ========================================================================
-
     /// 境界ボックスを取得（起点を含む十分大きな範囲）
     pub fn bounding_box(&self) -> geo_core::Aabb2D<T> {
         use geo_core::Point2D;
@@ -154,10 +131,6 @@ impl<T: Scalar> InfiniteLine2D<T> {
         self.contains_point(point, tolerance)
     }
 }
-
-// ============================================================================
-// Foundation Pattern Core Traits Implementation
-// ============================================================================
 
 use geo_contracts::{
     InfiniteLine2DConstructor, InfiniteLine2DContainment, InfiniteLine2DDistance,
@@ -202,8 +175,6 @@ impl<T: Scalar> InfiniteLine2DConstructor<T> for InfiniteLine2D<T> {
         let direction_vec = Vector2D::new(direction.0, direction.1);
         Self::new(origin, direction_vec)
     }
-
-    // ========== Phase 2 実装 ==========
 
     fn from_angle(angle: T) -> Self {
         let direction = Vector2D::new(angle.cos(), angle.sin());
@@ -285,8 +256,6 @@ impl<T: Scalar> InfiniteLine2DProperties<T> for InfiniteLine2D<T> {
         2
     }
 
-    // ========== Phase 2 実装 ==========
-
     fn angle(&self) -> T {
         self.direction.y().atan2(self.direction.x())
     }
@@ -338,8 +307,6 @@ impl<T: Scalar> InfiniteLine2DProjection<T> for InfiniteLine2D<T> {
         let projected = self.project_point(&p);
         (projected.x(), projected.y())
     }
-
-    // ========== Phase 2 実装 ==========
 
     fn mirror_point(&self, point: (T, T)) -> (T, T) {
         let p = Point2D::new(point.0, point.1);

--- a/model/geo_primitives/src/infinite_line_3d.rs
+++ b/model/geo_primitives/src/infinite_line_3d.rs
@@ -7,8 +7,10 @@ use crate::{Direction3D, Plane3D, Point3D, Vector3D};
 use geo_contracts::{
     default_distance_tolerance, default_orthogonality_dot_error_tolerance, AngularRelation,
     BasicIntersection, ClosestPointPair, CrossDistance, InfiniteLine3DConstructor,
-    InfiniteLine3DMeasure, InfiniteLine3DProperties, IntersectsRelation, OnPlaneRelation,
-    ParallelRelation, PerpendicularRelation, SameLineRelation, Scalar, SkewRelation,
+    InfiniteLine3DContainment, InfiniteLine3DDistance, InfiniteLine3DEvaluation,
+    InfiniteLine3DMeasure, InfiniteLine3DProjection, InfiniteLine3DProperties,
+    InfiniteLine3DTransform, IntersectsRelation, OnPlaneRelation, ParallelRelation,
+    PerpendicularRelation, SameLineRelation, Scalar, SkewRelation,
 };
 
 type LinePointPair3D<T> = ((T, T, T), (T, T, T));
@@ -509,38 +511,37 @@ impl<T: Scalar> InfiniteLine3DProperties<T> for InfiniteLine3D<T> {
 // Measure トレイト実装
 // ============================================================================
 
-impl<T: Scalar> InfiniteLine3DMeasure<T> for InfiniteLine3D<T> {
+impl<T: Scalar> InfiniteLine3DEvaluation<T> for InfiniteLine3D<T> {
     fn point_at_parameter(&self, t: T) -> (T, T, T) {
         let param_point = InfiniteLine3D::point_at_parameter(self, t);
         (param_point.x(), param_point.y(), param_point.z())
-    }
-
-    fn distance_to_point(&self, point: (T, T, T)) -> T {
-        let p = Point3D::new(point.0, point.1, point.2);
-        InfiniteLine3D::distance_to_point(self, &p)
-    }
-
-    fn contains_point(&self, point: (T, T, T)) -> bool {
-        let p = Point3D::new(point.0, point.1, point.2);
-        self.contains_point(&p, default_distance_tolerance::<T>())
-    }
-
-    fn project_point(&self, point: (T, T, T)) -> (T, T, T) {
-        let p = Point3D::new(point.0, point.1, point.2);
-        let projected = InfiniteLine3D::project_point(self, &p);
-        (projected.x(), projected.y(), projected.z())
     }
 
     fn parameter_for_point(&self, point: (T, T, T)) -> T {
         let p = Point3D::new(point.0, point.1, point.2);
         InfiniteLine3D::parameter_for_point(self, &p)
     }
+}
 
-    fn reverse(&self) -> Self {
-        let self_dir = <Self as InfiniteLine3DProperties<T>>::direction(self);
-        let self_point = <Self as InfiniteLine3DProperties<T>>::point(self);
-        let reversed_dir = (-self_dir.0, -self_dir.1, -self_dir.2);
-        <Self as InfiniteLine3DConstructor<T>>::new(self_point, reversed_dir).unwrap()
+impl<T: Scalar> InfiniteLine3DDistance<T> for InfiniteLine3D<T> {
+    fn distance_to_point(&self, point: (T, T, T)) -> T {
+        let p = Point3D::new(point.0, point.1, point.2);
+        InfiniteLine3D::distance_to_point(self, &p)
+    }
+}
+
+impl<T: Scalar> InfiniteLine3DContainment<T> for InfiniteLine3D<T> {
+    fn contains_point(&self, point: (T, T, T)) -> bool {
+        let p = Point3D::new(point.0, point.1, point.2);
+        self.contains_point(&p, default_distance_tolerance::<T>())
+    }
+}
+
+impl<T: Scalar> InfiniteLine3DProjection<T> for InfiniteLine3D<T> {
+    fn project_point(&self, point: (T, T, T)) -> (T, T, T) {
+        let p = Point3D::new(point.0, point.1, point.2);
+        let projected = InfiniteLine3D::project_point(self, &p);
+        (projected.x(), projected.y(), projected.z())
     }
 
     // ========== Phase 2 実装 ==========
@@ -551,6 +552,15 @@ impl<T: Scalar> InfiniteLine3DMeasure<T> for InfiniteLine3D<T> {
         // 鏡面点 = 2 * 投影点 - 元の点
         let mirrored = projected + (projected - p);
         (mirrored.x(), mirrored.y(), mirrored.z())
+    }
+}
+
+impl<T: Scalar> InfiniteLine3DTransform<T> for InfiniteLine3D<T> {
+    fn reverse(&self) -> Self {
+        let self_dir = <Self as InfiniteLine3DProperties<T>>::direction(self);
+        let self_point = <Self as InfiniteLine3DProperties<T>>::point(self);
+        let reversed_dir = (-self_dir.0, -self_dir.1, -self_dir.2);
+        <Self as InfiniteLine3DConstructor<T>>::new(self_point, reversed_dir).unwrap()
     }
 
     fn rotate_around_axis(

--- a/model/geo_primitives/src/infinite_line_3d.rs
+++ b/model/geo_primitives/src/infinite_line_3d.rs
@@ -25,14 +25,7 @@ pub struct InfiniteLine3D<T: Scalar> {
     pub(crate) direction: Direction3D<T>, // 方向ベクトル（正規化済み）
 }
 
-// ============================================================================
-// Core Implementation (必須機能のみ)
-// ============================================================================
-
 impl<T: Scalar> InfiniteLine3D<T> {
-    // ========================================================================
-    // Core Construction Methods
-    // ========================================================================
     /// 新しい無限直線を作成
     ///
     /// # 引数
@@ -57,10 +50,6 @@ impl<T: Scalar> InfiniteLine3D<T> {
         Self::new(p1, direction)
     }
 
-    // ========================================================================
-    // Core Accessor Methods
-    // ========================================================================
-
     /// 直線上の点を取得（内部用）
     pub(crate) fn point_internal(&self) -> Point3D<T> {
         self.point
@@ -70,10 +59,6 @@ impl<T: Scalar> InfiniteLine3D<T> {
     pub(crate) fn direction_internal(&self) -> Direction3D<T> {
         self.direction
     }
-
-    // ========================================================================
-    // Core Geometric Methods
-    // ========================================================================
 
     /// パラメータtでの直線上の点を取得
     /// 点 = point + t * direction
@@ -349,14 +334,6 @@ impl<T: Scalar> InfiniteLine3D<T> {
     }
 }
 
-// ============================================================================
-// Foundation Pattern - Core Traits Implementation
-// ============================================================================
-
-// ============================================================================
-// Constructor トレイト実装
-// ============================================================================
-
 impl<T: Scalar> InfiniteLine3DConstructor<T> for InfiniteLine3D<T> {
     fn new(point: (T, T, T), direction: (T, T, T)) -> Option<Self> {
         let p = Point3D::new(point.0, point.1, point.2);
@@ -412,8 +389,6 @@ impl<T: Scalar> InfiniteLine3DConstructor<T> for InfiniteLine3D<T> {
         InfiniteLine3D::new(origin, dir)
     }
 
-    // ========== Phase 2 実装 ==========
-
     fn from_xy_angle(angle: T) -> Self {
         let direction = Vector3D::new(angle.cos(), angle.sin(), T::ZERO);
         InfiniteLine3D::new(Point3D::origin(), direction).unwrap()
@@ -443,10 +418,6 @@ impl<T: Scalar> InfiniteLine3DConstructor<T> for InfiniteLine3D<T> {
         InfiniteLine3D::new(p, perp_dir)
     }
 }
-
-// ============================================================================
-// Properties トレイト実装
-// ============================================================================
 
 impl<T: Scalar> InfiniteLine3DProperties<T> for InfiniteLine3D<T> {
     fn point(&self) -> (T, T, T) {
@@ -496,8 +467,6 @@ impl<T: Scalar> InfiniteLine3DProperties<T> for InfiniteLine3D<T> {
         3
     }
 
-    // ========== Phase 2 実装 ==========
-
     fn xy_angle(&self) -> T {
         self.direction.y().atan2(self.direction.x())
     }
@@ -506,10 +475,6 @@ impl<T: Scalar> InfiniteLine3DProperties<T> for InfiniteLine3D<T> {
         self.is_x_parallel() || self.is_y_parallel() || self.is_z_parallel()
     }
 }
-
-// ============================================================================
-// Measure トレイト実装
-// ============================================================================
 
 impl<T: Scalar> InfiniteLine3DEvaluation<T> for InfiniteLine3D<T> {
     fn point_at_parameter(&self, t: T) -> (T, T, T) {
@@ -543,8 +508,6 @@ impl<T: Scalar> InfiniteLine3DProjection<T> for InfiniteLine3D<T> {
         let projected = InfiniteLine3D::project_point(self, &p);
         (projected.x(), projected.y(), projected.z())
     }
-
-    // ========== Phase 2 実装 ==========
 
     fn mirror_point(&self, point: (T, T, T)) -> (T, T, T) {
         let p = Point3D::new(point.0, point.1, point.2);

--- a/model/geo_primitives/src/line_segment_2d.rs
+++ b/model/geo_primitives/src/line_segment_2d.rs
@@ -5,7 +5,8 @@
 
 use crate::{InfiniteLine2D, Point2D, Vector2D};
 use geo_contracts::{
-    default_distance_tolerance, CrossDistance, LineSegment2DConstructor, LineSegment2DMeasure,
+    default_distance_tolerance, CrossDistance, LineSegment2DConstructor, LineSegment2DContainment,
+    LineSegment2DDerived, LineSegment2DDistance, LineSegment2DEvaluation, LineSegment2DProjection,
     LineSegment2DProperties, Scalar,
 };
 
@@ -347,27 +348,44 @@ impl<T: Scalar> LineSegment2DProperties<T> for LineSegment2D<T> {
     }
 }
 
-impl<T: Scalar> LineSegment2DMeasure<T> for LineSegment2D<T> {
+impl<T: Scalar> LineSegment2DDerived<T> for LineSegment2D<T> {
     fn measure(&self) -> T {
         (self.end_param - self.start_param).abs()
     }
 
+    fn direction_vector(&self) -> (T, T) {
+        let dir = self.direction();
+        (dir.x(), dir.y())
+    }
+
+    fn as_vector(&self) -> (T, T) {
+        let v = self.vector();
+        (v.x(), v.y())
+    }
+}
+
+impl<T: Scalar> LineSegment2DDistance<T> for LineSegment2D<T> {
     fn distance_to_point(&self, point: (T, T)) -> T {
         let p = Point2D::new(point.0, point.1);
         self.distance_to_point(&p)
     }
+}
 
+impl<T: Scalar> LineSegment2DContainment<T> for LineSegment2D<T> {
     fn contains_point(&self, point: (T, T)) -> bool {
         let p = Point2D::new(point.0, point.1);
         self.contains_point(&p, default_distance_tolerance::<T>())
     }
+}
 
+impl<T: Scalar> LineSegment2DEvaluation<T> for LineSegment2D<T> {
     fn point_at_parameter(&self, t: T) -> (T, T) {
         let p = self.point_at_normalized_parameter(t);
         (p.x(), p.y())
     }
+}
 
-    // Phase 2: 追加測度メソッド
+impl<T: Scalar> LineSegment2DProjection<T> for LineSegment2D<T> {
     fn closest_point_to(&self, point: (T, T)) -> (T, T) {
         let p = Point2D::new(point.0, point.1);
         let t = self.parameter_for_point(&p);
@@ -380,16 +398,6 @@ impl<T: Scalar> LineSegment2DMeasure<T> for LineSegment2D<T> {
             t
         };
         self.point_at_parameter(clamped_t)
-    }
-
-    fn direction_vector(&self) -> (T, T) {
-        let dir = self.direction();
-        (dir.x(), dir.y())
-    }
-
-    fn as_vector(&self) -> (T, T) {
-        let v = self.vector();
-        (v.x(), v.y())
     }
 }
 

--- a/model/geo_primitives/src/line_segment_2d.rs
+++ b/model/geo_primitives/src/line_segment_2d.rs
@@ -21,15 +21,7 @@ pub struct LineSegment2D<T: Scalar> {
     pub(crate) end_param: T,            // 終点のパラメータ
 }
 
-// ============================================================================
-// Core Implementation (必須機能のみ)
-// ============================================================================
-
 impl<T: Scalar> LineSegment2D<T> {
-    // ========================================================================
-    // Core Construction Methods
-    // ========================================================================
-
     /// 始点と終点から線分を作成
     pub fn new(start: Point2D<T>, end: Point2D<T>) -> Option<Self> {
         let line = InfiniteLine2D::from_two_points(start, end)?;
@@ -59,10 +51,6 @@ impl<T: Scalar> LineSegment2D<T> {
             end_param: length,
         })
     }
-
-    // ========================================================================
-    // Core Accessor Methods
-    // ========================================================================
 
     /// 始点を取得
     pub fn start_point(&self) -> Point2D<T> {
@@ -101,10 +89,6 @@ impl<T: Scalar> LineSegment2D<T> {
         Vector2D::from_points(start, end)
     }
 
-    // ========================================================================
-    // Core Parametric Methods
-    // ========================================================================
-
     /// 正規化されたパラメータ（0〜1）での点を取得
     pub fn point_at_normalized_parameter(&self, t: T) -> Point2D<T> {
         if t < T::ZERO || t > T::ONE {
@@ -131,10 +115,6 @@ impl<T: Scalar> LineSegment2D<T> {
             (line_param - self.start_param) / segment_length
         }
     }
-
-    // ========================================================================
-    // Core Containment Methods
-    // ========================================================================
 
     /// 点が線分上にあるかを判定
     pub fn contains_point(&self, point: &Point2D<T>, tolerance: T) -> bool {
@@ -181,10 +161,6 @@ impl<T: Scalar> LineSegment2D<T> {
         )
     }
 
-    // ========================================================================
-    // Internal Accessor Methods (for Extension implementation)
-    // ========================================================================
-
     /// 基盤となる無限直線を取得（Extension用）
     pub fn line(&self) -> &InfiniteLine2D<T> {
         &self.line
@@ -200,11 +176,6 @@ impl<T: Scalar> LineSegment2D<T> {
         self.end_param
     }
 }
-
-// ============================================================================
-// ============================================================================
-// Helper Methods (Foundation traits converted to methods)
-// ============================================================================
 
 impl<T: Scalar> LineSegment2D<T> {
     /// 方向を反転
@@ -252,10 +223,6 @@ impl<T: Scalar> LineSegment2D<T> {
         }
     }
 }
-
-// ============================================================================
-// Core Traits Implementation (Phase 1)
-// ============================================================================
 
 impl<T: Scalar> LineSegment2DConstructor<T> for LineSegment2D<T> {
     fn new(start: (T, T), end: (T, T)) -> Option<Self> {

--- a/model/geo_primitives/src/line_segment_3d.rs
+++ b/model/geo_primitives/src/line_segment_3d.rs
@@ -21,15 +21,7 @@ pub struct LineSegment3D<T: Scalar> {
     pub(crate) end_param: T,            // 終点のパラメータ
 }
 
-// ============================================================================
-// Core Implementation (必須機能のみ)
-// ============================================================================
-
 impl<T: Scalar> LineSegment3D<T> {
-    // ========================================================================
-    // Core Construction Methods
-    // ========================================================================
-
     /// 始点と終点から線分を作成
     pub fn new(start: Point3D<T>, end: Point3D<T>) -> Option<Self> {
         let line = InfiniteLine3D::from_two_points(start, end)?;
@@ -59,10 +51,6 @@ impl<T: Scalar> LineSegment3D<T> {
             end_param: length,
         })
     }
-
-    // ========================================================================
-    // Core Accessor Methods
-    // ========================================================================
 
     /// 始点を取得
     pub fn start(&self) -> Point3D<T> {
@@ -105,10 +93,6 @@ impl<T: Scalar> LineSegment3D<T> {
         self.end_param
     }
 
-    // ========================================================================
-    // Core Calculation Methods
-    // ========================================================================
-
     /// 点から線分への最短距離
     pub fn distance_to_point(&self, point: &Point3D<T>) -> T {
         let to_point = Vector3D::from_points(&self.line.point_internal(), point);
@@ -144,10 +128,6 @@ impl<T: Scalar> LineSegment3D<T> {
         self.length() <= tolerance
     }
 }
-
-// ============================================================================
-// Core Traits Implementation (Phase 1)
-// ============================================================================
 
 impl<T: Scalar> LineSegment3DConstructor<T> for LineSegment3D<T> {
     fn new(start: (T, T, T), end: (T, T, T)) -> Option<Self> {

--- a/model/geo_primitives/src/line_segment_3d.rs
+++ b/model/geo_primitives/src/line_segment_3d.rs
@@ -5,7 +5,8 @@
 
 use crate::{InfiniteLine3D, Point3D, Vector3D};
 use geo_contracts::{
-    default_distance_tolerance, CrossDistance, LineSegment3DConstructor, LineSegment3DMeasure,
+    default_distance_tolerance, CrossDistance, LineSegment3DConstructor, LineSegment3DContainment,
+    LineSegment3DDerived, LineSegment3DDistance, LineSegment3DEvaluation, LineSegment3DProjection,
     LineSegment3DProperties, Scalar,
 };
 
@@ -239,29 +240,48 @@ impl<T: Scalar> LineSegment3DProperties<T> for LineSegment3D<T> {
     }
 }
 
-impl<T: Scalar> LineSegment3DMeasure<T> for LineSegment3D<T> {
+impl<T: Scalar> LineSegment3DDerived<T> for LineSegment3D<T> {
     fn measure(&self) -> T {
         self.end_param - self.start_param
     }
 
+    fn direction_vector(&self) -> (T, T, T) {
+        let dir = self.direction();
+        (dir.x(), dir.y(), dir.z())
+    }
+
+    fn as_vector(&self) -> (T, T, T) {
+        let start = self.start();
+        let end = self.end();
+        let v = Vector3D::from_points(&start, &end);
+        (v.x(), v.y(), v.z())
+    }
+}
+
+impl<T: Scalar> LineSegment3DDistance<T> for LineSegment3D<T> {
     fn distance_to_point(&self, point: (T, T, T)) -> T {
         let p = Point3D::new(point.0, point.1, point.2);
         self.distance_to_point(&p)
     }
+}
 
+impl<T: Scalar> LineSegment3DContainment<T> for LineSegment3D<T> {
     fn contains_point(&self, point: (T, T, T)) -> bool {
         let p = Point3D::new(point.0, point.1, point.2);
         self.contains_point(&p, default_distance_tolerance::<T>())
     }
+}
 
+impl<T: Scalar> LineSegment3DEvaluation<T> for LineSegment3D<T> {
     fn point_at_parameter(&self, t: T) -> (T, T, T) {
         // 正規化パラメータ（0〜1）で線分上の点を取得
         let param = self.start_param + t * (self.end_param - self.start_param);
         let p = self.line.point_at_parameter(param);
         (p.x(), p.y(), p.z())
     }
+}
 
-    // Phase 2: 追加測度メソッド
+impl<T: Scalar> LineSegment3DProjection<T> for LineSegment3D<T> {
     fn closest_point_to(&self, point: (T, T, T)) -> (T, T, T) {
         let p = Point3D::new(point.0, point.1, point.2);
         // 直線上のパラメータを計算
@@ -276,18 +296,6 @@ impl<T: Scalar> LineSegment3DMeasure<T> for LineSegment3D<T> {
         };
         let result = self.line.point_at_parameter(clamped_param);
         (result.x(), result.y(), result.z())
-    }
-
-    fn direction_vector(&self) -> (T, T, T) {
-        let dir = self.direction();
-        (dir.x(), dir.y(), dir.z())
-    }
-
-    fn as_vector(&self) -> (T, T, T) {
-        let start = self.start();
-        let end = self.end();
-        let v = Vector3D::from_points(&start, &end);
-        (v.x(), v.y(), v.z())
     }
 }
 

--- a/model/geo_primitives/src/plane_3d.rs
+++ b/model/geo_primitives/src/plane_3d.rs
@@ -35,15 +35,7 @@ pub struct Plane3D<T: Scalar> {
     pub(crate) v_axis: Direction3D<T>,
 }
 
-// ============================================================================
-// Core Implementation (必須機能のみ)
-// ============================================================================
-
 impl<T: Scalar> Plane3D<T> {
-    // ========================================================================
-    // STEP準拠のコンストラクタ
-    // ========================================================================
-
     /// STEP AXIS2_PLACEMENT_3D 形式で平面座標系を作成
     ///
     /// # Arguments
@@ -155,10 +147,6 @@ impl<T: Scalar> Plane3D<T> {
         Self::from_origin_and_axes(point, normal, candidate_u)
     }
 
-    // ========================================================================
-    // アクセサメソッド
-    // ========================================================================
-
     /// 平面の原点を取得
     pub fn origin(&self) -> Point3D<T> {
         self.origin
@@ -178,10 +166,6 @@ impl<T: Scalar> Plane3D<T> {
     pub fn point(&self) -> Point3D<T> {
         self.origin
     }
-
-    // ========================================================================
-    // Core Geometric Operations
-    // ========================================================================
 
     /// 点が平面上にあるかチェック
     pub fn contains_point(&self, point: Point3D<T>, tolerance: T) -> bool {
@@ -270,20 +254,12 @@ impl<T: Scalar> Default for Plane3D<T> {
     }
 }
 
-// ============================================================================
-// Constants (注: ジェネリック型では const は制限があるため、メソッドで提供)
-// ============================================================================
-
 impl<T: Scalar> Plane3D<T> {
     /// XY平面（z = 0）の参照
     pub fn xy() -> Self {
         Self::xy_plane(T::ZERO)
     }
 }
-
-// ============================================================================
-// Display Implementation
-// ============================================================================
 
 impl<T: Scalar + std::fmt::Display> std::fmt::Display for Plane3D<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -306,13 +282,7 @@ impl<T: Scalar + std::fmt::Display> std::fmt::Display for Plane3D<T> {
     }
 }
 
-// ============================================================================
-// Core Traits Implementation
-// ============================================================================
-
 impl<T: Scalar> Plane3DConstructor<T> for Plane3D<T> {
-    // ========== Phase 1 実装 ==========
-
     fn from_origin_and_axes(
         origin: (T, T, T),
         normal: (T, T, T),
@@ -335,8 +305,6 @@ impl<T: Scalar> Plane3DConstructor<T> for Plane3D<T> {
         Self::xy_plane(T::ZERO)
     }
 
-    // ========== Phase 2 実装 ==========
-
     fn from_point_and_normal(point: (T, T, T), normal: (T, T, T)) -> Option<Self> {
         let origin = Point3D::new(point.0, point.1, point.2);
         let normal_vec = Vector3D::new(normal.0, normal.1, normal.2);
@@ -353,8 +321,6 @@ impl<T: Scalar> Plane3DConstructor<T> for Plane3D<T> {
 }
 
 impl<T: Scalar> Plane3DProperties<T> for Plane3D<T> {
-    // ========== Phase 1 実装 ==========
-
     fn origin(&self) -> (T, T, T) {
         (self.origin.x(), self.origin.y(), self.origin.z())
     }
@@ -374,8 +340,6 @@ impl<T: Scalar> Plane3DProperties<T> for Plane3D<T> {
     fn dimension(&self) -> u32 {
         2 // 2次元多様体
     }
-
-    // ========== Phase 2 実装 ==========
 
     fn is_xy_plane(&self) -> bool {
         let angle_tolerance = T::ORTHOGONALITY_DOT_ERROR_TOLERANCE;

--- a/model/geo_primitives/src/plane_3d.rs
+++ b/model/geo_primitives/src/plane_3d.rs
@@ -5,8 +5,9 @@
 
 use crate::{Direction3D, Point3D, Vector3D};
 use geo_contracts::{
-    default_distance_tolerance, BasicIntersection, Plane3DConstructor, Plane3DMeasure,
-    Plane3DProperties, Scalar,
+    default_distance_tolerance, BasicIntersection, Plane3DConstructor, Plane3DContainment,
+    Plane3DDerived, Plane3DDistance, Plane3DEvaluation, Plane3DProjection, Plane3DProperties,
+    Plane3DTransform, Scalar,
 };
 
 /// CAD用3次元平面（座標系付き）
@@ -401,9 +402,7 @@ impl<T: Scalar> Plane3DProperties<T> for Plane3D<T> {
     }
 }
 
-impl<T: Scalar + From<f64>> Plane3DMeasure<T> for Plane3D<T> {
-    // ========== Phase 1 実装 ==========
-
+impl<T: Scalar + From<f64>> Plane3DContainment<T> for Plane3D<T> {
     fn contains_point(&self, point: (T, T, T)) -> bool {
         let tolerance = default_distance_tolerance::<T>();
         // distance_to_point の計算を直接展開
@@ -415,7 +414,9 @@ impl<T: Scalar + From<f64>> Plane3DMeasure<T> for Plane3D<T> {
         let distance = relative.dot(&self.normal.as_vector()).abs();
         distance <= tolerance
     }
+}
 
+impl<T: Scalar + From<f64>> Plane3DDistance<T> for Plane3D<T> {
     fn distance_to_point(&self, point: (T, T, T)) -> T {
         let relative = Vector3D::new(
             point.0 - self.origin.x(),
@@ -424,7 +425,9 @@ impl<T: Scalar + From<f64>> Plane3DMeasure<T> for Plane3D<T> {
         );
         relative.dot(&self.normal.as_vector())
     }
+}
 
+impl<T: Scalar + From<f64>> Plane3DProjection<T> for Plane3D<T> {
     fn project_point(&self, point: (T, T, T)) -> (T, T, T) {
         // distance_to_point の計算を直接展開
         let relative = Vector3D::new(
@@ -440,7 +443,9 @@ impl<T: Scalar + From<f64>> Plane3DMeasure<T> for Plane3D<T> {
             point.2 - offset.z(),
         )
     }
+}
 
+impl<T: Scalar + From<f64>> Plane3DDerived<T> for Plane3D<T> {
     fn equation_coefficients(&self) -> (T, T, T, T) {
         let a = self.normal.x();
         let b = self.normal.y();
@@ -448,9 +453,9 @@ impl<T: Scalar + From<f64>> Plane3DMeasure<T> for Plane3D<T> {
         let d = -(a * self.origin.x() + b * self.origin.y() + c * self.origin.z());
         (a, b, c, d)
     }
+}
 
-    // ========== Phase 2 実装 ==========
-
+impl<T: Scalar + From<f64>> Plane3DEvaluation<T> for Plane3D<T> {
     fn point_to_uv(&self, point: (T, T, T)) -> (T, T) {
         let p = Point3D::new(point.0, point.1, point.2);
         let from_origin = Vector3D::from_points(&self.origin, &p);
@@ -464,7 +469,9 @@ impl<T: Scalar + From<f64>> Plane3DMeasure<T> for Plane3D<T> {
         let point = self.origin + offset;
         (point.x(), point.y(), point.z())
     }
+}
 
+impl<T: Scalar + From<f64>> Plane3DTransform<T> for Plane3D<T> {
     fn mirror_point(&self, point: (T, T, T)) -> (T, T, T) {
         // project_point の計算を直接展開
         let relative = Vector3D::new(

--- a/model/geo_primitives/src/ray_2d.rs
+++ b/model/geo_primitives/src/ray_2d.rs
@@ -138,7 +138,6 @@ impl<T: Scalar> Ray2D<T> {
     }
 }
 
-// === Helper methods ===
 impl<T: Scalar> Ray2D<T> {
     /// 境界ボックスを取得（起点のみ）
     pub fn bounding_box(&self) -> geo_core::Aabb2D<T> {
@@ -193,10 +192,6 @@ impl<T: Scalar> Ray2D<T> {
         }
     }
 }
-
-// ============================================================================
-// Core Traits Implementation
-// ============================================================================
 
 /// Ray2DConstructor トレイト実装
 impl<T: Scalar> Ray2DConstructor<T> for Ray2D<T> {
@@ -268,8 +263,6 @@ impl<T: Scalar> Ray2DConstructor<T> for Ray2D<T> {
         Self::along_positive_y((T::ZERO, T::ZERO))
     }
 
-    // ========== Phase 2 実装 ==========
-
     fn from_angle(origin: (T, T), angle: T) -> Self
     where
         Self: Sized,
@@ -324,8 +317,6 @@ impl<T: Scalar> Ray2DProperties<T> for Ray2D<T> {
         // Ray2D::new がSomeを返した時点で有効性は保証されている
         true
     }
-
-    // ========== Phase 2 実装 ==========
 
     fn angle(&self) -> T {
         self.direction.y().atan2(self.direction.x())

--- a/model/geo_primitives/src/ray_2d.rs
+++ b/model/geo_primitives/src/ray_2d.rs
@@ -16,7 +16,8 @@
 use crate::{Direction2D, InfiniteLine2D, Point2D, Vector2D};
 use geo_contracts::{
     AngleBetween, BasicIntersection, DirectionalRelation, ParallelRelation, PointsTowards,
-    Ray2DConstructor, Ray2DMeasure, Ray2DProperties, Scalar,
+    Ray2DConstructor, Ray2DContainment, Ray2DDistance, Ray2DEvaluation, Ray2DProjection,
+    Ray2DProperties, Ray2DTransform, Scalar,
 };
 
 /// 2次元半無限直線
@@ -341,30 +342,10 @@ impl<T: Scalar> Ray2DProperties<T> for Ray2D<T> {
     }
 }
 
-/// Ray2DMeasure トレイト実装
-impl<T: Scalar> Ray2DMeasure<T> for Ray2D<T> {
+impl<T: Scalar> Ray2DEvaluation<T> for Ray2D<T> {
     fn point_at_parameter(&self, t: T) -> (T, T) {
         let point = self.point_at_parameter(t);
         (point.x(), point.y())
-    }
-
-    fn closest_point(&self, point: (T, T)) -> (T, T) {
-        let target_point = Point2D::new(point.0, point.1);
-        let t = self.parameter_for_point(&target_point);
-        let clamped_t = if t < T::ZERO { T::ZERO } else { t };
-        let closest = self.point_at_parameter(clamped_t);
-        (closest.x(), closest.y())
-    }
-
-    fn distance_to_point(&self, point: (T, T)) -> T {
-        let target_point = Point2D::new(point.0, point.1);
-        self.distance_to_point(&target_point)
-    }
-
-    fn contains_point(&self, point: (T, T)) -> bool {
-        let target_point = Point2D::new(point.0, point.1);
-        use geo_contracts::default_distance_tolerance;
-        self.contains_point(&target_point, default_distance_tolerance::<T>())
     }
 
     fn parameter_for_point(&self, point: (T, T)) -> T {
@@ -372,6 +353,38 @@ impl<T: Scalar> Ray2DMeasure<T> for Ray2D<T> {
         self.parameter_for_point(&target_point)
     }
 
+    fn point_at_distance(&self, distance: T) -> (T, T) {
+        let point = self.point_at_parameter(distance);
+        (point.x(), point.y())
+    }
+}
+
+impl<T: Scalar> Ray2DProjection<T> for Ray2D<T> {
+    fn closest_point(&self, point: (T, T)) -> (T, T) {
+        let target_point = Point2D::new(point.0, point.1);
+        let t = self.parameter_for_point(&target_point);
+        let clamped_t = if t < T::ZERO { T::ZERO } else { t };
+        let closest = self.point_at_parameter(clamped_t);
+        (closest.x(), closest.y())
+    }
+}
+
+impl<T: Scalar> Ray2DDistance<T> for Ray2D<T> {
+    fn distance_to_point(&self, point: (T, T)) -> T {
+        let target_point = Point2D::new(point.0, point.1);
+        self.distance_to_point(&target_point)
+    }
+}
+
+impl<T: Scalar> Ray2DContainment<T> for Ray2D<T> {
+    fn contains_point(&self, point: (T, T)) -> bool {
+        let target_point = Point2D::new(point.0, point.1);
+        use geo_contracts::default_distance_tolerance;
+        self.contains_point(&target_point, default_distance_tolerance::<T>())
+    }
+}
+
+impl<T: Scalar> Ray2DTransform<T> for Ray2D<T> {
     fn reverse(&self) -> Self
     where
         Self: Sized,
@@ -392,12 +405,6 @@ impl<T: Scalar> Ray2DMeasure<T> for Ray2D<T> {
             Vector2D::new(self.direction_internal().x(), self.direction_internal().y());
 
         Ray2D::new(new_origin, direction_vec).unwrap()
-    }
-
-    fn point_at_distance(&self, distance: T) -> (T, T) {
-        // 方向ベクトルは正規化済みなので、パラメータ = 距離
-        let point = self.point_at_parameter(distance);
-        (point.x(), point.y())
     }
 
     fn rotate_around_origin(&self, angle: T) -> Self

--- a/model/geo_primitives/src/ray_3d.rs
+++ b/model/geo_primitives/src/ray_3d.rs
@@ -23,15 +23,7 @@ pub struct Ray3D<T: Scalar> {
     pub(crate) direction: Vector3D<T>,
 }
 
-// ============================================================================
-// Core Implementation (必須機能のみ)
-// ============================================================================
-
 impl<T: Scalar> Ray3D<T> {
-    // ========================================================================
-    // Core Construction Methods
-    // ========================================================================
-
     /// 起点と方向ベクトルから Ray3D を作成
     ///
     /// # 引数
@@ -65,10 +57,6 @@ impl<T: Scalar> Ray3D<T> {
         Self::new(start, direction)
     }
 
-    // ========================================================================
-    // Core Accessor Methods
-    // ========================================================================
-
     /// 起点を取得
     pub fn origin(&self) -> Point3D<T> {
         self.origin
@@ -88,10 +76,6 @@ impl<T: Scalar> Ray3D<T> {
     pub fn direction_vector(&self) -> Vector3D<T> {
         self.direction
     }
-
-    // ========================================================================
-    // Core Calculation Methods
-    // ========================================================================
 
     /// パラメータ t での点を計算
     ///
@@ -174,10 +158,6 @@ impl<T: Scalar> Ray3D<T> {
         clamped.acos()
     }
 
-    // ========================================================================
-    // Core Axis-Aligned Ray Constructors
-    // ========================================================================
-
     /// X軸に平行な Ray を作成
     pub fn along_x_axis(origin: Point3D<T>) -> Self {
         Self::new(origin, Vector3D::unit_x()).unwrap()
@@ -193,10 +173,6 @@ impl<T: Scalar> Ray3D<T> {
         Self::new(origin, Vector3D::unit_z()).unwrap()
     }
 }
-
-// ============================================================================
-// Core Traits Implementation
-// ============================================================================
 
 /// Ray3DConstructor トレイト実装
 impl<T: Scalar> Ray3DConstructor<T> for Ray3D<T> {
@@ -290,8 +266,6 @@ impl<T: Scalar> Ray3DConstructor<T> for Ray3D<T> {
         Ray3D::along_z_axis(Point3D::origin())
     }
 
-    // ========== Phase 2 実装 ==========
-
     fn from_spherical(origin: (T, T, T), azimuth: T, elevation: T) -> Self
     where
         Self: Sized,
@@ -363,8 +337,6 @@ impl<T: Scalar> Ray3DProperties<T> for Ray3D<T> {
         // Ray3D::new がSomeを返した時点で有効性は保証されている
         true
     }
-
-    // ========== Phase 2 実装 ==========
 
     fn azimuth(&self) -> T {
         self.direction.y().atan2(self.direction.x())

--- a/model/geo_primitives/src/ray_3d.rs
+++ b/model/geo_primitives/src/ray_3d.rs
@@ -7,7 +7,8 @@
 use crate::{Direction3D, Point3D, Vector3D};
 use geo_contracts::{
     AngleBetween, CrossDistance, DirectionalRelation, ParallelRelation, PointsTowards,
-    Ray3DConstructor, Ray3DMeasure, Ray3DProperties, Scalar,
+    Ray3DConstructor, Ray3DContainment, Ray3DDistance, Ray3DEvaluation, Ray3DProjection,
+    Ray3DProperties, Ray3DTransform, Scalar,
 };
 
 /// 3次元半無限直線
@@ -383,13 +384,24 @@ impl<T: Scalar> Ray3DProperties<T> for Ray3D<T> {
     }
 }
 
-/// Ray3DMeasure トレイト実装
-impl<T: Scalar> Ray3DMeasure<T> for Ray3D<T> {
+impl<T: Scalar> Ray3DEvaluation<T> for Ray3D<T> {
     fn point_at_parameter(&self, t: T) -> (T, T, T) {
         let point = self.point_at_parameter(t);
         (point.x(), point.y(), point.z())
     }
 
+    fn parameter_for_point(&self, point: (T, T, T)) -> T {
+        let target_point = Point3D::new(point.0, point.1, point.2);
+        self.parameter_for_point(&target_point)
+    }
+
+    fn point_at_distance(&self, distance: T) -> (T, T, T) {
+        let point = self.point_at_parameter(distance);
+        (point.x(), point.y(), point.z())
+    }
+}
+
+impl<T: Scalar> Ray3DProjection<T> for Ray3D<T> {
     fn closest_point(&self, point: (T, T, T)) -> (T, T, T) {
         let target_point = Point3D::new(point.0, point.1, point.2);
         let t = self.parameter_for_point(&target_point);
@@ -397,7 +409,9 @@ impl<T: Scalar> Ray3DMeasure<T> for Ray3D<T> {
         let closest = self.point_at_parameter(clamped_t);
         (closest.x(), closest.y(), closest.z())
     }
+}
 
+impl<T: Scalar> Ray3DDistance<T> for Ray3D<T> {
     fn distance_to_point(&self, point: (T, T, T)) -> T {
         let target_point = Point3D::new(point.0, point.1, point.2);
         let to_point = target_point - self.origin;
@@ -415,18 +429,17 @@ impl<T: Scalar> Ray3DMeasure<T> for Ray3D<T> {
             target_point.distance_to(&projection)
         }
     }
+}
 
+impl<T: Scalar> Ray3DContainment<T> for Ray3D<T> {
     fn contains_point(&self, point: (T, T, T)) -> bool {
         let target_point = Point3D::new(point.0, point.1, point.2);
         use geo_contracts::default_distance_tolerance;
         self.contains_point(&target_point, default_distance_tolerance::<T>())
     }
+}
 
-    fn parameter_for_point(&self, point: (T, T, T)) -> T {
-        let target_point = Point3D::new(point.0, point.1, point.2);
-        self.parameter_for_point(&target_point)
-    }
-
+impl<T: Scalar> Ray3DTransform<T> for Ray3D<T> {
     fn reverse(&self) -> Self
     where
         Self: Sized,
@@ -442,12 +455,6 @@ impl<T: Scalar> Ray3DMeasure<T> for Ray3D<T> {
         let new_origin = self.origin + offset_vector;
 
         Ray3D::new(new_origin, self.direction).unwrap()
-    }
-
-    fn point_at_distance(&self, distance: T) -> (T, T, T) {
-        // 方向ベクトルは正規化済みなので、パラメータ = 距離
-        let point = self.point_at_parameter(distance);
-        (point.x(), point.y(), point.z())
     }
 
     fn rotate_around_axis(&self, axis: (T, T, T), angle: T) -> Option<Self>

--- a/model/geo_primitives/src/rectangle_2d.rs
+++ b/model/geo_primitives/src/rectangle_2d.rs
@@ -1,7 +1,9 @@
 //! Rect2D Core 実装
 
 use crate::Point2D;
-use geo_contracts::{Rect2DConstructor, Rect2DMeasure, Rect2DProperties, Scalar};
+use geo_contracts::{
+    Rect2DConstructor, Rect2DContainment, Rect2DDerived, Rect2DProperties, Scalar,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Rect2D<T: Scalar> {
@@ -127,11 +129,13 @@ impl<T: Scalar> Rect2DProperties<T> for Rect2D<T> {
     }
 }
 
-impl<T: Scalar> Rect2DMeasure<T> for Rect2D<T> {
+impl<T: Scalar> Rect2DContainment<T> for Rect2D<T> {
     fn contains_point(&self, point: (T, T)) -> bool {
         Self::contains_point(self, &Point2D::new(point.0, point.1))
     }
+}
 
+impl<T: Scalar> Rect2DDerived<T> for Rect2D<T> {
     fn area(&self) -> T {
         Self::area(self)
     }

--- a/model/geo_primitives/src/rectangle_3d.rs
+++ b/model/geo_primitives/src/rectangle_3d.rs
@@ -1,7 +1,9 @@
 //! Rect3D Core 実装（任意平面）
 
 use crate::{Direction3D, Point3D, Vector3D};
-use geo_contracts::{Rect3DConstructor, Rect3DMeasure, Rect3DProperties, Scalar};
+use geo_contracts::{
+    Rect3DConstructor, Rect3DContainment, Rect3DDerived, Rect3DEvaluation, Rect3DProperties, Scalar,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Rect3D<T: Scalar> {
@@ -194,11 +196,13 @@ impl<T: Scalar> Rect3DProperties<T> for Rect3D<T> {
     }
 }
 
-impl<T: Scalar> Rect3DMeasure<T> for Rect3D<T> {
+impl<T: Scalar> Rect3DContainment<T> for Rect3D<T> {
     fn contains_point(&self, point: (T, T, T), tolerance: T) -> bool {
         Self::contains_point(self, &Point3D::new(point.0, point.1, point.2), tolerance)
     }
+}
 
+impl<T: Scalar> Rect3DDerived<T> for Rect3D<T> {
     fn area(&self) -> T {
         Self::area(self)
     }
@@ -213,12 +217,14 @@ impl<T: Scalar> Rect3DMeasure<T> for Rect3D<T> {
         ]
     }
 
-    fn distance_to_plane(&self, point: (T, T, T)) -> T {
-        Self::distance_to_plane(self, Point3D::new(point.0, point.1, point.2))
-    }
-
     fn is_valid(&self) -> bool {
         self.width >= T::ZERO && self.height >= T::ZERO
+    }
+}
+
+impl<T: Scalar> Rect3DEvaluation<T> for Rect3D<T> {
+    fn distance_to_plane(&self, point: (T, T, T)) -> T {
+        Self::distance_to_plane(self, Point3D::new(point.0, point.1, point.2))
     }
 }
 


### PR DESCRIPTION
## 概要

- Rect と linear shape 群に capability taxonomy を統一適用
- `*Measure` を capability ごとに分割し、旧 `*Measure` は互換集約 trait として維持
- `*Core` を `Constructor + Properties` に縮小
- contracts / primitives / re-export / 設計文書を一貫して更新

## 変更内容

- `Rect2D/3D` を `Containment / Derived / Evaluation` に整理
- `InfiniteLine2D/3D` を `Evaluation / Distance / Containment / Projection / Transform` に整理
- `Ray2D/3D` を `Evaluation / Projection / Distance / Containment / Transform` に整理
- `LineSegment2D/3D` を `Derived / Distance / Containment / Evaluation / Projection` に整理
- `Plane3D` を `Containment / Distance / Projection / Derived / Evaluation / Transform` に整理
- `geo_contracts` の re-export を新 capability trait に追従
- `dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md` に Rect と linear shape への適用方針を反映

## 検証

- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo test --workspace`

Closes #551