### PR TITLE
refactor: NURBS curve capability taxonomy を適用

### DIFF
--- a/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
+++ b/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
@@ -336,6 +336,31 @@ Ellipse は閉曲線 shape であり、Circle と同様に endpoint capability �
 - `measure` は新規責務説明には使わず、後方互換の集約 API としてのみ扱う
 - `focus1/focus2/focal_distance/eccentricity/linear_eccentricity/is_circle` は定義パラメータではなく unary `derived` とみなす
 
+### NURBS Curve の再分類
+
+NURBS curve は endpoint を shape 意味論の正本として持たず、parameter evaluation と length 語彙を中心に整理する。
+既存 API は 2D/3D ともに `*Measure` へ point evaluation、接線、長さ、曲率、弧長逆算が混在しているため、少なくとも evaluation と derived を分ける必要がある。
+
+本整理では、curve family の primary measure vocabulary として `length` を維持し、`*Measure` は後方互換の集約 trait として後退させる。
+
+| 現行 trait / API | 再分類 |
+| --- | --- |
+| `NurbsCurve2DConstructor` / `NurbsCurve3DConstructor` | `definition` |
+| `NurbsCurve2DProperties::degree/num_control_points/knot_vector/is_rational/dimension` | `definition` |
+| `NurbsCurve3DProperties::degree/knot_vector/control_points_count/weights/is_rational/parameter_domain/coordinates` | `definition` |
+| `NurbsCurve2DEvaluation::point_at/tangent_at` | `evaluation` |
+| `NurbsCurve3DEvaluation::evaluate/parameter_at_length` | `evaluation` |
+| `NurbsCurve2DDerived::length/curvature_at` | `derived` |
+| `NurbsCurve3DDerived::arc_length/arc_length_total` | `derived` |
+| `NurbsCurve2DCore` / `NurbsCurve3DCore` | `Constructor + Properties` へ縮退候補 |
+
+補足:
+
+- NURBS curve は `Circle` のような closed curve ではないため、主語彙は `circumference` ではなく `length` を維持する
+- `parameter_at_length` は endpoint ではなく、length から parameter を求める evaluation capability として扱う
+- `arc_length(u_start, u_end, tolerance)` は区間に対する unary derived quantity とみなし、後方互換の `*Measure` から分離する
+- adaptive tessellation や近似戦略は operations/strategy 側の論点であり、本整理では core capability へ持ち込まない
+
 ### Circle の再分類
 
 Circle は閉曲線であり、parameter evaluation を持っても endpoint capability は持たない。

