### PR TITLE
[Phase4] refactor: LineSegment の endpoint semantics を topology 責務分離へ対称化

### DIFF
--- a/dev/architecture/GEOMETRY_SHAPE_SEMANTICS_DESIGN.md
+++ b/dev/architecture/GEOMETRY_SHAPE_SEMANTICS_DESIGN.md
@@ -41,7 +41,7 @@ Arc / EllipseArc / Circle / Triangle などを含む shape 横断の `Measure / 
 
 | Shape | 現状の主な意味要素 | 現状の混在状況 |
 | --- | --- | --- |
-| `LineSegment` | support line、拘束端点、長さ、parameter 評価 | endpoint は `Properties`、evaluation / containment / distance / projection は `Measure` 系から分離済み |
+| `LineSegment` | support line、理想端点、長さ、parameter 評価 | endpoint は `Properties`、拘束端点は topology 側責務として分離対象 |
 | `Arc` | 中心、半径、角度区間、始終点、parameter 評価 | `Measure` に始終点、midpoint、angle 評価、distance、containment が同居 |
 | `EllipseArc` | 中心、主軸情報、角度区間、始終点、parameter 評価 | `Measure` に始終点、midpoint、angle 評価、containment、bounding box が同居 |
 | `Circle` | 中心、半径、周回 parameter 評価、閉曲線性 | `Measure` に circumference、area、containment、distance、projection、parameter 評価が同居 |
@@ -194,28 +194,33 @@ shape 横断で `measure` だけを共通語彙にすると、長さ、面積、
 
 ### 基本方針
 
-RedRing における `LineSegment2D/3D` は、単なる exact な有限線分ではなく、**support line を正本とし、拘束点としての始点・終点を併せ持つ tolerant な trimmed line** として扱う。
+`#592` の設計では、RedRing における `LineSegment2D/3D` を **bounded curve 共通ルールに従う exact な有限線分 primitive** として扱う。
 
-これにより、以下の意図を表現できる。
+すなわち、primitive 側では次を固定する。
 
-- 理想的には一直線上にある線分である
-- ただし始点・終点は拘束や数値誤差の結果として、理想支持線からトレランス以内でずれる可能性がある
-- topology 側では、その拘束点の一致/不一致が接続判定や編集挙動に影響する
+- support line と trim 区間が shape 定義を与える
+- `start` / `end` は support line 上の ideal endpoint を返す
+- topology 上の拘束端点は primitive ではなく `Edge` の `start_vertex` / `end_vertex` 側で管理する
+
+これにより、bounded curve 全体で「primitive は ideal endpoint、拘束端点は topology 管理」という責務分離を揃える。
 
 ### 正本と派生
 
 `LineSegment` では、概念的に次の値を区別する。
 
 - 正本: `support_line`
-- 正本: `start` / `end`（拘束点）
-- 派生: support line 上の理想トリム区間
-- 派生: ideal な端点
+- 正本: trim 区間
+- 正本 endpoint capability: `start` / `end`（ideal endpoint）
+- 派生: `midpoint`
+- 派生: `length`
 - 派生: support line 上の評価点
+- topology 管理: constraint endpoint
 
 重要:
 
 - 具体的な struct フィールド構成は実装都合で調整してよい
-- ただし API と意味論は、上記の区別を壊してはならない
+- ただし public API と意味論は、拘束端点を primitive 正本として扱わない
+- 実装移行中に補助フィールドが残っていても、最終的な公開意味論は ideal endpoint 基準で固定する
 
 ### API 意味の固定
 
@@ -223,16 +228,16 @@ RedRing における `LineSegment2D/3D` は、単なる exact な有限線分で
 
 | API | 意味 |
 | --- | --- |
-| 拘束点としての始点を返す API（現行: `start()` / `start_point()`） | 拘束点としての始点を返す |
-| 拘束点としての終点を返す API（現行: `end()` / `end_point()`） | 拘束点としての終点を返す |
-| `length()` | 拘束点間距離を返す |
+| 始点を返す API（現行: `start()` / `start_point()`） | support line と trim 区間から定まる ideal start endpoint を返す |
+| 終点を返す API（現行: `end()` / `end_point()`） | support line と trim 区間から定まる ideal end endpoint を返す |
+| `length()` | 有限線分 primitive としての長さを返す |
 | `point_at_parameter(t)` | support line 上の評価点を返す |
 | `measure()` | 主語彙にしない。互換の委譲としてのみ扱う |
 
 補足:
 
-- `start/end` と `point_at_parameter(0/1)` は一致を前提としない
-- `length()` は support line 上の ideal length を意味しない
+- `start/end` と `point_at_parameter(0/1)` は ideal endpoint / evaluation endpoint の関係として整合させる
+- 拘束端点とのずれは primitive API ではなく topology の binding で扱う
 
 ### 補助 API の扱い
 
