### PR TITLE
[Phase4] refactor: shape capability taxonomy の export 面を整理

### DIFF
--- a/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
+++ b/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
@@ -735,6 +735,16 @@ Triangle は面 shape であり、curve endpoint や curve parameter capability 
 - 新規責務説明では `measure` を主語彙にせず、単独線 shape には `length`、閉曲線 shape には `circumference`、複数辺境界 shape には `perimeter`、面や立体には `area` / `volume` / `surface_area` を優先する
 - `point_at_parameter` と `point_at_angle` は evaluation capability に限定し、boundary access と混在させない
 
+## 2026-04-06 合意更新: Phase4 export 面の整理
+
+`#582` では、shape ごとの capability 分離結果を crate root の export 面へ反映する。
+
+- `geo_contracts::geometry::core::mod.rs` と `geo_contracts::lib.rs` は capability trait の正本 export 面とする
+- compatibility alias は trait定義 側に残してもよいが、crate root で canonical capability と同列に再公開しない
+- Triangle では `Triangle2DBoundaryAccess` / `Triangle3DBoundaryAccess` を正本とし、`Triangle2DProperties` / `Triangle3DProperties` は互換経路へ後退させる
+- `geo_primitives::lib.rs` は shape 型と最小限の基本型公開を優先し、contract trait の再公開を正本経路として扱わない
+- downstream が capability trait を参照する場合は `geo_contracts` から直接 import する
+
 ## 現行構造の棚卸し
 
 ### `geometry/core`

