### PR TITLE
refactor: migrate ellipse3d downstream vocabulary (#586)

### DIFF
--- a/model/geo_algorithms/src/collision/primitive_3d.rs
+++ b/model/geo_algorithms/src/collision/primitive_3d.rs
@@ -341,7 +341,7 @@ pub fn ellipse3d_point3d_collides<T: Scalar + From<f64>>(
     point: &Point3D<T>,
     tolerance: T,
 ) -> bool {
-    <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(
+    <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(
         ellipse,
         (point.x(), point.y(), point.z()),
     ) <= tolerance
@@ -353,7 +353,7 @@ pub fn ellipse3d_circle3d_collides<T: Scalar + From<f64>>(
     tolerance: T,
 ) -> bool {
     let (cx, cy, cz) = circle.center();
-    <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(ellipse, (cx, cy, cz))
+    <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (cx, cy, cz))
         <= circle.radius() + tolerance
 }
 
@@ -364,7 +364,7 @@ pub fn ellipse3d_arc3d_collides<T: Scalar + From<f64>>(
 ) -> bool {
     let (cx, cy, cz) = Arc3DProperties::center(arc);
     let arc_radius = Arc3DProperties::radius(arc);
-    <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(ellipse, (cx, cy, cz))
+    <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (cx, cy, cz))
         <= arc_radius + tolerance
 }
 
@@ -375,22 +375,16 @@ pub fn ellipse3d_line_segment3d_collides<T: Scalar + From<f64>>(
 ) -> bool {
     let s = segment.start();
     let e = segment.end();
-    let dist_start = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(
-        ellipse,
-        (s.x(), s.y(), s.z()),
-    );
-    let dist_end = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(
-        ellipse,
-        (e.x(), e.y(), e.z()),
-    );
+    let dist_start =
+        <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (s.x(), s.y(), s.z()));
+    let dist_end =
+        <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (e.x(), e.y(), e.z()));
     let two = T::from_f64(2.0);
     let mid_x = (s.x() + e.x()) / two;
     let mid_y = (s.y() + e.y()) / two;
     let mid_z = (s.z() + e.z()) / two;
-    let dist_mid = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(
-        ellipse,
-        (mid_x, mid_y, mid_z),
-    );
+    let dist_mid =
+        <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (mid_x, mid_y, mid_z));
     dist_start <= tolerance || dist_end <= tolerance || dist_mid <= tolerance
 }
 
@@ -400,7 +394,7 @@ pub fn ellipse3d_infinite_line3d_collides<T: Scalar + From<f64>>(
     tolerance: T,
 ) -> bool {
     let (px, py, pz) = line.point();
-    <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(ellipse, (px, py, pz)) <= tolerance
+    <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (px, py, pz)) <= tolerance
 }
 
 pub fn ellipse3d_ray3d_collides<T: Scalar + From<f64>>(
@@ -409,7 +403,7 @@ pub fn ellipse3d_ray3d_collides<T: Scalar + From<f64>>(
     tolerance: T,
 ) -> bool {
     let o = ray.origin();
-    <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(ellipse, (o.x(), o.y(), o.z()))
+    <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (o.x(), o.y(), o.z()))
         <= tolerance
 }
 
@@ -430,17 +424,14 @@ pub fn ellipse3d_triangle3d_collides<T: Scalar + From<f64>>(
     let (ax, ay, az) = triangle.vertex_a();
     let (bx, by, bz) = triangle.vertex_b();
     let (cx, cy, cz) = triangle.vertex_c();
-    let dist_a =
-        <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(ellipse, (ax, ay, az));
-    let dist_b =
-        <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(ellipse, (bx, by, bz));
-    let dist_c =
-        <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(ellipse, (cx, cy, cz));
+    let dist_a = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (ax, ay, az));
+    let dist_b = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (bx, by, bz));
+    let dist_c = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (cx, cy, cz));
     let three = T::from_f64(3.0);
     let centroid_x = (ax + bx + cx) / three;
     let centroid_y = (ay + by + cy) / three;
     let centroid_z = (az + bz + cz) / three;