@@ -241,9 +246,9 @@ RedRing における `LineSegment2D/3D` は、単なる exact な有限線分で
 - `support_line()`
 - `ideal_start()` / `ideal_end()`
 - `ideal_length()`
-- support line 評価と拘束点補間を分ける追加 API
+- support line 評価と topology 側拘束参照を分ける追加 API
 
-補助 API を導入する場合は、拘束点系と ideal 系を名称で明確に分離する。
+補助 API を導入する場合は、ideal 系と topology 依存語彙を名称で明確に分離する。
 
 ## geo_primitives と geo_topology の境界
 
@@ -251,31 +256,31 @@ RedRing における `LineSegment2D/3D` は、単なる exact な有限線分で
 
 一方、`geo_topology` は以下を追加で管理する。
 
-- vertex binding
+- constraint endpoint と vertex binding
 - same_sense
 - parameter range
 - edge / wire / face 文脈での接続関係
 
-したがって、topology は `LineSegment` の意味論を再定義しない。
-topology 側の Edge 正規形は、shape 意味論を前提に、接続・向き・トリムを管理する層として扱う。
+したがって、topology は `LineSegment` の endpoint semantics を上書きしない。
+topology 側の Edge 正規形は、primitive の ideal endpoint を前提に、拘束端点・接続・向き・トリムを管理する層として扱う。
 
-## `#557` における topology 未修正の暫定許容範囲
+## `#592` 着手時点の実装ギャップ
 
-`#557` では、LineSegment の shape semantics を先に固定する。
+`#592` 着手時点では、設計目標と実装が完全には一致していない可能性がある。
 
-その際、topology 側は未修正のまま次の範囲までを暫定的に許容する。
+特に確認対象は次の通りである。
 
 - `CurveRef::Line::point_at_parameter` が support line 上の評価を返すこと
-- `Edge` が `curve + parameter range + same_sense + vertex binding` を保持する現行構造を維持すること
-- `Wire` / `CompositeCurve` が拘束点ベースの端点参照を使うこと
+- `CurveRef::Line::start_point` / `end_point` が legacy な拘束点語彙を残していないか
+- `Edge` / `Wire` / `CompositeCurve` が LineSegment の endpoint を拘束端点として暗黙利用していないか
 
-一方、次の項目は `#557` の完了条件には含めず、別途 topology 側で設計確定が必要とする。
+このギャップは「現状実装の確認対象」であり、最終設計では次を満たす必要がある。
 
-- `Edge::is_vertex_binding_consistent` のように、母曲線評価端点と vertex の一致を前提にする不変条件の最終定義
-- 拘束点と ideal endpoint のずれを topology がどう許容するかという binding ルール
-- 位相専用 tolerance の正本化と運用方針
+- primitive endpoint は ideal endpoint として解釈される
+- 拘束端点とのずれは topology の binding rule で吸収する
+- 位相専用 tolerance の正本化と運用方針は topology 側で維持する
 
-したがって `#557` の段階では、「topology の現行構造を直ちに変更しないこと」は許容されるが、「現行 topology 不変条件が最終設計である」とはみなさない。
+したがって `#592` では、legacy な拘束点語彙を残したまま既成事実化せず、設計と実装の差分を埋める。
 
 ## 非目標
 
@@ -288,11 +293,11 @@ topology 側の Edge 正規形は、shape 意味論を前提に、接続・向�
 
 ## #557 での利用
 
-`#557` では、本書を前提に以下を整理する。
+`#592` では、本書を前提に以下を整理する。
 
-- `LineSegment` の API を tolerant trimmed line semantics に沿って明文化する
+- `LineSegment` の API を bounded curve 共通ルールに沿って明文化する
 - `length` と `measure` の役割分担を整理する
-- 利用側が exact finite segment と誤解しないよう contracts / primitives / topology 周辺を調整する
+- primitive と topology の endpoint 責務を混同しないよう contracts / primitives / topology 周辺を調整する
 
 ## 今後の拡張
 

--- a/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
+++ b/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
@@ -443,7 +443,8 @@ Point / Vector の `*Measure` は、互換 alias や非推奨 trait を長期維
 
 補足:
 
-- `LineSegment` では endpoint が shape 意味論上の正本なので、`start/end/midpoint/length` を `Properties` に残す方針を維持する
+- `LineSegment` では bounded curve の endpoint capability が shape 意味論上の正本なので、`start/end/midpoint/length` を `Properties` に残す方針を維持する
+- ただし `start/end` は拘束点ではなく ideal endpoint として扱い、拘束端点は topology 側責務とする
 - `measure` は primary vocabulary ではなく、`derived` 側の互換 API とみなす
 - 実装進捗として `LineSegment2DMeasure` / `LineSegment3DMeasure` は削除済みで、export は capability trait のみとする
 