--- a/model/geo_contracts/src/geometry/core/mod.rs
+++ b/model/geo_contracts/src/geometry/core/mod.rs
@@ -97,10 +97,12 @@ pub use linesegment_traits::{
     LineSegment3DProjection, LineSegment3DProperties,
 };
 pub use nurbs_curve_2d_traits::{
-    NurbsCurve2DConstructor, NurbsCurve2DCore, NurbsCurve2DMeasure, NurbsCurve2DProperties,
+    NurbsCurve2DConstructor, NurbsCurve2DCore, NurbsCurve2DDerived, NurbsCurve2DEvaluation,
+    NurbsCurve2DMeasure, NurbsCurve2DProperties,
 };
 pub use nurbs_curve_3d_traits::{
-    NurbsCurve3DConstructor, NurbsCurve3DCore, NurbsCurve3DMeasure, NurbsCurve3DProperties,
+    NurbsCurve3DConstructor, NurbsCurve3DCore, NurbsCurve3DDerived, NurbsCurve3DEvaluation,
+    NurbsCurve3DMeasure, NurbsCurve3DProperties,
 };
 pub use nurbs_surface_3d_traits::{
     NurbsSurface3DConstructor, NurbsSurface3DCore, NurbsSurface3DMeasure, NurbsSurface3DProperties,

--- a/model/geo_contracts/src/geometry/core/nurbs_curve_2d_traits.rs
+++ b/model/geo_contracts/src/geometry/core/nurbs_curve_2d_traits.rs
@@ -1,15 +1,8 @@
-//! NurbsCurve2D Core Traits - NURBS 2D曲線の3つのCore機能統合
-//!
-//! Core機能（Constructor/Properties/Measure）を形状別に統合
-//! Transform機能は共通のAnalysisTransformトレイトを使用
+//! NurbsCurve2D の trait定義を capability taxonomy に沿って分離する。
 
 use crate::Scalar;
 
-// ============================================================================
-// 1. Constructor Traits - NurbsCurve2D生成機能
-// ============================================================================
-
-/// NurbsCurve2D生成のためのConstructorトレイト
+/// NurbsCurve2D の生成 trait
 pub trait NurbsCurve2DConstructor<T: Scalar> {
     /// NURBS曲線を作成
     ///
@@ -45,11 +38,7 @@ pub trait NurbsCurve2DConstructor<T: Scalar> {
         Self: Sized;
 }
 
-// ============================================================================
-// 2. Properties Traits - NurbsCurve2D基本情報取得
-// ============================================================================
-
-/// NurbsCurve2D基本プロパティ取得トレイト
+/// NurbsCurve2D の定義パラメータ
 pub trait NurbsCurve2DProperties<T: Scalar> {
     /// NURBS次数を取得
     fn degree(&self) -> usize;
@@ -69,18 +58,17 @@ pub trait NurbsCurve2DProperties<T: Scalar> {
     }
 }
 
-// ============================================================================
-// 3. Measure Traits - NurbsCurve2D測定・評価機能
-// ============================================================================
-
-/// NurbsCurve2D測定・評価機能トレイト
-pub trait NurbsCurve2DMeasure<T: Scalar> {
+/// NurbsCurve2D の評価
+pub trait NurbsCurve2DEvaluation<T: Scalar> {
     /// パラメータ t での曲線上の点を計算
     fn point_at(&self, t: T) -> (T, T);
 
     /// パラメータ t での接線ベクトルを計算
     fn tangent_at(&self, t: T) -> (T, T);
+}
 
+/// NurbsCurve2D の派生量
+pub trait NurbsCurve2DDerived<T: Scalar> {
     /// 曲線の長さを計算（数値積分により近似計算）
     fn length(&self) -> T;
 
@@ -88,12 +76,39 @@ pub trait NurbsCurve2DMeasure<T: Scalar> {
     fn curvature_at(&self, t: T) -> T;
 }
 
-// ============================================================================
-// 4. Core統合トレイト
-// ============================================================================
+/// NurbsCurve2D の後方互換集約 trait
+pub trait NurbsCurve2DMeasure<T: Scalar>:
+    NurbsCurve2DEvaluation<T> + NurbsCurve2DDerived<T>
+{
+    fn point_at(&self, t: T) -> (T, T) {
+        <Self as NurbsCurve2DEvaluation<T>>::point_at(self, t)
+    }
 
-/// NurbsCurve2DのCore機能を統合するトレイト
+    fn tangent_at(&self, t: T) -> (T, T) {
+        <Self as NurbsCurve2DEvaluation<T>>::tangent_at(self, t)
+    }
+
+    fn length(&self) -> T {
+        <Self as NurbsCurve2DDerived<T>>::length(self)
+    }
+
+    fn curvature_at(&self, t: T) -> T {
+        <Self as NurbsCurve2DDerived<T>>::curvature_at(self, t)
+    }
+}
+
+/// NurbsCurve2D の互換 Core trait
 pub trait NurbsCurve2DCore<T: Scalar>:
-    NurbsCurve2DConstructor<T> + NurbsCurve2DProperties<T> + NurbsCurve2DMeasure<T>
+    NurbsCurve2DConstructor<T> + NurbsCurve2DProperties<T>
+{
+}
+
+impl<T: Scalar, Curve> NurbsCurve2DMeasure<T> for Curve where
+    Curve: NurbsCurve2DEvaluation<T> + NurbsCurve2DDerived<T>
+{
+}
+
+impl<T: Scalar, Curve> NurbsCurve2DCore<T> for Curve where
+    Curve: NurbsCurve2DConstructor<T> + NurbsCurve2DProperties<T>
 {
 }

--- a/model/geo_contracts/src/geometry/core/nurbs_curve_3d_traits.rs
+++ b/model/geo_contracts/src/geometry/core/nurbs_curve_3d_traits.rs
@@ -1,15 +1,8 @@
-//! NurbsCurve3D Core Traits - NURBS曲線の3つのCore機能統合
-//!
-//! Core機能（Constructor/Properties/Measure）を形状別に統合
-//! Transform機能は共通のAnalysisTransformトレイトを使用
+//! NurbsCurve3D の trait定義を capability taxonomy に沿って分離する。
 
 use crate::Scalar;
 
-// ============================================================================
-// 1. Constructor Traits - NURBS Curve生成機能
-// ============================================================================
-
-/// NurbsCurve3D生成のためのConstructorトレイト
+/// NurbsCurve3D の生成 trait
 pub trait NurbsCurve3DConstructor<T: Scalar> {
     /// 基本コンストラクタ（次数、ノット、制御点、重み）
     ///
@@ -38,11 +31,7 @@ pub trait NurbsCurve3DConstructor<T: Scalar> {
         Self: Sized;
 }
 
-// ============================================================================
-// 2. Properties Traits - NURBS Curve基本情報取得
-// ============================================================================
-
-/// NurbsCurve3D基本プロパティ取得トレイト
+/// NurbsCurve3D の定義パラメータ
 pub trait NurbsCurve3DProperties<T: Scalar> {
     /// NURBS曲線の次数を取得
     fn degree(&self) -> usize;
@@ -68,18 +57,17 @@ pub trait NurbsCurve3DProperties<T: Scalar> {
     fn coordinates(&self) -> &[T];
 }
 
-// ============================================================================
-// 3. Measure Traits - NURBS Curve計量・評価機能
-// ============================================================================
-
-/// NurbsCurve3D計量・評価トレイト
-pub trait NurbsCurve3DMeasure<T: Scalar> {
+/// NurbsCurve3D の派生量
+pub trait NurbsCurve3DDerived<T: Scalar> {
     /// 指定されたパラメータ範囲の曲線長を計算（数値積分）
     fn arc_length(&self, u_start: T, u_end: T, tolerance: T) -> T;
 
     /// 曲線全体の長さを計算
     fn arc_length_total(&self, tolerance: T) -> T;
+}
 
+/// NurbsCurve3D の評価
+pub trait NurbsCurve3DEvaluation<T: Scalar> {
     /// 指定された曲線長に対応するパラメータ値を計算
     fn parameter_at_length(&self, arc_length: T, tolerance: T) -> Option<T>;
 
@@ -87,12 +75,39 @@ pub trait NurbsCurve3DMeasure<T: Scalar> {
     fn evaluate(&self, u: T) -> Option<(T, T, T)>;
 }
 
-// ============================================================================
-// 4. Core統合トレイト
-// ============================================================================
+/// NurbsCurve3D の後方互換集約 trait
+pub trait NurbsCurve3DMeasure<T: Scalar>:
+    NurbsCurve3DDerived<T> + NurbsCurve3DEvaluation<T>
+{
+    fn arc_length(&self, u_start: T, u_end: T, tolerance: T) -> T {
+        <Self as NurbsCurve3DDerived<T>>::arc_length(self, u_start, u_end, tolerance)
+    }
 
-/// NurbsCurve3DのCore機能を統合するトレイト
+    fn arc_length_total(&self, tolerance: T) -> T {
+        <Self as NurbsCurve3DDerived<T>>::arc_length_total(self, tolerance)
+    }
+
+    fn parameter_at_length(&self, arc_length: T, tolerance: T) -> Option<T> {
+        <Self as NurbsCurve3DEvaluation<T>>::parameter_at_length(self, arc_length, tolerance)
+    }
+
+    fn evaluate(&self, u: T) -> Option<(T, T, T)> {
+        <Self as NurbsCurve3DEvaluation<T>>::evaluate(self, u)
+    }
+}
+
+/// NurbsCurve3D の互換 Core trait
 pub trait NurbsCurve3DCore<T: Scalar>:
-    NurbsCurve3DConstructor<T> + NurbsCurve3DProperties<T> + NurbsCurve3DMeasure<T>
+    NurbsCurve3DConstructor<T> + NurbsCurve3DProperties<T>
+{
+}
+
+impl<T: Scalar, Curve> NurbsCurve3DMeasure<T> for Curve where
+    Curve: NurbsCurve3DDerived<T> + NurbsCurve3DEvaluation<T>
+{
+}
+
+impl<T: Scalar, Curve> NurbsCurve3DCore<T> for Curve where
+    Curve: NurbsCurve3DConstructor<T> + NurbsCurve3DProperties<T>
 {
 }

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -69,8 +69,9 @@ pub use geometry::core::{
     Ray3DMeasure, Ray3DProjection, Ray3DProperties, Ray3DTransform,
 };
 pub use geometry::core::{
-    NurbsCurve2DConstructor, NurbsCurve2DCore, NurbsCurve2DMeasure, NurbsCurve2DProperties,
-    NurbsCurve3DConstructor, NurbsCurve3DCore, NurbsCurve3DMeasure, NurbsCurve3DProperties,
+    NurbsCurve2DConstructor, NurbsCurve2DCore, NurbsCurve2DDerived, NurbsCurve2DEvaluation,
+    NurbsCurve2DMeasure, NurbsCurve2DProperties, NurbsCurve3DConstructor, NurbsCurve3DCore,
+    NurbsCurve3DDerived, NurbsCurve3DEvaluation, NurbsCurve3DMeasure, NurbsCurve3DProperties,
     NurbsSurface3DConstructor, NurbsSurface3DCore, NurbsSurface3DMeasure, NurbsSurface3DProperties,
     Triangle2DConstructor, Triangle2DContainment, Triangle2DCore, Triangle2DDerived,
     Triangle2DDistance, Triangle2DMeasure, Triangle2DProperties, Triangle3DConstructor,

--- a/model/geo_nurbs/src/curve_2d.rs
+++ b/model/geo_nurbs/src/curve_2d.rs
@@ -6,7 +6,7 @@
 use crate::{constants, KnotVector, NurbsError, Result, Scalar};
 use analysis::linalg::vector::Vector2;
 use geo_contracts::{
-    NurbsCurve2DConstructor, NurbsCurve2DCore, NurbsCurve2DMeasure, NurbsCurve2DProperties,
+    NurbsCurve2DConstructor, NurbsCurve2DDerived, NurbsCurve2DEvaluation, NurbsCurve2DProperties,
 };
 
 /// 重み配列の効率的管理（2D曲線用）
@@ -262,10 +262,6 @@ impl<T: Scalar> NurbsCurve2D<T> {
     }
 }
 
-// ============================================================================
-// Core Traits 実装
-// ============================================================================
-
 impl<T: Scalar> NurbsCurve2DConstructor<T> for NurbsCurve2D<T> {
     fn new(
         control_points: &[(T, T)],
@@ -328,7 +324,7 @@ impl<T: Scalar> NurbsCurve2DProperties<T> for NurbsCurve2D<T> {
     }
 }
 
-impl<T: Scalar> NurbsCurve2DMeasure<T> for NurbsCurve2D<T> {
+impl<T: Scalar> NurbsCurve2DEvaluation<T> for NurbsCurve2D<T> {
     fn point_at(&self, t: T) -> (T, T) {
         let point = self.evaluate_at(t);
         (point.x(), point.y())
@@ -345,7 +341,9 @@ impl<T: Scalar> NurbsCurve2DMeasure<T> for NurbsCurve2D<T> {
             (derivative.x() / len, derivative.y() / len)
         }
     }
+}
 
+impl<T: Scalar> NurbsCurve2DDerived<T> for NurbsCurve2D<T> {
     fn length(&self) -> T {
         self.approximate_length(constants::CURVE_LENGTH_SUBDIVISIONS)
     }
@@ -372,12 +370,6 @@ impl<T: Scalar> NurbsCurve2DMeasure<T> for NurbsCurve2D<T> {
         }
     }
 }
-
-impl<T: Scalar> NurbsCurve2DCore<T> for NurbsCurve2D<T> {}
-
-// ============================================================================
-// テスト
-// ============================================================================
 
 #[cfg(test)]
 mod tests {

--- a/model/geo_nurbs/src/curve_3d.rs
+++ b/model/geo_nurbs/src/curve_3d.rs
@@ -5,6 +5,9 @@
 
 use crate::{constants, KnotVector, NurbsError, Result, Scalar};
 use analysis::linalg::vector::Vector3;
+use geo_contracts::{
+    NurbsCurve3DConstructor, NurbsCurve3DDerived, NurbsCurve3DEvaluation, NurbsCurve3DProperties,
+};
 
 /// 重み配列の効率的管理（3D曲線用）
 #[derive(Debug, Clone)]
@@ -379,12 +382,6 @@ mod tests {
     }
 }
 
-// ============================================================================
-// Core Traits Implementation (Foundation Pattern)
-// ============================================================================
-
-use geo_contracts::{NurbsCurve3DConstructor, NurbsCurve3DMeasure, NurbsCurve3DProperties};
-
 impl<T: Scalar> NurbsCurve3DConstructor<T> for NurbsCurve3D<T> {
     fn new(
         degree: usize,
@@ -516,7 +513,7 @@ impl<T: Scalar> NurbsCurve3DProperties<T> for NurbsCurve3D<T> {
     }
 }
 
-impl<T: Scalar> NurbsCurve3DMeasure<T> for NurbsCurve3D<T> {
+impl<T: Scalar> NurbsCurve3DDerived<T> for NurbsCurve3D<T> {
     fn arc_length(&self, u_start: T, u_end: T, tolerance: T) -> T {
         // 簡易実装：一定間隔でサンプリング
         let tolerance_f64 = tolerance.to_f64();
@@ -550,7 +547,9 @@ impl<T: Scalar> NurbsCurve3DMeasure<T> for NurbsCurve3D<T> {
         let (u_start, u_end) = self.parameter_domain();
         self.arc_length(u_start, u_end, tolerance)
     }
+}
 
+impl<T: Scalar> NurbsCurve3DEvaluation<T> for NurbsCurve3D<T> {
     fn parameter_at_length(&self, arc_length: T, tolerance: T) -> Option<T> {
         let (u_start, u_end) = self.parameter_domain();
         let total_length = self.arc_length_total(tolerance);


### PR DESCRIPTION
## 概要
- NURBS curve 2D/3D の trait定義を capability taxonomy に沿って再分類
- `*Measure` に混在していた evaluation と derived を分離
- `*Core` を Constructor + Properties の互換 alias へ縮退

## 変更内容
- `model/geo_contracts/src/geometry/core/nurbs_curve_2d_traits.rs`
  - `NurbsCurve2DEvaluation` と `NurbsCurve2DDerived` を追加
  - `NurbsCurve2DMeasure` を後方互換集約 trait に変更
  - `NurbsCurve2DCore` を `Constructor + Properties` の alias に変更
- `model/geo_contracts/src/geometry/core/nurbs_curve_3d_traits.rs`
  - `NurbsCurve3DEvaluation` と `NurbsCurve3DDerived` を追加
  - `NurbsCurve3DMeasure` を後方互換集約 trait に変更
  - `NurbsCurve3DCore` を `Constructor + Properties` の alias に変更
- `model/geo_nurbs/src/curve_2d.rs`
  - `point_at` / `tangent_at` を `Evaluation` 実装へ移動
  - `length` / `curvature_at` を `Derived` 実装へ移動
- `model/geo_nurbs/src/curve_3d.rs`
  - `evaluate` / `parameter_at_length` を `Evaluation` 実装へ移動
  - `arc_length` / `arc_length_total` を `Derived` 実装へ移動
- re-export を更新
- architecture doc に NURBS curve の再分類方針を反映

## 背景
- 親 Issue: #568
- 対象 Issue: #570
- NURBS curve は endpoint capability を shape 意味論の正本として持たないため、curve family の primary vocabulary として `length` を維持しつつ、evaluation と derived を分離する

## 検証
- cargo clippy -- -D warnings
- cargo fmt
- cargo test --workspace
