### PR TITLE
refactor(geo_topology): トポロジーの binding 検証意味論を整合

### DIFF
--- a/dev/architecture/TOPOLOGY_ENTITY_LAYER_DESIGN.md
+++ b/dev/architecture/TOPOLOGY_ENTITY_LAYER_DESIGN.md
@@ -40,6 +40,43 @@
 
 Face / Shell / Solid / PCurve の詳細仕様は、必要に応じて本書から派生文書へ分離してよい。
 
+CompositeCurve は、閉曲線であっても topology Loop の正本とはみなさず、Wire / Loop 構築前段の幾何補助表現として扱う。
+
+## 標準的な命名と用途
+
+本書では、B-Rep / CAD kernel 文脈で一般的な命名に合わせて、少なくとも次の用途で用語を固定する。
+
+- `Vertex`: 位相上の点要素。共有接続点の正本として使う。
+- `Edge`: 母曲線参照、parameter range、same_sense、start/end vertex を持つ位相要素。曲線そのものではなく、曲線の位相的利用を表す。
+- `Wire`: 向きつけられた連続 Edge 列。Face 境界の候補となるが、それ自体はまだ Face 上の意味付けを持たない。
+- `Loop`: 閉じた Wire が Face 境界として意味付けされた概念。outer / inner の区別は Face 側で与える。
+- `CompositeCurve`: 複数曲線セグメントからなる幾何補助表現。閉曲線であっても topology の Edge / Wire / Loop の正本とはみなさない。
+
+したがって、RedRing では「閉じた CompositeCurve をそのまま Loop と呼ぶ」ことはせず、CompositeCurve は Wire / Loop 構築前段の幾何入力または補助表現として扱う。
+
+## 将来実装を見越した存在と設計確定項目
+
+未実装であっても、topology entity layer の将来対象として少なくとも次の要素は存在を明示しておく。
+
+- `Loop`: 閉じた Wire を Face 境界として意味付けるための概念
+- `Face`: outer / inner loop、必要に応じて PCurve や surface 参照を伴う面位相要素
+- `Shell`: 複数 Face の接続集合としての位相要素
+- `Solid`: 閉じた Shell により境界づけられる立体位相要素
+- `PCurve`: Face 上の境界表現を扱うための補助概念
+
+これらは現時点では詳細未実装だが、本書のスコープ外ではない。用語の表記ゆれを防ぐため、少なくとも存在名は本書で固定する。
+
+また、将来実装で設計確定が必要な項目として、少なくとも次を認識しておく。
+
+- `Loop` を独立要素として持つか、閉じた `Wire` への意味付けとして扱うか
+- `Face` における outer / inner loop の責務境界
+- `Face` が 3D 母表現と `PCurve` をどう併用するか
+- point-on-surface / curve-on-surface 判定における topology 専用 tolerance の責務分離
+- `Shell` の閉性判定と法線整合の扱い
+- `Solid` の境界閉包条件と non-manifold 拒否条件
+
+したがって、本書は現時点で Edge / Wire 周辺を主に固定しているが、Face / Shell / Solid / PCurve を将来対象から除外しているわけではない。
+
 ## topology entity layer の基本方針
 
 ### 1. topology は shape 意味論を再定義しない
@@ -83,20 +120,96 @@ topology で保持する vertex は、shape の拘束点と接続して扱う。
 
 このため、support line 上の ideal endpoint と vertex が一致しない場合を許容できる topology invariant が必要になる。
 
-## vertex binding invariant の現行判断
+## vertex binding invariant の設計方針
 
 現時点では、次を固定する。
 
 - vertex binding は topology の責務である
-- binding 判定は shape 意味論を前提に行う
+- binding の正判定は拘束点主導で行う
 - 母曲線評価端点と vertex の完全一致を前提にしない
+- ideal endpoint は binding の正本ではなく、補助検証として扱う
 - binding の許容条件には topology 専用 tolerance を用いる
+
+したがって、`Edge::is_vertex_binding_consistent` 相当の判定は少なくとも次の二段を分離できる形が望ましい。
+
+- binding consistency: 拘束点と vertex の整合を判定する
+- support consistency: ideal endpoint と拘束点のずれが許容範囲内かを補助検証する
+
+このとき、1 本の Edge の局所整合に使う局所予算（局所許容誤差） `\delta_{edge}` は、少なくとも次の部分予算へ分解できる形が望ましい。
+
+- `\delta_{support}`: ideal endpoint と拘束点の整合に使う予算
+- `\delta_{bind}`: 拘束点と vertex の整合に使う予算
+
+基本条件は次とする。
+
+$$
+\delta_{support} + \delta_{bind} \le \delta_{edge}
+$$
+
+すなわち、support consistency と binding consistency は独立した局所判定として扱うが、その許容差の総和は単一 Edge の局所予算 `\delta_{edge}` の範囲で閉じなければならない。
+
+現時点では、shape 種別、拘束の意味、評価カーネルの性質に応じて `\delta_{support}` と `\delta_{bind}` の配分余地を残す。
+
+ただし、shape 固有の根拠や別途の配分規約が存在しない場合の fallback として、対称配分を採用してよい。
+
+$$
+\delta_{support} = \delta_{bind} = \delta_{edge} / 2
+$$
+
+この対称配分は、単一 Edge の局所整合に限定した既定値である。shared vertex を介した連続性整合にそのまま流用してはならず、`\delta_{shared}` は別予算として扱う。
+
+すなわち、fallback として対称配分を持つ場合でも、「各段に同じ値を重複適用する」のではなく、`\delta_{edge}` の内訳として明示的に定義する。
+
+fallback を上書きできる判断基準は、少なくとも次とする。
+
+- 拘束点が単なる端点ではなく、編集拘束やスナップ結果として強い位相的意味を持つか
+- ideal endpoint の評価誤差が、拘束点側より大きくなりやすい評価カーネルを使うか
+- 数値反復、近似、投影により support consistency 側へ追加の誤差源が入るか
+- 下流の continuity / point-on-surface / pitch 判定が、support 側誤差と binding 側誤差のどちらにより敏感か
+
+上記のいずれかに明確な偏りがある場合は、`\delta_{support}` と `\delta_{bind}` を非対称に配分してよい。ただし、その場合でも配分根拠を shape 仕様または判定仕様で明示し、`\delta_{support} + \delta_{bind} \le \delta_{edge}` を維持する。
 
 未確定項目:
 
