### PR TITLE
feat(geo): align LineSegment support-line semantics

### DIFF
--- a/dev/architecture/ARCHITECTURE.md
+++ b/dev/architecture/ARCHITECTURE.md
@@ -71,6 +71,7 @@ foundation/analysis（将来改名候補）
 #### レイヤー設計の重要ポイント
 
 - **`geo_contracts` は境界定義層**: shape definition core / extension / operations の公開面は `geo_contracts` を正本とする
+- **shape 意味論の正本は別文書**: 個別 shape の意味と API 意図は `dev/architecture/GEOMETRY_SHAPE_SEMANTICS_DESIGN.md` を正本とし、`geo_contracts` の責務分離文書とは分けて管理する
 - **`geo_commons` は存続対象**: `analysis` のみに依存する数値カーネル置き場として意図的に維持する。`geo_algorithms` の代替でも、廃止前提の移行対象でもない
 - **`geo_core`は低レイヤー**: `geo_primitives`と`geo_nurbs`より下位に位置
 - **直接アクセス許可**: `geo_core`からのインポート（特にAabb2D/Aabb3D）は許可

--- a/dev/architecture/GEOMETRY_SHAPE_SEMANTICS_DESIGN.md
+++ b/dev/architecture/GEOMETRY_SHAPE_SEMANTICS_DESIGN.md
@@ -1,0 +1,162 @@
+# Geometry Shape Semantics Design
+
+## 目的
+
+本書は、RedRing における **shape の意味論と意図** の正本を定義する。
+
+特に、以下のような問いに対する答えを固定する。
+
+- ある shape は exact primitive か、tolerant な shape か
+- どの値が正本で、どの値が派生か
+- `start` / `end` / `length` / `point_at_parameter` などの API が何を返すか
+
+本書は trait の責務分担や topology 正規形そのものを定義する文書ではない。
+
+## 正本の役割分担
+
+- shape 意味論の正本: 本書
+- trait 境界と capability 分担の正本: `GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md`
+- topology entity layer 設計の正本: `TOPOLOGY_ENTITY_LAYER_DESIGN.md`
+- topology 実装計画の補助説明: `PHASE4_TOPOLOGY_ENTITY_DESIGN.md`
+- #458 時点の topology 正規形凍結スナップショット: `TOPO_NORMAL_FORM_INVARIANTS_FREEZE_458.md`
+
+補足:
+
+- 本書は「shape が何を意味するか」を定義する
+- trait 構成やモジュール配置は、本書で固定した意味論を前提に別文書で扱う
+
+## スコープ
+
+現時点では、`#557` で論点化された `LineSegment2D/3D` の意味論を最初の固定対象として定義する。
+
+ただし本論点は `LineSegment` 固有ではなく、shape 横断で再発しうる意味論項目を先に `LineSegment` で明文化する位置付けとする。
+
+Arc / EllipseArc / Circle / Triangle などを含む shape 横断の `Measure / parameter / endpoint` capability 論点は `#558` で別途整理する。
+
+## 横展開前提の論点
+
+`#557` で固定する内容は、将来的に他 shape へ横展開が必要な論点として扱う。
+
+- exact primitive と tolerant shape の区別
+- どの値を正本とし、どの値を派生として扱うか
+- `start` / `end` 系 API が拘束点を返すのか、ideal endpoint を返すのか
+- `length` / `measure` / parameter range が何を表すのか
+- `point_at_parameter` が support curve 上の評価か、拘束点補間か
+
+したがって `LineSegment` は局所例外ではなく、shape semantics の横断整理を先行して具体化する最初のケースとして扱う。
+
+## LineSegment の意味論
+
+### 基本方針
+
+RedRing における `LineSegment2D/3D` は、単なる exact な有限線分ではなく、**support line を正本とし、拘束点としての始点・終点を併せ持つ tolerant な trimmed line** として扱う。
+
+これにより、以下の意図を表現できる。
+
+- 理想的には一直線上にある線分である
+- ただし始点・終点は拘束や数値誤差の結果として、理想支持線からトレランス以内でずれる可能性がある
+- topology 側では、その拘束点の一致/不一致が接続判定や編集挙動に影響する
+
+### 正本と派生
+
+`LineSegment` では、概念的に次の値を区別する。
+
+- 正本: `support_line`
+- 正本: `start` / `end`（拘束点）
+- 派生: support line 上の理想トリム区間
+- 派生: ideal な端点
+- 派生: support line 上の評価点
+
+重要:
+
+- 具体的な struct フィールド構成は実装都合で調整してよい
+- ただし API と意味論は、上記の区別を壊してはならない
+
+### API 意味の固定
+
+`LineSegment2D/3D` の主要 API は次の意味で扱う。
+
+| API | 意味 |
+| --- | --- |
+| 拘束点としての始点を返す API（現行: `start()` / `start_point()`） | 拘束点としての始点を返す |
+| 拘束点としての終点を返す API（現行: `end()` / `end_point()`） | 拘束点としての終点を返す |
+| `length()` | 拘束点間距離を返す |
+| `point_at_parameter(t)` | support line 上の評価点を返す |
+| `measure()` | 主語彙にしない。互換の委譲としてのみ扱う |
+
+補足:
+
+- `start/end` と `point_at_parameter(0/1)` は一致を前提としない
+- `length()` は support line 上の ideal length を意味しない
+
+### 補助 API の扱い
+
+以下の補助 API は、意味の明確化に有効であれば導入を許容する。
+
+- `support_line()`
+- `ideal_start()` / `ideal_end()`
+- `ideal_length()`
+- support line 評価と拘束点補間を分ける追加 API
+
+補助 API を導入する場合は、拘束点系と ideal 系を名称で明確に分離する。
+
+## geo_primitives と geo_topology の境界
+
+`geo_primitives::LineSegment2D/3D` は shape 意味論を持つ。
+
+一方、`geo_topology` は以下を追加で管理する。
+
+- vertex binding
+- same_sense
+- parameter range
+- edge / wire / face 文脈での接続関係
+
+したがって、topology は `LineSegment` の意味論を再定義しない。
+topology 側の Edge 正規形は、shape 意味論を前提に、接続・向き・トリムを管理する層として扱う。
+
+## `#557` における topology 未修正の暫定許容範囲
+
+`#557` では、LineSegment の shape semantics を先に固定する。
+
+その際、topology 側は未修正のまま次の範囲までを暫定的に許容する。
+
+- `CurveRef::Line::point_at_parameter` が support line 上の評価を返すこと
+- `Edge` が `curve + parameter range + same_sense + vertex binding` を保持する現行構造を維持すること
+- `Wire` / `CompositeCurve` が拘束点ベースの端点参照を使うこと
+
+一方、次の項目は `#557` の完了条件には含めず、別途 topology 側で設計確定が必要とする。
+
+- `Edge::is_vertex_binding_consistent` のように、母曲線評価端点と vertex の一致を前提にする不変条件の最終定義
+- 拘束点と ideal endpoint のずれを topology がどう許容するかという binding ルール
+- 位相専用 tolerance の正本化と運用方針
+
+したがって `#557` の段階では、「topology の現行構造を直ちに変更しないこと」は許容されるが、「現行 topology 不変条件が最終設計である」とはみなさない。
+
+## 非目標
+
+本書は以下を直接の対象としない。
+
+- `Measure` の shape 横断 taxonomy の最終確定
+- Arc / EllipseArc / Circle / Triangle など各 shape の個別 semantics 確定
+- topology 正規形の完全仕様
+- tolerance 値そのものの単一正本化
+
+## #557 での利用
+
+`#557` では、本書を前提に以下を整理する。
+
+- `LineSegment` の API を tolerant trimmed line semantics に沿って明文化する
+- `length` と `measure` の役割分担を整理する
+- 利用側が exact finite segment と誤解しないよう contracts / primitives / topology 周辺を調整する
+
+## 今後の拡張
+
+本書は将来的に、`#557` で固定した論点を横展開し、次の shape semantics を追加できる形で維持する。
+
+- Arc
+- EllipseArc
+- Circle
+- Triangle
+- NURBS curve / surface
+
+ただしその追加は、shape 横断 capability 整理を扱う `#558` の方針確定後に行う。