@@ -728,7 +729,7 @@ Triangle は面 shape であり、curve endpoint や curve parameter capability 
 
 今回の整理で、少なくとも次を設計上の固定ルールとして扱う。
 
-- `LineSegment` の `start/end/midpoint/length` は拘束点ベースの definition 語彙として `Properties` に残す
+- `LineSegment` の `start/end/midpoint/length` は ideal endpoint ベースの bounded curve 語彙として `Properties` に残す
 - `Arc` / `EllipseArc` の endpoint capability は `start_point/end_point` のみに絞り、中間点取得は evaluation 側の明示 API へ委譲する
 - `Circle` / `Ellipse` は閉曲線 shape として endpoint capability を持たず、`ref_direction` や `rotation` は parameter 原点の基準に限定する
 - `Triangle` は curve endpoint capability を持たず、`vertex_a/b/c` と edge length は面 shape の boundary / derived 語彙として扱う

--- a/dev/architecture/TOPOLOGY_ENTITY_LAYER_DESIGN.md
+++ b/dev/architecture/TOPOLOGY_ENTITY_LAYER_DESIGN.md
@@ -85,7 +85,7 @@ CompositeCurve は、閉曲線であっても topology Loop の正本とはみ�
 
 topology はそれを前提に、接続・向き・トリム・共有関係を管理する層として扱う。
 
-したがって `LineSegment` の `support_line` / 拘束点 / `length()` / `point_at_parameter()` の意味は、topology 側で独自に上書きしない。
+したがって `LineSegment` の `support_line` / ideal endpoint / `length()` / `point_at_parameter()` の意味は、topology 側で独自に上書きしない。
 
 ### 2. Edge の正本は母曲線参照と位相情報の組である
 
@@ -124,20 +124,24 @@ topology で保持する vertex は、shape の拘束点と接続して扱う。
 
 ## LineSegment と topology の接続
 
-`#557` で固定した `LineSegment` semantics を前提に、topology では次を採用する。
+`#592` の設計では、LineSegment も Arc / EllipseArc と同じ bounded curve 共通ルールで扱う。したがって topology では次を採用する。
 
 - `CurveRef::Line::point_at_parameter` は support line 上の評価として扱う
-- `CurveRef::Line::start_point` / `end_point` は拘束点参照として扱う
+- `CurveRef::Line::start_point` / `end_point` は primitive の ideal endpoint を返す
 - `Edge` の `parameter_range` は support line / 母曲線上の有効区間を表す
-- `start_vertex` / `end_vertex` は拘束点との binding を表す
+- `start_vertex` / `end_vertex` は拘束端点との binding を表す
 
-このため、support line 上の ideal endpoint と vertex が一致しない場合を許容できる topology invariant が必要になる。
+したがって、LineSegment の Edge でも少なくとも次の 3 種類の点を区別する。
+
+- `constraint endpoint`: topology が binding の正本として扱う拘束端点
+- `ideal endpoint`: primitive の endpoint capability が返す support line 上の端点
+- `evaluation endpoint`: `parameter_range` の両端を母曲線評価した点
 
 補足:
 
-- この LineSegment の扱いは `#567` の最終結論ではなく、`#557` 起点の既存前提としてここに残している
-- bounded curve 全体で primitive は ideal endpoint、拘束端点は topology 管理という原則へ揃える対称化は `#592` で別途扱う
-- したがって `#567` の結論は Arc / EllipseArc と topology の責務境界固定であり、LineSegment の特別扱いをこの段階で既成事実化しない
+- `#592` 着手時点では実装に legacy な拘束点語彙が残る可能性があるが、これは移行対象であって最終設計ではない
+- bounded curve 全体で primitive は ideal endpoint、拘束端点は topology 管理という原則を LineSegment にも揃える
+- したがって LineSegment だけを topology 接続の例外として扱わない
 
 ## Arc / EllipseArc と topology の接続
 
@@ -474,17 +478,18 @@ fallback を採用する場合でも、少なくとも次を維持しなけれ�
 
 ## `#557` 時点の暫定許容範囲
 
-`#557` の段階では、topology の現行構造を直ちに変更しないことを許容する。
+`#557` では topology の現行構造を直ちに変更しないことを許容したが、`#592` ではその legacy 前提を最終設計として残さない。
 
 許容する範囲:
 
 - `CurveRef`
 - `Edge` の基本保持フィールド
-- `Wire` / `CompositeCurve` の拘束点ベース利用
+- `Wire` / `CompositeCurve` の基本構造そのもの
 
 未確定として残す範囲:
 
 - `Edge` / `Wire` / validator の具体 API 形状
+- LineSegment の endpoint を ideal endpoint として解釈した上での topology 接続語彙
 - tolerance 名と設定オブジェクトの最終配置
 - Face / Shell / PCurve へ展開したときの個別判定フロー
 