-- binding 判定を拘束点ベースで固定するか、ideal endpoint との二重検証にするか
-- `Edge::is_vertex_binding_consistent` 相当 API の最終仕様
-- topology 専用 tolerance の正本配置
+- `Edge::is_vertex_binding_consistent` 相当 API を `Edge` メソッドとして残すか、validator 系へ分離するか
+- support consistency を常時必須にするか、診断系チェックとして分離するか
+- tolerance を結果へどこまで記録するか
+- 上書き判断基準を shape 別ガイドとして独立管理するか
+
+### Edge の正規判定フロー
+
+`Edge` の binding invariant は、少なくとも次の順で判定する。
+
+1. `curve`、`parameter_range`、`same_sense`、`start_vertex`、`end_vertex` を入力として受け取る。
+2. `CurveRef::start_point()` / `end_point()` から、shape 意味論上の拘束点を取得する。
+3. `same_sense` を適用し、Edge の向きに沿った拘束点対 `(oriented_constraint_start, oriented_constraint_end)` を決定する。
+4. `start_vertex` / `end_vertex` と拘束点対を `\delta_{bind}` で比較し、binding consistency を判定する。
+5. `parameter_range` から母曲線上の ideal endpoint 対を評価する。
+6. `same_sense` を適用し、Edge の向きに沿った ideal endpoint 対 `(oriented_ideal_start, oriented_ideal_end)` を決定する。
+7. ideal endpoint 対と拘束点対を `\delta_{support}` で比較し、support consistency を判定する。
+8. full edge invariant は、binding consistency と support consistency の両方が成立したときにのみ通過とする。
+
+重要:
+
+- `\delta_{shared}` は Edge 単独の判定では使用しない。
+- `\delta_{shared}` は Wire など、shared vertex を介した隣接 Edge 間の連続性判定でのみ使用する。
+- したがって Edge 判定だけでは、隣接 Edge 間の連続性保証までは与えない。
+
+擬似フロー:
+
+```text
+input: edge, δ_bind, δ_support
+
+constraint_pair = oriented_constraint_points(edge.curve, edge.same_sense)
+binding_ok = compare_vertices_to_constraints(edge.vertices, constraint_pair, δ_bind)
+
+ideal_pair = oriented_ideal_points(edge.curve, edge.parameter_range, edge.same_sense)
+support_ok = compare_ideal_to_constraints(ideal_pair, constraint_pair, δ_support)
+
+edge_ok = binding_ok && support_ok
+```
+
+このフローにより、Edge は「拘束点と vertex の整合」と「母曲線 ideal endpoint と拘束点の整合」を明示的に分けて検証する。一方で、shared vertex を介した連続性は次段の Wire 判定へ委譲する。
 
 ## topology 専用 tolerance の方針
 
@@ -109,7 +222,202 @@ topology で保持する vertex は、shape の拘束点と接続して扱う。
 
 このため、topology は幾何一般の tolerance をそのまま流用するだけではなく、位相判定に必要な tolerance の責務境界を持つ。
 
