### PR TITLE
[Design] refactor: clarify CompositeCurve endpoint vocabulary

### DIFF
--- a/dev/architecture/TOPOLOGY_ENTITY_LAYER_DESIGN.md
+++ b/dev/architecture/TOPOLOGY_ENTITY_LAYER_DESIGN.md
@@ -54,6 +54,15 @@ CompositeCurve は、閉曲線であっても topology Loop の正本とはみ�
 
 したがって、RedRing では「閉じた CompositeCurve をそのまま Loop と呼ぶ」ことはせず、CompositeCurve は Wire / Loop 構築前段の幾何入力または補助表現として扱う。
 
+CompositeCurve の endpoint 語彙は、少なくとも次で固定する。
+
+- `CurveSegment::start/end`: 個別セグメントの ideal endpoint
+- `CurveSegment::constraint_start/constraint_end`: topology 接続に使う拘束端点
+- `CompositeCurve::start_point/end_point`: 複合曲線全体の拘束端点を返す public endpoint
+- `CompositeCurve::ideal_start_point/ideal_end_point`: 複合曲線全体の ideal endpoint を返す補助語彙
+
+つまり CompositeCurve は、segment 単位では ideal/constraint の両方を名前で分離しつつ、複合曲線全体の public endpoint は Wire / Loop 構築前段で使う拘束端点を正本とする。
+
 ## 将来実装を見越した存在と設計確定項目
 
 未実装であっても、topology entity layer の将来対象として少なくとも次の要素は存在を明示しておく。

--- a/model/geo_topology/src/composite_curve.rs
+++ b/model/geo_topology/src/composite_curve.rs
@@ -64,7 +64,7 @@ impl<T: Scalar> CurveSegment3D<T> {
 /// 端点で連結された複数セグメントからなる複合曲線
 ///
 /// 保持する不変条件:
-/// - 全セグメントが連続している（N番目終点 == N+1番目始点）
+/// - 全セグメントが拘束端点で連続している（N番目拘束終点 == N+1番目拘束始点）
 /// - セグメント数は1以上
 /// - セグメントは順序付き
 #[derive(Clone, Debug)]
@@ -81,7 +81,7 @@ impl<T: Scalar> CompositeCurve3D<T> {
     ///
     /// 次の場合は None を返す:
     /// - segments が空
-    /// - セグメントが連続していない（N番目終点 != N+1番目始点）
+    /// - セグメントが拘束端点で連続していない
     pub fn new(segments: Vec<CurveSegment3D<T>>) -> Option<Self> {
         Self::new_with_tolerance(segments, T::ZERO)
     }
@@ -110,6 +110,16 @@ impl<T: Scalar> CompositeCurve3D<T> {
         &self.segments
     }
 
+    /// 複合曲線全体の ideal 始点を返す
+    pub fn ideal_start_point(&self) -> Point3D<T> {
+        self.segments[0].start()
+    }
+
+    /// 複合曲線全体の ideal 終点を返す
+    pub fn ideal_end_point(&self) -> Point3D<T> {
+        self.segments[self.segments.len() - 1].end()
+    }
+
     /// 複合曲線全体の拘束始点を返す
     pub fn constraint_start_point(&self) -> Point3D<T> {
         self.segments[0].constraint_start()
@@ -121,11 +131,15 @@ impl<T: Scalar> CompositeCurve3D<T> {
     }
 
     /// 複合曲線全体の始点を返す
+    ///
+    /// CompositeCurve の public endpoint は topology 接続に使う拘束端点を正本とする。
     pub fn start_point(&self) -> Point3D<T> {
         self.constraint_start_point()
     }
 
     /// 複合曲線全体の終点を返す
+    ///
+    /// CompositeCurve の public endpoint は topology 接続に使う拘束端点を正本とする。
     pub fn end_point(&self) -> Point3D<T> {
         self.constraint_end_point()
     }
@@ -203,6 +217,8 @@ mod tests {
 
         assert_eq!(composite.start_point(), Point3D::new(0.0, 0.0, 0.0));
         assert_eq!(composite.end_point(), Point3D::new(1.0, 0.0, 0.0));
+        assert_eq!(composite.ideal_start_point(), Point3D::new(0.0, 0.0, 0.0));
+        assert_eq!(composite.ideal_end_point(), Point3D::new(1.0, 0.0, 0.0));
         assert_eq!(composite.segments().len(), 1);
     }
 
@@ -305,6 +321,8 @@ mod tests {
 
         assert_eq!(composite.start_point(), Point3D::new(0.0, 1.0, 0.0));
         assert_eq!(composite.end_point(), Point3D::new(2.0, 1.0, 0.0));
+        assert_eq!(composite.ideal_start_point(), Point3D::new(0.0, 0.0, 0.0));
+        assert_eq!(composite.ideal_end_point(), Point3D::new(2.0, 0.0, 0.0));
     }
 
     #[test]

--- a/model/geo_topology/src/lib.rs
+++ b/model/geo_topology/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! 交差判定・モデリングで利用する最小のトポロジー構造を提供する。
 //! 現在の提供:
-//! - CompositeCurve3D: 端点で連結された複合曲線
-//! - CurveSegment3D: 個別セグメント（Line / Arc）
+//! - CompositeCurve3D: 拘束端点で連結された複合曲線
+//! - CurveSegment3D: 個別セグメント（Line / Arc、ideal/constraint endpoint を区別）
 //!
 //! 将来拡張（#205 連携）:
 //! - Vertex: 点トポロジー


### PR DESCRIPTION
## Summary
- clarify that `CompositeCurve3D::start_point/end_point` are the public vocabulary for constraint endpoints
- add `ideal_start_point/ideal_end_point` to expose whole-curve ideal endpoints explicitly
- align topology design and crate docs with the same ideal/constraint terminology

## Validation
- cargo clippy -- -D warnings
- cargo fmt
- cargo test --workspace

Closes #595