-    let dist_centroid = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(
+    let dist_centroid = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(
         ellipse,
         (centroid_x, centroid_y, centroid_z),
     );

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -578,7 +578,7 @@ fn ellipse3d_point3d_intersection_raw<T: Scalar + From<f64>>(
 ) -> Option<Point3D<T>> {
     point_intersection_if(
         point,
-        <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(
+        <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(
             ellipse,
             (point.x(), point.y(), point.z()),
         ) <= tolerance,
@@ -603,7 +603,7 @@ pub fn ellipse3d_circle3d_intersections<T: Scalar + From<f64>>(
     tolerance: T,
 ) -> IntersectionResult<T> {
     let (cx, cy, cz) = Circle3DProperties::center(circle);
-    let dist = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(ellipse, (cx, cy, cz));
+    let dist = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (cx, cy, cz));
     let points = if dist <= Circle3DProperties::radius(circle) + tolerance {
         vec![Point3D::new(cx, cy, cz)]
     } else {
@@ -618,7 +618,7 @@ pub fn ellipse3d_arc3d_intersections<T: Scalar + From<f64>>(
     tolerance: T,
 ) -> IntersectionResult<T> {
     let (cx, cy, cz) = Arc3DProperties::center(arc);
-    let dist = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(ellipse, (cx, cy, cz));
+    let dist = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (cx, cy, cz));
     let points = if dist <= Arc3DProperties::radius(arc) + tolerance {
         vec![Point3D::new(cx, cy, cz)]
     } else {
@@ -635,14 +635,14 @@ pub fn ellipse3d_line_segment3d_intersections<T: Scalar + From<f64>>(
     let start = segment.start();
     let end = segment.end();
     let mut intersections = Vec::new();
-    if <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(
+    if <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(
         ellipse,
         (start.x(), start.y(), start.z()),
     ) <= tolerance
     {
         intersections.push(start);
     }
-    if <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(
+    if <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(
         ellipse,
         (end.x(), end.y(), end.z()),
     ) <= tolerance
@@ -658,7 +658,7 @@ pub fn ellipse3d_infinite_line3d_intersections<T: Scalar + From<f64>>(
     tolerance: T,
 ) -> IntersectionResult<T> {
     let (px, py, pz) = InfiniteLine3DProperties::point(line);
-    let dist = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(ellipse, (px, py, pz));
+    let dist = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (px, py, pz));
     let points = if dist <= tolerance {
         vec![Point3D::new(px, py, pz)]
     } else {
@@ -673,10 +673,8 @@ pub fn ellipse3d_ray3d_intersections<T: Scalar + From<f64>>(
     tolerance: T,
 ) -> IntersectionResult<T> {
     let o = ray.origin();
-    let dist = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(
-        ellipse,
-        (o.x(), o.y(), o.z()),
-    );
+    let dist =
+        <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (o.x(), o.y(), o.z()));
     let points = if dist <= tolerance {
         vec![o]
     } else {
@@ -719,18 +717,15 @@ pub fn ellipse3d_triangle3d_intersections<T: Scalar + From<f64>>(
     let (bx, by, bz) = Triangle3DBoundaryAccess::vertex_b(triangle);
     let (cx, cy, cz) = Triangle3DBoundaryAccess::vertex_c(triangle);
     let mut intersections = Vec::new();
-    if <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(ellipse, (ax, ay, az))
-        <= tolerance
+    if <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (ax, ay, az)) <= tolerance
     {
         intersections.push(Point3D::new(ax, ay, az));
     }
-    if <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(ellipse, (bx, by, bz))
-        <= tolerance
+    if <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (bx, by, bz)) <= tolerance
     {
         intersections.push(Point3D::new(bx, by, bz));
     }
-    if <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point_3d(ellipse, (cx, cy, cz))
-        <= tolerance
+    if <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (cx, cy, cz)) <= tolerance
     {
         intersections.push(Point3D::new(cx, cy, cz));
     }


### PR DESCRIPTION
## 概要

#586 に対応し、Ellipse3D の downstream 呼び出しを compatibility alias から正本語彙へ移行しました。

主な変更:
- `geo_algorithms` の 3D collision で `Ellipse3DDistance::distance_to_point_3d` を `distance_to_point` へ置換
- `geo_algorithms` の 3D intersection で `Ellipse3DDistance::distance_to_point_3d` を `distance_to_point` へ置換
- model / workspace 全体で Ellipse3D に対する `_3d` compatibility alias 参照が残っていないことを確認

## 補足

- `contains_point_3d` / `distance_to_point_3d` の alias 自体は現時点では残しています
- 今回の未変更箇所として残る `_3d` 語彙は Circle3D 由来であり、#586 の対象外です
- `closest_point_to` は既に canonical 語彙として維持されており、本 PR では変更していません

## 検証

- powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/check_pr_preflight.ps1
- cargo clippy -- -D warnings
- cargo fmt
- cargo test --workspace

## 関連

- #586
- #580