--- a/model/geo_contracts/src/geometry/core/linesegment_traits.rs
+++ b/model/geo_contracts/src/geometry/core/linesegment_traits.rs
@@ -77,16 +77,16 @@ pub trait LineSegment3DConstructor<T: Scalar> {
 
 /// LineSegment2D基本プロパティ取得トレイト
 pub trait LineSegment2DProperties<T: Scalar> {
-    /// 拘束点としての開始点を取得
+    /// bounded curve primitive の ideal start endpoint を取得
     fn start(&self) -> (T, T);
 
-    /// 拘束点としての終了点を取得
+    /// bounded curve primitive の ideal end endpoint を取得
     fn end(&self) -> (T, T);
 
     /// 中点を取得
     fn midpoint(&self) -> (T, T);
 
-    /// 拘束点間距離としての長さを取得
+    /// bounded curve primitive としての長さを取得
     fn length(&self) -> T;
 
     /// 形状の次元数（2）
@@ -104,16 +104,16 @@ pub trait LineSegment2DProperties<T: Scalar> {
 
 /// LineSegment3D基本プロパティ取得トレイト
 pub trait LineSegment3DProperties<T: Scalar> {
-    /// 拘束点としての開始点を取得
+    /// bounded curve primitive の ideal start endpoint を取得
     fn start(&self) -> (T, T, T);
 
-    /// 拘束点としての終了点を取得
+    /// bounded curve primitive の ideal end endpoint を取得
     fn end(&self) -> (T, T, T);
 
     /// 中点を取得
     fn midpoint(&self) -> (T, T, T);
 
-    /// 拘束点間距離としての長さを取得
+    /// bounded curve primitive としての長さを取得
     fn length(&self) -> T;
 
     /// 形状の次元数（3）

--- a/model/geo_primitives/src/line_segment_2d.rs
+++ b/model/geo_primitives/src/line_segment_2d.rs
@@ -12,7 +12,7 @@ use geo_contracts::{
 
 /// 2次元平面の線分。
 ///
-/// support line と拘束点を併せ持つ有限線形 shape を表す。
+/// support line と trim 区間を正本とし、必要に応じて拘束端点も保持できる有限線形 shape を表す。
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LineSegment2D<T: Scalar> {
     pub(crate) line: InfiniteLine2D<T>,
@@ -36,7 +36,7 @@ impl<T: Scalar> LineSegment2D<T> {
         Self::from_support_line_and_constraint_points(line, start, end)
     }
 
-    /// support line と拘束点から線分を作成
+    /// support line と拘束端点から線分を作成
     pub fn from_support_line_and_constraint_points(
         line: InfiniteLine2D<T>,
         start_point: Point2D<T>,
@@ -97,14 +97,29 @@ impl<T: Scalar> LineSegment2D<T> {
         (self.end_param - self.start_param).abs()
     }
 
+    /// topology 連携用の拘束始点を取得
+    pub fn constraint_start_point(&self) -> Point2D<T> {
+        self.start_point
+    }
+
+    /// topology 連携用の拘束終点を取得
+    pub fn constraint_end_point(&self) -> Point2D<T> {
+        self.end_point
+    }
+
+    /// 拘束端点間の距離を取得
+    pub fn constraint_length(&self) -> T {
+        self.start_point.distance_to(&self.end_point)
+    }
+
     /// 始点を取得
     pub fn start_point(&self) -> Point2D<T> {
-        self.start_point
+        self.ideal_start()
     }
 
     /// 終点を取得
     pub fn end_point(&self) -> Point2D<T> {
-        self.end_point
+        self.ideal_end()
     }
 
     /// 中点を取得
@@ -117,7 +132,7 @@ impl<T: Scalar> LineSegment2D<T> {
 
     /// 線分の長さを取得
     pub fn length(&self) -> T {
-        self.start_point.distance_to(&self.end_point)
+        self.ideal_length()
     }
 
     /// 方向ベクトルを取得（正規化済み）
@@ -421,7 +436,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn support_line_and_constraint_points_are_distinct() {
+    fn public_endpoints_follow_ideal_support_line() {
         let line = InfiniteLine2D::new(Point2D::origin(), Vector2D::new(1.0_f64, 0.0)).unwrap();
         let start = Point2D::new(0.0, 1.0);
         let end = Point2D::new(2.0, 1.0);
@@ -429,15 +444,18 @@ mod tests {
         let segment =
             LineSegment2D::from_support_line_and_constraint_points(line, start, end).unwrap();
 
-        assert_eq!(segment.start_point(), start);
-        assert_eq!(segment.end_point(), end);
+        assert_eq!(segment.constraint_start_point(), start);
+        assert_eq!(segment.constraint_end_point(), end);
         assert_eq!(segment.ideal_start(), Point2D::new(0.0, 0.0));
         assert_eq!(segment.ideal_end(), Point2D::new(2.0, 0.0));
+        assert_eq!(segment.start_point(), Point2D::new(0.0, 0.0));
+        assert_eq!(segment.end_point(), Point2D::new(2.0, 0.0));
         assert_eq!(
             segment.point_at_normalized_parameter(0.5),
             Point2D::new(1.0, 0.0)
         );
         assert_eq!(segment.length(), 2.0);
+        assert_eq!(segment.constraint_length(), 2.0);
         assert_eq!(segment.ideal_length(), 2.0);
     }
 }

--- a/model/geo_primitives/src/line_segment_2d_transform.rs
+++ b/model/geo_primitives/src/line_segment_2d_transform.rs
@@ -20,12 +20,12 @@ pub mod analysis_transform {
         matrix: &Matrix3x3<T>,
     ) -> Result<LineSegment2D<T>, TransformError> {
         // 始点の変換
-        let start_vec: Vector2<T> = line_segment.start_point().into();
+        let start_vec: Vector2<T> = line_segment.constraint_start_point().into();
         let transformed_start_vec = matrix.transform_point_2d(&start_vec);
         let new_start: Point2D<T> = transformed_start_vec.into();
 
         // 終点の変換
-        let end_vec: Vector2<T> = line_segment.end_point().into();
+        let end_vec: Vector2<T> = line_segment.constraint_end_point().into();
         let transformed_end_vec = matrix.transform_point_2d(&end_vec);
         let new_end: Point2D<T> = transformed_end_vec.into();
 
@@ -382,6 +382,26 @@ mod tests {
                 (result.end_point().y() - (original.end_point().y() + 5.0)).abs() < f64::EPSILON
             );
         }
+    }
+
+    #[test]
+    fn test_transform_preserves_constraint_points_separately_from_public_endpoints() {
+        let support_line = crate::InfiniteLine2D::new(Point2D::origin(), Vector2D::new(1.0, 0.0))
+            .unwrap();
+        let segment = LineSegment2D::from_support_line_and_constraint_points(
+            support_line,
+            Point2D::new(0.0, 1.0),
+            Point2D::new(2.0, 1.0),
+        )
+        .unwrap();
+
+        let translation = Vector2::new(1.0, 2.0);
+        let result = segment.translate_analysis_2d(&translation).unwrap();
+
+        assert_eq!(result.start_point(), Point2D::new(1.0, 2.0));
+        assert_eq!(result.end_point(), Point2D::new(3.0, 2.0));
+        assert_eq!(result.constraint_start_point(), Point2D::new(1.0, 3.0));
+        assert_eq!(result.constraint_end_point(), Point2D::new(3.0, 3.0));
     }
 
     /// エラーハンドリングテスト（ゼロスケール）

--- a/model/geo_primitives/src/line_segment_3d.rs
+++ b/model/geo_primitives/src/line_segment_3d.rs
@@ -12,7 +12,7 @@ use geo_contracts::{
 
 /// 3次元空間の線分。
 ///
-/// support line と拘束点を併せ持つ有限線形 shape を表す。
+/// support line と trim 区間を正本とし、必要に応じて拘束端点も保持できる有限線形 shape を表す。
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LineSegment3D<T: Scalar> {
     pub(crate) line: InfiniteLine3D<T>,
@@ -36,7 +36,7 @@ impl<T: Scalar> LineSegment3D<T> {
         Self::from_support_line_and_constraint_points(line, start, end)
     }
 
-    /// support line と拘束点から線分を作成
+    /// support line と拘束端点から線分を作成
     pub fn from_support_line_and_constraint_points(
         line: InfiniteLine3D<T>,
         start_point: Point3D<T>,
@@ -97,14 +97,29 @@ impl<T: Scalar> LineSegment3D<T> {
         (self.end_param - self.start_param).abs()
     }
 
+    /// topology 連携用の拘束始点を取得
+    pub fn constraint_start_point(&self) -> Point3D<T> {
+        self.start_point
+    }
+
+    /// topology 連携用の拘束終点を取得
+    pub fn constraint_end_point(&self) -> Point3D<T> {
+        self.end_point
+    }
+
+    /// 拘束端点間の距離を取得
+    pub fn constraint_length(&self) -> T {
+        self.start_point.distance_to(&self.end_point)
+    }
+
     /// 始点を取得
     pub fn start(&self) -> Point3D<T> {
-        self.start_point
+        self.ideal_start()
     }
 
     /// 終点を取得
     pub fn end(&self) -> Point3D<T> {
-        self.end_point
+        self.ideal_end()
     }
 
     /// 中点を取得
@@ -121,7 +136,7 @@ impl<T: Scalar> LineSegment3D<T> {
 
     /// 線分の長さを取得
     pub fn length(&self) -> T {
-        self.start_point.distance_to(&self.end_point)
+        self.ideal_length()
     }
 
     /// 方向ベクトルを取得
@@ -369,7 +384,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn support_line_and_constraint_points_are_distinct() {
+    fn public_endpoints_follow_ideal_support_line() {
         let line =
             InfiniteLine3D::new(Point3D::origin(), Vector3D::new(1.0_f64, 0.0, 0.0)).unwrap();
         let start = Point3D::new(0.0, 1.0, 0.0);
@@ -378,12 +393,15 @@ mod tests {
         let segment =
             LineSegment3D::from_support_line_and_constraint_points(line, start, end).unwrap();
 
-        assert_eq!(segment.start(), start);
-        assert_eq!(segment.end(), end);
+        assert_eq!(segment.constraint_start_point(), start);
+        assert_eq!(segment.constraint_end_point(), end);
         assert_eq!(segment.ideal_start(), Point3D::new(0.0, 0.0, 0.0));
         assert_eq!(segment.ideal_end(), Point3D::new(2.0, 0.0, 0.0));
+        assert_eq!(segment.start(), Point3D::new(0.0, 0.0, 0.0));
+        assert_eq!(segment.end(), Point3D::new(2.0, 0.0, 0.0));
         assert_eq!(segment.point_at_parameter(0.5), Point3D::new(1.0, 0.0, 0.0));
         assert_eq!(segment.length(), 2.0);
+        assert_eq!(segment.constraint_length(), 2.0);
         assert_eq!(segment.ideal_length(), 2.0);
     }
 }

--- a/model/geo_primitives/src/line_segment_3d_extensions.rs
+++ b/model/geo_primitives/src/line_segment_3d_extensions.rs
@@ -50,8 +50,8 @@ impl<T: Scalar> LineSegment3D<T> {
             line: self.line,
             start_param: self.end_param,
             end_param: self.start_param,
-            start_point: self.end(),
-            end_point: self.start(),
+            start_point: self.constraint_end_point(),
+            end_point: self.constraint_start_point(),
         }
     }
 

--- a/model/geo_primitives/src/line_segment_3d_transform.rs
+++ b/model/geo_primitives/src/line_segment_3d_transform.rs
@@ -19,11 +19,15 @@ pub mod analysis_transform {
         matrix: &Matrix4x4<T>,
     ) -> LineSegment3D<T> {
         let start_vec = Vector3::new(
-            segment.start().x(),
-            segment.start().y(),
-            segment.start().z(),
+            segment.constraint_start_point().x(),
+            segment.constraint_start_point().y(),
+            segment.constraint_start_point().z(),
         );
-        let end_vec = Vector3::new(segment.end().x(), segment.end().y(), segment.end().z());
+        let end_vec = Vector3::new(
+            segment.constraint_end_point().x(),
+            segment.constraint_end_point().y(),
+            segment.constraint_end_point().z(),
+        );
 
         // Matrix4x4による一括変換
         let transformed_start = matrix.transform_point_3d(&start_vec);
@@ -368,6 +372,29 @@ mod tests {
         assert!((results[1].start().x() - 8.0).abs() < 1e-10);
         assert!((results[1].start().y() - 9.0).abs() < 1e-10);
         assert!((results[1].start().z() - 10.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_transform_preserves_constraint_points_separately_from_public_endpoints() {
+        let support_line = crate::InfiniteLine3D::new(
+            Point3D::origin(),
+            Vector3D::new(1.0, 0.0, 0.0),
+        )
+        .unwrap();
+        let segment = LineSegment3D::from_support_line_and_constraint_points(
+            support_line,
+            Point3D::new(0.0, 1.0, 0.0),
+            Point3D::new(2.0, 1.0, 0.0),
+        )
+        .unwrap();
+
+        let translation = Vector3::new(1.0, 2.0, 3.0);
+        let result = segment.translate_analysis(&translation).unwrap();
+
+        assert_eq!(result.start(), Point3D::new(1.0, 2.0, 3.0));
+        assert_eq!(result.end(), Point3D::new(3.0, 2.0, 3.0));
+        assert_eq!(result.constraint_start_point(), Point3D::new(1.0, 3.0, 3.0));
+        assert_eq!(result.constraint_end_point(), Point3D::new(3.0, 3.0, 3.0));
     }
 
     #[test]

--- a/model/geo_topology/src/composite_curve.rs
+++ b/model/geo_topology/src/composite_curve.rs
@@ -17,7 +17,7 @@ pub enum CurveSegment3D<T: Scalar> {
 }
 
 impl<T: Scalar> CurveSegment3D<T> {
-    /// セグメント始点を返す
+    /// セグメントの ideal start endpoint を返す
     pub fn start(&self) -> Point3D<T> {
         match self {
             Self::Line(seg) => seg.start(),
@@ -25,10 +25,26 @@ impl<T: Scalar> CurveSegment3D<T> {
         }
     }
 
-    /// セグメント終点を返す
+    /// セグメントの ideal end endpoint を返す
     pub fn end(&self) -> Point3D<T> {
         match self {
             Self::Line(seg) => seg.end(),
+            Self::Arc(arc) => arc.end_point(),
+        }
+    }
+
+    /// topology 接続に使う拘束始点を返す
+    pub fn constraint_start(&self) -> Point3D<T> {
+        match self {
+            Self::Line(seg) => seg.constraint_start_point(),
+            Self::Arc(arc) => arc.start_point(),
+        }
+    }
+
+    /// topology 接続に使う拘束終点を返す
+    pub fn constraint_end(&self) -> Point3D<T> {
+        match self {
+            Self::Line(seg) => seg.constraint_end_point(),
             Self::Arc(arc) => arc.end_point(),
         }
     }
@@ -78,8 +94,8 @@ impl<T: Scalar> CompositeCurve3D<T> {
 
         // 連続性検証: N番目終点とN+1番目始点が許容差内で接続すること
         for i in 0..segments.len() - 1 {
-            let end = segments[i].end();
-            let next_start = segments[i + 1].start();
+            let end = segments[i].constraint_end();
+            let next_start = segments[i + 1].constraint_start();
 
             if !Self::points_are_connected(end, next_start, tolerance) {
                 return None;
@@ -94,14 +110,24 @@ impl<T: Scalar> CompositeCurve3D<T> {
         &self.segments
     }
 
+    /// 複合曲線全体の拘束始点を返す
+    pub fn constraint_start_point(&self) -> Point3D<T> {
+        self.segments[0].constraint_start()
+    }
+
+    /// 複合曲線全体の拘束終点を返す
+    pub fn constraint_end_point(&self) -> Point3D<T> {
+        self.segments[self.segments.len() - 1].constraint_end()
+    }
+
     /// 複合曲線全体の始点を返す
     pub fn start_point(&self) -> Point3D<T> {
-        self.segments[0].start()
+        self.constraint_start_point()
     }
 
     /// 複合曲線全体の終点を返す
     pub fn end_point(&self) -> Point3D<T> {
-        self.segments[self.segments.len() - 1].end()
+        self.constraint_end_point()
     }
 
     /// 全セグメント長の合計を返す
@@ -119,8 +145,8 @@ impl<T: Scalar> CompositeCurve3D<T> {
 
     /// 許容誤差付きで閉曲線かどうかを返す
     pub fn is_closed_with_tolerance(&self, tolerance: T) -> bool {
-        let start = self.start_point();
-        let end = self.end_point();
+        let start = self.constraint_start_point();
+        let end = self.constraint_end_point();
         Self::points_are_connected(start, end, tolerance)
     }
 }
@@ -146,6 +172,27 @@ mod tests {
         let curve_seg = CurveSegment3D::Line(seg);
 
         assert_eq!(curve_seg.length(), 5.0);
+    }
+
+    #[test]
+    fn curve_segment_line_constraint_endpoints_follow_constraint_points() {
+        let support_line = crate::TopoInfiniteLine3D::from_two_points(
+            Point3D::new(0.0, 0.0, 0.0),
+            Point3D::new(2.0, 0.0, 0.0),
+        )
+        .unwrap();
+        let seg = TopoLineSegment3D::from_support_line_and_constraint_points(
+            support_line,
+            Point3D::new(0.0, 1.0, 0.0),
+            Point3D::new(2.0, 1.0, 0.0),
+        )
+        .unwrap();
+        let curve_seg = CurveSegment3D::Line(seg);
+
+        assert_eq!(curve_seg.start(), Point3D::new(0.0, 0.0, 0.0));
+        assert_eq!(curve_seg.end(), Point3D::new(2.0, 0.0, 0.0));
+        assert_eq!(curve_seg.constraint_start(), Point3D::new(0.0, 1.0, 0.0));
+        assert_eq!(curve_seg.constraint_end(), Point3D::new(2.0, 1.0, 0.0));
     }
 
     #[test]
@@ -228,6 +275,39 @@ mod tests {
     }
 
     #[test]
+    fn composite_curve_connectivity_uses_constraint_endpoints_for_line_segments() {
+        let support_line_a = crate::TopoInfiniteLine3D::from_two_points(
+            Point3D::new(0.0, 0.0, 0.0),
+            Point3D::new(1.0, 0.0, 0.0),
+        )
+        .unwrap();
+        let support_line_b = crate::TopoInfiniteLine3D::from_two_points(
+            Point3D::new(1.0, 0.0, 0.0),
+            Point3D::new(2.0, 0.0, 0.0),
+        )
+        .unwrap();
+        let seg1 = TopoLineSegment3D::from_support_line_and_constraint_points(
+            support_line_a,
+            Point3D::new(0.0, 1.0, 0.0),
+            Point3D::new(1.0, 1.0, 0.0),
+        )
+        .unwrap();
+        let seg2 = TopoLineSegment3D::from_support_line_and_constraint_points(
+            support_line_b,
+            Point3D::new(1.0, 1.0, 0.0),
+            Point3D::new(2.0, 1.0, 0.0),
+        )
+        .unwrap();
+
+        let composite =
+            CompositeCurve3D::new(vec![CurveSegment3D::Line(seg1), CurveSegment3D::Line(seg2)])
+                .unwrap();
+
+        assert_eq!(composite.start_point(), Point3D::new(0.0, 1.0, 0.0));
+        assert_eq!(composite.end_point(), Point3D::new(2.0, 1.0, 0.0));
+    }
+
+    #[test]
     fn composite_curve_empty_fails() {
         assert!(CompositeCurve3D::<f64>::new(vec![]).is_none());
     }
@@ -241,11 +321,14 @@ mod tests {
         let seg3 = TopoLineSegment3D::new(Point3D::new(0.0, 1.0, 0.0), Point3D::new(0.0, 0.0, 0.0))
             .unwrap();
 
-        let composite = CompositeCurve3D::new(vec![
-            CurveSegment3D::Line(seg1),
-            CurveSegment3D::Line(seg2),
-            CurveSegment3D::Line(seg3),
-        ])
+        let composite = CompositeCurve3D::new_with_tolerance(
+            vec![
+                CurveSegment3D::Line(seg1),
+                CurveSegment3D::Line(seg2),
+                CurveSegment3D::Line(seg3),
+            ],
+            1.0e-9,
+        )
         .unwrap();
 
         assert!(composite.is_closed());

--- a/model/geo_topology/src/topology_core.rs
+++ b/model/geo_topology/src/topology_core.rs
@@ -324,7 +324,7 @@ mod tests {
     }
 
     #[test]
-    fn edge_binding_ideal_and_evaluated_consistency_are_separated() {
+    fn edge_binding_is_separated_from_curve_consistency_for_offset_constraints() {
         let support_line = TopoInfiniteLine3D::from_two_points(
             Point3D::new(0.0, 0.0, 0.0),
             Point3D::new(2.0, 0.0, 0.0),
@@ -344,9 +344,27 @@ mod tests {
         .unwrap();
 
         assert!(edge.is_binding_consistent(1e-9));
-        assert!(edge.is_ideal_endpoint_consistent(1e-9));
+        assert!(!edge.is_ideal_endpoint_consistent(1e-9));
         assert!(!edge.is_evaluated_endpoint_consistent(1e-9));
         assert!(edge.is_local_consistent(0.31));
         assert!(!edge.is_local_consistent(0.29));
+    }
+
+    #[test]
+    fn edge_ideal_and_evaluated_consistency_are_separated_by_parameter_range() {
+        let start = Point3D::new(0.0, 0.0, 0.0);
+        let end = Point3D::new(2.0, 0.0, 0.0);
+        let line = TopoLineSegment3D::new(start, end).unwrap();
+        let edge = Edge::new(
+            Arc::new(Vertex::new(start)),
+            Arc::new(Vertex::new(end)),
+            CurveRef::Line(line),
+            (0.1, 1.9),
+        )
+        .unwrap();
+
+        assert!(edge.is_binding_consistent(1e-9));
+        assert!(edge.is_ideal_endpoint_consistent(1e-9));
+        assert!(!edge.is_evaluated_endpoint_consistent(1e-9));
     }
 }


### PR DESCRIPTION
## 概要

LineSegment の endpoint semantics を bounded curve 共通ルールへ揃え、primitive は ideal endpoint、拘束端点は topology 側責務として扱う形に整理しました。

Closes #592

## 変更点

- LineSegment 2D/3D の public endpoint と length を ideal endpoint 基準へ変更
- `constraint_start_point` / `constraint_end_point` / `constraint_length` を追加し、拘束端点を明示 accessor として分離
- LineSegment trait 語彙を ideal endpoint 基準へ更新
- 2D/3D transform 実装で拘束端点保持を明示
- topology_core のテストを更新し、binding / ideal endpoint / evaluated endpoint の分離を固定
- CompositeCurve で LineSegment の連結判定を constraint endpoint 基準へ明示化
- #592 の設計文書を実装内容に合わせて更新

## 意図

- Arc / EllipseArc と同じく、LineSegment も primitive 側では ideal endpoint を返す
- topology 側は拘束端点と binding を管理する
- `Wire` と `CompositeCurve` が LineSegment の public endpoint を暗黙に拘束端点として解釈しないようにする

## 検証

- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo test --workspace`
