### PR TITLE
[Design] topology: Arc / EllipseArc の拘束端点責務を整理

### DIFF
--- a/dev/architecture/GEOMETRY_SHAPE_SEMANTICS_DESIGN.md
+++ b/dev/architecture/GEOMETRY_SHAPE_SEMANTICS_DESIGN.md
@@ -387,3 +387,11 @@ topology 側の Edge 正規形は、shape 意味論を前提に、接続・向�
 - Arc / EllipseArc primitive の endpoint semantics を拘束端点へ変更すること
 - `point_at_parameter(0/1)` と `start_point/end_point` の常時一致を不変条件にすること
 - Topology の trim / binding 完全仕様をこの段階で完了すること
+
+`#567` では、この実装単位 A の意味論を topology 側の拘束端点語彙と接続して固定する。すなわち、Arc / EllipseArc primitive の endpoint semantics は ideal endpoint のまま維持し、拘束端点の正本は topology 側へ置く。
+
+補足:
+
+- `#567` は Arc / EllipseArc と topology の責務境界を固定する設計 Issue として扱う
+- LineSegment を bounded curve 共通ルールへ対称化する作業は `#592` の follow-up として分離する
+- したがって `#567` では Arc / EllipseArc の primitive semantics を動かさず、topology 側の語彙整理で閉じる

--- a/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
+++ b/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
@@ -956,6 +956,14 @@ Triangle は面 shape であり、curve endpoint や curve parameter capability 
 - containment と distance は endpoint/evaluation と同居させない
 - topology が拘束端点を必要とする場合でも、primitive の endpoint semantics は直ちに変更しない
 
+`#567` の設計結論としては、この方針を topology endpoint 語彙の正本とする。すなわち、contract / primitive 側では Arc / EllipseArc の `start_point` / `end_point` を ideal endpoint 語彙として維持し、拘束端点は topology 側の `constraint_*` 語彙へ分離する。
+
+補足:
+
+- `#567` は Arc / EllipseArc の primitive semantics を固定し、topology の拘束端点責務を明示するための設計整理として扱う
+- LineSegment の endpoint semantics を bounded curve 共通ルールへ対称化する作業は `#592` で扱う
+- したがって contract / primitive の endpoint 語彙は Arc / EllipseArc から先に固定し、LineSegment の対称化は別論点として切り出す
+
 ### 実装単位 B: Circle / Ellipse の closed curve vocabulary 固定
 
 目的:

--- a/dev/architecture/TOPOLOGY_ENTITY_LAYER_DESIGN.md
+++ b/dev/architecture/TOPOLOGY_ENTITY_LAYER_DESIGN.md
@@ -109,6 +109,19 @@ topology で保持する vertex は、shape の拘束点と接続して扱う。
 
 したがって、vertex binding invariant は「母曲線評価端点と vertex が常に一致すること」ではなく、shape 意味論を前提にした binding ルールとして定義し直す。
 
+## `#567` の設計結論
+
+`#567` では、Arc / EllipseArc の endpoint semantics と topology の拘束端点責務を次のように固定する。
+
+- primitive は exact geometry を表す
+- Arc / EllipseArc の `start_point` / `end_point` は primitive の ideal endpoint として扱う
+- topology 上の拘束端点は `Edge` の `start_vertex` / `end_vertex` 側で管理する
+- `parameter_range` は evaluated endpoint を導く位相情報として扱う
+- Edge の局所整合は `binding consistency`、`ideal endpoint consistency`、`evaluation endpoint consistency` を分離して定義する
+- shared vertex を介した隣接 Edge 間の連続性整合は、Edge 単独の局所判定とは分けて `\delta_{shared}` 側で扱う
+
+このとき、`#567` のスコープは Arc / EllipseArc と topology の責務境界を固定するところまでとし、LineSegment の endpoint semantics を bounded curve 共通ルールへ対称化する作業は follow-up の `#592` で扱う。
+
 ## LineSegment と topology の接続
 
 `#557` で固定した `LineSegment` semantics を前提に、topology では次を採用する。
@@ -119,6 +132,12 @@ topology で保持する vertex は、shape の拘束点と接続して扱う。
 - `start_vertex` / `end_vertex` は拘束点との binding を表す
 
 このため、support line 上の ideal endpoint と vertex が一致しない場合を許容できる topology invariant が必要になる。
