### PR TITLE
refactor: NURBS surface capability taxonomy を適用

### DIFF
--- a/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
+++ b/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
@@ -361,6 +361,27 @@ NURBS curve は endpoint を shape 意味論の正本として持たず、parame
 - `arc_length(u_start, u_end, tolerance)` は区間に対する unary derived quantity とみなし、後方互換の `*Measure` から分離する
 - adaptive tessellation や近似戦略は operations/strategy 側の論点であり、本整理では core capability へ持ち込まない
 
+### NURBS Surface の再分類
+
+NURBS surface は curve family と異なり、UV parameter evaluation と surface area 語彙を中心に整理する。
+既存 API は `*Measure` に point evaluation、normal/tangent evaluation、surface area が混在しているため、少なくとも evaluation と derived を分ける必要がある。
+
+本整理では、surface family の primary measure vocabulary として `surface_area` を維持し、`*Measure` は後方互換の集約 trait として後退させる。
+
+| 現行 trait / API | 再分類 |
+| --- | --- |
+| `NurbsSurface3DConstructor` | `definition` |
+| `NurbsSurface3DProperties::u_degree/v_degree/u_count/v_count/u_knots/v_knots/is_rational/coordinates/weights` | `definition` |
+| `NurbsSurface3DEvaluation::point_at_uv/normal_at/tangent_vectors_at` | `evaluation` |
+| `NurbsSurface3DDerived::surface_area` | `derived` |
+| `NurbsSurface3DCore` | `Constructor + Properties` へ縮退候補 |
+
+補足:
+
+- NURBS surface では `surface_area` を primary vocabulary とし、`measure` は新規責務説明の中心に置かない
+- `normal_at` と `tangent_vectors_at` は unary derived quantity ではなく、UV parameter に依存する evaluation capability として扱う
+- adaptive tessellation や近似戦略は operations/strategy 側の論点であり、本整理では core capability へ持ち込まない
+
 ### Circle の再分類
 
 Circle は閉曲線であり、parameter evaluation を持っても endpoint capability は持たない。

