### PR TITLE
[Phase1] Arc / EllipseArc の capability trait を分離

### DIFF
--- a/model/geo_contracts/src/geometry/core/arc_traits.rs
+++ b/model/geo_contracts/src/geometry/core/arc_traits.rs
@@ -83,25 +83,86 @@ pub trait Arc3DProperties<T: Scalar> {
 }
 
 // TODO(#318): Measure 契約は責務分離フェーズで shape definition から分離する。
-pub trait Arc2DMeasure<T: Scalar> {
+pub trait Arc2DDerived<T: Scalar> {
     fn measure(&self) -> T;
-    fn start_point(&self) -> (T, T);
-    fn end_point(&self) -> (T, T);
-    fn point_at_parameter(&self, t: T) -> (T, T);
-    fn midpoint(&self) -> (T, T);
-    fn point_at_angle(&self, angle: T) -> (T, T);
-    fn distance_to_point(&self, point: (T, T)) -> T;
-    fn contains_point(&self, point: (T, T)) -> bool;
 }
 
-pub trait Arc3DMeasure<T: Scalar> {
+pub trait Arc2DEndpoint<T: Scalar> {
+    fn start_point(&self) -> (T, T);
+    fn end_point(&self) -> (T, T);
+    fn midpoint(&self) -> (T, T);
+}
+
+pub trait Arc2DEvaluation<T: Scalar> {
+    fn point_at_parameter(&self, t: T) -> (T, T);
+    fn point_at_angle(&self, angle: T) -> (T, T);
+}
+
+pub trait Arc2DDistance<T: Scalar> {
+    fn distance_to_point(&self, point: (T, T)) -> T;
+}
+
+pub trait Arc2DContainment<T: Scalar> {
+    fn contains_point(&self, point: (T, T)) -> bool;
+    fn contains_angle(&self, angle: T) -> bool;
+}
+
+pub trait Arc2DMeasure<T: Scalar>:
+    Arc2DDerived<T> + Arc2DEndpoint<T> + Arc2DEvaluation<T> + Arc2DDistance<T> + Arc2DContainment<T>
+{
+    fn measure(&self) -> T {
+        <Self as Arc2DDerived<T>>::measure(self)
+    }
+
+    fn start_point(&self) -> (T, T) {
+        <Self as Arc2DEndpoint<T>>::start_point(self)
+    }
+
+    fn end_point(&self) -> (T, T) {
+        <Self as Arc2DEndpoint<T>>::end_point(self)
+    }
+
+    fn point_at_parameter(&self, t: T) -> (T, T) {
+        <Self as Arc2DEvaluation<T>>::point_at_parameter(self, t)
+    }
+
+    fn midpoint(&self) -> (T, T) {
+        <Self as Arc2DEndpoint<T>>::midpoint(self)
+    }
+
+    fn point_at_angle(&self, angle: T) -> (T, T) {
+        <Self as Arc2DEvaluation<T>>::point_at_angle(self, angle)
+    }
+
+    fn distance_to_point(&self, point: (T, T)) -> T {
+        <Self as Arc2DDistance<T>>::distance_to_point(self, point)
+    }
+
+    fn contains_point(&self, point: (T, T)) -> bool {
+        <Self as Arc2DContainment<T>>::contains_point(self, point)
+    }
+}
+
+pub trait Arc3DDerived<T: Scalar> {
     fn measure(&self) -> T;
+}
+
+pub trait Arc3DEndpoint<T: Scalar> {
     fn start_point(&self) -> (T, T, T);
     fn end_point(&self) -> (T, T, T);
-    fn point_at_parameter(&self, t: T) -> (T, T, T);
     fn midpoint(&self) -> (T, T, T);
+}
+
+pub trait Arc3DEvaluation<T: Scalar> {
+    fn point_at_parameter(&self, t: T) -> (T, T, T);
     fn point_at_angle(&self, angle: T) -> (T, T, T);
+}
+
+pub trait Arc3DDistance<T: Scalar> {
     fn distance_to_point(&self, point: (T, T, T)) -> T;
+}
+
+pub trait Arc3DContainment<T: Scalar> {
     fn contains_point(&self, point: (T, T, T)) -> bool;
 }
 
@@ -110,21 +171,63 @@ pub trait Arc2DSampling<T: Scalar> {
     fn sample_by_arc_length(&self, arc_length_step: T) -> Vec<(T, T)>;
 }
 
-pub trait Arc2DContainment<T: Scalar> {
-    fn contains_point(&self, point: (T, T)) -> bool;
-    fn contains_angle(&self, angle: T) -> bool;
-    fn point_at_angle(&self, angle: T) -> (T, T);
+pub trait Arc3DMeasure<T: Scalar>:
+    Arc3DDerived<T> + Arc3DEndpoint<T> + Arc3DEvaluation<T> + Arc3DDistance<T> + Arc3DContainment<T>
+{
+    fn measure(&self) -> T {
+        <Self as Arc3DDerived<T>>::measure(self)
+    }
+
+    fn start_point(&self) -> (T, T, T) {
+        <Self as Arc3DEndpoint<T>>::start_point(self)
+    }
+
+    fn end_point(&self) -> (T, T, T) {
+        <Self as Arc3DEndpoint<T>>::end_point(self)
+    }
+
+    fn point_at_parameter(&self, t: T) -> (T, T, T) {
+        <Self as Arc3DEvaluation<T>>::point_at_parameter(self, t)
+    }
+
+    fn midpoint(&self) -> (T, T, T) {
+        <Self as Arc3DEndpoint<T>>::midpoint(self)
+    }
+
+    fn point_at_angle(&self, angle: T) -> (T, T, T) {
+        <Self as Arc3DEvaluation<T>>::point_at_angle(self, angle)
+    }
+
+    fn distance_to_point(&self, point: (T, T, T)) -> T {
+        <Self as Arc3DDistance<T>>::distance_to_point(self, point)
+    }
+
+    fn contains_point(&self, point: (T, T, T)) -> bool {
+        <Self as Arc3DContainment<T>>::contains_point(self, point)
+    }
 }
 
-pub trait Arc2DCore<T: Scalar>: Arc2DConstructor<T> + Arc2DProperties<T> + Arc2DMeasure<T> {}
-pub trait Arc3DCore<T: Scalar>: Arc3DConstructor<T> + Arc3DProperties<T> + Arc3DMeasure<T> {}
-
-impl<T: Scalar, A> Arc2DCore<T> for A where
-    A: Arc2DConstructor<T> + Arc2DProperties<T> + Arc2DMeasure<T>
+impl<T: Scalar, A> Arc2DMeasure<T> for A where
+    A: Arc2DDerived<T>
+        + Arc2DEndpoint<T>
+        + Arc2DEvaluation<T>
+        + Arc2DDistance<T>
+        + Arc2DContainment<T>
 {
 }
 
-impl<T: Scalar, A> Arc3DCore<T> for A where
-    A: Arc3DConstructor<T> + Arc3DProperties<T> + Arc3DMeasure<T>
+impl<T: Scalar, A> Arc3DMeasure<T> for A where
+    A: Arc3DDerived<T>
+        + Arc3DEndpoint<T>
+        + Arc3DEvaluation<T>
+        + Arc3DDistance<T>
+        + Arc3DContainment<T>
 {
 }
+
+pub trait Arc2DCore<T: Scalar>: Arc2DConstructor<T> + Arc2DProperties<T> {}
+pub trait Arc3DCore<T: Scalar>: Arc3DConstructor<T> + Arc3DProperties<T> {}
+
+impl<T: Scalar, A> Arc2DCore<T> for A where A: Arc2DConstructor<T> + Arc2DProperties<T> {}
+
+impl<T: Scalar, A> Arc3DCore<T> for A where A: Arc3DConstructor<T> + Arc3DProperties<T> {}

--- a/model/geo_contracts/src/geometry/core/ellipse_arc_traits.rs
+++ b/model/geo_contracts/src/geometry/core/ellipse_arc_traits.rs
@@ -168,77 +168,184 @@ pub trait EllipseArc3DProperties<T: Scalar> {
 }
 
 /// EllipseArc2D計量・関係演算機能トレイト（Phase 1 + Phase 2）
-pub trait EllipseArc2DMeasure<T: Scalar> {
+pub trait EllipseArc2DDerived<T: Scalar> {
     /// 楕円弧の長さ（測度）
     fn measure(&self) -> T;
 
+    /// 楕円弧の境界ボックスを取得（最小点、最大点）
+    fn bounding_box(&self) -> ((T, T), (T, T));
+}
+
+pub trait EllipseArc2DEndpoint<T: Scalar> {
     /// 開始点を取得
     fn start_point(&self) -> (T, T);
 
     /// 終了点を取得
     fn end_point(&self) -> (T, T);
 
+    /// 中点を取得（パラメータt=0.5の点）
+    fn mid_point(&self) -> (T, T);
+}
+
+pub trait EllipseArc2DEvaluation<T: Scalar> {
     /// パラメータt（0<=t<=1）での点を取得
     fn point_at_parameter(&self, t: T) -> (T, T);
 
-    /// 中点を取得（パラメータt=0.5の点）
-    fn mid_point(&self) -> (T, T);
-
     /// 指定角度での点を取得（ラジアン）
     fn point_at_angle(&self, angle: T) -> Option<(T, T)>;
+}
 
+pub trait EllipseArc2DContainment<T: Scalar> {
     /// 点が楕円弧上にあるか判定（許容誤差付き）
     fn contains_point(&self, point: (T, T), tolerance: T) -> bool;
+}
 
-    /// 楕円弧の境界ボックスを取得（最小点、最大点）
-    fn bounding_box(&self) -> ((T, T), (T, T));
+/// EllipseArc2D計量・関係演算機能トレイト（Phase 1 + Phase 2）
+pub trait EllipseArc2DMeasure<T: Scalar>:
+    EllipseArc2DDerived<T>
+    + EllipseArc2DEndpoint<T>
+    + EllipseArc2DEvaluation<T>
+    + EllipseArc2DContainment<T>
+{
+    fn measure(&self) -> T {
+        <Self as EllipseArc2DDerived<T>>::measure(self)
+    }
+
+    fn start_point(&self) -> (T, T) {
+        <Self as EllipseArc2DEndpoint<T>>::start_point(self)
+    }
+
+    fn end_point(&self) -> (T, T) {
+        <Self as EllipseArc2DEndpoint<T>>::end_point(self)
+    }
+
+    fn point_at_parameter(&self, t: T) -> (T, T) {
+        <Self as EllipseArc2DEvaluation<T>>::point_at_parameter(self, t)
+    }
+
+    fn mid_point(&self) -> (T, T) {
+        <Self as EllipseArc2DEndpoint<T>>::mid_point(self)
+    }
+
+    fn point_at_angle(&self, angle: T) -> Option<(T, T)> {
+        <Self as EllipseArc2DEvaluation<T>>::point_at_angle(self, angle)
+    }
+
+    fn contains_point(&self, point: (T, T), tolerance: T) -> bool {
+        <Self as EllipseArc2DContainment<T>>::contains_point(self, point, tolerance)
+    }
+
+    fn bounding_box(&self) -> ((T, T), (T, T)) {
+        <Self as EllipseArc2DDerived<T>>::bounding_box(self)
+    }
 }
 
 /// EllipseArc3D計量・関係演算機能トレイト（Phase 1 + Phase 2）
-pub trait EllipseArc3DMeasure<T: Scalar> {
+pub trait EllipseArc3DDerived<T: Scalar> {
     /// 楕円弧の長さ（測度）
     fn measure(&self) -> T;
 
+    /// 楕円弧の境界ボックスを取得（最小点、最大点）
+    fn bounding_box(&self) -> ((T, T, T), (T, T, T));
+}
+
+pub trait EllipseArc3DEndpoint<T: Scalar> {
     /// 開始点を取得
     fn start_point(&self) -> (T, T, T);
 
     /// 終了点を取得
     fn end_point(&self) -> (T, T, T);
 
+    /// 中点を取得（パラメータt=0.5の点）
+    fn mid_point(&self) -> (T, T, T);
+}
+
+pub trait EllipseArc3DEvaluation<T: Scalar> {
     /// パラメータt（0<=t<=1）での点を取得
     fn point_at_parameter(&self, t: T) -> (T, T, T);
 
-    /// 中点を取得（パラメータt=0.5の点）
-    fn mid_point(&self) -> (T, T, T);
-
     /// 指定角度での点を取得（ラジアン）
     fn point_at_angle(&self, angle: T) -> Option<(T, T, T)>;
+}
 
+pub trait EllipseArc3DContainment<T: Scalar> {
     /// 点が楕円弧上にあるか判定（許容誤差付き）
     fn contains_point(&self, point: (T, T, T), tolerance: T) -> bool;
+}
 
-    /// 楕円弧の境界ボックスを取得（最小点、最大点）
-    fn bounding_box(&self) -> ((T, T, T), (T, T, T));
+pub trait EllipseArc3DMeasure<T: Scalar>:
+    EllipseArc3DDerived<T>
+    + EllipseArc3DEndpoint<T>
+    + EllipseArc3DEvaluation<T>
+    + EllipseArc3DContainment<T>
+{
+    fn measure(&self) -> T {
+        <Self as EllipseArc3DDerived<T>>::measure(self)
+    }
+
+    fn start_point(&self) -> (T, T, T) {
+        <Self as EllipseArc3DEndpoint<T>>::start_point(self)
+    }
+
+    fn end_point(&self) -> (T, T, T) {
+        <Self as EllipseArc3DEndpoint<T>>::end_point(self)
+    }
+
+    fn point_at_parameter(&self, t: T) -> (T, T, T) {
+        <Self as EllipseArc3DEvaluation<T>>::point_at_parameter(self, t)
+    }
+
+    fn mid_point(&self) -> (T, T, T) {
+        <Self as EllipseArc3DEndpoint<T>>::mid_point(self)
+    }
+
+    fn point_at_angle(&self, angle: T) -> Option<(T, T, T)> {
+        <Self as EllipseArc3DEvaluation<T>>::point_at_angle(self, angle)
+    }
+
+    fn contains_point(&self, point: (T, T, T), tolerance: T) -> bool {
+        <Self as EllipseArc3DContainment<T>>::contains_point(self, point, tolerance)
+    }
+
+    fn bounding_box(&self) -> ((T, T, T), (T, T, T)) {
+        <Self as EllipseArc3DDerived<T>>::bounding_box(self)
+    }
 }
 
 /// EllipseArc2Dの3つのCore機能統合トレイト
 pub trait EllipseArc2DCore<T: Scalar>:
-    EllipseArc2DConstructor<T> + EllipseArc2DProperties<T> + EllipseArc2DMeasure<T>
+    EllipseArc2DConstructor<T> + EllipseArc2DProperties<T>
 {
 }
 
 /// EllipseArc3Dの3つのCore機能統合トレイト
 pub trait EllipseArc3DCore<T: Scalar>:
-    EllipseArc3DConstructor<T> + EllipseArc3DProperties<T> + EllipseArc3DMeasure<T>
+    EllipseArc3DConstructor<T> + EllipseArc3DProperties<T>
+{
+}
+
+impl<T: Scalar, E> EllipseArc2DMeasure<T> for E where
+    E: EllipseArc2DDerived<T>
+        + EllipseArc2DEndpoint<T>
+        + EllipseArc2DEvaluation<T>
+        + EllipseArc2DContainment<T>
+{
+}
+
+impl<T: Scalar, E> EllipseArc3DMeasure<T> for E where
+    E: EllipseArc3DDerived<T>
+        + EllipseArc3DEndpoint<T>
+        + EllipseArc3DEvaluation<T>
+        + EllipseArc3DContainment<T>
 {
 }
 
 impl<T: Scalar, E> EllipseArc2DCore<T> for E where
-    E: EllipseArc2DConstructor<T> + EllipseArc2DProperties<T> + EllipseArc2DMeasure<T>
+    E: EllipseArc2DConstructor<T> + EllipseArc2DProperties<T>
 {
 }
 
 impl<T: Scalar, E> EllipseArc3DCore<T> for E where
-    E: EllipseArc3DConstructor<T> + EllipseArc3DProperties<T> + EllipseArc3DMeasure<T>
+    E: EllipseArc3DConstructor<T> + EllipseArc3DProperties<T>
 {
 }

--- a/model/geo_contracts/src/geometry/core/mod.rs
+++ b/model/geo_contracts/src/geometry/core/mod.rs
@@ -31,7 +31,9 @@ pub mod vector_traits;
 
 pub use aabb_traits::{Aabb2DDerived, Aabb2DProperties, Aabb3DDerived, Aabb3DProperties};
 pub use arc_traits::{
-    Arc2DConstructor, Arc2DCore, Arc2DMeasure, Arc2DProperties, Arc3DConstructor, Arc3DCore,
+    Arc2DConstructor, Arc2DContainment, Arc2DCore, Arc2DDerived, Arc2DDistance, Arc2DEndpoint,
+    Arc2DEvaluation, Arc2DMeasure, Arc2DProperties, Arc2DSampling, Arc3DConstructor,
+    Arc3DContainment, Arc3DCore, Arc3DDerived, Arc3DDistance, Arc3DEndpoint, Arc3DEvaluation,
     Arc3DMeasure, Arc3DProperties,
 };
 pub use circle_traits::{
@@ -58,8 +60,10 @@ pub use direction_traits::{
     Direction3DConstructor, Direction3DCore, Direction3DMeasure, Direction3DProperties,
 };
 pub use ellipse_arc_traits::{
-    EllipseArc2DConstructor, EllipseArc2DCore, EllipseArc2DMeasure, EllipseArc2DProperties,
-    EllipseArc3DConstructor, EllipseArc3DCore, EllipseArc3DMeasure, EllipseArc3DProperties,
+    EllipseArc2DConstructor, EllipseArc2DContainment, EllipseArc2DCore, EllipseArc2DDerived,
+    EllipseArc2DEndpoint, EllipseArc2DEvaluation, EllipseArc2DMeasure, EllipseArc2DProperties,
+    EllipseArc3DConstructor, EllipseArc3DContainment, EllipseArc3DCore, EllipseArc3DDerived,
+    EllipseArc3DEndpoint, EllipseArc3DEvaluation, EllipseArc3DMeasure, EllipseArc3DProperties,
 };
 pub use ellipse_traits::{
     Ellipse2DConstructor, Ellipse2DCore, Ellipse2DMeasure, Ellipse2DProperties,

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -11,14 +11,15 @@ pub mod tolerance;
 pub use analysis::abstract_types::{Angle, Scalar, TolerantEq};
 pub use classification::{DimensionClass, GeometryPrimitive, PrimitiveKind};
 pub use entity::{EntityDisplayProperties, EntityIdentity, LineEntity3DProperties};
-pub use geometry::core::arc_traits::{Arc2DContainment, Arc2DSampling};
 pub use geometry::core::plane3d_traits::{
     Plane3DConstructor, Plane3DContainment, Plane3DCore, Plane3DDerived, Plane3DDistance,
     Plane3DEvaluation, Plane3DMeasure, Plane3DProjection, Plane3DProperties, Plane3DTransform,
 };
 pub use geometry::core::{Aabb2DDerived, Aabb2DProperties, Aabb3DDerived, Aabb3DProperties};
 pub use geometry::core::{
-    Arc2DConstructor, Arc2DCore, Arc2DMeasure, Arc2DProperties, Arc3DConstructor, Arc3DCore,
+    Arc2DConstructor, Arc2DContainment, Arc2DCore, Arc2DDerived, Arc2DDistance, Arc2DEndpoint,
+    Arc2DEvaluation, Arc2DMeasure, Arc2DProperties, Arc2DSampling, Arc3DConstructor,
+    Arc3DContainment, Arc3DCore, Arc3DDerived, Arc3DDistance, Arc3DEndpoint, Arc3DEvaluation,
     Arc3DMeasure, Arc3DProperties, Circle2DConstructor, Circle2DCore, Circle2DMeasure,
     Circle2DProperties, Circle3DConstructor, Circle3DCore, Circle3DMeasure, Circle3DProperties,
     ConicalSolid3DConstructor, ConicalSolid3DCore, ConicalSolid3DMeasure, ConicalSolid3DProperties,
@@ -30,8 +31,10 @@ pub use geometry::core::{
     Direction3DConstructor, Direction3DCore, Direction3DMeasure, Direction3DProperties,
     Ellipse2DConstructor, Ellipse2DCore, Ellipse2DMeasure, Ellipse2DProperties,
     Ellipse3DConstructor, Ellipse3DCore, Ellipse3DMeasure, Ellipse3DProperties,
-    EllipseArc2DConstructor, EllipseArc2DCore, EllipseArc2DMeasure, EllipseArc2DProperties,
-    EllipseArc3DConstructor, EllipseArc3DCore, EllipseArc3DMeasure, EllipseArc3DProperties,
+    EllipseArc2DConstructor, EllipseArc2DContainment, EllipseArc2DCore, EllipseArc2DDerived,
+    EllipseArc2DEndpoint, EllipseArc2DEvaluation, EllipseArc2DMeasure, EllipseArc2DProperties,
+    EllipseArc3DConstructor, EllipseArc3DContainment, EllipseArc3DCore, EllipseArc3DDerived,
+    EllipseArc3DEndpoint, EllipseArc3DEvaluation, EllipseArc3DMeasure, EllipseArc3DProperties,
     EllipsoidalSolid3DConstructor, EllipsoidalSolid3DCore, EllipsoidalSolid3DMeasure,
     EllipsoidalSolid3DProperties, EllipsoidalSurface3DConstructor, EllipsoidalSurface3DCore,
     EllipsoidalSurface3DMeasure, EllipsoidalSurface3DProperties, Point2DConstructor, Point2DCore,

--- a/model/geo_primitives/src/arc_2d.rs
+++ b/model/geo_primitives/src/arc_2d.rs
@@ -6,8 +6,9 @@
 use crate::{Circle2D, Direction2D, Point2D, Vector2D};
 use analysis::Angle;
 use geo_contracts::{
-    default_angle_tolerance, default_distance_tolerance, Arc2DConstructor, Arc2DMeasure,
-    Arc2DProperties, Circle2DProperties, Scalar,
+    default_angle_tolerance, default_distance_tolerance, Arc2DConstructor, Arc2DContainment,
+    Arc2DDerived, Arc2DDistance, Arc2DEndpoint, Arc2DEvaluation, Arc2DProperties,
+    Circle2DProperties, Scalar,
 };
 
 /// 2次元円弧
@@ -333,12 +334,14 @@ impl<T: Scalar> Arc2DProperties<T> for Arc2D<T> {
     }
 }
 
-impl<T: Scalar> Arc2DMeasure<T> for Arc2D<T> {
+impl<T: Scalar> Arc2DDerived<T> for Arc2D<T> {
     fn measure(&self) -> T {
         // arc_length の計算を直接展開: radius * angular_span
         self.radius_internal() * self.angular_span()
     }
+}
 
+impl<T: Scalar> Arc2DEndpoint<T> for Arc2D<T> {
     fn start_point(&self) -> (T, T) {
         let p = self.point_at_angle_internal(self.start_angle.to_radians());
         (p.x(), p.y())
@@ -349,6 +352,15 @@ impl<T: Scalar> Arc2DMeasure<T> for Arc2D<T> {
         (p.x(), p.y())
     }
 
+    fn midpoint(&self) -> (T, T) {
+        let mid_angle =
+            (self.start_angle.to_radians() + self.end_angle.to_radians()) / (T::ONE + T::ONE);
+        let p = self.point_at_angle_internal(mid_angle);
+        (p.x(), p.y())
+    }
+}
+
+impl<T: Scalar> Arc2DEvaluation<T> for Arc2D<T> {
     fn point_at_parameter(&self, t: T) -> (T, T) {
         let start_rad = self.start_angle.to_radians();
         let end_rad = self.end_angle.to_radians();
@@ -357,29 +369,49 @@ impl<T: Scalar> Arc2DMeasure<T> for Arc2D<T> {
         (p.x(), p.y())
     }
 
-    // Phase 2: 追加測度メソッド
-    fn midpoint(&self) -> (T, T) {
-        let mid_angle =
-            (self.start_angle.to_radians() + self.end_angle.to_radians()) / (T::ONE + T::ONE);
-        let p = self.point_at_angle_internal(mid_angle);
-        (p.x(), p.y())
-    }
-
     fn point_at_angle(&self, angle: T) -> (T, T) {
         let p = self.point_at_angle_internal(angle);
         (p.x(), p.y())
     }
+}
 
+impl<T: Scalar> Arc2DDistance<T> for Arc2D<T> {
     fn distance_to_point(&self, point: (T, T)) -> T {
         // 簡易実装: 円弧の中心からの距離との差分
         let center = self.center_internal();
         let distance_from_center = center.distance_to(&Point2D::new(point.0, point.1));
         (distance_from_center - self.radius_internal()).abs()
     }
+}
 
+impl<T: Scalar> Arc2DContainment<T> for Arc2D<T> {
     fn contains_point(&self, point: (T, T)) -> bool {
-        let distance = self.distance_to_point(point);
-        distance <= default_distance_tolerance::<T>()
+        let point = Point2D::new(point.0, point.1);
+        let distance = <Self as Arc2DDistance<T>>::distance_to_point(self, (point.x(), point.y()));
+        distance <= default_distance_tolerance::<T>() && self.contains_point_angle(point)
+    }
+
+    fn contains_angle(&self, angle: T) -> bool {
+        let normalize = |mut value: T| {
+            while value < T::ZERO {
+                value += T::TAU;
+            }
+            while value >= T::TAU {
+                value -= T::TAU;
+            }
+            value
+        };
+
+        let angle = normalize(angle);
+        let start = normalize(self.start_angle.to_radians());
+        let end = normalize(self.end_angle.to_radians());
+        let tolerance = default_angle_tolerance::<T>();
+
+        if start <= end {
+            angle + tolerance >= start && angle <= end + tolerance
+        } else {
+            angle + tolerance >= start || angle <= end + tolerance
+        }
     }
 }
 

--- a/model/geo_primitives/src/arc_3d.rs
+++ b/model/geo_primitives/src/arc_3d.rs
@@ -7,7 +7,10 @@ use geo_contracts::Scalar;
 use geo_contracts::{
     default_angle_tolerance, default_distance_tolerance, default_kernel_numerical_zero_tolerance,
 };
-use geo_contracts::{Arc3DConstructor, Arc3DMeasure, Arc3DProperties as ContractsArc3DProperties};
+use geo_contracts::{
+    Arc3DConstructor, Arc3DContainment, Arc3DDerived, Arc3DDistance, Arc3DEndpoint,
+    Arc3DEvaluation, Arc3DProperties as ContractsArc3DProperties,
+};
 
 /// 3次元円弧（基本実装）
 ///
@@ -352,7 +355,7 @@ impl<T: Scalar> ContractsArc3DProperties<T> for Arc3D<T> {
     }
 }
 
-impl<T: Scalar> Arc3DMeasure<T> for Arc3D<T> {
+impl<T: Scalar> Arc3DDerived<T> for Arc3D<T> {
     fn measure(&self) -> T {
         // arc_length の計算を直接展開: radius * angle_span
         let mut span = self.end_angle - self.start_angle;
@@ -361,7 +364,9 @@ impl<T: Scalar> Arc3DMeasure<T> for Arc3D<T> {
         }
         self.radius * span.to_radians()
     }
+}
 
+impl<T: Scalar> Arc3DEndpoint<T> for Arc3D<T> {
     fn start_point(&self) -> (T, T, T) {
         let p = self.point_at_angle_internal(self.start_angle);
         (p.x(), p.y(), p.z())
@@ -372,16 +377,17 @@ impl<T: Scalar> Arc3DMeasure<T> for Arc3D<T> {
         (p.x(), p.y(), p.z())
     }
 
-    fn point_at_parameter(&self, t: T) -> (T, T, T) {
-        let angle = self.start_angle + (self.end_angle - self.start_angle) * t;
-        let p = self.point_at_angle_internal(angle);
-        (p.x(), p.y(), p.z())
-    }
-
-    // Phase 2: 追加測度メソッド
     fn midpoint(&self) -> (T, T, T) {
         let mid_angle = (self.start_angle + self.end_angle) / (T::ONE + T::ONE);
         let p = self.point_at_angle_internal(mid_angle);
+        (p.x(), p.y(), p.z())
+    }
+}
+
+impl<T: Scalar> Arc3DEvaluation<T> for Arc3D<T> {
+    fn point_at_parameter(&self, t: T) -> (T, T, T) {
+        let angle = self.start_angle + (self.end_angle - self.start_angle) * t;
+        let p = self.point_at_angle_internal(angle);
         (p.x(), p.y(), p.z())
     }
 
@@ -389,14 +395,18 @@ impl<T: Scalar> Arc3DMeasure<T> for Arc3D<T> {
         let p = self.point_at_angle_internal(Angle::from_radians(angle));
         (p.x(), p.y(), p.z())
     }
+}
 
+impl<T: Scalar> Arc3DDistance<T> for Arc3D<T> {
     fn distance_to_point(&self, point: (T, T, T)) -> T {
         // 簡易実装: 円弧上の最近点までの距離
         let center_pt = self.center_internal();
         (center_pt.distance_to(&Point3D::new(point.0, point.1, point.2)) - self.radius_internal())
             .abs()
     }
+}
 
+impl<T: Scalar> Arc3DContainment<T> for Arc3D<T> {
     fn contains_point(&self, point: (T, T, T)) -> bool {
         // 簡易実装: 半径と角度範囲をチェック
         let center_pt = self.center_internal();

--- a/model/geo_primitives/src/ellipse_arc_2d.rs
+++ b/model/geo_primitives/src/ellipse_arc_2d.rs
@@ -4,8 +4,9 @@
 
 use crate::{Ellipse2D, Point2D, Vector2D};
 use geo_contracts::{
-    default_angle_tolerance, Angle, EllipseArc2DConstructor, EllipseArc2DMeasure,
-    EllipseArc2DProperties, Scalar,
+    default_angle_tolerance, Angle, EllipseArc2DConstructor, EllipseArc2DContainment,
+    EllipseArc2DDerived, EllipseArc2DEndpoint, EllipseArc2DEvaluation, EllipseArc2DProperties,
+    Scalar,
 };
 
 /// 2次元楕円弧
@@ -403,105 +404,13 @@ impl<T: Scalar> EllipseArc2DProperties<T> for EllipseArc2D<T> {
     }
 }
 
-impl<T: Scalar> EllipseArc2DMeasure<T> for EllipseArc2D<T> {
+impl<T: Scalar> EllipseArc2DDerived<T> for EllipseArc2D<T> {
     fn measure(&self) -> T {
         // arc_length の計算を直接展開: 楕円周囲長に角度比率を掛ける
         let full_perimeter = self.ellipse.perimeter();
         let angle_ratio =
             (self.end_angle.to_radians() - self.start_angle.to_radians()).abs() / T::TAU;
         full_perimeter * angle_ratio
-    }
-
-    fn start_point(&self) -> (T, T) {
-        let p = self
-            .ellipse
-            .point_at_parameter(self.start_angle.to_radians());
-        (p.x(), p.y())
-    }
-
-    fn end_point(&self) -> (T, T) {
-        let p = self.ellipse.point_at_parameter(self.end_angle.to_radians());
-        (p.x(), p.y())
-    }
-
-    fn point_at_parameter(&self, t: T) -> (T, T) {
-        let angle = self.start_angle.to_radians()
-            + (self.end_angle.to_radians() - self.start_angle.to_radians()) * t;
-        let p = self.ellipse.point_at_parameter(angle);
-        (p.x(), p.y())
-    }
-
-    // ========== Phase 2: 追加計量 ==========
-
-    fn mid_point(&self) -> (T, T) {
-        let p = self.point_at_parameter(T::ONE / (T::ONE + T::ONE));
-        (p.x(), p.y())
-    }
-
-    fn point_at_angle(&self, angle: T) -> Option<(T, T)> {
-        // 角度が範囲内かチェック
-        let normalized_angle = if angle < T::ZERO {
-            angle + T::TAU
-        } else if angle >= T::TAU {
-            angle - T::TAU
-        } else {
-            angle
-        };
-
-        let start = self.start_angle.to_radians();
-        let end = self.end_angle.to_radians();
-
-        let in_range = if start <= end {
-            normalized_angle >= start && normalized_angle <= end
-        } else {
-            normalized_angle >= start || normalized_angle <= end
-        };
-
-        if !in_range {
-            return None;
-        }
-
-        // 楕円上の点を計算
-        let a = self.semi_major();
-        let b = self.semi_minor();
-        let rot = self.ellipse.rotation();
-        let center = self.center();
-
-        let cos_a = angle.cos();
-        let sin_a = angle.sin();
-        let cos_r = rot.cos();
-        let sin_r = rot.sin();
-
-        let x_local = a * cos_a;
-        let y_local = b * sin_a;
-
-        let x = center.x() + x_local * cos_r - y_local * sin_r;
-        let y = center.y() + x_local * sin_r + y_local * cos_r;
-
-        Some((x, y))
-    }
-
-    fn contains_point(&self, point: (T, T), tolerance: T) -> bool {
-        let p = Point2D::new(point.0, point.1);
-
-        // まず楕円上にあるかチェック
-        if !self.ellipse.contains_point(&p, tolerance) {
-            return false;
-        }
-
-        // 次に角度範囲内かチェック
-        let center = self.center();
-        let vec = Vector2D::from_points(center, p);
-        let angle = vec.y().atan2(vec.x());
-
-        let start = self.start_angle.to_radians();
-        let end = self.end_angle.to_radians();
-
-        if start <= end {
-            angle >= start - tolerance && angle <= end + tolerance
-        } else {
-            angle >= start - tolerance || angle <= end + tolerance
-        }
     }
 
     fn bounding_box(&self) -> ((T, T), (T, T)) {
@@ -552,5 +461,101 @@ impl<T: Scalar> EllipseArc2DMeasure<T> for EllipseArc2D<T> {
         }
 
         ((min_x, min_y), (max_x, max_y))
+    }
+}
+
+impl<T: Scalar> EllipseArc2DEndpoint<T> for EllipseArc2D<T> {
+    fn start_point(&self) -> (T, T) {
+        let p = self
+            .ellipse
+            .point_at_parameter(self.start_angle.to_radians());
+        (p.x(), p.y())
+    }
+
+    fn end_point(&self) -> (T, T) {
+        let p = self.ellipse.point_at_parameter(self.end_angle.to_radians());
+        (p.x(), p.y())
+    }
+
+    fn mid_point(&self) -> (T, T) {
+        let p = self.point_at_parameter(T::ONE / (T::ONE + T::ONE));
+        (p.x(), p.y())
+    }
+}
+
+impl<T: Scalar> EllipseArc2DEvaluation<T> for EllipseArc2D<T> {
+    fn point_at_parameter(&self, t: T) -> (T, T) {
+        let angle = self.start_angle.to_radians()
+            + (self.end_angle.to_radians() - self.start_angle.to_radians()) * t;
+        let p = self.ellipse.point_at_parameter(angle);
+        (p.x(), p.y())
+    }
+
+    fn point_at_angle(&self, angle: T) -> Option<(T, T)> {
+        // 角度が範囲内かチェック
+        let normalized_angle = if angle < T::ZERO {
+            angle + T::TAU
+        } else if angle >= T::TAU {
+            angle - T::TAU
+        } else {
+            angle
+        };
+
+        let start = self.start_angle.to_radians();
+        let end = self.end_angle.to_radians();
+
+        let in_range = if start <= end {
+            normalized_angle >= start && normalized_angle <= end
+        } else {
+            normalized_angle >= start || normalized_angle <= end
+        };
+
+        if !in_range {
+            return None;
+        }
+
+        // 楕円上の点を計算
+        let a = self.semi_major();
+        let b = self.semi_minor();
+        let rot = self.ellipse.rotation();
+        let center = self.center();
+
+        let cos_a = angle.cos();
+        let sin_a = angle.sin();
+        let cos_r = rot.cos();
+        let sin_r = rot.sin();
+
+        let x_local = a * cos_a;
+        let y_local = b * sin_a;
+
+        let x = center.x() + x_local * cos_r - y_local * sin_r;
+        let y = center.y() + x_local * sin_r + y_local * cos_r;
+
+        Some((x, y))
+    }
+}
+
+impl<T: Scalar> EllipseArc2DContainment<T> for EllipseArc2D<T> {
+    fn contains_point(&self, point: (T, T), tolerance: T) -> bool {
+        let p = Point2D::new(point.0, point.1);
+
+        // まず楕円上にあるかチェック
+        if !self.ellipse.contains_point(&p, tolerance) {
+            return false;
+        }
+
+        // 次に角度範囲内かチェック
+        let center = self.center();
+        let vec = Vector2D::from_points(center, p);
+        let angle = vec.y().atan2(vec.x());
+
+        let start = self.start_angle.to_radians();
+        let end = self.end_angle.to_radians();
+
+        if start <= end {
+            angle >= start - tolerance && angle <= end + tolerance
+        } else {
+            angle >= start - tolerance || angle <= end + tolerance
+        }
     }
 }

--- a/model/geo_primitives/src/ellipse_arc_3d.rs
+++ b/model/geo_primitives/src/ellipse_arc_3d.rs
@@ -5,8 +5,8 @@
 
 use crate::{Arc3D, Circle3D, Direction3D, Ellipse3D, Point3D, Vector3D};
 use geo_contracts::{
-    Angle, Arc3DProperties, EllipseArc3DConstructor, EllipseArc3DMeasure, EllipseArc3DProperties,
-    Scalar,
+    Angle, Arc3DProperties, EllipseArc3DConstructor, EllipseArc3DContainment, EllipseArc3DDerived,
+    EllipseArc3DEndpoint, EllipseArc3DEvaluation, EllipseArc3DProperties, Scalar,
 };
 
 /// 3次元楕円弧
@@ -428,7 +428,7 @@ impl<T: Scalar> EllipseArc3DProperties<T> for EllipseArc3D<T> {
     }
 }
 
-impl<T: Scalar> EllipseArc3DMeasure<T> for EllipseArc3D<T> {
+impl<T: Scalar> EllipseArc3DDerived<T> for EllipseArc3D<T> {
     fn measure(&self) -> T {
         // 楕円弧の長さの簡易近似: angle_span計算を直接展開
         let full_perimeter = self.ellipse.perimeter();
@@ -442,6 +442,56 @@ impl<T: Scalar> EllipseArc3DMeasure<T> for EllipseArc3D<T> {
         full_perimeter * angle_ratio
     }
 
+    fn bounding_box(&self) -> ((T, T, T), (T, T, T)) {
+        let start = <Self as EllipseArc3DEndpoint<T>>::start_point(self);
+        let end = <Self as EllipseArc3DEndpoint<T>>::end_point(self);
+
+        let mut min_x = start.0.min(end.0);
+        let mut max_x = start.0.max(end.0);
+        let mut min_y = start.1.min(end.1);
+        let mut max_y = start.1.max(end.1);
+        let mut min_z = start.2.min(end.2);
+        let mut max_z = start.2.max(end.2);
+
+        let t_values = [
+            T::ZERO,
+            T::ONE
+                / (T::ONE
+                    + T::ONE
+                    + T::ONE
+                    + T::ONE
+                    + T::ONE
+                    + T::ONE
+                    + T::ONE
+                    + T::ONE
+                    + T::ONE
+                    + T::ONE
+                    + T::ONE
+                    + T::ONE
+                    + T::ONE
+                    + T::ONE
+                    + T::ONE
+                    + T::ONE),
+            T::ONE / (T::ONE + T::ONE + T::ONE + T::ONE + T::ONE + T::ONE + T::ONE + T::ONE),
+            T::ONE / (T::ONE + T::ONE + T::ONE + T::ONE),
+            T::ONE / (T::ONE + T::ONE),
+            T::ONE,
+        ];
+        for &t in &t_values {
+            let p = <Self as EllipseArc3DEvaluation<T>>::point_at_parameter(self, t);
+            min_x = min_x.min(p.0);
+            max_x = max_x.max(p.0);
+            min_y = min_y.min(p.1);
+            max_y = max_y.max(p.1);
+            min_z = min_z.min(p.2);
+            max_z = max_z.max(p.2);
+        }
+
+        ((min_x, min_y, min_z), (max_x, max_y, max_z))
+    }
+}
+
+impl<T: Scalar> EllipseArc3DEndpoint<T> for EllipseArc3D<T> {
     fn start_point(&self) -> (T, T, T) {
         let p = self.ellipse.point_at_angle(self.start_angle);
         (p.x(), p.y(), p.z())
@@ -452,19 +502,18 @@ impl<T: Scalar> EllipseArc3DMeasure<T> for EllipseArc3D<T> {
         (p.x(), p.y(), p.z())
     }
 
+    fn mid_point(&self) -> (T, T, T) {
+        <Self as EllipseArc3DEvaluation<T>>::point_at_parameter(self, T::ONE / (T::ONE + T::ONE))
+    }
+}
+
+impl<T: Scalar> EllipseArc3DEvaluation<T> for EllipseArc3D<T> {
     fn point_at_parameter(&self, t: T) -> (T, T, T) {
         let angle_diff = self.end_angle.to_radians() - self.start_angle.to_radians();
         let current_angle = self.start_angle.to_radians() + t * angle_diff;
         let p = self
             .ellipse
             .point_at_angle(Angle::from_radians(current_angle));
-        (p.x(), p.y(), p.z())
-    }
-
-    // ========== Phase 2: 追加計量 ==========
-
-    fn mid_point(&self) -> (T, T, T) {
-        let p = self.point_at_parameter(T::ONE / (T::ONE + T::ONE));
         (p.x(), p.y(), p.z())
     }
 
@@ -491,10 +540,13 @@ impl<T: Scalar> EllipseArc3DMeasure<T> for EllipseArc3D<T> {
         }
 
         let t = (normalized_angle - start) / (end - start);
-        let p = self.point_at_parameter(t);
-        Some((p.x(), p.y(), p.z()))
+        Some(<Self as EllipseArc3DEvaluation<T>>::point_at_parameter(
+            self, t,
+        ))
     }
+}
 
+impl<T: Scalar> EllipseArc3DContainment<T> for EllipseArc3D<T> {
     fn contains_point(&self, point: (T, T, T), tolerance: T) -> bool {
         let p = Point3D::new(point.0, point.1, point.2);
         let center = self.center();
@@ -516,54 +568,5 @@ impl<T: Scalar> EllipseArc3DMeasure<T> for EllipseArc3D<T> {
         } else {
             angle >= start - tolerance || angle <= end + tolerance
         }
-    }
-
-    fn bounding_box(&self) -> ((T, T, T), (T, T, T)) {
-        let start = self.start_point();
-        let end = self.end_point();
-
-        let mut min_x = start.x().min(end.x());
-        let mut max_x = start.x().max(end.x());
-        let mut min_y = start.y().min(end.y());
-        let mut max_y = start.y().max(end.y());
-        let mut min_z = start.z().min(end.z());
-        let mut max_z = start.z().max(end.z());
-
-        // 16分割でサンプリング
-        let t_values = [
-            T::ZERO,
-            T::ONE
-                / (T::ONE
-                    + T::ONE
-                    + T::ONE
-                    + T::ONE
-                    + T::ONE
-                    + T::ONE
-                    + T::ONE
-                    + T::ONE
-                    + T::ONE
-                    + T::ONE
-                    + T::ONE
-                    + T::ONE
-                    + T::ONE
-                    + T::ONE
-                    + T::ONE
-                    + T::ONE),
-            T::ONE / (T::ONE + T::ONE + T::ONE + T::ONE + T::ONE + T::ONE + T::ONE + T::ONE),
-            T::ONE / (T::ONE + T::ONE + T::ONE + T::ONE),
-            T::ONE / (T::ONE + T::ONE),
-            T::ONE,
-        ];
-        for &t in &t_values {
-            let p = self.point_at_parameter(t);
-            min_x = min_x.min(p.x());
-            max_x = max_x.max(p.x());
-            min_y = min_y.min(p.y());
-            max_y = max_y.max(p.y());
-            min_z = min_z.min(p.z());
-            max_z = max_z.max(p.z());
-        }
-
-        ((min_x, min_y, min_z), (max_x, max_y, max_z))
     }
 }


### PR DESCRIPTION
## 概要

#562 の最初の実装PRとして、Arc / EllipseArc の `Measure` 混在を capability ごとに分離します。

今回の目的は、#558 で固定した設計に沿って、Arc 系 shape の責務を最小範囲でコードへ反映することです。

## 変更内容

- `arc_traits.rs` で Arc の責務を `Derived / Endpoint / Evaluation / Distance / Containment / Sampling` へ分離
- `ellipse_arc_traits.rs` で EllipseArc の責務を `Derived / Endpoint / Evaluation / Containment` へ分離
- `Arc2DCore / Arc3DCore / EllipseArc2DCore / EllipseArc3DCore` を `Constructor + Properties` へ縮退
- 旧 `Measure` は blanket impl による compatibility aggregation trait として維持
- `geo_contracts` の公開経路を新 trait 群に追従
- `geo_primitives` の Arc / EllipseArc 実装を新 trait 群へ追従

## 変更ファイル

- `model/geo_contracts/src/geometry/core/arc_traits.rs`
- `model/geo_contracts/src/geometry/core/ellipse_arc_traits.rs`
- `model/geo_contracts/src/geometry/core/mod.rs`
- `model/geo_contracts/src/lib.rs`
- `model/geo_primitives/src/arc_2d.rs`
- `model/geo_primitives/src/arc_3d.rs`
- `model/geo_primitives/src/ellipse_arc_2d.rs`
- `model/geo_primitives/src/ellipse_arc_3d.rs`

## 設計との対応

- shape 意味論の正本: `dev/architecture/GEOMETRY_SHAPE_SEMANTICS_DESIGN.md`
- trait 境界の正本: `dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md`

今回の PR では、Arc / EllipseArc を境界付き曲線 shape として扱い、endpoint と evaluation を分ける方針を実装に反映しています。

## 検証

- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo test --workspace`

## 関連

- refs #562
- parent design: #558