### PR TITLE
[Design] audit: clarify geo_algorithms endpoint semantics assumptions

### DIFF
--- a/model/geo_algorithms/src/intersection/nurbs_3d.rs
+++ b/model/geo_algorithms/src/intersection/nurbs_3d.rs
@@ -12,6 +12,8 @@
 //! - collision 実装と対称性を保つ（同一ペア数・同一形状セット）
 //! - orphan rules への対応は collision 側の Newtype パターンを参照
 //! - Phase C では最小実装（tolerance ベース交点判定）を提供
+//! - Phase C の一部 API は厳密交点ではなく代表点を返す
+//! - `LineSegment*::start/end` は ideal endpoint 基準で解釈する
 //! - 重複排除・pair_base 抽出は Step C で実施
 
 use crate::{
@@ -53,6 +55,7 @@ pub fn nurbscurve3d_line_segment3d_intersection<T: Scalar>(
     let distance = crate::collision::nurbscurve3d_line_segment3d_distance(curve, segment);
 
     if distance <= tolerance {
+        // Phase C の最小実装では代表点として線分の ideal start endpoint を返す。
         Some(segment.start())
     } else {
         None
@@ -67,6 +70,7 @@ pub fn nurbscurve3d_ray3d_intersection<T: Scalar>(
     let distance = crate::collision::nurbscurve3d_ray3d_distance(curve, ray);
 
     if distance <= tolerance {
+        // Phase C の最小実装では代表点として Ray origin を返す。
         Some(ray.origin())
     } else {
         None
@@ -111,6 +115,7 @@ pub fn nurbscurve3d_plane3d_intersection<T: Scalar>(
     let distance = crate::collision::nurbscurve3d_plane3d_distance(curve, plane);
 
     if distance <= tolerance {
+        // Phase C の最小実装では代表点として Plane origin を返す。
         Some(plane.origin())
     } else {
         None
@@ -203,6 +208,7 @@ pub fn nurbssurface3d_ray3d_intersection<T: Scalar>(
     let distance = crate::collision::nurbssurface3d_ray3d_distance(surface, ray);
 
     if distance <= tolerance {
+        // Phase C の最小実装では代表点として Ray origin を返す。
         Some(ray.origin())
     } else {
         None
@@ -217,6 +223,7 @@ pub fn nurbssurface3d_line_segment3d_intersection<T: Scalar>(
     let distance = crate::collision::nurbssurface3d_line_segment3d_distance(surface, segment);
 
     if distance <= tolerance {
+        // Phase C の最小実装では代表点として線分の ideal start endpoint を返す。
         Some(segment.start())
     } else {
         None

--- a/model/geo_algorithms/src/intersection/nurbs_3d.rs
+++ b/model/geo_algorithms/src/intersection/nurbs_3d.rs
@@ -85,6 +85,7 @@ pub fn nurbscurve3d_infinite_line3d_intersection<T: Scalar>(
     let distance = crate::collision::nurbscurve3d_infinite_line3d_distance(curve, line);
 
     if distance <= tolerance {
+        // Phase C の最小実装では代表点として InfiniteLine の基準点を返す。
         let (px, py, pz) = geo_contracts::InfiniteLine3DProperties::point(line);
         Some(Point3D::new(px, py, pz))
     } else {
@@ -100,6 +101,7 @@ pub fn nurbscurve3d_circle3d_intersection<T: Scalar>(
     let distance = crate::collision::nurbscurve3d_circle3d_distance(curve, circle);
 
     if distance <= tolerance {
+        // Phase C の最小実装では代表点として Circle center を返す。
         let (cx, cy, cz) = geo_contracts::Circle3DProperties::center(circle);
         Some(Point3D::new(cx, cy, cz))
     } else {
@@ -130,7 +132,7 @@ pub fn nurbscurve3d_spherical_solid3d_intersection<T: Scalar>(
     let distance = crate::collision::nurbscurve3d_spherical_solid3d_distance(curve, sphere);
 
     if distance <= tolerance {
-        // 曲線の始点を返す（Step C で改良）
+        // Phase C の最小実装では代表点として NURBS curve の parameter domain 始端を返す。
         let (u_min, _) = curve.parameter_domain();
         let vec = curve.evaluate_at(u_min);
         Some(Point3D::new(vec.x(), vec.y(), vec.z()))
@@ -147,7 +149,7 @@ pub fn nurbscurve3d_ellipsoidal_solid3d_intersection<T: Scalar>(
     let distance = crate::collision::nurbscurve3d_ellipsoidal_solid3d_distance(curve, ellipsoid);
 
     if distance <= tolerance {
-        // 曲線の始点を返す（Step C で改良）
+        // Phase C の最小実装では代表点として NURBS curve の parameter domain 始端を返す。
         let (u_min, _) = curve.parameter_domain();
         let vec = curve.evaluate_at(u_min);
         Some(Point3D::new(vec.x(), vec.y(), vec.z()))
@@ -164,7 +166,7 @@ pub fn nurbscurve3d_cylindrical_solid3d_intersection<T: Scalar>(
     let distance = crate::collision::nurbscurve3d_cylindrical_solid3d_distance(curve, cylinder);
 
     if distance <= tolerance {
-        // 曲線の始点を返す（Step C で改良）
+        // Phase C の最小実装では代表点として NURBS curve の parameter domain 始端を返す。
         let (u_min, _) = curve.parameter_domain();
         let vec = curve.evaluate_at(u_min);
         Some(Point3D::new(vec.x(), vec.y(), vec.z()))
@@ -194,6 +196,7 @@ pub fn nurbssurface3d_plane3d_intersection<T: Scalar>(
     let distance = crate::collision::nurbssurface3d_plane3d_distance(surface, plane);
 
     if distance <= tolerance {
+        // Phase C の最小実装では代表点として Plane origin を返す。
         Some(plane.origin())
     } else {
         None
@@ -238,6 +241,7 @@ pub fn nurbssurface3d_infinite_line3d_intersection<T: Scalar>(
     let distance = crate::collision::nurbssurface3d_infinite_line3d_distance(surface, line);
 
     if distance <= tolerance {
+        // Phase C の最小実装では代表点として InfiniteLine の基準点を返す。
         let (px, py, pz) = geo_contracts::InfiniteLine3DProperties::point(line);
         Some(Point3D::new(px, py, pz))
     } else {
@@ -253,6 +257,7 @@ pub fn nurbssurface3d_circle3d_intersection<T: Scalar>(
     let distance = crate::collision::nurbssurface3d_circle3d_distance(surface, circle);
 
     if distance <= tolerance {
+        // Phase C の最小実装では代表点として Circle center を返す。
         let (cx, cy, cz) = geo_contracts::Circle3DProperties::center(circle);
         Some(Point3D::new(cx, cy, cz))
     } else {
@@ -268,6 +273,7 @@ pub fn nurbssurface3d_spherical_solid3d_intersection<T: Scalar>(
     let distance = crate::collision::nurbssurface3d_spherical_solid3d_distance(surface, sphere);
 
     if distance <= tolerance {
+        // Phase C の最小実装では代表点として surface parameter domain の始端評価点を返す。
         let ((u_min, _), (v_min, _)) = surface.parameter_domain();
         let p = surface.evaluate_at(u_min, v_min);
         Some(Point3D::new(p.x(), p.y(), p.z()))
@@ -285,6 +291,7 @@ pub fn nurbssurface3d_ellipsoidal_solid3d_intersection<T: Scalar>(
         crate::collision::nurbssurface3d_ellipsoidal_solid3d_distance(surface, ellipsoid);
 
     if distance <= tolerance {
+        // Phase C の最小実装では代表点として surface parameter domain の始端評価点を返す。
         let ((u_min, _), (v_min, _)) = surface.parameter_domain();
         let p = surface.evaluate_at(u_min, v_min);
         Some(Point3D::new(p.x(), p.y(), p.z()))
@@ -301,6 +308,7 @@ pub fn nurbssurface3d_cylindrical_solid3d_intersection<T: Scalar>(
     let distance = crate::collision::nurbssurface3d_cylindrical_solid3d_distance(surface, cylinder);
 
     if distance <= tolerance {
+        // Phase C の最小実装では代表点として surface parameter domain の始端評価点を返す。
         let ((u_min, _), (v_min, _)) = surface.parameter_domain();
         let p = surface.evaluate_at(u_min, v_min);
         Some(Point3D::new(p.x(), p.y(), p.z()))

--- a/model/geo_algorithms/src/lib.rs
+++ b/model/geo_algorithms/src/lib.rs
@@ -2,6 +2,11 @@
 //!
 //! このクレートは、衝突判定・交点計算・空間分割などの幾何アルゴリズムを提供する
 //! 設計方針と全体構成は `dev/architecture/ARCHITECTURE.md` を参照
+//!
+//! endpoint semantics に関する前提:
+//! - `LineSegment2D` / `LineSegment3D` は bounded geometry の ideal endpoint 基準
+//! - `CompositeCurve3D` / `CurveSegment3D` は `geo_topology` の語彙をそのまま再公開する
+//!   ため、whole-curve の public endpoint は拘束端点基準
 
 pub mod angle_utils;
 pub mod collision;
@@ -36,6 +41,7 @@ pub use geo_nurbs::adaptive_tessellation;
 pub use geo_nurbs::{NurbsCurve3D, NurbsSurface3D};
 
 // Topology types from geo_topology
+// `CompositeCurve3D` の public endpoint は拘束端点基準であることに注意。
 pub use geo_topology::{CompositeCurve3D, CurveSegment3D};
 
 // geo_primitives の基本型を再エクスポート（ViewModel層がgeo_primitivesに直接依存しないように）

--- a/model/geo_algorithms/src/result.rs
+++ b/model/geo_algorithms/src/result.rs
@@ -11,6 +11,13 @@ use crate::{CompositeCurve3D, InfiniteLine3D, LineSegment2D, LineSegment3D, Poin
 use geo_contracts::Scalar;
 
 /// 交差結果の幾何内容
+///
+/// `LineSegment*` を保持する variant は、#592 以降の semantics に従い
+/// bounded geometry の ideal endpoint 基準の線分を表す。
+/// topology 上の拘束端点を含意しない。
+///
+/// `CompositeCurve` は `geo_topology` の語彙をそのまま保持するため、
+/// whole-curve の public endpoint は拘束端点基準で解釈する。
 #[derive(Clone, Debug)]
 pub enum IntersectionGeometry<T: Scalar> {
     /// 交差なし
@@ -22,8 +29,13 @@ pub enum IntersectionGeometry<T: Scalar> {
     /// 無限直線（例: 非平行な平面同士の交差）
     InfiniteLine(InfiniteLine3D<T>),
     /// 線分（例: 有界な面同士の交差）
+    ///
+    /// ここで返す線分は ideal endpoint 基準の幾何線分。
     Segment(LineSegment3D<T>),
     /// 複合曲線（例: 連結した複数セグメント）
+    ///
+    /// `CompositeCurve3D` の public endpoint 語彙は `geo_topology` に従い、
+    /// 拘束端点を返す。
     CompositeCurve(CompositeCurve3D<T>),
     /// 完全一致（形状が全域で重なる）
     Coincident,
@@ -32,6 +44,8 @@ pub enum IntersectionGeometry<T: Scalar> {
     /// 複数の孤立点（2D）
     Points2D(Vec<Point2D<T>>),
     /// 部分重複区間（2D、例: コリニア線分の有限重複）
+    ///
+    /// ここで返す線分は ideal endpoint 基準の幾何線分。
     Segment2D(LineSegment2D<T>),
 }
 


### PR DESCRIPTION
## Summary
- audit geo_algorithms endpoint assumptions after the LineSegment / CompositeCurve semantics changes in #592 and #595
- clarify public endpoint semantics in `geo_algorithms::result` and the crate re-export surface
- document that Phase C NURBS intersection APIs may return representative points rather than exact intersections
- split unrelated follow-up concerns into #599 and #600

## Validation
- cargo clippy -- -D warnings
- cargo fmt
- cargo test --workspace

## Notes
- #596 scope is treated as endpoint semantics audit and clarification
- asymmetric endpoint-near check in `arc3d_line_segment3d_intersection_raw` was split to #599
- NURBS representative-point semantics was split to #600

Closes #596