### PR TITLE
chore: legacy foundation コメント残骸を整理

### DIFF
--- a/model/geo_nurbs/src/surface_3d_bounds.rs
+++ b/model/geo_nurbs/src/surface_3d_bounds.rs
@@ -313,14 +313,14 @@ mod tests {
     }
 
     #[test]
-    fn test_extension_foundation() {
+    fn test_metadata_and_surface_area_capabilities() {
         let surface = <NurbsSurface3D<f64> as NurbsSurface3DConstructor<f64>>::unit_plane();
 
         // PrimitiveKind
         let kind = <NurbsSurface3D<f64> as PrimitiveMetadata>::primitive_kind(&surface);
         assert_eq!(kind, PrimitiveKind::NurbsSurface3D);
 
-        // Measure (面積)
+        // Derived capability (面積)
         let area = <NurbsSurface3D<f64> as NurbsSurface3DDerived<f64>>::surface_area(&surface);
         assert!((area - 1.0).abs() < 0.1); // 単位平面の面積は1.0
     }

--- a/model/geo_primitives/src/arc_3d_bounds.rs
+++ b/model/geo_primitives/src/arc_3d_bounds.rs
@@ -50,7 +50,7 @@ mod tests {
     use geo_contracts::{PrimitiveKind, PrimitiveMetadata};
 
     #[test]
-    fn test_extension_foundation() {
+    fn test_metadata_and_bounds_capabilities() {
         let center = Point3D::new(0.0, 0.0, 0.0);
         let normal = Direction3D::from_vector(Vector3D::new(0.0, 0.0, 1.0)).unwrap();
         let start_dir = Direction3D::from_vector(Vector3D::new(1.0, 0.0, 0.0)).unwrap();

--- a/model/geo_primitives/src/circle_3d_bounds.rs
+++ b/model/geo_primitives/src/circle_3d_bounds.rs
@@ -43,7 +43,7 @@ mod tests {
     use geo_contracts::{PrimitiveKind, PrimitiveMetadata};
 
     #[test]
-    fn test_extension_foundation() {
+    fn test_metadata_and_bounds_capabilities() {
         let center = Point3D::new(1.0, 2.0, 3.0);
         let normal = Direction3D::from_vector(Vector3D::new(0.0, 0.0, 1.0)).unwrap();
         let circle = Circle3D::new(center, normal, 5.0).unwrap();

--- a/model/geo_primitives/src/conical_solid_3d_bounds.rs
+++ b/model/geo_primitives/src/conical_solid_3d_bounds.rs
@@ -1,6 +1,6 @@
-//! ConicalSolid3D Foundation Implementation
+//! ConicalSolid3D の Bounds 実装
 //!
-//! ExtensionFoundation トレイトによる統一インターフェースの実装
+//! PrimitiveMetadata と Bounded に関わる補助実装を保持する。
 
 use crate::ConicalSolid3D;
 use geo_contracts::{Bounded, Scalar};
@@ -22,7 +22,7 @@ mod tests {
     use geo_contracts::{PrimitiveKind, PrimitiveMetadata};
 
     #[test]
-    fn test_extension_foundation() {
+    fn test_metadata_and_bounds_capabilities() {
         let center = Point3D::new(1.0, 2.0, 3.0);
         let axis = Vector3D::new(0.0, 0.0, 1.0);
         let ref_direction = Vector3D::new(1.0, 0.0, 0.0);

--- a/model/geo_primitives/src/cylindrical_solid_3d_bounds.rs
+++ b/model/geo_primitives/src/cylindrical_solid_3d_bounds.rs
@@ -1,4 +1,4 @@
-//! CylindricalSolid3D の Foundation トレイト実装
+//! CylindricalSolid3D の Bounds 実装
 
 use crate::CylindricalSolid3D;
 use geo_contracts::{Bounded, Scalar};
@@ -24,7 +24,7 @@ mod tests {
     use geo_contracts::{PrimitiveKind, PrimitiveMetadata};
 
     #[test]
-    fn test_extension_foundation() {
+    fn test_metadata_and_bounds_capabilities() {
         let center = Point3D::new(1.0, 2.0, 3.0);
         let axis = Vector3D::new(0.0, 0.0, 1.0);
         let ref_direction = Vector3D::new(1.0, 0.0, 0.0);

--- a/model/geo_primitives/src/cylindrical_surface_3d_bounds.rs
+++ b/model/geo_primitives/src/cylindrical_surface_3d_bounds.rs
@@ -1,7 +1,6 @@
-//! CylindricalSurface3D の Foundation Pattern 実装
+//! CylindricalSurface3D の Bounds 実装
 //!
-//! ExtensionFoundation と TolerantEq トレイトの実装
-//! ハイブリッドモデラーの分類システムとの統合
+//! PrimitiveMetadata と Bounded に関わる補助実装を保持する。
 
 use crate::CylindricalSurface3D;
 use geo_contracts::{Bounded, Scalar};
@@ -24,7 +23,7 @@ mod tests {
     use geo_contracts::{PrimitiveKind, PrimitiveMetadata};
 
     #[test]
-    fn test_extension_foundation() {
+    fn test_metadata_and_bounds_capabilities() {
         let surface = CylindricalSurface3D::new_z_axis(Point3D::new(1.0, 2.0, 3.0), 5.0).unwrap();
 
         assert_eq!(surface.primitive_kind(), PrimitiveKind::CylindricalSurface);

--- a/model/geo_primitives/src/triangle_3d_bounds.rs
+++ b/model/geo_primitives/src/triangle_3d_bounds.rs
@@ -1,4 +1,4 @@
-//! Triangle3D の Foundation トレイト実装
+//! Triangle3D の Bounds 実装
 
 use crate::Triangle3D;
 use geo_contracts::{Bounded, Scalar};
@@ -56,7 +56,7 @@ mod tests {
     use geo_contracts::{PrimitiveKind, PrimitiveMetadata};
 
     #[test]
-    fn test_extension_foundation() {
+    fn test_metadata_and_bounds_capabilities() {
         let triangle = Triangle3D::new(
             Point3D::new(0.0, 0.0, 0.0),
             Point3D::new(1.0, 0.0, 0.0),

--- a/model/geo_primitives/src/triangle_mesh_3d_bounds.rs
+++ b/model/geo_primitives/src/triangle_mesh_3d_bounds.rs
@@ -1,4 +1,4 @@
-//! TriangleMesh3D の Foundation トレイト実装
+//! TriangleMesh3D の Bounds 実装
 
 use crate::TriangleMesh3D;
 use geo_contracts::{Bounded, Scalar};
@@ -24,7 +24,7 @@ mod tests {
     use geo_contracts::{PrimitiveKind, PrimitiveMetadata};
 
     #[test]
-    fn test_extension_foundation() {
+    fn test_metadata_and_bounds_capabilities() {
         let vertices = vec![
             Point3D::new(0.0, 0.0, 0.0),
             Point3D::new(1.0, 0.0, 0.0),


### PR DESCRIPTION
## 概要
- bounds 実装ファイルと関連テストに残っていた legacy Foundation 表現を現在の責務に合わせて整理
- `ExtensionFoundation` 前提のコメントや test 名を、`PrimitiveMetadata` / `Bounded` / derived capability に沿う表現へ更新

## 変更内容
- `*_bounds.rs` の先頭コメントを Foundation 実装ではなく bounds 実装として明確化
- `test_extension_foundation` という旧前提の test 名を現在の capability に合う名前へ変更
- NURBS surface のテストコメント内の `Measure` 表現を derived capability ベースへ更新

## 検証
- cargo clippy -- -D warnings
- cargo fmt
- cargo test --workspace
- ./scripts/check_pr_preflight.ps1

## 補足
- 変更はコメント・テスト名の cleanup に限定し、実装ロジックは変更していません