--- a/model/geo_contracts/src/geometry/core/mod.rs
+++ b/model/geo_contracts/src/geometry/core/mod.rs
@@ -105,7 +105,8 @@ pub use nurbs_curve_3d_traits::{
     NurbsCurve3DMeasure, NurbsCurve3DProperties,
 };
 pub use nurbs_surface_3d_traits::{
-    NurbsSurface3DConstructor, NurbsSurface3DCore, NurbsSurface3DMeasure, NurbsSurface3DProperties,
+    NurbsSurface3DConstructor, NurbsSurface3DCore, NurbsSurface3DDerived, NurbsSurface3DEvaluation,
+    NurbsSurface3DMeasure, NurbsSurface3DProperties,
 };
 pub use plane3d_traits::{
     Plane3DConstructor, Plane3DContainment, Plane3DCore, Plane3DDerived, Plane3DDistance,

--- a/model/geo_contracts/src/geometry/core/nurbs_surface_3d_traits.rs
+++ b/model/geo_contracts/src/geometry/core/nurbs_surface_3d_traits.rs
@@ -1,15 +1,8 @@
-//! NurbsSurface3D Core Traits - NURBSサーフェスの3つのCore機能統合
-//!
-//! Core機能（Constructor/Properties/Measure）を形状別に統合
-//! Transform機能は共通のAnalysisTransformトレイトを使用
+//! NurbsSurface3D の trait定義を capability taxonomy に沿って分離する。
 
 use crate::Scalar;
 
-// ============================================================================
-// 1. Constructor Traits - NurbsSurface3D生成機能
-// ============================================================================
-
-/// NurbsSurface3D生成のためのConstructorトレイト
+/// NurbsSurface3D の生成 trait
 pub trait NurbsSurface3DConstructor<T: Scalar> {
     /// NURBSサーフェスを作成
     ///
@@ -46,11 +39,7 @@ pub trait NurbsSurface3DConstructor<T: Scalar> {
         Self: Sized;
 }
 
-// ============================================================================
-// 2. Properties Traits - NurbsSurface3D基本情報取得
-// ============================================================================
-
-/// NurbsSurface3D基本プロパティ取得トレイト
+/// NurbsSurface3D の定義パラメータ
 pub trait NurbsSurface3DProperties<T: Scalar> {
     /// u方向のNURBS次数を取得
     fn u_degree(&self) -> usize;
@@ -80,31 +69,57 @@ pub trait NurbsSurface3DProperties<T: Scalar> {
     fn weights(&self) -> Option<&[T]>;
 }
 
-// ============================================================================
-// 3. Measure Traits - NurbsSurface3D測定・評価機能
-// ============================================================================
-
-/// NurbsSurface3D測定・評価機能トレイト
-pub trait NurbsSurface3DMeasure<T: Scalar> {
+/// NurbsSurface3D の評価
+pub trait NurbsSurface3DEvaluation<T: Scalar> {
     /// パラメータ座標(u, v)でのサーフェス上の点を計算
     fn point_at_uv(&self, u: T, v: T) -> (T, T, T);
 
     /// パラメータ座標(u, v)での法線ベクトルを計算
     fn normal_at(&self, u: T, v: T) -> (T, T, T);
 
-    /// サーフェスの表面積を計算（数値積分により近似計算）
-    fn surface_area(&self) -> T;
-
     /// パラメータ座標(u, v)での接線ベクトル(du, dv)を計算
     fn tangent_vectors_at(&self, u: T, v: T) -> ((T, T, T), (T, T, T));
 }
 
-// ============================================================================
-// 4. Core統合トレイト
-// ============================================================================
+/// NurbsSurface3D の派生量
+pub trait NurbsSurface3DDerived<T: Scalar> {
+    /// サーフェスの表面積を計算（数値積分により近似計算）
+    fn surface_area(&self) -> T;
+}
 
-/// NurbsSurface3DのCore機能を統合するトレイト
+/// NurbsSurface3D の後方互換集約 trait
+pub trait NurbsSurface3DMeasure<T: Scalar>:
+    NurbsSurface3DEvaluation<T> + NurbsSurface3DDerived<T>
+{
+    fn point_at_uv(&self, u: T, v: T) -> (T, T, T) {
+        <Self as NurbsSurface3DEvaluation<T>>::point_at_uv(self, u, v)
+    }
+
+    fn normal_at(&self, u: T, v: T) -> (T, T, T) {
+        <Self as NurbsSurface3DEvaluation<T>>::normal_at(self, u, v)
+    }
+
+    fn tangent_vectors_at(&self, u: T, v: T) -> ((T, T, T), (T, T, T)) {
+        <Self as NurbsSurface3DEvaluation<T>>::tangent_vectors_at(self, u, v)
+    }
+
+    fn surface_area(&self) -> T {
+        <Self as NurbsSurface3DDerived<T>>::surface_area(self)
+    }
+}
+
+/// NurbsSurface3D の互換 Core trait
 pub trait NurbsSurface3DCore<T: Scalar>:
-    NurbsSurface3DConstructor<T> + NurbsSurface3DProperties<T> + NurbsSurface3DMeasure<T>
+    NurbsSurface3DConstructor<T> + NurbsSurface3DProperties<T>
+{
+}
+
+impl<T: Scalar, Surface> NurbsSurface3DMeasure<T> for Surface where
+    Surface: NurbsSurface3DEvaluation<T> + NurbsSurface3DDerived<T>
+{
+}
+
+impl<T: Scalar, Surface> NurbsSurface3DCore<T> for Surface where
+    Surface: NurbsSurface3DConstructor<T> + NurbsSurface3DProperties<T>
 {
 }

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -72,11 +72,11 @@ pub use geometry::core::{
     NurbsCurve2DConstructor, NurbsCurve2DCore, NurbsCurve2DDerived, NurbsCurve2DEvaluation,
     NurbsCurve2DMeasure, NurbsCurve2DProperties, NurbsCurve3DConstructor, NurbsCurve3DCore,
     NurbsCurve3DDerived, NurbsCurve3DEvaluation, NurbsCurve3DMeasure, NurbsCurve3DProperties,
-    NurbsSurface3DConstructor, NurbsSurface3DCore, NurbsSurface3DMeasure, NurbsSurface3DProperties,
-    Triangle2DConstructor, Triangle2DContainment, Triangle2DCore, Triangle2DDerived,
-    Triangle2DDistance, Triangle2DMeasure, Triangle2DProperties, Triangle3DConstructor,
-    Triangle3DContainment, Triangle3DCore, Triangle3DDerived, Triangle3DDistance,
-    Triangle3DMeasure, Triangle3DProperties,
+    NurbsSurface3DConstructor, NurbsSurface3DCore, NurbsSurface3DDerived, NurbsSurface3DEvaluation,
+    NurbsSurface3DMeasure, NurbsSurface3DProperties, Triangle2DConstructor, Triangle2DContainment,
+    Triangle2DCore, Triangle2DDerived, Triangle2DDistance, Triangle2DMeasure, Triangle2DProperties,
+    Triangle3DConstructor, Triangle3DContainment, Triangle3DCore, Triangle3DDerived,
+    Triangle3DDistance, Triangle3DMeasure, Triangle3DProperties,
 };
 pub use geometry::foundation::{
     Bounded, ExtensionFoundation, MeasureFoundation, Point2DMeasure, Point3DMeasure,

--- a/model/geo_nurbs/src/surface_3d.rs
+++ b/model/geo_nurbs/src/surface_3d.rs
@@ -5,6 +5,10 @@
 
 use crate::{constants, KnotVector, NurbsError, Result, Scalar};
 use analysis::linalg::vector::Vector3;
+use geo_contracts::{
+    NurbsSurface3DConstructor, NurbsSurface3DDerived, NurbsSurface3DEvaluation,
+    NurbsSurface3DProperties,
+};
 
 /// 重み配列の効率的管理
 #[derive(Debug, Clone)]
@@ -440,14 +444,6 @@ impl<T: Scalar> NurbsSurface3D<T> {
     }
 }
 
-// ============================================================================
-// Core Traits 実装
-// ============================================================================
-
-use geo_contracts::{
-    NurbsSurface3DConstructor, NurbsSurface3DCore, NurbsSurface3DMeasure, NurbsSurface3DProperties,
-};
-
 impl<T: Scalar> NurbsSurface3DConstructor<T> for NurbsSurface3D<T> {
     fn new(
         control_points: Vec<Vec<(T, T, T)>>,
@@ -571,7 +567,7 @@ impl<T: Scalar> NurbsSurface3DProperties<T> for NurbsSurface3D<T> {
     }
 }
 
-impl<T: Scalar> NurbsSurface3DMeasure<T> for NurbsSurface3D<T> {
+impl<T: Scalar> NurbsSurface3DEvaluation<T> for NurbsSurface3D<T> {
     fn point_at_uv(&self, u: T, v: T) -> (T, T, T) {
         let point = self.evaluate_at(u, v);
         (point.x(), point.y(), point.z())
@@ -600,6 +596,15 @@ impl<T: Scalar> NurbsSurface3DMeasure<T> for NurbsSurface3D<T> {
         }
     }
 
+    fn tangent_vectors_at(&self, u: T, v: T) -> ((T, T, T), (T, T, T)) {
+        let du = self.u_derivative_at(u, v);
+        let dv = self.v_derivative_at(u, v);
+
+        ((du.x(), du.y(), du.z()), (dv.x(), dv.y(), dv.z()))
+    }
+}
+
+impl<T: Scalar> NurbsSurface3DDerived<T> for NurbsSurface3D<T> {
     #[allow(clippy::similar_names)]
     fn surface_area(&self) -> T {
         // 簡易実装: 中央差分で近似
@@ -630,16 +635,7 @@ impl<T: Scalar> NurbsSurface3DMeasure<T> for NurbsSurface3D<T> {
 
         total_area
     }
-
-    fn tangent_vectors_at(&self, u: T, v: T) -> ((T, T, T), (T, T, T)) {
-        let du = self.u_derivative_at(u, v);
-        let dv = self.v_derivative_at(u, v);
-
-        ((du.x(), du.y(), du.z()), (dv.x(), dv.y(), dv.z()))
-    }
 }
-
-impl<T: Scalar> NurbsSurface3DCore<T> for NurbsSurface3D<T> {}
 
 // ============================================================================
 // テスト


### PR DESCRIPTION
## 概要
- NURBS surface の trait定義を capability taxonomy に沿って再分類
- `*Measure` に混在していた evaluation と derived を分離
- `*Core` を Constructor + Properties の互換 alias へ縮退

## 変更内容
- `model/geo_contracts/src/geometry/core/nurbs_surface_3d_traits.rs`
  - `NurbsSurface3DEvaluation` と `NurbsSurface3DDerived` を追加
  - `NurbsSurface3DMeasure` を後方互換集約 trait に変更
  - `NurbsSurface3DCore` を `Constructor + Properties` の alias に変更
- `model/geo_nurbs/src/surface_3d.rs`
  - `point_at_uv` / `normal_at` / `tangent_vectors_at` を `Evaluation` 実装へ移動
  - `surface_area` を `Derived` 実装へ移動
- `model/geo_contracts/src/geometry/core/mod.rs`, `model/geo_contracts/src/lib.rs`
  - 新しい capability trait の re-export を追加
- `dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md`
  - NURBS surface の再分類方針を追記

## 背景
- Parent #568
- 対象 Issue #573
- NURBS surface では UV parameter evaluation と surface area 語彙を中心に整理し、curve family の整理結果と整合する capability taxonomy を適用する

## 検証
- cargo clippy -- -D warnings
- cargo fmt
- cargo test --workspace
