### PR TITLE
refactor: separate triangle boundary access and quantity (#581)

### DIFF
--- a/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
+++ b/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
@@ -986,9 +986,10 @@ Triangle は面 shape であり、curve endpoint や curve parameter capability 
 
 実装観点:
 
-- `vertex_a/b/c` は definition 側に残す
+- `vertex_a/b/c` は face boundary access として独立 trait に分離する
 - Triangle は pre-topology の単一 face primitive とし、オイラー操作を前提にしない mesh 表現は TriangleMesh 側で扱う
-- `edge_*_length` / `perimeter` / `measure` / `is_clockwise` / `is_planar` は derived に置く
+- `edge_*_length` は boundary quantity、`perimeter` は boundary 全体の derived quantity として boundary 側に置く
+- `is_clockwise` / `is_planar` は derived に置く
 - `area` は Triangle 全体の primary quantity、`edge_*_length` は boundary quantity、`perimeter` は boundary 全体の derived quantity として扱う
 - `contains_point` は containment、`distance_to_point` は distance に置く
 - parameter evaluation を導入する場合は surface family の evaluation として扱い、trimmed range と periodic parameter は導入しない

--- a/model/geo_algorithms/src/collision/primitive_2d.rs
+++ b/model/geo_algorithms/src/collision/primitive_2d.rs
@@ -18,7 +18,7 @@ use crate::{
     Triangle2D, Vector2D,
 };
 use geo_contracts::{
-    Arc2DProperties, Circle2DProperties, LineSegment2DProperties, Scalar, Triangle2DProperties,
+    Arc2DProperties, Circle2DProperties, LineSegment2DProperties, Scalar, Triangle2DBoundaryAccess,
 };
 
 pub fn circle2d_point2d_collides<T: Scalar>(

--- a/model/geo_algorithms/src/collision/primitive_3d.rs
+++ b/model/geo_algorithms/src/collision/primitive_3d.rs
@@ -16,7 +16,7 @@ use geo_contracts::{
     CylindricalSolid3DProperties, CylindricalSurface3DDistance, CylindricalSurface3DProperties,
     Ellipse3DDistance, EllipsoidalSolid3DProperties, InfiniteLine3DProperties, Scalar,
     SphericalSolid3DProperties, SphericalSurface3DProperties, TorusSurface3DDistance,
-    Triangle3DProperties,
+    Triangle3DBoundaryAccess,
 };
 
 // ── SphericalSolid3D ──────────────────────────────────────────────────────────
@@ -71,9 +71,9 @@ pub fn spherical_solid3d_triangle3d_collides<T: Scalar>(
     triangle: &Triangle3D<T>,
     tolerance: T,
 ) -> bool {
-    let (ax, ay, az) = Triangle3DProperties::vertex_a(triangle);
-    let (bx, by, bz) = Triangle3DProperties::vertex_b(triangle);
-    let (cx, cy, cz) = Triangle3DProperties::vertex_c(triangle);
+    let (ax, ay, az) = Triangle3DBoundaryAccess::vertex_a(triangle);
+    let (bx, by, bz) = Triangle3DBoundaryAccess::vertex_b(triangle);
+    let (cx, cy, cz) = Triangle3DBoundaryAccess::vertex_c(triangle);
     sphere.distance_to_surface(Point3D::new(ax, ay, az)) <= tolerance
         || sphere.distance_to_surface(Point3D::new(bx, by, bz)) <= tolerance
         || sphere.distance_to_surface(Point3D::new(cx, cy, cz)) <= tolerance
@@ -640,12 +640,12 @@ pub fn triangle3d_triangle3d_collides<T: Scalar>(
     triangle_b: &Triangle3D<T>,
     tolerance: T,
 ) -> bool {
-    let (ax, ay, az) = Triangle3DProperties::vertex_a(triangle_a);
-    let (bx, by, bz) = Triangle3DProperties::vertex_b(triangle_a);
-    let (cx, cy, cz) = Triangle3DProperties::vertex_c(triangle_a);
-    let (ax2, ay2, az2) = Triangle3DProperties::vertex_a(triangle_b);
-    let (bx2, by2, bz2) = Triangle3DProperties::vertex_b(triangle_b);
-    let (cx2, cy2, cz2) = Triangle3DProperties::vertex_c(triangle_b);
+    let (ax, ay, az) = Triangle3DBoundaryAccess::vertex_a(triangle_a);
+    let (bx, by, bz) = Triangle3DBoundaryAccess::vertex_b(triangle_a);
+    let (cx, cy, cz) = Triangle3DBoundaryAccess::vertex_c(triangle_a);
+    let (ax2, ay2, az2) = Triangle3DBoundaryAccess::vertex_a(triangle_b);
+    let (bx2, by2, bz2) = Triangle3DBoundaryAccess::vertex_b(triangle_b);
+    let (cx2, cy2, cz2) = Triangle3DBoundaryAccess::vertex_c(triangle_b);
     triangle_b.distance_to_point(&Point3D::new(ax, ay, az)) <= tolerance
         || triangle_b.distance_to_point(&Point3D::new(bx, by, bz)) <= tolerance
         || triangle_b.distance_to_point(&Point3D::new(cx, cy, cz)) <= tolerance

--- a/model/geo_algorithms/src/intersection/pair_base.rs
+++ b/model/geo_algorithms/src/intersection/pair_base.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use geo_contracts::{
     Arc2DProperties, Circle2DProperties, InfiniteLine3DProperties, LineSegment2DProperties, Scalar,
-    SphericalSurface3DProperties, Triangle3DProperties,
+    SphericalSurface3DProperties, Triangle3DBoundaryAccess,
 };
 
 #[cfg(test)]

--- a/model/geo_algorithms/src/intersection/primitive_2d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_2d.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use geo_contracts::{
     Arc2DProperties, Circle2DProperties, Ellipse2DProperties, InfiniteLine2DProperties,
-    LineSegment2DProperties, Ray2DProperties, Scalar, Triangle2DProperties,
+    LineSegment2DProperties, Ray2DProperties, Scalar, Triangle2DBoundaryAccess,
 };
 
 pub fn circle2d_point2d_intersection<T: Scalar>(

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -18,7 +18,7 @@ use geo_contracts::{
     ConicalSolid3DProperties, ConicalSurface3DProperties, CylindricalSurface3DDistance,
     CylindricalSurface3DProperties, Ellipse3DDistance, EllipsoidalSolid3DProperties,
     InfiniteLine3DProperties, Scalar, SphericalSolid3DProperties, SphericalSurface3DProperties,
-    TorusSurface3DDistance, Triangle3DProperties,
+    TorusSurface3DDistance, Triangle3DBoundaryAccess,
 };
 
 fn point_intersection_if<T: Scalar>(point: &Point3D<T>, condition: bool) -> Option<Point3D<T>> {
@@ -441,9 +441,9 @@ fn cylindrical_surface3d_triangle3d_intersection_raw<T: Scalar>(
     triangle: &Triangle3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    let (ax, ay, az) = Triangle3DProperties::vertex_a(triangle);
-    let (bx, by, bz) = Triangle3DProperties::vertex_b(triangle);
-    let (cx, cy, cz) = Triangle3DProperties::vertex_c(triangle);
+    let (ax, ay, az) = Triangle3DBoundaryAccess::vertex_a(triangle);
+    let (bx, by, bz) = Triangle3DBoundaryAccess::vertex_b(triangle);
+    let (cx, cy, cz) = Triangle3DBoundaryAccess::vertex_c(triangle);
     if <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
         cyl,
         (ax, ay, az),
@@ -715,9 +715,9 @@ pub fn ellipse3d_triangle3d_intersections<T: Scalar + From<f64>>(
     triangle: &Triangle3D<T>,
     tolerance: T,
 ) -> IntersectionResult<T> {
-    let (ax, ay, az) = Triangle3DProperties::vertex_a(triangle);
-    let (bx, by, bz) = Triangle3DProperties::vertex_b(triangle);
-    let (cx, cy, cz) = Triangle3DProperties::vertex_c(triangle);
+    let (ax, ay, az) = Triangle3DBoundaryAccess::vertex_a(triangle);
+    let (bx, by, bz) = Triangle3DBoundaryAccess::vertex_b(triangle);
+    let (cx, cy, cz) = Triangle3DBoundaryAccess::vertex_c(triangle);
     let mut intersections = Vec::new();
     if <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(ellipse, (ax, ay, az))
         <= tolerance

--- a/model/geo_contracts/src/geometry/core/mod.rs
+++ b/model/geo_contracts/src/geometry/core/mod.rs
@@ -150,9 +150,11 @@ pub use torus_surface_traits::{
     TorusSurface3DEvaluation, TorusSurface3DProperties,
 };
 pub use triangle_traits::{
-    Triangle2DConstructor, Triangle2DContainment, Triangle2DCore, Triangle2DDerived,
-    Triangle2DDistance, Triangle2DProperties, Triangle3DConstructor, Triangle3DContainment,
-    Triangle3DCore, Triangle3DDerived, Triangle3DDistance, Triangle3DProperties,
+    Triangle2DBoundaryAccess, Triangle2DBoundaryQuantity, Triangle2DConstructor,
+    Triangle2DContainment, Triangle2DCore, Triangle2DDerived, Triangle2DDistance,
+    Triangle2DProperties, Triangle3DBoundaryAccess, Triangle3DBoundaryQuantity,
+    Triangle3DConstructor, Triangle3DContainment, Triangle3DCore, Triangle3DDerived,
+    Triangle3DDistance, Triangle3DProperties,
 };
 pub use vector_traits::{
     Vector2DConstructor, Vector2DCore, Vector2DMetric, Vector2DProduct, Vector2DProjection,

--- a/model/geo_contracts/src/geometry/core/triangle_traits.rs
+++ b/model/geo_contracts/src/geometry/core/triangle_traits.rs
@@ -28,8 +28,8 @@ pub trait Triangle2DConstructor<T: Scalar>: Sized {
     fn reversed(&self) -> Self;
 }
 
-/// Triangle2D Properties トレイト（5+3メソッド）
-pub trait Triangle2DProperties<T: Scalar> {
+/// Triangle2D の face boundary access
+pub trait Triangle2DBoundaryAccess<T: Scalar> {
     /// 頂点A座標を取得
     fn vertex_a(&self) -> (T, T);
 
@@ -39,6 +39,9 @@ pub trait Triangle2DProperties<T: Scalar> {
     /// 頂点C座標を取得
     fn vertex_c(&self) -> (T, T);
 }
+
+/// Triangle2D の互換 Properties trait
+pub trait Triangle2DProperties<T: Scalar>: Triangle2DBoundaryAccess<T> {}
 
 pub trait Triangle2DDerived<T: Scalar> {
     /// 重心座標を取得
@@ -59,6 +62,11 @@ pub trait Triangle2DDerived<T: Scalar> {
     /// 三角形の面積を計算
     fn area(&self) -> T;
 
+    /// 三角形が時計回りか判定
+    fn is_clockwise(&self) -> bool;
+}
+
+pub trait Triangle2DBoundaryQuantity<T: Scalar> {
     /// 辺ABの長さ
     fn edge_ab_length(&self) -> T;
 
@@ -70,9 +78,6 @@ pub trait Triangle2DDerived<T: Scalar> {
 
     /// 周囲長を計算
     fn perimeter(&self) -> T;
-
-    /// 三角形が時計回りか判定
-    fn is_clockwise(&self) -> bool;
 }
 
 pub trait Triangle2DContainment<T: Scalar> {
@@ -86,7 +91,10 @@ pub trait Triangle2DDistance<T: Scalar> {
 }
 
 /// Triangle2D Core トレイト（統合インターフェース）
-pub trait Triangle2DCore<T: Scalar>: Triangle2DConstructor<T> + Triangle2DProperties<T> {}
+pub trait Triangle2DCore<T: Scalar>:
+    Triangle2DConstructor<T> + Triangle2DBoundaryAccess<T>
+{
+}
 
 /// Triangle3D Constructor トレイト（3+3メソッド）
 pub trait Triangle3DConstructor<T: Scalar>: Sized {
@@ -111,8 +119,8 @@ pub trait Triangle3DConstructor<T: Scalar>: Sized {
     fn reversed(&self) -> Self;
 }
 
-/// Triangle3D Properties トレイト（5+3メソッド）
-pub trait Triangle3DProperties<T: Scalar> {
+/// Triangle3D の face boundary access
+pub trait Triangle3DBoundaryAccess<T: Scalar> {
     /// 頂点A座標を取得
     fn vertex_a(&self) -> (T, T, T);
 
@@ -122,6 +130,9 @@ pub trait Triangle3DProperties<T: Scalar> {
     /// 頂点C座標を取得
     fn vertex_c(&self) -> (T, T, T);
 }
+
+/// Triangle3D の互換 Properties trait
+pub trait Triangle3DProperties<T: Scalar>: Triangle3DBoundaryAccess<T> {}
 
 pub trait Triangle3DDerived<T: Scalar> {
     /// 重心座標を取得
@@ -142,6 +153,11 @@ pub trait Triangle3DDerived<T: Scalar> {
     /// 三角形の面積を計算
     fn area(&self) -> T;
 
+    /// 三角形が平面上にあるか判定
+    fn is_planar(&self) -> bool;
+}
+
+pub trait Triangle3DBoundaryQuantity<T: Scalar> {
     /// 辺ABの長さ
     fn edge_ab_length(&self) -> T;
 
@@ -153,9 +169,6 @@ pub trait Triangle3DDerived<T: Scalar> {
 
     /// 周囲長を計算
     fn perimeter(&self) -> T;
-
-    /// 三角形が平面上にあるか判定
-    fn is_planar(&self) -> bool;
 }
 
 pub trait Triangle3DContainment<T: Scalar> {
@@ -169,14 +182,27 @@ pub trait Triangle3DDistance<T: Scalar> {
 }
 
 /// Triangle3D Core トレイト（統合インターフェース）
-pub trait Triangle3DCore<T: Scalar>: Triangle3DConstructor<T> + Triangle3DProperties<T> {}
+pub trait Triangle3DCore<T: Scalar>:
+    Triangle3DConstructor<T> + Triangle3DBoundaryAccess<T>
+{
+}
 
 impl<T: Scalar, Triangle> Triangle2DCore<T> for Triangle where
-    Triangle: Triangle2DConstructor<T> + Triangle2DProperties<T>
+    Triangle: Triangle2DConstructor<T> + Triangle2DBoundaryAccess<T>
 {
 }
 
 impl<T: Scalar, Triangle> Triangle3DCore<T> for Triangle where
-    Triangle: Triangle3DConstructor<T> + Triangle3DProperties<T>
+    Triangle: Triangle3DConstructor<T> + Triangle3DBoundaryAccess<T>
+{
+}
+
+impl<T: Scalar, Triangle> Triangle2DProperties<T> for Triangle where
+    Triangle: Triangle2DBoundaryAccess<T>
+{
+}
+
+impl<T: Scalar, Triangle> Triangle3DProperties<T> for Triangle where
+    Triangle: Triangle3DBoundaryAccess<T>
 {
 }

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -85,9 +85,11 @@ pub use geometry::core::{
     NurbsCurve2DProperties, NurbsCurve3DConstructor, NurbsCurve3DCore, NurbsCurve3DDerived,
     NurbsCurve3DEvaluation, NurbsCurve3DProperties, NurbsSurface3DConstructor, NurbsSurface3DCore,
     NurbsSurface3DDerived, NurbsSurface3DEvaluation, NurbsSurface3DProperties,
-    Triangle2DConstructor, Triangle2DContainment, Triangle2DCore, Triangle2DDerived,
-    Triangle2DDistance, Triangle2DProperties, Triangle3DConstructor, Triangle3DContainment,
-    Triangle3DCore, Triangle3DDerived, Triangle3DDistance, Triangle3DProperties,
+    Triangle2DBoundaryAccess, Triangle2DBoundaryQuantity, Triangle2DConstructor,
+    Triangle2DContainment, Triangle2DCore, Triangle2DDerived, Triangle2DDistance,
+    Triangle2DProperties, Triangle3DBoundaryAccess, Triangle3DBoundaryQuantity,
+    Triangle3DConstructor, Triangle3DContainment, Triangle3DCore, Triangle3DDerived,
+    Triangle3DDistance, Triangle3DProperties,
 };
 pub use geometry::foundation::{Bounded, PrimitiveMetadata};
 pub use geometry::operations::{

--- a/model/geo_io/src/stl.rs
+++ b/model/geo_io/src/stl.rs
@@ -4,7 +4,7 @@
 //! 自動フォーマット判定機能付き。
 
 use crate::error::StlError;
-use geo_contracts::{Scalar, Triangle3DProperties};
+use geo_contracts::{Scalar, Triangle3DBoundaryAccess};
 use geo_primitives::{Point3D, TriangleMesh3D, Vector3D};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Write};

--- a/model/geo_io/tests/stl_tests.rs
+++ b/model/geo_io/tests/stl_tests.rs
@@ -1,6 +1,6 @@
 //! STLローダーのテスト
 
-use geo_contracts::Triangle3DProperties;
+use geo_contracts::Triangle3DBoundaryAccess;
 use geo_io::stl;
 use geo_primitives::{Point3D, TriangleMesh3D};
 use std::io::Write;

--- a/model/geo_primitives/src/lib.rs
+++ b/model/geo_primitives/src/lib.rs
@@ -159,9 +159,11 @@ pub use geo_contracts::{
     LineSegment3DProperties,
 };
 pub use geo_contracts::{
-    Triangle2DConstructor, Triangle2DContainment, Triangle2DCore, Triangle2DDerived,
-    Triangle2DDistance, Triangle2DProperties, Triangle3DConstructor, Triangle3DContainment,
-    Triangle3DCore, Triangle3DDerived, Triangle3DDistance, Triangle3DProperties,
+    Triangle2DBoundaryAccess, Triangle2DBoundaryQuantity, Triangle2DConstructor,
+    Triangle2DContainment, Triangle2DCore, Triangle2DDerived, Triangle2DDistance,
+    Triangle2DProperties, Triangle3DBoundaryAccess, Triangle3DBoundaryQuantity,
+    Triangle3DConstructor, Triangle3DContainment, Triangle3DCore, Triangle3DDerived,
+    Triangle3DDistance, Triangle3DProperties,
 };
 pub mod ellipse_2d;
 pub mod ellipse_2d_bounds;

--- a/model/geo_primitives/src/triangle_2d.rs
+++ b/model/geo_primitives/src/triangle_2d.rs
@@ -4,8 +4,8 @@
 
 use crate::{Point2D, Vector2D};
 use geo_contracts::{
-    PrimitiveKind, PrimitiveMetadata, Scalar, Triangle2DConstructor, Triangle2DContainment,
-    Triangle2DDerived, Triangle2DDistance, Triangle2DProperties,
+    PrimitiveKind, PrimitiveMetadata, Scalar, Triangle2DBoundaryAccess, Triangle2DBoundaryQuantity,
+    Triangle2DConstructor, Triangle2DContainment, Triangle2DDerived, Triangle2DDistance,
 };
 
 /// 2次元三角形（Core実装）
@@ -314,7 +314,7 @@ impl<T: Scalar> Triangle2DConstructor<T> for Triangle2D<T> {
     }
 }
 
-impl<T: Scalar> Triangle2DProperties<T> for Triangle2D<T> {
+impl<T: Scalar> Triangle2DBoundaryAccess<T> for Triangle2D<T> {
     fn vertex_a(&self) -> (T, T) {
         let p = self.vertex_a_internal();
         (p.x(), p.y())
@@ -358,6 +358,12 @@ impl<T: Scalar> Triangle2DDerived<T> for Triangle2D<T> {
         Triangle2D::area(self)
     }
 
+    fn is_clockwise(&self) -> bool {
+        Triangle2D::is_clockwise(self)
+    }
+}
+
+impl<T: Scalar> Triangle2DBoundaryQuantity<T> for Triangle2D<T> {
     fn edge_ab_length(&self) -> T {
         Triangle2D::edge_ab(self).length()
     }
@@ -372,10 +378,6 @@ impl<T: Scalar> Triangle2DDerived<T> for Triangle2D<T> {
 
     fn perimeter(&self) -> T {
         Triangle2D::perimeter(self)
-    }
-
-    fn is_clockwise(&self) -> bool {
-        Triangle2D::is_clockwise(self)
     }
 }
 

--- a/model/geo_primitives/src/triangle_3d.rs
+++ b/model/geo_primitives/src/triangle_3d.rs
@@ -4,8 +4,8 @@
 
 use crate::{Point3D, Vector3D};
 use geo_contracts::{
-    Scalar, Triangle3DConstructor, Triangle3DContainment, Triangle3DDerived, Triangle3DDistance,
-    Triangle3DProperties,
+    Scalar, Triangle3DBoundaryAccess, Triangle3DBoundaryQuantity, Triangle3DConstructor,
+    Triangle3DContainment, Triangle3DDerived, Triangle3DDistance,
 };
 
 /// 3次元三角形（Core実装）
@@ -353,7 +353,7 @@ impl<T: Scalar> Triangle3DConstructor<T> for Triangle3D<T> {
     }
 }
 
-impl<T: Scalar> Triangle3DProperties<T> for Triangle3D<T> {
+impl<T: Scalar> Triangle3DBoundaryAccess<T> for Triangle3D<T> {
     fn vertex_a(&self) -> (T, T, T) {
         let p = self.vertex_a_internal();
         (p.x(), p.y(), p.z())
@@ -397,6 +397,12 @@ impl<T: Scalar> Triangle3DDerived<T> for Triangle3D<T> {
         Triangle3D::area(self)
     }
 
+    fn is_planar(&self) -> bool {
+        Triangle3D::is_planar(self)
+    }
+}
+
+impl<T: Scalar> Triangle3DBoundaryQuantity<T> for Triangle3D<T> {
     fn edge_ab_length(&self) -> T {
         Triangle3D::edge_ab(self).length()
     }
@@ -411,10 +417,6 @@ impl<T: Scalar> Triangle3DDerived<T> for Triangle3D<T> {
 
     fn perimeter(&self) -> T {
         Triangle3D::perimeter(self)
-    }
-
-    fn is_planar(&self) -> bool {
-        Triangle3D::is_planar(self)
     }
 }
 

--- a/viewmodel/converter/src/mesh_converter.rs
+++ b/viewmodel/converter/src/mesh_converter.rs
@@ -4,7 +4,7 @@
 //! geo_primitives の具体型を使用して TriangleMesh3D を GPU レンダリング用の頂点データに変換します。
 
 use geo_algorithms::{Point3D, TriangleMesh3D, Vector3D};
-use geo_contracts::Triangle3DProperties;
+use geo_contracts::Triangle3DBoundaryAccess;
 
 /// GPU用頂点データ（renderクレートのMeshVertexと同じ構造）
 #[repr(C)]

--- a/viewmodel/converter/src/shape_converter.rs
+++ b/viewmodel/converter/src/shape_converter.rs
@@ -28,7 +28,7 @@ use geo_contracts::{
     EllipsoidalSolid3DProperties, EllipsoidalSurface3DEvaluation, InfiniteLine3DProperties,
     Plane3DProperties, PrimitiveKind, Ray3DProperties, SphericalSolid3DProperties,
     SphericalSurface3DEvaluation, TorusSolid3DProperties, TorusSurface3DEvaluation,
-    Triangle3DProperties,
+    Triangle3DBoundaryAccess,
 };
 // geo_algorithms を経由して全ての型にアクセス（Foundation Pattern遵守）
 // - 基本型 (Point3D, Vector3D from geo_core)


### PR DESCRIPTION
## 概要

#581 に対応し、Triangle を pre-topology の単一 face primitive として扱う前提を API 面へ反映しました。

主な変更:
- Triangle2D / Triangle3D に `BoundaryAccess` trait を追加し、`vertex_a/b/c` を face boundary access として分離
- Triangle2D / Triangle3D に `BoundaryQuantity` trait を追加し、`edge_*_length` と `perimeter` を boundary quantity / boundary derived として分離
- `area` と `is_clockwise` / `is_planar` は `Derived` 側へ整理
- `Triangle2DProperties` / `Triangle3DProperties` は downstream 互換の alias として維持
- contracts / primitives / geo_algorithms / geo_io / viewmodel の import を新しい trait 構成へ追従
- 設計書を option 2 の方針に合わせて更新

## 設計意図

- Triangle に curve endpoint capability を持ち込まず、face boundary access と boundary quantity を明示しました
- TriangleMesh と Triangle primitive の責務を混同しないよう、triangle 単体の boundary / derived 語彙だけを整理しています
- 既存 downstream への破壊的影響を抑えるため、`Properties` は alias として残しています

## 検証

- powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/check_pr_preflight.ps1
- cargo clippy -- -D warnings
- cargo fmt
- cargo test --workspace

## 関連

- #581
- #558