-ただし、値の最終配置と API は別 Issue で確定する。
+現時点の設計方針は次の通りとする。
+
+- topology 専用 tolerance の責務は `geo_topology` の判定側に置く
+- 初期段階では判定 API へ明示入力し、暗黙既定値に依存しない
+- 将来的な値の正本は `ToleranceSettings` 系の共通 context と接続してよい
+- ただし topology 側では、どの判定にどの tolerance を使うかという責務境界を保持する
+
+### 誤差伝搬を抑えるための局所予算と共有予算の分離
+
+vertex 一致判定では、単一の許容差をそのまま全ての段へ使い回すのではなく、少なくとも次の 2 種類の予算へ分けて扱う。
+
+- Edge 単独の局所整合を扱う局所予算（局所許容誤差）
+- shared vertex を介して隣接 Edge へ伝搬する連続性整合を扱う共有予算（共有許容誤差）
+
+例えば、次を区別する。
+
+- $\delta_{edge}$: 1 本の Edge の中で、ideal endpoint / 拘束点 / vertex の整合に使う局所予算（局所許容誤差）
+- $\delta_{shared}$: shared vertex を介して隣接 Edge 同士の接続整合に使う共有予算（共有許容誤差）
+
+さらに $\delta_{edge}$ の内訳として、少なくとも次を区別する。
+
+- $\delta_{support}$: ideal endpoint と拘束点の整合に使う部分予算
+- $\delta_{bind}$: 拘束点と vertex の整合に使う部分予算
+
+基本関係は次とする。
+
+$$
+\delta_{support} + \delta_{bind} \le \delta_{edge}
+$$
+
+このとき、binding consistency と support consistency の配分は、少なくとも $\delta_{edge}$ の範囲で閉じるように設計する。
+
+shape 固有の配分根拠がない場合の fallback は、次とする。
+
+$$
+\delta_{support} = \delta_{bind} = \delta_{edge} / 2
+$$
+
+ただし、この対称配分は単一 Edge 内の局所整合にのみ適用し、shared vertex を介した連続性整合へそのまま拡張しない。
+
+重要なのは、`LineSegment` の 1 本の Edge 内で許した局所誤差と、shared vertex を介した隣接 Edge 間の誤差伝搬を同じ 1 つの値で管理しないことである。
+
+これにより、ある Edge で許容した ideal endpoint と拘束点のずれが、shared vertex を介して隣接 Edge のずれと累積し、設計意図を超えた全体誤差へ膨らむことを避けやすくなる。
+
+この考え方は `LineSegment` の binding だけに限定しない。Face 上の point-on-surface 判定、curve-on-surface 判定、ピッチ判定のような「母表現と拘束表現のずれ」を扱う場面でも、局所整合の予算と複数要素をまたぐ共有整合の予算を分離するトレラントモデリングの基本思想として再利用する。
+
+ただし、個別の tolerance 名、値の最終配置、API 形状は別設計で具体化する。
+
+### ニット前段で固定する設計判断
+
+shared edge の一本化そのものを確定する前段として、少なくとも次を固定する。
+
+- RedRing の通常 topology では non-manifold を受け付けない
+- ニット判定の既定対象は 2 本の境界 Edge による bilateral knit とする
+- アプリケーション層は shared edge 用の総許容差 `\delta` のみを与える
+- カーネル内部は bilateral knit の既定規則として各側比較に `\delta / 2` を適用する
+- この `\delta / 2` 配分規則は kernel invariant としてカプセル化し、外部 API へ露出しない
+
+このとき、アプリケーション側は「共有境界全体としてどこまで許容するか」という総予算 `\delta` だけを指定し、A 側と B 側への配分責務はカーネルが負う。
+
+bilateral knit の既定規則では、各側の比較条件を次で表す。
+
+$$
+d(A, E_{ref}) \le \delta / 2
+$$
+
+$$
+d(B, E_{ref}) \le \delta / 2
+$$
+
+ここで `E_{ref}` は、共有境界候補を評価するための kernel 内部基準表現を表す。一本化後の正準 shared edge を直ちに意味するとは限らない。
+
+この規則を採ることで、同一距離尺度の下では導出的に次を保証できる。
+
+$$
+d(A, B) \le \delta
+$$
+
+重要なのは、外部から受け取った同じ `\delta` を A 側比較と B 側比較へそのまま重複適用しないことである。各側に同じ `\delta` を直適用すると、導出的上界は `2\delta` となり、外部契約として期待した総許容差とずれる。
+
+### ニット候補判定の安定化方針
+
+non-manifold を拒否する前提であっても、spike 形状や鋭角合流では、境界線距離だけに依存した候補選択は不安定になりうる。
+
+したがって、ニット候補判定は単一の最近傍距離だけで決めず、少なくとも次を満たすことを要求する。
+
+- 距離条件: 候補境界間の乖離が総許容差 `\delta` の範囲内にあること
+- 端点整合条件: 両端の対応が取れ、端点近傍だけの擬似一致でないこと
+- 方向整合条件: 接線方向や走査向きが矛盾せず、対応追跡が単調に取れること
+- 区間整合条件: 局所点一致ではなく、共有境界候補として扱うだけの連続区間が存在すること
+- 曖昧性拒否条件: 同程度に成立する複数候補がある場合は、無理に採用せず reject すること
+
+したがって、ニット処理の前段は少なくとも次の順で構成するのが望ましい。
+
+1. 候補探索
+2. 候補検証
+3. 曖昧性判定
+4. 共有境界の採否決定
+
+この段階では、shared edge を最終的に 1 本化するか、どの幾何生成規則で正準化するかは未確定とする。ただし、少なくとも候補対応の安定化は上記の規則で先に固定する。
+
+### shared edge 一本化の採用条件
+
+shared edge を最終的に 1 本化するかどうかは、「G1 連続であるか」だけでは決めない。一本化は、shared boundary としての対応が一意かつ安定に追跡できる場合に限って採用する。
+
+したがって、G1 は一本化を後押しする補助条件として扱うが、単独で十分条件とはみなさない。
+
+一本化を採用してよい既定条件は、少なくとも次とする。
+
+- bilateral knit として 2 本の境界 Edge の対応が一意に定まること
+- 候補境界間の距離条件が総許容差 `\delta` の範囲内で成立すること
+- 両端の対応が安定に定まり、端点近傍だけの擬似一致でないこと
+- 対応区間の追跡が単調に行え、途中で相手候補が入れ替わらないこと
+- 方向整合が取れ、接線方向の不連続が shared boundary として許容できる範囲に収まること
+- 同程度に成立する競合候補が存在しないこと
+
+上記を満たす場合、カーネルは 2 本の入力 Edge を 1 本の shared edge へ正準化してよい。
+
+一方で、次のいずれかに該当する場合は、一本化を採用してはならない。
+
+- spike 形状や鋭角合流により、距離最小候補が微小擾乱で入れ替わる
+- 一部の局所区間だけが近接し、共有境界として扱う連続区間が安定に取れない
+- 接線方向は近いが、端点対応または区間対応が一意に定まらない
+- 複数候補が同程度に成立し、どれを shared edge 正本とすべきか決定できない
+
+この場合、カーネルは「なるべく 1 本化する」よりも「誤った 1 本化を行わない」ことを優先し、一本化を reject する。
+
+したがって、一本化の基本方針は次とする。
+
+1. 候補対応が一意かつ安定に追跡できる場合のみ 1 本化する
+2. G1 は一本化可否の補助条件として使う
+3. 曖昧性が残る場合は 1 本化せず reject する
+
+未確定項目:
+
+- 正準 shared edge の具体的な幾何生成規則を、中間表現・片側優先・最適化近似のどれで定めるか
+- 一本化後の parameter range をどの表現で正本化するか
+- shared vertex 側の同時正準化を必須にするか
+
+### 正準 shared edge の既定生成規則
+
+一本化を採用する場合でも、正準 shared edge の生成規則は「2 本の入力を機械的に中間化すること」を既定としない。既定規則は、幾何平均よりも対応の安定性、端点拘束の保存、parameter 対応の単調性を優先する。
+
+したがって、bilateral knit における正準 shared edge の生成は、少なくとも次の優先順で扱う。
+
+1. 端点対応が安定に定まることを先に確認し、必要なら shared vertex を shared edge と同時に正準化する
+2. 2 本の入力 Edge から、同一の母表現または安定な基準表現を選べる場合は、その表現を shared edge の正本候補として優先する
+3. 一方の入力 Edge を基準として採用しても他方が `\delta / 2` 以内へ安定に再拘束できる場合は、決定的規則に基づく片側優先を許容する
+4. 上記で安定な基準表現を得られない場合に限り、最適化近似または中間表現を fallback として検討してよい
+5. fallback を用いても距離条件・端点整合・方向整合・区間整合・曖昧性拒否条件を満たせない場合は、一本化を reject する
+
+この優先順において、既定の思想は「まず安定な参照を選ぶ」「平均化は最後の手段とする」である。
+
+#### 1. 母表現優先
+
+2 本の入力 Edge が、同一の解析曲線、同一 support line、または同一 NURBS 系表現として無理なく正準化できる場合は、その母表現を shared edge の正本候補として優先する。
+
+この場合の shared edge は、入力 Edge の中点的平均ではなく、「両入力が整合すべき共通基準表現」として扱う。
+
+#### 2. 片側優先
+
+両入力を完全に対称な共通表現へ落とすより、一方の入力 Edge を基準として採用した方が安定である場合は、片側優先を許容してよい。
+
+ただし、片側優先は任意に決めてはならず、少なくとも次のいずれかのような決定的規則に従う必要がある。
+
+- 解析的により強い表現を優先する
+- 数値評価の安定性が高い表現を優先する
+- 既存 topology 所有者として継続利用すべき正本が定まっている
+
+この場合でも、非採用側は採用側 shared edge へ `\delta / 2` 以内で再拘束できなければならない。
+
+#### 3. 中間表現・最適化近似は fallback
+
+中間表現や最適化近似は、入力 2 本の対称性を保ちやすい一方で、元の解析構造や parameter 意味を弱める可能性がある。
+
+したがって、これらは既定の第一選択ではなく、母表現優先または片側優先で安定な shared edge を定められない場合の fallback とする。
+
+fallback を採用する場合でも、少なくとも次を維持しなければならない。
+
+- 両端の shared vertex との整合
+- 各入力 Edge からの `\delta / 2` 以内の再拘束可能性
+- 対応区間追跡の単調性
+- 後段の topology 判定で利用できる一意な parameter 意味
+
+このため、「G1 で見た目が滑らかだから平均化する」という理由だけで中間表現を既定採用してはならない。
+
+#### 4. 現時点の既定方針
+
+現時点では、正準 shared edge の既定方針を次とする。
+
+1. まず母表現優先で共通基準を探す
+2. それが無理なら決定的規則に基づく片側優先を検討する
+3. それでも安定に定まらない場合に限り、中間表現または最適化近似を fallback 候補とする
+4. fallback でも条件を満たせない場合は一本化を reject する
+
+したがって、正準 shared edge の生成は「対称平均を既定とする設計」ではなく、「安定な正本を段階的に選び、それが無理なら reject する設計」とする。
 
 ## `#557` 時点の暫定許容範囲
 
