### PR TITLE
[Phase3] capability trait の公開経路を整理

### DIFF
--- a/model/geo_primitives/src/lib.rs
+++ b/model/geo_primitives/src/lib.rs
@@ -114,8 +114,10 @@ pub use geo_contracts::{
 
 // Arc の Core trait定義 再公開
 pub use geo_contracts::{
-    Arc2DConstructor, Arc2DMeasure, Arc2DProperties, Arc3DConstructor, Arc3DMeasure,
-    Arc3DProperties,
+    Arc2DConstructor, Arc2DContainment, Arc2DCore, Arc2DDerived, Arc2DDistance, Arc2DEndpoint,
+    Arc2DEvaluation, Arc2DMeasure, Arc2DProperties, Arc2DSampling, Arc3DConstructor,
+    Arc3DContainment, Arc3DCore, Arc3DDerived, Arc3DDistance, Arc3DEndpoint, Arc3DEvaluation,
+    Arc3DMeasure, Arc3DProperties,
 };
 
 pub mod circle_2d_metrics;
@@ -135,6 +137,19 @@ pub use geo_contracts::{
 pub use geo_contracts::{
     AngleBetween, DirectionalRelation, PointsTowards, Ray2DConstructor, Ray2DMeasure,
     Ray2DProperties, Ray3DConstructor, Ray3DMeasure, Ray3DProperties,
+};
+pub use geo_contracts::{
+    EllipseArc2DConstructor, EllipseArc2DContainment, EllipseArc2DCore, EllipseArc2DDerived,
+    EllipseArc2DEndpoint, EllipseArc2DEvaluation, EllipseArc2DMeasure, EllipseArc2DProperties,
+    EllipseArc3DConstructor, EllipseArc3DContainment, EllipseArc3DCore, EllipseArc3DDerived,
+    EllipseArc3DEndpoint, EllipseArc3DEvaluation, EllipseArc3DMeasure, EllipseArc3DProperties,
+};
+pub use geo_contracts::{
+    LineSegment2DConstructor, LineSegment2DContainment, LineSegment2DCore, LineSegment2DDerived,
+    LineSegment2DDistance, LineSegment2DEvaluation, LineSegment2DMeasure, LineSegment2DProjection,
+    LineSegment2DProperties, LineSegment3DConstructor, LineSegment3DContainment, LineSegment3DCore,
+    LineSegment3DDerived, LineSegment3DDistance, LineSegment3DEvaluation, LineSegment3DMeasure,
+    LineSegment3DProjection, LineSegment3DProperties,
 };
 pub use geo_contracts::{
     Triangle2DConstructor, Triangle2DContainment, Triangle2DCore, Triangle2DDerived,


### PR DESCRIPTION
## 概要
- geo_primitives の re-export を capability 分離後の trait 構成に揃える
- Arc / EllipseArc / LineSegment の split trait を geo_contracts から再公開する
- shape capability taxonomy 適用後に残っていた公開経路の不整合を解消する

## 変更詳細
- [model/geo_primitives/src/lib.rs](model/geo_primitives/src/lib.rs)
  - Arc の re-export を `Containment / Core / Derived / Distance / Endpoint / Evaluation / Sampling` まで拡張
  - EllipseArc の re-export を `Containment / Core / Derived / Endpoint / Evaluation` まで追加
  - LineSegment の re-export を `Containment / Core / Derived / Distance / Evaluation / Projection` まで追加

## 意図
- geo_contracts では capability 分離済みだが、geo_primitives 側の再公開が旧粒度のまま残っていた
- 利用側が geo_primitives 経由で trait を参照する場合にも、Arc / EllipseArc / Circle / Triangle / LineSegment の公開粒度を揃える
- ロジック変更は含めず、公開 API の整合のみを扱う

## 検証
- cargo clippy -- -D warnings
- cargo fmt
- cargo test --workspace

## 関連
- refs #562
- 設計: #558