--- a/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
+++ b/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
@@ -10,6 +10,12 @@ Issue #535 では、`geo_contracts` の trait構造を次の最小構造へ再�
 
 本書は、その前提として現行 trait を棚卸しし、一次分類と曖昧境界の個別判定を明文化する。
 
+補足:
+
+- 本書は shape の意味論そのものの正本ではない
+- 個別 shape の意味と API 意図は `GEOMETRY_SHAPE_SEMANTICS_DESIGN.md` を正本とする
+- 本書はその意味論を前提に、trait の責務分担と配置境界を定義する
+
 ## 現行構造の棚卸し
 
 ### `geometry/core`

--- a/dev/architecture/PHASE4_TOPOLOGY_ENTITY_DESIGN.md
+++ b/dev/architecture/PHASE4_TOPOLOGY_ENTITY_DESIGN.md
@@ -16,15 +16,16 @@
 5. [ロードマップ統合](#ロードマップ統合)
 
 関連設計ドキュメント:
-- topo正規形不変条件凍結（#458）: `dev/architecture/TOPO_NORMAL_FORM_INVARIANTS_FREEZE_458.md`
 
-> 本ドキュメントは #458 の凍結内容を参照する実装設計書であり、
-> topo正規形の定義そのものは `TOPO_NORMAL_FORM_INVARIANTS_FREEZE_458.md` を正本とする。
+- topology entity layer 設計正本: `dev/architecture/TOPOLOGY_ENTITY_LAYER_DESIGN.md`
+- topo正規形不変条件凍結（#458 時点のスナップショット）: `dev/architecture/TOPO_NORMAL_FORM_INVARIANTS_FREEZE_458.md`
 
+> 本ドキュメントは topology entity layer の実装計画・補助設計書であり、
+> topology 設計の正本は `TOPOLOGY_ENTITY_LAYER_DESIGN.md` を参照する。
+> `TOPO_NORMAL_FORM_INVARIANTS_FREEZE_458.md` は #458 時点の簡易実装前提でまとめた凍結スナップショットであり、
+> 現行 topology 設計の単独正本とはみなさない。
 > 2026年3月28日更新: #458 向けに「正規形不変条件 凍結候補 v0.1」を作成
-
 > 2026年3月28日更新: #407 向けに「モデリング用正規形」と「表示用トリム表現」の境界を明文化
-
 > **2026年3月追記**: PCurve・トリム表現・δ/2 トレランスモデルの設計方針を Phase 4.4 として追加
 
 ---
@@ -47,7 +48,7 @@ Phase 3（交差判定・衝突判定）の次に実装すべきコア機能と�
 
 現在の `geo_primitives` は**幾何情報のみ**を扱います：
 - Circle3D は「数学的な円」
-- LineSegment3D は「数学的な線分」
+- LineSegment3D は線形 shape 実装であり、意味論の正本は `GEOMETRY_SHAPE_SEMANTICS_DESIGN.md` を参照する
 
 しかし、実際のCADシステムでは：
 - 「この円弧は、この平面の境界の一部」
@@ -1044,6 +1045,8 @@ Face
 - PCurve は Face 側の境界表現であり、Edge の正規形そのものではない。
 - `TrimmedCurve<T>` / `TrimmedSurface<T>` は表示・交換・評価補助の派生表現であり、トポロジー比較の正本として扱わない。
 - 交差演算や編集演算で必要な場合は、まず母曲線/母曲面と parameter range に正規化してから処理する。
+- `LineSegment` の `support_line` / 拘束点 / `length()` / `point_at_parameter()` の意味論は、本書ではなく `GEOMETRY_SHAPE_SEMANTICS_DESIGN.md` を正本とする。
+- `#557` の段階では topology 現行構造の暫定維持を許容するが、vertex binding invariant と位相専用 tolerance は未確定論点として別管理する。
 
 #### 4.2 PCurve の定義
 

--- a/dev/architecture/TOPOLOGY_ENTITY_LAYER_DESIGN.md
+++ b/dev/architecture/TOPOLOGY_ENTITY_LAYER_DESIGN.md
@@ -1,0 +1,143 @@
+# Topology Entity Layer Design
+
+## 目的
+
+本書は、RedRing における topology entity layer の設計正本を定義する。
+
+特に、以下を固定する。
+
+- `geo_topology` が何を正本として保持するか
+- `curve + parameter range + same_sense + vertex binding` の責務境界
+- shape 意味論と topology 不変条件の接続方法
+- vertex binding と位相専用 tolerance をどこで扱うか
+
+本書は、個別 shape の意味論や実装計画そのものを定義する文書ではない。
+
+## 正本の役割分担
+
+- shape 意味論の正本: `GEOMETRY_SHAPE_SEMANTICS_DESIGN.md`
+- topology entity layer 設計の正本: 本書
+- trait 境界と capability 分担の正本: `GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md`
+- Phase 4 実装計画の補助説明: `PHASE4_TOPOLOGY_ENTITY_DESIGN.md`
+- #458 時点の凍結スナップショット: `TOPO_NORMAL_FORM_INVARIANTS_FREEZE_458.md`
+
+補足:
+
+- `TOPO_NORMAL_FORM_INVARIANTS_FREEZE_458.md` は、#458 時点の簡易実装前提でまとめた凍結文書であり、現行 topology 設計の単独正本とはみなさない
+- topology の現行設計判断は、本書を起点に管理する
+
+## スコープ
+
+本書は、少なくとも次を対象とする。
+
+- `Vertex`
+- `CurveRef`
+- `Edge`
+- `Wire`
+- `CompositeCurve`
+- vertex binding invariant
+- topology 専用 tolerance の責務境界
+
+Face / Shell / Solid / PCurve の詳細仕様は、必要に応じて本書から派生文書へ分離してよい。
+
+## topology entity layer の基本方針
+
+### 1. topology は shape 意味論を再定義しない
+
+`geo_primitives` の shape は、それぞれの意味論を自分で持つ。
+
+topology はそれを前提に、接続・向き・トリム・共有関係を管理する層として扱う。
+
+したがって `LineSegment` の `support_line` / 拘束点 / `length()` / `point_at_parameter()` の意味は、topology 側で独自に上書きしない。
+
+### 2. Edge の正本は母曲線参照と位相情報の組である
+
+`Edge` は少なくとも次を保持する。
+
+- `curve`
+- `parameter_range`
+- `same_sense`
+- `start_vertex`
+- `end_vertex`
+
+このとき、母曲線の幾何と位相上の走査向きは分離して扱う。
+
+### 3. 向き反転は `same_sense` で表現する
+
+母曲線自体を破壊的に反転せず、位相上の走査方向は `same_sense` で管理する。
+
+### 4. vertex binding は母曲線評価そのものと同一視しない
+
+topology で保持する vertex は、shape の拘束点と接続して扱う。
+
+したがって、vertex binding invariant は「母曲線評価端点と vertex が常に一致すること」ではなく、shape 意味論を前提にした binding ルールとして定義し直す。
+
+## LineSegment と topology の接続
+
+`#557` で固定した `LineSegment` semantics を前提に、topology では次を採用する。
+
+- `CurveRef::Line::point_at_parameter` は support line 上の評価として扱う
+- `CurveRef::Line::start_point` / `end_point` は拘束点参照として扱う
+- `Edge` の `parameter_range` は support line / 母曲線上の有効区間を表す
+- `start_vertex` / `end_vertex` は拘束点との binding を表す
+
+このため、support line 上の ideal endpoint と vertex が一致しない場合を許容できる topology invariant が必要になる。
+
+## vertex binding invariant の現行判断
+
+現時点では、次を固定する。
+
+- vertex binding は topology の責務である
+- binding 判定は shape 意味論を前提に行う
+- 母曲線評価端点と vertex の完全一致を前提にしない
+- binding の許容条件には topology 専用 tolerance を用いる
+
+未確定項目:
+
+- binding 判定を拘束点ベースで固定するか、ideal endpoint との二重検証にするか
+- `Edge::is_vertex_binding_consistent` 相当 API の最終仕様
+- topology 専用 tolerance の正本配置
+
+## topology 専用 tolerance の方針
+
+幾何判定全体のトレランス正本は別途 `ToleranceSettings` 系で管理するとしても、topology には少なくとも次の用途がある。
+
+- vertex coincidence
+- edge continuity
+- binding consistency
+- closed loop / closed shell 判定
+
+このため、topology は幾何一般の tolerance をそのまま流用するだけではなく、位相判定に必要な tolerance の責務境界を持つ。
+
+ただし、値の最終配置と API は別 Issue で確定する。
+
+## `#557` 時点の暫定許容範囲
+
+`#557` の段階では、topology の現行構造を直ちに変更しないことを許容する。
+
+許容する範囲:
+
+- `CurveRef`
+- `Edge` の基本保持フィールド
+- `Wire` / `CompositeCurve` の拘束点ベース利用
+
+未確定として残す範囲:
+
+- vertex binding invariant
+- topology 専用 tolerance
+- ideal endpoint と拘束点のずれを含む binding ルール
+
+## 非目標
+
+本書は以下を直接対象としない。
+
+- shape 個別意味論の定義
+- `geo_primitives` の API 詳細
+- full B-Rep 実装計画
+- ロードマップや週次計画
+
+## 利用ルール
+
+- topology 設計判断を追加する場合は、まず本書の責務境界に反しないか確認する
+- 実装計画や過去凍結内容は本書を上書きしない
+- `PHASE4_TOPOLOGY_ENTITY_DESIGN.md` と `TOPO_NORMAL_FORM_INVARIANTS_FREEZE_458.md` は、必要なら本書への参照を追加して利用する

--- a/dev/architecture/TOPO_NORMAL_FORM_INVARIANTS_FREEZE_458.md
+++ b/dev/architecture/TOPO_NORMAL_FORM_INVARIANTS_FREEZE_458.md
@@ -1,4 +1,4 @@
-# topo正規形不変条件 凍結ドキュメント（Issue #458）
+# topo正規形不変条件 凍結スナップショット（Issue #458）
 
 作成日: 2026-03-28
 対象Issue: #458
@@ -7,12 +7,14 @@
 
 ## 目的
 
-Issue #406 の完了条件「正規形不変条件の合意」を、#338 再開前提として参照可能な形で明文化・凍結する。
+Issue #406 の完了条件「正規形不変条件の合意」を、#338 再開前提として参照可能な形で明文化し、#458 時点の判断として凍結する。
 
 ## ドキュメント状態
 
 - 状態: レビュー提出版（凍結候補 v0.1）
 - 本版の目的: #338 再開前に「正規形の判定軸」を固定する
+- 現在の位置付け: #458 時点の簡易実装前提スナップショット
+- 現行 topology 設計の正本: `TOPOLOGY_ENTITY_LAYER_DESIGN.md`
 
 ## 完了条件チェック
 
@@ -26,11 +28,17 @@ Issue #406 の完了条件「正規形不変条件の合意」を、#338 再開�
 - 交差結果との整合ルール（IntersectionTopology / IntersectionGeometry）
 - 設計レビューで判断可能なDoDの明文化
 
+補足:
+
+- 本書は #458 時点の凍結内容を保存するための文書である
+- LineSegment semantics 更新後の topology binding invariant や位相専用 tolerance の最終設計は本書では扱わない
+
 ## 非スコープ
 
 - コード実装
 - 既存APIの挙動変更
 - full B-Rep 実装詳細
+- 現行 topology entity layer の正本管理
 
 ## 用語定義（凍結）
 
@@ -86,7 +94,7 @@ Issue #406 の完了条件「正規形不変条件の合意」を、#338 再開�
 ## 境界ケース規約表（凍結候補 v0.1）
 
 | ケース | Topology | Geometry | 最低保証 | 備考 |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | 非交差 | Disjoint | None | 結果空であること | 早期終了可 |
 | 点接触 | Touching | Point / Points | 0次元で表現可能 | 接線判定を併記 |
 | 点交差 | Crossing | Point / Points | 交点集合が得られること | 線×線/線×面で発生 |
@@ -96,7 +104,7 @@ Issue #406 の完了条件「正規形不変条件の合意」を、#338 再開�
 ## 組み合わせ別返却規約（#405 整合）
 
 | 組み合わせ | 非交差 | 点接触/点交差 | 線/曲線交差 | 一致 |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | 線×線 | None+Disjoint | Point+Crossing | InfiniteLine+Coincident | - |
 | 線×面 | None+Disjoint | Point+Crossing | Segment+Coincident | - |
 | 面×面 | None+Disjoint | Point+Touching | InfiniteLine/CompositeCurve+Crossing | Coincident |

--- a/model/geo_contracts/src/geometry/core/linesegment_traits.rs
+++ b/model/geo_contracts/src/geometry/core/linesegment_traits.rs
@@ -77,16 +77,16 @@ pub trait LineSegment3DConstructor<T: Scalar> {
 
 /// LineSegment2D基本プロパティ取得トレイト
 pub trait LineSegment2DProperties<T: Scalar> {
-    /// 開始点を取得
+    /// 拘束点としての開始点を取得
     fn start(&self) -> (T, T);
 
-    /// 終了点を取得
+    /// 拘束点としての終了点を取得
     fn end(&self) -> (T, T);
 
     /// 中点を取得
     fn midpoint(&self) -> (T, T);
 
-    /// 線分の長さを取得
+    /// 拘束点間距離としての長さを取得
     fn length(&self) -> T;
 
     /// 形状の次元数（2）
@@ -104,16 +104,16 @@ pub trait LineSegment2DProperties<T: Scalar> {
 
 /// LineSegment3D基本プロパティ取得トレイト
 pub trait LineSegment3DProperties<T: Scalar> {
-    /// 開始点を取得
+    /// 拘束点としての開始点を取得
     fn start(&self) -> (T, T, T);
 
-    /// 終了点を取得
+    /// 拘束点としての終了点を取得
     fn end(&self) -> (T, T, T);
 
     /// 中点を取得
     fn midpoint(&self) -> (T, T, T);
 
-    /// 線分の長さを取得
+    /// 拘束点間距離としての長さを取得
     fn length(&self) -> T;
 
     /// 形状の次元数（3）
@@ -152,7 +152,7 @@ pub trait LineSegment2DMeasure<T: Scalar>:
         <Self as LineSegment2DContainment<T>>::contains_point(self, point)
     }
 
-    /// パラメータt（0<=t<=1）での点を取得
+    /// 正規化パラメータt（0<=t<=1）で support line 上の評価点を取得
     fn point_at_parameter(&self, t: T) -> (T, T) {
         <Self as LineSegment2DEvaluation<T>>::point_at_parameter(self, t)
     }
@@ -174,7 +174,7 @@ pub trait LineSegment2DMeasure<T: Scalar>:
 }
 
 pub trait LineSegment2DDerived<T: Scalar> {
-    /// 線分の長さ（測度）
+    /// 互換目的の測度。意味は拘束点間距離とする
     fn measure(&self) -> T;
 
     /// 方向ベクトルを取得
@@ -195,7 +195,7 @@ pub trait LineSegment2DContainment<T: Scalar> {
 }
 
 pub trait LineSegment2DEvaluation<T: Scalar> {
-    /// パラメータt（0<=t<=1）での点を取得
+    /// 正規化パラメータt（0<=t<=1）で support line 上の評価点を取得
     fn point_at_parameter(&self, t: T) -> (T, T);
 }
 
@@ -236,7 +236,7 @@ pub trait LineSegment3DMeasure<T: Scalar>:
         <Self as LineSegment3DContainment<T>>::contains_point(self, point)
     }
 
-    /// パラメータt（0<=t<=1）での点を取得
+    /// 正規化パラメータt（0<=t<=1）で support line 上の評価点を取得
     fn point_at_parameter(&self, t: T) -> (T, T, T) {
         <Self as LineSegment3DEvaluation<T>>::point_at_parameter(self, t)
     }
@@ -258,7 +258,7 @@ pub trait LineSegment3DMeasure<T: Scalar>:
 }
 
 pub trait LineSegment3DDerived<T: Scalar> {
-    /// 線分の長さ（測度）
+    /// 互換目的の測度。意味は拘束点間距離とする
     fn measure(&self) -> T;
 
     /// 方向ベクトルを取得
@@ -279,7 +279,7 @@ pub trait LineSegment3DContainment<T: Scalar> {
 }
 
 pub trait LineSegment3DEvaluation<T: Scalar> {
-    /// パラメータt（0<=t<=1）での点を取得
+    /// 正規化パラメータt（0<=t<=1）で support line 上の評価点を取得
     fn point_at_parameter(&self, t: T) -> (T, T, T);
 }
 

--- a/model/geo_primitives/src/line_segment_2d.rs
+++ b/model/geo_primitives/src/line_segment_2d.rs
@@ -10,15 +10,16 @@ use geo_contracts::{
     LineSegment2DProperties, Scalar,
 };
 
-/// 2次元平面の線分
+/// 2次元平面の線分。
 ///
-/// 始点と終点を持つ有限の線分
-/// 内部的に InfiniteLine2D とパラメータ範囲を使用
+/// support line と拘束点を併せ持つ有限線形 shape を表す。
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LineSegment2D<T: Scalar> {
-    pub(crate) line: InfiniteLine2D<T>, // 基盤となる無限直線
-    pub(crate) start_param: T,          // 始点のパラメータ
-    pub(crate) end_param: T,            // 終点のパラメータ
+    pub(crate) line: InfiniteLine2D<T>,
+    pub(crate) start_param: T,
+    pub(crate) end_param: T,
+    pub(crate) start_point: Point2D<T>,
+    pub(crate) end_point: Point2D<T>,
 }
 
 impl<T: Scalar> LineSegment2D<T> {
@@ -26,10 +27,28 @@ impl<T: Scalar> LineSegment2D<T> {
     pub fn new(start: Point2D<T>, end: Point2D<T>) -> Option<Self> {
         let line = InfiniteLine2D::from_two_points(start, end)?;
 
+        Self::from_support_line_and_constraint_points(line, start, end)
+    }
+
+    /// support line と拘束点から線分を作成
+    pub fn from_support_line_and_constraint_points(
+        line: InfiniteLine2D<T>,
+        start_point: Point2D<T>,
+        end_point: Point2D<T>,
+    ) -> Option<Self> {
+        let start_param = line.parameter_for_point(&start_point);
+        let end_param = line.parameter_for_point(&end_point);
+
+        if (end_param - start_param).abs() <= T::EPSILON {
+            return None;
+        }
+
         Some(Self {
             line,
-            start_param: T::ZERO,
-            end_param: start.distance_to(&end),
+            start_param,
+            end_param,
+            start_point,
+            end_point,
         })
     }
 
@@ -44,33 +63,55 @@ impl<T: Scalar> LineSegment2D<T> {
         }
 
         let line = InfiniteLine2D::new(start, direction)?;
+        let end = line.point_at_parameter(length);
 
-        Some(Self {
-            line,
-            start_param: T::ZERO,
-            end_param: length,
-        })
+        Self::from_support_line_and_constraint_points(line, start, end)
+    }
+
+    fn ordered_params(&self) -> (T, T) {
+        if self.start_param <= self.end_param {
+            (self.start_param, self.end_param)
+        } else {
+            (self.end_param, self.start_param)
+        }
+    }
+
+    /// support line 上の理想始点を取得
+    pub fn ideal_start(&self) -> Point2D<T> {
+        self.line.point_at_parameter(self.start_param)
+    }
+
+    /// support line 上の理想終点を取得
+    pub fn ideal_end(&self) -> Point2D<T> {
+        self.line.point_at_parameter(self.end_param)
+    }
+
+    /// support line 上の理想長を取得
+    pub fn ideal_length(&self) -> T {
+        (self.end_param - self.start_param).abs()
     }
 
     /// 始点を取得
     pub fn start_point(&self) -> Point2D<T> {
-        self.line.point_at_parameter(self.start_param)
+        self.start_point
     }
 
     /// 終点を取得
     pub fn end_point(&self) -> Point2D<T> {
-        self.line.point_at_parameter(self.end_param)
+        self.end_point
     }
 
     /// 中点を取得
     pub fn midpoint(&self) -> Point2D<T> {
-        let mid_param = (self.start_param + self.end_param) / (T::ONE + T::ONE);
-        self.line.point_at_parameter(mid_param)
+        let two = T::from_f64(2.0);
+        let start = self.start_point();
+        let end = self.end_point();
+        Point2D::new((start.x() + end.x()) / two, (start.y() + end.y()) / two)
     }
 
     /// 線分の長さを取得
     pub fn length(&self) -> T {
-        (self.end_param - self.start_param).abs()
+        self.start_point.distance_to(&self.end_point)
     }
 
     /// 方向ベクトルを取得（正規化済み）
@@ -92,11 +133,10 @@ impl<T: Scalar> LineSegment2D<T> {
     /// 正規化されたパラメータ（0〜1）での点を取得
     pub fn point_at_normalized_parameter(&self, t: T) -> Point2D<T> {
         if t < T::ZERO || t > T::ONE {
-            // パラメータが範囲外の場合は最も近い端点を返す
             if t < T::ZERO {
-                return self.start_point();
+                return self.ideal_start();
             } else {
-                return self.end_point();
+                return self.ideal_end();
             }
         }
 
@@ -123,20 +163,20 @@ impl<T: Scalar> LineSegment2D<T> {
             return false;
         }
 
-        // パラメータが線分の範囲内にあるかチェック
         let param = self.line.parameter_for_point(point);
-        param >= self.start_param - tolerance && param <= self.end_param + tolerance
+        let (min_param, max_param) = self.ordered_params();
+        param >= min_param - tolerance && param <= max_param + tolerance
     }
 
     /// 点を線分に投影（線分内に制限）
     pub fn project_point_to_segment(&self, point: &Point2D<T>) -> Point2D<T> {
         let projected_param = self.line.parameter_for_point(point);
+        let (min_param, max_param) = self.ordered_params();
 
-        // パラメータを線分の範囲内に制限
-        let clamped_param = if projected_param < self.start_param {
-            self.start_param
-        } else if projected_param > self.end_param {
-            self.end_param
+        let clamped_param = if projected_param < min_param {
+            min_param
+        } else if projected_param > max_param {
+            max_param
         } else {
             projected_param
         };
@@ -166,6 +206,11 @@ impl<T: Scalar> LineSegment2D<T> {
         &self.line
     }
 
+    /// 基盤となる support line を取得
+    pub fn support_line(&self) -> &InfiniteLine2D<T> {
+        &self.line
+    }
+
     /// 開始パラメータを取得（Extension用）
     pub fn start_parameter(&self) -> T {
         self.start_param
@@ -184,6 +229,8 @@ impl<T: Scalar> LineSegment2D<T> {
             line: self.line,
             start_param: self.end_param,
             end_param: self.start_param,
+            start_point: self.end_point,
+            end_point: self.start_point,
         }
     }
 
@@ -243,7 +290,6 @@ impl<T: Scalar> LineSegment2DConstructor<T> for LineSegment2D<T> {
         Self::new(start, end).unwrap()
     }
 
-    // Phase 2: 追加コンストラクタ
     fn from_midpoint_length_horizontal(midpoint: (T, T), length: T) -> Option<Self> {
         if length <= T::ZERO {
             return None;
@@ -273,23 +319,22 @@ impl<T: Scalar> LineSegment2DConstructor<T> for LineSegment2D<T> {
 
 impl<T: Scalar> LineSegment2DProperties<T> for LineSegment2D<T> {
     fn start(&self) -> (T, T) {
-        let p = self.line.point_at_parameter(self.start_param);
+        let p = self.start_point();
         (p.x(), p.y())
     }
 
     fn end(&self) -> (T, T) {
-        let p = self.line.point_at_parameter(self.end_param);
+        let p = self.end_point();
         (p.x(), p.y())
     }
 
     fn midpoint(&self) -> (T, T) {
-        let mid_param = (self.start_param + self.end_param) / (T::ONE + T::ONE);
-        let p = self.line.point_at_parameter(mid_param);
+        let p = self.midpoint();
         (p.x(), p.y())
     }
 
     fn length(&self) -> T {
-        (self.end_param - self.start_param).abs()
+        self.length()
     }
 
     fn dimension(&self) -> u32 {
@@ -298,7 +343,7 @@ impl<T: Scalar> LineSegment2DProperties<T> for LineSegment2D<T> {
 
     // Phase 2: 追加プロパティ
     fn is_unit_length(&self) -> bool {
-        let length = (self.end_param - self.start_param).abs();
+        let length = self.length();
         (length - T::ONE).abs() <= T::EPSILON
     }
 
@@ -317,7 +362,7 @@ impl<T: Scalar> LineSegment2DProperties<T> for LineSegment2D<T> {
 
 impl<T: Scalar> LineSegment2DDerived<T> for LineSegment2D<T> {
     fn measure(&self) -> T {
-        (self.end_param - self.start_param).abs()
+        self.length()
     }
 
     fn direction_vector(&self) -> (T, T) {
@@ -371,5 +416,31 @@ impl<T: Scalar> LineSegment2DProjection<T> for LineSegment2D<T> {
 impl<T: Scalar> CrossDistance<T, Self> for LineSegment2D<T> {
     fn distance_to(&self, other: &Self) -> T {
         LineSegment2D::distance_to_segment(self, other)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn support_line_and_constraint_points_are_distinct() {
+        let line = InfiniteLine2D::new(Point2D::origin(), Vector2D::new(1.0_f64, 0.0)).unwrap();
+        let start = Point2D::new(0.0, 1.0);
+        let end = Point2D::new(2.0, 1.0);
+
+        let segment =
+            LineSegment2D::from_support_line_and_constraint_points(line, start, end).unwrap();
+
+        assert_eq!(segment.start_point(), start);
+        assert_eq!(segment.end_point(), end);
+        assert_eq!(segment.ideal_start(), Point2D::new(0.0, 0.0));
+        assert_eq!(segment.ideal_end(), Point2D::new(2.0, 0.0));
+        assert_eq!(
+            segment.point_at_normalized_parameter(0.5),
+            Point2D::new(1.0, 0.0)
+        );
+        assert_eq!(segment.length(), 2.0);
+        assert_eq!(segment.ideal_length(), 2.0);
     }
 }

--- a/model/geo_primitives/src/line_segment_2d_foundation.rs
+++ b/model/geo_primitives/src/line_segment_2d_foundation.rs
@@ -15,6 +15,6 @@ impl<T: Scalar> PrimitiveMetadata for LineSegment2D<T> {
 impl<T: Scalar> MeasureFoundation<T> for LineSegment2D<T> {
     fn measure(&self) -> Option<T> {
         // 線分の長さを測度として返す
-        Some((self.end_param - self.start_param).abs())
+        Some(self.length())
     }
 }

--- a/model/geo_primitives/src/line_segment_2d_transform.rs
+++ b/model/geo_primitives/src/line_segment_2d_transform.rs
@@ -29,8 +29,27 @@ pub mod analysis_transform {
         let transformed_end_vec = matrix.transform_point_2d(&end_vec);
         let new_end: Point2D<T> = transformed_end_vec.into();
 
+        let ideal_start_vec: Vector2<T> = line_segment.ideal_start().into();
+        let transformed_ideal_start_vec = matrix.transform_point_2d(&ideal_start_vec);
+        let transformed_ideal_start: Point2D<T> = transformed_ideal_start_vec.into();
+
+        let ideal_end_vec: Vector2<T> = line_segment.ideal_end().into();
+        let transformed_ideal_end_vec = matrix.transform_point_2d(&ideal_end_vec);
+        let transformed_ideal_end: Point2D<T> = transformed_ideal_end_vec.into();
+
+        let support_line = crate::InfiniteLine2D::from_two_points(
+            transformed_ideal_start,
+            transformed_ideal_end,
+        )
+        .ok_or_else(|| {
+            TransformError::InvalidGeometry(
+                "Transformed support line has coincident ideal points".to_string(),
+            )
+        })?;
+
         // 変換後の線分を構築
-        LineSegment2D::new(new_start, new_end).ok_or_else(|| {
+        LineSegment2D::from_support_line_and_constraint_points(support_line, new_start, new_end)
+            .ok_or_else(|| {
             TransformError::InvalidGeometry(
                 "Transformed line segment has coincident points".to_string(),
             )

--- a/model/geo_primitives/src/line_segment_3d.rs
+++ b/model/geo_primitives/src/line_segment_3d.rs
@@ -10,15 +10,16 @@ use geo_contracts::{
     LineSegment3DProperties, Scalar,
 };
 
-/// 3次元空間の線分
+/// 3次元空間の線分。
 ///
-/// 始点と終点を持つ有限の線分
-/// 内部的に InfiniteLine3D とパラメータ範囲を使用
+/// support line と拘束点を併せ持つ有限線形 shape を表す。
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LineSegment3D<T: Scalar> {
-    pub(crate) line: InfiniteLine3D<T>, // 基盤となる無限直線
-    pub(crate) start_param: T,          // 始点のパラメータ
-    pub(crate) end_param: T,            // 終点のパラメータ
+    pub(crate) line: InfiniteLine3D<T>,
+    pub(crate) start_param: T,
+    pub(crate) end_param: T,
+    pub(crate) start_point: Point3D<T>,
+    pub(crate) end_point: Point3D<T>,
 }
 
 impl<T: Scalar> LineSegment3D<T> {
@@ -26,10 +27,28 @@ impl<T: Scalar> LineSegment3D<T> {
     pub fn new(start: Point3D<T>, end: Point3D<T>) -> Option<Self> {
         let line = InfiniteLine3D::from_two_points(start, end)?;
 
+        Self::from_support_line_and_constraint_points(line, start, end)
+    }
+
+    /// support line と拘束点から線分を作成
+    pub fn from_support_line_and_constraint_points(
+        line: InfiniteLine3D<T>,
+        start_point: Point3D<T>,
+        end_point: Point3D<T>,
+    ) -> Option<Self> {
+        let start_param = line.parameter_for_point(&start_point);
+        let end_param = line.parameter_for_point(&end_point);
+
+        if (end_param - start_param).abs() <= T::EPSILON {
+            return None;
+        }
+
         Some(Self {
             line,
-            start_param: T::ZERO,
-            end_param: start.distance_to(&end),
+            start_param,
+            end_param,
+            start_point,
+            end_point,
         })
     }
 
@@ -44,42 +63,77 @@ impl<T: Scalar> LineSegment3D<T> {
         }
 
         let line = InfiniteLine3D::new(start, direction)?;
+        let end = line.point_at_parameter(length);
 
-        Some(Self {
-            line,
-            start_param: T::ZERO,
-            end_param: length,
-        })
+        Self::from_support_line_and_constraint_points(line, start, end)
+    }
+
+    fn ordered_params(&self) -> (T, T) {
+        if self.start_param <= self.end_param {
+            (self.start_param, self.end_param)
+        } else {
+            (self.end_param, self.start_param)
+        }
+    }
+
+    /// support line 上の理想始点を取得
+    pub fn ideal_start(&self) -> Point3D<T> {
+        self.line.point_at_parameter(self.start_param)
+    }
+
+    /// support line 上の理想終点を取得
+    pub fn ideal_end(&self) -> Point3D<T> {
+        self.line.point_at_parameter(self.end_param)
+    }
+
+    /// support line 上の理想長を取得
+    pub fn ideal_length(&self) -> T {
+        (self.end_param - self.start_param).abs()
     }
 
     /// 始点を取得
     pub fn start(&self) -> Point3D<T> {
-        self.line.point_at_parameter(self.start_param)
+        self.start_point
     }
 
     /// 終点を取得
     pub fn end(&self) -> Point3D<T> {
-        self.line.point_at_parameter(self.end_param)
+        self.end_point
     }
 
     /// 中点を取得
     pub fn midpoint(&self) -> Point3D<T> {
-        let mid_param = (self.start_param + self.end_param) / (T::ONE + T::ONE);
-        self.line.point_at_parameter(mid_param)
+        let two = T::from_f64(2.0);
+        let start = self.start();
+        let end = self.end();
+        Point3D::new(
+            (start.x() + end.x()) / two,
+            (start.y() + end.y()) / two,
+            (start.z() + end.z()) / two,
+        )
     }
 
     /// 線分の長さを取得
     pub fn length(&self) -> T {
-        self.end_param - self.start_param
+        self.start_point.distance_to(&self.end_point)
     }
 
     /// 方向ベクトルを取得
     pub fn direction(&self) -> Vector3D<T> {
-        *self.line.direction_internal()
+        if self.end_param >= self.start_param {
+            *self.line.direction_internal()
+        } else {
+            (*self.line.direction_internal()).negate()
+        }
     }
 
     /// 基盤となる無限直線を取得
     pub fn line(&self) -> &InfiniteLine3D<T> {
+        &self.line
+    }
+
+    /// 基盤となる support line を取得
+    pub fn support_line(&self) -> &InfiniteLine3D<T> {
         &self.line
     }
 
@@ -97,12 +151,12 @@ impl<T: Scalar> LineSegment3D<T> {
     pub fn distance_to_point(&self, point: &Point3D<T>) -> T {
         let to_point = Vector3D::from_points(&self.line.point_internal(), point);
         let t = to_point.dot(&self.line.direction_internal());
+        let (min_param, max_param) = self.ordered_params();
 
-        // パラメータを線分の範囲内に制限
-        let clamped_param = if t < self.start_param {
-            self.start_param
-        } else if t > self.end_param {
-            self.end_param
+        let clamped_param = if t < min_param {
+            min_param
+        } else if t > max_param {
+            max_param
         } else {
             t
         };
@@ -113,14 +167,13 @@ impl<T: Scalar> LineSegment3D<T> {
 
     /// 点が線分上にあるかを判定
     pub fn contains_point(&self, point: &Point3D<T>, tolerance: T) -> bool {
-        // まず無限直線上にあるかチェック
         if !self.line.contains_point(point, tolerance) {
             return false;
         }
 
-        // パラメータが線分の範囲内にあるかチェック
         let param = self.line.parameter_for_point(point);
-        param >= self.start_param - tolerance && param <= self.end_param + tolerance
+        let (min_param, max_param) = self.ordered_params();
+        param >= min_param - tolerance && param <= max_param + tolerance
     }
 
     /// 線分が退化しているか（長さが0）を判定
@@ -152,7 +205,6 @@ impl<T: Scalar> LineSegment3DConstructor<T> for LineSegment3D<T> {
         Self::new(start, end).unwrap()
     }
 
-    // Phase 2: 追加コンストラクタ
     fn unit_y() -> Self {
         let start = Point3D::origin();
         let end = Point3D::new(T::ZERO, T::ONE, T::ZERO);
@@ -178,51 +230,49 @@ impl<T: Scalar> LineSegment3DConstructor<T> for LineSegment3D<T> {
 
 impl<T: Scalar> LineSegment3DProperties<T> for LineSegment3D<T> {
     fn start(&self) -> (T, T, T) {
-        let p = self.line.point_at_parameter(self.start_param);
+        let p = self.start();
         (p.x(), p.y(), p.z())
     }
 
     fn end(&self) -> (T, T, T) {
-        let p = self.line.point_at_parameter(self.end_param);
+        let p = self.end();
         (p.x(), p.y(), p.z())
     }
 
     fn midpoint(&self) -> (T, T, T) {
-        let mid_param = (self.start_param + self.end_param) / (T::ONE + T::ONE);
-        let p = self.line.point_at_parameter(mid_param);
+        let p = self.midpoint();
         (p.x(), p.y(), p.z())
     }
 
     fn length(&self) -> T {
-        self.end_param - self.start_param
+        self.length()
     }
 
     fn dimension(&self) -> u32 {
         3
     }
 
-    // Phase 2: 追加プロパティ
     fn is_unit_length(&self) -> bool {
-        let length = self.end_param - self.start_param;
+        let length = self.length();
         (length - T::ONE).abs() <= T::EPSILON
     }
 
     fn is_on_xy_plane(&self) -> bool {
-        let start = self.line.point_at_parameter(self.start_param);
-        let end = self.line.point_at_parameter(self.end_param);
+        let start = self.start();
+        let end = self.end();
         (start.z() - end.z()).abs() <= T::EPSILON
     }
 
     fn is_on_yz_plane(&self) -> bool {
-        let start = self.line.point_at_parameter(self.start_param);
-        let end = self.line.point_at_parameter(self.end_param);
+        let start = self.start();
+        let end = self.end();
         (start.x() - end.x()).abs() <= T::EPSILON
     }
 }
 
 impl<T: Scalar> LineSegment3DDerived<T> for LineSegment3D<T> {
     fn measure(&self) -> T {
-        self.end_param - self.start_param
+        self.length()
     }
 
     fn direction_vector(&self) -> (T, T, T) {
@@ -254,7 +304,6 @@ impl<T: Scalar> LineSegment3DContainment<T> for LineSegment3D<T> {
 
 impl<T: Scalar> LineSegment3DEvaluation<T> for LineSegment3D<T> {
     fn point_at_parameter(&self, t: T) -> (T, T, T) {
-        // 正規化パラメータ（0〜1）で線分上の点を取得
         let param = self.start_param + t * (self.end_param - self.start_param);
         let p = self.line.point_at_parameter(param);
         (p.x(), p.y(), p.z())
@@ -264,13 +313,12 @@ impl<T: Scalar> LineSegment3DEvaluation<T> for LineSegment3D<T> {
 impl<T: Scalar> LineSegment3DProjection<T> for LineSegment3D<T> {
     fn closest_point_to(&self, point: (T, T, T)) -> (T, T, T) {
         let p = Point3D::new(point.0, point.1, point.2);
-        // 直線上のパラメータを計算
         let line_param = self.line.parameter_for_point(&p);
-        // 線分範囲にクランプ
-        let clamped_param = if line_param < self.start_param {
-            self.start_param
-        } else if line_param > self.end_param {
-            self.end_param
+        let (min_param, max_param) = self.ordered_params();
+        let clamped_param = if line_param < min_param {
+            min_param
+        } else if line_param > max_param {
+            max_param
         } else {
             line_param
         };
@@ -311,5 +359,29 @@ impl<T: Scalar> CrossDistance<T, ((T, T, T), (T, T, T))> for LineSegment3D<T> {
         let end = (end_point.x(), end_point.y(), end_point.z());
 
         line_segment_to_aabb_distance(start, end, other.0, other.1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn support_line_and_constraint_points_are_distinct() {
+        let line =
+            InfiniteLine3D::new(Point3D::origin(), Vector3D::new(1.0_f64, 0.0, 0.0)).unwrap();
+        let start = Point3D::new(0.0, 1.0, 0.0);
+        let end = Point3D::new(2.0, 1.0, 0.0);
+
+        let segment =
+            LineSegment3D::from_support_line_and_constraint_points(line, start, end).unwrap();
+
+        assert_eq!(segment.start(), start);
+        assert_eq!(segment.end(), end);
+        assert_eq!(segment.ideal_start(), Point3D::new(0.0, 0.0, 0.0));
+        assert_eq!(segment.ideal_end(), Point3D::new(2.0, 0.0, 0.0));
+        assert_eq!(segment.point_at_parameter(0.5), Point3D::new(1.0, 0.0, 0.0));
+        assert_eq!(segment.length(), 2.0);
+        assert_eq!(segment.ideal_length(), 2.0);
     }
 }

--- a/model/geo_primitives/src/line_segment_3d_extensions.rs
+++ b/model/geo_primitives/src/line_segment_3d_extensions.rs
@@ -54,7 +54,13 @@ impl<T: Scalar> LineSegment3D<T> {
 
     /// 線分の逆方向を作成
     pub fn reverse(&self) -> Self {
-        Self::new(self.end(), self.start()).expect("Valid segment should always reverse")
+        Self {
+            line: self.line,
+            start_param: self.end_param,
+            end_param: self.start_param,
+            start_point: self.end(),
+            end_point: self.start(),
+        }
     }
 
     /// 境界上判定（線分では contains_point と同じ）

--- a/model/geo_primitives/src/line_segment_3d_foundation.rs
+++ b/model/geo_primitives/src/line_segment_3d_foundation.rs
@@ -15,6 +15,6 @@ impl<T: Scalar> PrimitiveMetadata for LineSegment3D<T> {
 impl<T: Scalar> MeasureFoundation<T> for LineSegment3D<T> {
     fn measure(&self) -> Option<T> {
         // 線分の長さを測度として返す
-        Some(self.end_param - self.start_param)
+        Some(self.length())
     }
 }

--- a/model/geo_primitives/src/line_segment_3d_transform.rs
+++ b/model/geo_primitives/src/line_segment_3d_transform.rs
@@ -40,7 +40,35 @@ pub mod analysis_transform {
             transformed_end.z(),
         );
 
-        LineSegment3D::new(new_start, new_end).unwrap()
+        let ideal_start_vec = Vector3::new(
+            segment.ideal_start().x(),
+            segment.ideal_start().y(),
+            segment.ideal_start().z(),
+        );
+        let transformed_ideal_start = matrix.transform_point_3d(&ideal_start_vec);
+        let new_ideal_start = Point3D::new(
+            transformed_ideal_start.x(),
+            transformed_ideal_start.y(),
+            transformed_ideal_start.z(),
+        );
+
+        let ideal_end_vec = Vector3::new(
+            segment.ideal_end().x(),
+            segment.ideal_end().y(),
+            segment.ideal_end().z(),
+        );
+        let transformed_ideal_end = matrix.transform_point_3d(&ideal_end_vec);
+        let new_ideal_end = Point3D::new(
+            transformed_ideal_end.x(),
+            transformed_ideal_end.y(),
+            transformed_ideal_end.z(),
+        );
+
+        let support_line = crate::InfiniteLine3D::from_two_points(new_ideal_start, new_ideal_end)
+            .expect("Transformed support line should remain valid");
+
+        LineSegment3D::from_support_line_and_constraint_points(support_line, new_start, new_end)
+            .unwrap()
     }
 
     /// 複数線分の一括行列変換


### PR DESCRIPTION
## 概要

`LineSegment2D/3D` を exact な有限線分ではなく、support line と拘束点を併せ持つ tolerant な trimmed line として整理する。

あわせて、shape semantics と topology entity layer の正本を分離し、`#557` の範囲と後続論点の境界を明文化する。

Closes #557
Related #558
Related #559

## 変更内容

- `LineSegment2D/3D` に拘束点 `start_point` / `end_point` を保持
- support line と拘束点から構築する API を追加
- `start/end` は拘束点、`point_at_parameter()` は support line 上の評価として整理
- `length()` / `measure()` を拘束点間距離へそろえる
- transform / reverse 処理が support line semantics を保つよう修正
- contracts の doc comment を新 semantics に合わせて更新
- shape semantics 正本 `GEOMETRY_SHAPE_SEMANTICS_DESIGN.md` を追加
- topology entity layer 正本 `TOPOLOGY_ENTITY_LAYER_DESIGN.md` を追加
- `PHASE4_TOPOLOGY_ENTITY_DESIGN.md` と `TOPO_NORMAL_FORM_INVARIANTS_FREEZE_458.md` の役割を補助文書 / 凍結スナップショットとして整理

## 設計上の位置づけ

- `#557` は `LineSegment` を先行ケースとして shape semantics を具体化する Issue
- shape 横断の capability / taxonomy 整理は `#558` に委譲
- topology 側の vertex binding invariant と位相専用 tolerance は `#559` に委譲

## 検証

- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo test --workspace`