@@ -123,9 +431,9 @@ topology で保持する vertex は、shape の拘束点と接続して扱う。
 
 未確定として残す範囲:
 
-- vertex binding invariant
-- topology 専用 tolerance
-- ideal endpoint と拘束点のずれを含む binding ルール
+- `Edge` / `Wire` / validator の具体 API 形状
+- tolerance 名と設定オブジェクトの最終配置
+- Face / Shell / PCurve へ展開したときの個別判定フロー
 
 ## 非目標
 

--- a/model/geo_topology/src/composite_curve.rs
+++ b/model/geo_topology/src/composite_curve.rs
@@ -57,24 +57,31 @@ pub struct CompositeCurve3D<T: Scalar> {
 }
 
 impl<T: Scalar> CompositeCurve3D<T> {
+    fn points_are_connected(start: Point3D<T>, end: Point3D<T>, tolerance: T) -> bool {
+        start.distance_to(&end) <= tolerance
+    }
+
     /// セグメント列から複合曲線を生成
     ///
     /// 次の場合は None を返す:
     /// - segments が空
     /// - セグメントが連続していない（N番目終点 != N+1番目始点）
     pub fn new(segments: Vec<CurveSegment3D<T>>) -> Option<Self> {
+        Self::new_with_tolerance(segments, T::ZERO)
+    }
+
+    /// 許容誤差付きでセグメント列から複合曲線を生成
+    pub fn new_with_tolerance(segments: Vec<CurveSegment3D<T>>, tolerance: T) -> Option<Self> {
         if segments.is_empty() {
             return None;
         }
 
-        // 連続性検証: N番目終点とN+1番目始点が一致すること
+        // 連続性検証: N番目終点とN+1番目始点が許容差内で接続すること
         for i in 0..segments.len() - 1 {
             let end = segments[i].end();
             let next_start = segments[i + 1].start();
 
-            // 接続判定は明示的な座標比較で行う
-            // （トレランス考慮は構築処理ではなく検証層の責務）
-            if end.x() != next_start.x() || end.y() != next_start.y() || end.z() != next_start.z() {
+            if !Self::points_are_connected(end, next_start, tolerance) {
                 return None;
             }
         }
@@ -107,9 +114,14 @@ impl<T: Scalar> CompositeCurve3D<T> {
 
     /// 閉曲線かどうかを返す（始点 == 終点）
     pub fn is_closed(&self) -> bool {
+        self.is_closed_with_tolerance(T::ZERO)
+    }
+
+    /// 許容誤差付きで閉曲線かどうかを返す
+    pub fn is_closed_with_tolerance(&self, tolerance: T) -> bool {
         let start = self.start_point();
         let end = self.end_point();
-        start.x() == end.x() && start.y() == end.y() && start.z() == end.z()
+        Self::points_are_connected(start, end, tolerance)
     }
 }
 
@@ -178,6 +190,44 @@ mod tests {
     }
 
     #[test]
+    fn composite_curve_tolerance_allows_near_connected_segments() {
+        let seg1 = TopoLineSegment3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(1.0, 0.0, 0.0))
+            .unwrap();
+        let seg2 = TopoLineSegment3D::new(
+            Point3D::new(1.0, 0.0, 1.0e-4),
+            Point3D::new(2.0, 0.0, 1.0e-4),
+        )
+        .unwrap();
+
+        assert!(CompositeCurve3D::new(vec![
+            CurveSegment3D::Line(seg1),
+            CurveSegment3D::Line(seg2),
+        ])
+        .is_none());
+
+        assert!(CompositeCurve3D::new_with_tolerance(
+            vec![
+                CurveSegment3D::Line(
+                    TopoLineSegment3D::new(
+                        Point3D::new(0.0, 0.0, 0.0),
+                        Point3D::new(1.0, 0.0, 0.0),
+                    )
+                    .unwrap()
+                ),
+                CurveSegment3D::Line(
+                    TopoLineSegment3D::new(
+                        Point3D::new(1.0, 0.0, 1.0e-4),
+                        Point3D::new(2.0, 0.0, 1.0e-4),
+                    )
+                    .unwrap(),
+                ),
+            ],
+            1.0e-3,
+        )
+        .is_some());
+    }
+
+    #[test]
     fn composite_curve_empty_fails() {
         assert!(CompositeCurve3D::<f64>::new(vec![]).is_none());
     }
@@ -199,5 +249,23 @@ mod tests {
         .unwrap();
 
         assert!(composite.is_closed());
+    }
+
+    #[test]
+    fn composite_curve_closed_with_tolerance() {
+        let seg1 = TopoLineSegment3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(1.0, 0.0, 0.0))
+            .unwrap();
+        let seg2 =
+            TopoLineSegment3D::new(Point3D::new(1.0, 0.0, 0.0), Point3D::new(0.0, 0.0, 5.0e-4))
+                .unwrap();
+
+        let composite = CompositeCurve3D::new_with_tolerance(
+            vec![CurveSegment3D::Line(seg1), CurveSegment3D::Line(seg2)],
+            1.0e-3,
+        )
+        .unwrap();
+
+        assert!(!composite.is_closed());
+        assert!(composite.is_closed_with_tolerance(1.0e-3));
     }
 }