--- a/model/geo_contracts/src/geometry/core/mod.rs
+++ b/model/geo_contracts/src/geometry/core/mod.rs
@@ -152,9 +152,8 @@ pub use torus_surface_traits::{
 pub use triangle_traits::{
     Triangle2DBoundaryAccess, Triangle2DBoundaryQuantity, Triangle2DConstructor,
     Triangle2DContainment, Triangle2DCore, Triangle2DDerived, Triangle2DDistance,
-    Triangle2DProperties, Triangle3DBoundaryAccess, Triangle3DBoundaryQuantity,
-    Triangle3DConstructor, Triangle3DContainment, Triangle3DCore, Triangle3DDerived,
-    Triangle3DDistance, Triangle3DProperties,
+    Triangle3DBoundaryAccess, Triangle3DBoundaryQuantity, Triangle3DConstructor,
+    Triangle3DContainment, Triangle3DCore, Triangle3DDerived, Triangle3DDistance,
 };
 pub use vector_traits::{
     Vector2DConstructor, Vector2DCore, Vector2DMetric, Vector2DProduct, Vector2DProjection,

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -87,9 +87,8 @@ pub use geometry::core::{
     NurbsSurface3DDerived, NurbsSurface3DEvaluation, NurbsSurface3DProperties,
     Triangle2DBoundaryAccess, Triangle2DBoundaryQuantity, Triangle2DConstructor,
     Triangle2DContainment, Triangle2DCore, Triangle2DDerived, Triangle2DDistance,
-    Triangle2DProperties, Triangle3DBoundaryAccess, Triangle3DBoundaryQuantity,
-    Triangle3DConstructor, Triangle3DContainment, Triangle3DCore, Triangle3DDerived,
-    Triangle3DDistance, Triangle3DProperties,
+    Triangle3DBoundaryAccess, Triangle3DBoundaryQuantity, Triangle3DConstructor,
+    Triangle3DContainment, Triangle3DCore, Triangle3DDerived, Triangle3DDistance,
 };
 pub use geometry::foundation::{Bounded, PrimitiveMetadata};
 pub use geometry::operations::{

--- a/model/geo_primitives/src/lib.rs
+++ b/model/geo_primitives/src/lib.rs
@@ -102,69 +102,9 @@ pub mod circle_2d;
 pub mod circle_2d_bounds;
 pub mod circle_2d_extensions;
 
-// Circle の Core trait定義 再公開
-pub use geo_contracts::{
-    Circle2DConstructor, Circle2DContainment, Circle2DCore, Circle2DDerived, Circle2DDistance,
-    Circle2DEvaluation, Circle2DProjection, Circle2DProperties,
-};
-pub use geo_contracts::{
-    Circle3DConstructor, Circle3DContainment, Circle3DCore, Circle3DDerived, Circle3DDistance,
-    Circle3DEvaluation, Circle3DProjection, Circle3DProperties,
-};
-
-// Arc の Core trait定義 再公開
-pub use geo_contracts::{
-    Arc2DConstructor, Arc2DContainment, Arc2DCore, Arc2DDerived, Arc2DDistance, Arc2DEndpoint,
-    Arc2DEvaluation, Arc2DProperties, Arc2DSampling, Arc2DTrimRange, Arc3DConstructor,
-    Arc3DContainment, Arc3DCore, Arc3DDerived, Arc3DDistance, Arc3DEndpoint, Arc3DEvaluation,
-    Arc3DProperties, Arc3DTrimRange,
-};
-
 pub mod circle_2d_metrics;
 pub mod direction_2d;
 pub mod direction_2d_extensions;
-pub use geo_contracts::{
-    Direction3DConstructor, Direction3DProperties, Direction3DRelation, Direction3DTransform,
-};
-
-// InfiniteLine の Core trait定義 再公開
-pub use geo_contracts::{
-    AngularRelation, ClosestPointPair, InfiniteLine2DConstructor, InfiniteLine2DProperties,
-    InfiniteLine3DConstructor, InfiniteLine3DProperties, IntersectsRelation, OnPlaneRelation,
-    ParallelRelation, PerpendicularRelation, SameLineRelation, SkewRelation,
-};
-
-// Ray の Core trait定義 再公開
-pub use geo_contracts::{
-    AngleBetween, DirectionalRelation, PointsTowards, Ray2DConstructor, Ray2DProperties,
-    Ray3DConstructor, Ray3DProperties,
-};
-pub use geo_contracts::{
-    Ellipse2DConstructor, Ellipse2DContainment, Ellipse2DCore, Ellipse2DDerived, Ellipse2DDistance,
-    Ellipse2DEvaluation, Ellipse2DProjection, Ellipse2DProperties, Ellipse3DConstructor,
-    Ellipse3DContainment, Ellipse3DCore, Ellipse3DDerived, Ellipse3DDistance, Ellipse3DEvaluation,
-    Ellipse3DProjection, Ellipse3DProperties,
-};
-pub use geo_contracts::{
-    EllipseArc2DConstructor, EllipseArc2DContainment, EllipseArc2DCore, EllipseArc2DDerived,
-    EllipseArc2DEndpoint, EllipseArc2DEvaluation, EllipseArc2DProperties, EllipseArc2DTrimRange,
-    EllipseArc3DConstructor, EllipseArc3DContainment, EllipseArc3DCore, EllipseArc3DDerived,
-    EllipseArc3DEndpoint, EllipseArc3DEvaluation, EllipseArc3DProperties, EllipseArc3DTrimRange,
-};
-pub use geo_contracts::{
-    LineSegment2DConstructor, LineSegment2DContainment, LineSegment2DCore, LineSegment2DDerived,
-    LineSegment2DDistance, LineSegment2DEvaluation, LineSegment2DProjection,
-    LineSegment2DProperties, LineSegment3DConstructor, LineSegment3DContainment, LineSegment3DCore,
-    LineSegment3DDerived, LineSegment3DDistance, LineSegment3DEvaluation, LineSegment3DProjection,
-    LineSegment3DProperties,
-};
-pub use geo_contracts::{
-    Triangle2DBoundaryAccess, Triangle2DBoundaryQuantity, Triangle2DConstructor,
-    Triangle2DContainment, Triangle2DCore, Triangle2DDerived, Triangle2DDistance,
-    Triangle2DProperties, Triangle3DBoundaryAccess, Triangle3DBoundaryQuantity,
-    Triangle3DConstructor, Triangle3DContainment, Triangle3DCore, Triangle3DDerived,
-    Triangle3DDistance, Triangle3DProperties,
-};
 pub mod ellipse_2d;
 pub mod ellipse_2d_bounds;
 pub mod ellipse_2d_transform;
@@ -197,14 +137,10 @@ mod ellipse_3d_tests;
 #[cfg(test)]
 mod foundation_tests;
 
+// capability trait は geo_contracts を正本 export とし、この crate では shape 型公開を優先する。
+
 // 基本型
 pub use geo_contracts::{Angle, Scalar};
-
-// Foundation trait定義
-pub use geo_contracts::{
-    AdvancedCollision, BBoxCollision, BasicCollision, BasicIntersection, MultipleIntersection,
-    PointDistance, SelfIntersection,
-};
 
 // 3D プリミティブ
 pub use arc_3d::Arc3D;
@@ -242,7 +178,3 @@ pub use line_segment_2d::LineSegment2D;
 pub use ray_2d::Ray2D;
 pub use rectangle_2d::Rect2D;
 pub use triangle_2d::Triangle2D;
-
-// Core trait定義
-pub use geo_contracts::{InfiniteLine2DCore, InfiniteLine3DCore};
-pub use geo_contracts::{Ray2DCore, Ray3DCore};


### PR DESCRIPTION
## 概要
- #558 で合意した capability taxonomy に合わせて、geo_contracts の export 面を整理
- Triangle の互換 alias 再公開を crate root から外し、boundary access を正本 export として優先
- geo_primitives crate root の contract trait 再公開を縮小し、geo_contracts を canonical な trait 参照経路に統一

## 変更内容
- canonical capability export の方針を設計文書へ追記
- geo_contracts の crate root 再公開から Triangle2DProperties / Triangle3DProperties を外し、互換 alias は trait定義 側のみに残置
- geo_primitives::lib.rs の広範な geo_contracts trait 再公開を削減し、shape 型と基本型中心の公開へ整理

## 検証
- cargo clippy -- -D warnings
- cargo fmt
- cargo test --workspace
- ./scripts/check_architecture_dependencies.ps1 -ExitOnError
- ./scripts/check_pr_preflight.ps1

Closes #582