+
+補足:
+
+- この LineSegment の扱いは `#567` の最終結論ではなく、`#557` 起点の既存前提としてここに残している
+- bounded curve 全体で primitive は ideal endpoint、拘束端点は topology 管理という原則へ揃える対称化は `#592` で別途扱う
+- したがって `#567` の結論は Arc / EllipseArc と topology の責務境界固定であり、LineSegment の特別扱いをこの段階で既成事実化しない
 
 ## Arc / EllipseArc と topology の接続
 

--- a/model/geo_topology/src/topology_core.rs
+++ b/model/geo_topology/src/topology_core.rs
@@ -271,12 +271,17 @@ impl<T: Scalar> Edge<T> {
     }
 
     /// Edge の局所整合を確認する
-    pub fn is_vertex_binding_consistent(&self, edge_tolerance: T) -> bool {
+    pub fn is_local_consistent(&self, edge_tolerance: T) -> bool {
         let third_tolerance = edge_tolerance / T::from_f64(3.0);
 
         self.is_binding_consistent(third_tolerance)
             && self.is_ideal_endpoint_consistent(third_tolerance)
             && self.is_evaluated_endpoint_consistent(third_tolerance)
+    }
+
+    /// 既存呼び出し向けの互換メソッド
+    pub fn is_vertex_binding_consistent(&self, edge_tolerance: T) -> bool {
+        self.is_local_consistent(edge_tolerance)
     }
 }
 
@@ -309,13 +314,13 @@ mod tests {
     }
 
     #[test]
-    fn edge_vertex_binding_consistency() {
+    fn edge_local_consistency() {
         let v0 = Arc::new(Vertex::new(Point3D::new(0.0, 0.0, 0.0)));
         let v1 = Arc::new(Vertex::new(Point3D::new(1.0, 0.0, 0.0)));
         let line = TopoLineSegment3D::new(v0.point(), v1.point()).unwrap();
         let edge = Edge::new(v0, v1, CurveRef::Line(line), (0.0, 1.0)).unwrap();
 
-        assert!(edge.is_vertex_binding_consistent(1e-9));
+        assert!(edge.is_local_consistent(1e-9));
     }
 
     #[test]
@@ -341,7 +346,7 @@ mod tests {
         assert!(edge.is_binding_consistent(1e-9));
         assert!(edge.is_ideal_endpoint_consistent(1e-9));
         assert!(!edge.is_evaluated_endpoint_consistent(1e-9));
-        assert!(edge.is_vertex_binding_consistent(0.31));
-        assert!(!edge.is_vertex_binding_consistent(0.29));
+        assert!(edge.is_local_consistent(0.31));
+        assert!(!edge.is_local_consistent(0.29));
     }
 }

--- a/model/geo_topology/src/wire.rs
+++ b/model/geo_topology/src/wire.rs
@@ -46,7 +46,7 @@ impl<T: Scalar> Wire<T> {
         if !self
             .edges
             .iter()
-            .all(|edge| edge.is_vertex_binding_consistent(edge_tolerance))
+            .all(|edge| edge.is_local_consistent(edge_tolerance))
         {
             return false;
         }


### PR DESCRIPTION
## 概要

Arc / EllipseArc の endpoint semantics と topology の拘束端点責務を整理し、`#567` の設計結論を文書へ反映しました。

あわせて、`geo_topology` の局所整合判定メソッド名を最小限で整理し、設計文言とコード上の呼び方を揃えています。

Closes #567

## 変更内容

- `TOPOLOGY_ENTITY_LAYER_DESIGN.md` に `#567` の設計結論を追加
- Arc / EllipseArc の `start_point` / `end_point` は ideal endpoint のまま維持し、拘束端点は topology 側で管理する方針を明文化
- `binding consistency` / `ideal endpoint consistency` / `evaluation endpoint consistency` の分離と、`δ_shared` を Edge 局所判定と分離する方針を明文化
- LineSegment の対称化は follow-up の `#592` で扱うことを明記
- `geo_topology` に `is_local_consistent` を追加し、Wire 側の呼び出しを局所整合の語彙へ揃える

## 意図

この PR の目的は、Arc / EllipseArc と topology の責務境界を固定し、bounded curve 全体の endpoint semantics を一気に動かさないことです。

LineSegment については、bounded curve 共通ルールへの対称化が妥当ですが、これは `#567` の主論点とは切り分け、follow-up の `#592` で扱います。

## 検証

- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo test --workspace`

## 関連

- #592