--- a/model/geo_topology/src/lib.rs
+++ b/model/geo_topology/src/lib.rs
@@ -22,4 +22,5 @@ pub use wire::Wire;
 
 pub type TopoArc3D<T> = geo_primitives::Arc3D<T>;
 pub type TopoEllipseArc3D<T> = geo_primitives::EllipseArc3D<T>;
+pub type TopoInfiniteLine3D<T> = geo_primitives::InfiniteLine3D<T>;
 pub type TopoLineSegment3D<T> = geo_primitives::LineSegment3D<T>;

--- a/model/geo_topology/src/topology_core.rs
+++ b/model/geo_topology/src/topology_core.rs
@@ -262,7 +262,7 @@ impl<T: Scalar> Edge<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use geo_primitives::InfiniteLine3D;
+    use crate::TopoInfiniteLine3D;
 
     #[test]
     fn edge_new_rejects_invalid_range() {
@@ -299,7 +299,7 @@ mod tests {
 
     #[test]
     fn edge_binding_and_support_consistency_are_separated() {
-        let support_line = InfiniteLine3D::from_two_points(
+        let support_line = TopoInfiniteLine3D::from_two_points(
             Point3D::new(0.0, 0.0, 0.0),
             Point3D::new(2.0, 0.0, 0.0),
         )

--- a/model/geo_topology/src/topology_core.rs
+++ b/model/geo_topology/src/topology_core.rs
@@ -194,6 +194,30 @@ impl<T: Scalar> Edge<T> {
         self.end_vertex.point()
     }
 
+    fn oriented_curve_points(
+        &self,
+        start: Point3D<T>,
+        end: Point3D<T>,
+    ) -> (Point3D<T>, Point3D<T>) {
+        if self.same_sense {
+            (start, end)
+        } else {
+            (end, start)
+        }
+    }
+
+    fn oriented_constraint_points(&self) -> (Point3D<T>, Point3D<T>) {
+        self.oriented_curve_points(self.curve.start_point(), self.curve.end_point())
+    }
+
+    fn oriented_ideal_points(&self) -> (Point3D<T>, Point3D<T>) {
+        let (t0, t1) = self.parameter_range;
+        let ideal_start = self.curve.point_at_parameter(t0);
+        let ideal_end = self.curve.point_at_parameter(t1);
+
+        self.oriented_curve_points(ideal_start, ideal_end)
+    }
+
     /// 曲線評価（0..1 のローカルパラメータ）
     pub fn point_at(&self, local_t: T) -> Option<Point3D<T>> {
         if local_t < T::ZERO || local_t > T::ONE {
@@ -210,26 +234,35 @@ impl<T: Scalar> Edge<T> {
         Some(self.curve.point_at_parameter(mapped_t))
     }
 
-    /// Edge が保持する頂点と幾何端点の整合を確認する
-    pub fn is_vertex_binding_consistent(&self, tolerance: T) -> bool {
-        let (t0, t1) = self.parameter_range;
-        let curve_start = self.curve.point_at_parameter(t0);
-        let curve_end = self.curve.point_at_parameter(t1);
+    /// 拘束点と Vertex の整合を確認する
+    pub fn is_binding_consistent(&self, bind_tolerance: T) -> bool {
+        let (constraint_start, constraint_end) = self.oriented_constraint_points();
 
-        let (expected_start, expected_end) = if self.same_sense {
-            (curve_start, curve_end)
-        } else {
-            (curve_end, curve_start)
-        };
+        self.start_vertex.point().distance_to(&constraint_start) <= bind_tolerance
+            && self.end_vertex.point().distance_to(&constraint_end) <= bind_tolerance
+    }
 
-        self.start_vertex.point().distance_to(&expected_start) <= tolerance
-            && self.end_vertex.point().distance_to(&expected_end) <= tolerance
+    /// 母曲線 ideal endpoint と拘束点の整合を確認する
+    pub fn is_support_consistent(&self, support_tolerance: T) -> bool {
+        let (constraint_start, constraint_end) = self.oriented_constraint_points();
+        let (ideal_start, ideal_end) = self.oriented_ideal_points();
+
+        ideal_start.distance_to(&constraint_start) <= support_tolerance
+            && ideal_end.distance_to(&constraint_end) <= support_tolerance
+    }
+
+    /// Edge の局所整合を確認する
+    pub fn is_vertex_binding_consistent(&self, edge_tolerance: T) -> bool {
+        let half_tolerance = edge_tolerance / T::from_f64(2.0);
+
+        self.is_binding_consistent(half_tolerance) && self.is_support_consistent(half_tolerance)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use geo_primitives::InfiniteLine3D;
 
     #[test]
     fn edge_new_rejects_invalid_range() {
@@ -262,5 +295,31 @@ mod tests {
         let edge = Edge::new(v0, v1, CurveRef::Line(line), (0.0, 1.0)).unwrap();
 
         assert!(edge.is_vertex_binding_consistent(1e-9));
+    }
+
+    #[test]
+    fn edge_binding_and_support_consistency_are_separated() {
+        let support_line = InfiniteLine3D::from_two_points(
+            Point3D::new(0.0, 0.0, 0.0),
+            Point3D::new(2.0, 0.0, 0.0),
+        )
+        .unwrap();
+        let start = Point3D::new(0.0, 0.0, 0.1);
+        let end = Point3D::new(2.0, 0.0, 0.1);
+        let line =
+            TopoLineSegment3D::from_support_line_and_constraint_points(support_line, start, end)
+                .unwrap();
+        let edge = Edge::new(
+            Arc::new(Vertex::new(start)),
+            Arc::new(Vertex::new(end)),
+            CurveRef::Line(line),
+            (0.0, 2.0),
+        )
+        .unwrap();
+
+        assert!(edge.is_binding_consistent(1e-9));
+        assert!(!edge.is_support_consistent(1e-9));
+        assert!(edge.is_vertex_binding_consistent(0.25));
+        assert!(!edge.is_vertex_binding_consistent(0.1));
     }
 }

--- a/model/geo_topology/src/wire.rs
+++ b/model/geo_topology/src/wire.rs
@@ -76,8 +76,7 @@ impl<T: Scalar> Wire<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CurveRef, Point3D, TopoLineSegment3D, Vertex};
-    use geo_primitives::InfiniteLine3D;
+    use crate::{CurveRef, Point3D, TopoInfiniteLine3D, TopoLineSegment3D, Vertex};
     use std::sync::Arc;
 
     fn make_edge(start: Point3D<f64>, end: Point3D<f64>) -> Edge<f64> {
@@ -96,7 +95,7 @@ mod tests {
     fn make_offset_support_edge(start: Point3D<f64>, end: Point3D<f64>) -> Edge<f64> {
         let support_start = Point3D::new(start.x(), start.y(), 0.0);
         let support_end = Point3D::new(end.x(), end.y(), 0.0);
-        let support_line = InfiniteLine3D::from_two_points(support_start, support_end).unwrap();
+        let support_line = TopoInfiniteLine3D::from_two_points(support_start, support_end).unwrap();
         let line =
             TopoLineSegment3D::from_support_line_and_constraint_points(support_line, start, end)
                 .unwrap();

--- a/model/geo_topology/src/wire.rs
+++ b/model/geo_topology/src/wire.rs
@@ -12,7 +12,7 @@ pub struct Wire<T: Scalar> {
 
 impl<T: Scalar> Wire<T> {
     /// 連続性を検証した上で Wire を生成する
-    pub fn new(edges: Vec<Edge<T>>, tolerance: T) -> Option<Self> {
+    pub fn new(edges: Vec<Edge<T>>, edge_tolerance: T, shared_tolerance: T) -> Option<Self> {
         if edges.is_empty() {
             return None;
         }
@@ -22,7 +22,7 @@ impl<T: Scalar> Wire<T> {
             edges,
         };
 
-        if wire.is_continuous(tolerance) {
+        if wire.is_continuous(edge_tolerance, shared_tolerance) {
             Some(wire)
         } else {
             None
@@ -37,8 +37,8 @@ impl<T: Scalar> Wire<T> {
         &self.edges
     }
 
-    /// 端点連続性 + 各 Edge の頂点拘束整合を検証
-    pub fn is_continuous(&self, tolerance: T) -> bool {
+    /// 各 Edge の局所整合と、shared vertex を介した連続性を検証
+    pub fn is_continuous(&self, edge_tolerance: T, shared_tolerance: T) -> bool {
         if self.edges.is_empty() {
             return false;
         }
@@ -46,7 +46,7 @@ impl<T: Scalar> Wire<T> {
         if !self
             .edges
             .iter()
-            .all(|edge| edge.is_vertex_binding_consistent(tolerance))
+            .all(|edge| edge.is_vertex_binding_consistent(edge_tolerance))
         {
             return false;
         }
@@ -54,7 +54,7 @@ impl<T: Scalar> Wire<T> {
         for i in 0..self.edges.len() - 1 {
             let end = self.edges[i].oriented_end_point();
             let next_start = self.edges[i + 1].oriented_start_point();
-            if end.distance_to(&next_start) > tolerance {
+            if end.distance_to(&next_start) > shared_tolerance {
                 return false;
             }
         }
@@ -63,13 +63,13 @@ impl<T: Scalar> Wire<T> {
     }
 
     /// 閉ループかを判定
-    pub fn is_closed(&self, tolerance: T) -> bool {
+    pub fn is_closed(&self, shared_tolerance: T) -> bool {
         let first = self.edges.first().expect("wire has at least one edge");
         let last = self.edges.last().expect("wire has at least one edge");
         first
             .oriented_start_point()
             .distance_to(&last.oriented_end_point())
-            <= tolerance
+            <= shared_tolerance
     }
 }
 
@@ -77,6 +77,7 @@ impl<T: Scalar> Wire<T> {
 mod tests {
     use super::*;
     use crate::{CurveRef, Point3D, TopoLineSegment3D, Vertex};
+    use geo_primitives::InfiniteLine3D;
     use std::sync::Arc;
 
     fn make_edge(start: Point3D<f64>, end: Point3D<f64>) -> Edge<f64> {
@@ -92,13 +93,30 @@ mod tests {
         .unwrap()
     }
 
+    fn make_offset_support_edge(start: Point3D<f64>, end: Point3D<f64>) -> Edge<f64> {
+        let support_start = Point3D::new(start.x(), start.y(), 0.0);
+        let support_end = Point3D::new(end.x(), end.y(), 0.0);
+        let support_line = InfiniteLine3D::from_two_points(support_start, support_end).unwrap();
+        let line =
+            TopoLineSegment3D::from_support_line_and_constraint_points(support_line, start, end)
+                .unwrap();
+
+        Edge::new(
+            Arc::new(Vertex::new(start)),
+            Arc::new(Vertex::new(end)),
+            CurveRef::Line(line),
+            (line.start_param(), line.end_param()),
+        )
+        .unwrap()
+    }
+
     #[test]
     fn wire_continuous_edges() {
         let e1 = make_edge(Point3D::new(0.0, 0.0, 0.0), Point3D::new(1.0, 0.0, 0.0));
         let e2 = make_edge(Point3D::new(1.0, 0.0, 0.0), Point3D::new(2.0, 0.0, 0.0));
 
-        let wire = Wire::new(vec![e1, e2], 1e-9).unwrap();
-        assert!(wire.is_continuous(1e-9));
+        let wire = Wire::new(vec![e1, e2], 1e-9, 1e-9).unwrap();
+        assert!(wire.is_continuous(1e-9, 1e-9));
         assert!(!wire.is_closed(1e-9));
     }
 
@@ -107,7 +125,7 @@ mod tests {
         let e1 = make_edge(Point3D::new(0.0, 0.0, 0.0), Point3D::new(1.0, 0.0, 0.0));
         let e2 = make_edge(Point3D::new(3.0, 0.0, 0.0), Point3D::new(4.0, 0.0, 0.0));
 
-        assert!(Wire::new(vec![e1, e2], 1e-9).is_none());
+        assert!(Wire::new(vec![e1, e2], 1e-9, 1e-9).is_none());
     }
 
     #[test]
@@ -116,7 +134,20 @@ mod tests {
         let e2 = make_edge(Point3D::new(1.0, 0.0, 0.0), Point3D::new(1.0, 1.0, 0.0));
         let e3 = make_edge(Point3D::new(1.0, 1.0, 0.0), Point3D::new(0.0, 0.0, 0.0));
 
-        let wire = Wire::new(vec![e1, e2, e3], 1e-9).unwrap();
+        let wire = Wire::new(vec![e1, e2, e3], 1e-9, 1e-9).unwrap();
         assert!(wire.is_closed(1e-9));
+    }
+
+    #[test]
+    fn wire_uses_separate_edge_and_shared_tolerances() {
+        let start = Point3D::new(0.0, 0.0, 0.1);
+        let middle = Point3D::new(1.0, 0.0, 0.1);
+        let end = Point3D::new(2.0, 0.0, 0.1);
+
+        let e1 = make_offset_support_edge(start, middle);
+        let e2 = make_offset_support_edge(middle, end);
+
+        assert!(Wire::new(vec![e1.clone(), e2.clone()], 0.25, 1e-9).is_some());
+        assert!(Wire::new(vec![e1, e2], 0.1, 1e-9).is_none());
     }
 }


### PR DESCRIPTION
## 概要
- #559 で合意した topology binding 意味論に実装を合わせる
- Edge の検証を、拘束点主導の binding consistency と support consistency に分離する
- Wire の局所 Edge 検証と shared continuity 検証を分離する
- CompositeCurve を topology Loop ではなく幾何補助表現として整理する
- topology 設計正本に、命名・責務・将来要素・shared edge 設計方針を反映する

## 変更内容
- TOPOLOGY_ENTITY_LAYER_DESIGN.md を更新し、以下を明文化
  - Vertex / Edge / Wire / Loop / CompositeCurve の命名と用途
  - 拘束点主導の binding 検証フロー
  - 局所 tolerance と shared tolerance の分離
  - bilateral knit の前提条件と shared edge 正準化方針
  - Face / Shell / Solid / PCurve の存在と今後の設計確定項目
- model/geo_topology/src/topology_core.rs を更新し、以下を追加
  - oriented constraint / ideal endpoint helper
  - is_binding_consistent と is_support_consistent の分離
  - is_vertex_binding_consistent は、現時点の最小実装として対称配分 fallback を使う wrapper に整理
- model/geo_topology/src/wire.rs を更新し、以下を反映
  - edge_tolerance と shared_tolerance の分離
  - Edge 単独の局所整合と shared continuity の責務分離
- model/geo_topology/src/composite_curve.rs を更新し、以下を反映
  - tolerance-aware な構築と閉曲線判定を追加
  - CompositeCurve は topology 正本ではなく幾何補助表現として扱う
- topology テスト内の primitive 直接 import を、topology 側の再エクスポート経路へ置換

## 今回含めないもの
- knit 実行や shared edge 生成アルゴリズムの実装
- Loop / Face / Shell / Solid / PCurve の具体実装
- validator モジュールへの大規模分離

## 検証
- cargo clippy -- -D warnings
- cargo fmt
- cargo test --workspace

Closes #559