### PR TITLE
[Design] refactor: geo_topology validator へ tolerance budget 入口を整理

### DIFF
--- a/dev/architecture/TOPOLOGY_ENTITY_LAYER_DESIGN.md
+++ b/dev/architecture/TOPOLOGY_ENTITY_LAYER_DESIGN.md
@@ -371,6 +371,38 @@ ResolvedEdgeToleranceSettings<T>
 
 既定の対称配分が必要な場合は、`TopologyToleranceSettings<T>` の `distance_tolerance` から内部で `ResolvedEdgeToleranceSettings<T>` を導出し、`bind = ideal = eval = distance_tolerance / 3` を構成する。将来的に局所 override が必要になった場合だけ、公開 API を壊さずに内部解決 budget 側を拡張する。
 
+### `#606` の validator 入口具体化
+
+`#606` では、`Edge` / `Wire` 自身が持つ最小整合判定を残しつつ、診断や将来拡張の入口として validator を追加する。
+
+最小実装の構造は次を想定する。
+
+```text
+TopologyValidator<T>
+  - tolerances: TopologyToleranceSettings<T>
+
+ResolvedTopologyToleranceBudget<T>
+  - edge: ResolvedEdgeToleranceSettings<T>
+  - shared_tolerance
+
+EdgeValidationReport<T>
+  - binding_consistent
+  - ideal_endpoint_consistent
+  - evaluated_endpoint_consistent
+
+WireValidationReport<T>
+  - edge_reports
+  - shared_vertex_consistent
+```
+
+責務分担は次で固定する。
+
+- `Edge` / `Wire`: 最小の整合判定 API を持ってよい
+- `TopologyValidator<T>`: 公開設定から内部解決 budget を導出し、診断可能な report を返す入口とする
+- report 型: `Edge` / `Wire` のどの段が失敗したかを将来 validator で観測できる最小単位とする
+
+したがって、`Wire::is_continuous` のような bool API は残してよいが、validator はそれを置き換えるのではなく、判定理由を保持できる診断入口として追加する。
+
 用語の使い分けは次で固定する。
 
 - `shared boundary`: 2 つの位相要素が共有境界として対応しうる関係、またはその候補区間を指す一般語

--- a/model/geo_topology/src/lib.rs
+++ b/model/geo_topology/src/lib.rs
@@ -14,12 +14,14 @@
 pub mod composite_curve;
 pub mod tolerance;
 pub mod topology_core;
+pub mod topology_validator;
 pub mod wire;
 
 pub use composite_curve::{CompositeCurve3D, CurveSegment3D};
 pub use geo_core::{Point3D, Vector3D};
 pub use tolerance::TopologyToleranceSettings;
 pub use topology_core::{CurveRef, Edge, TopoId, Vertex};
+pub use topology_validator::{EdgeValidationReport, TopologyValidator, WireValidationReport};
 pub use wire::Wire;
 
 pub type TopoArc3D<T> = geo_primitives::Arc3D<T>;

--- a/model/geo_topology/src/tolerance.rs
+++ b/model/geo_topology/src/tolerance.rs
@@ -32,6 +32,11 @@ impl<T: Scalar> TopologyToleranceSettings<T> {
     pub(crate) fn resolve_edge_tolerances(&self) -> ResolvedEdgeToleranceSettings<T> {
         ResolvedEdgeToleranceSettings::symmetric(self.distance_tolerance)
     }
+
+    /// 代表トレランスから validator 用の内部解決 budget を導出する。
+    pub(crate) fn resolve_validator_budget(&self) -> ResolvedTopologyToleranceBudget<T> {
+        ResolvedTopologyToleranceBudget::new(self.resolve_edge_tolerances(), self.shared_tolerance)
+    }
 }
 
 /// Edge 局所整合でのみ使う内部解決 budget。
@@ -71,9 +76,29 @@ impl<T: Scalar> ResolvedEdgeToleranceSettings<T> {
     }
 }
 
+/// validator で使う内部解決 budget。
+///
+/// 将来 `Face` / `Shell` / knit が追加された場合は、この型を拡張して扱う。
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct ResolvedTopologyToleranceBudget<T: Scalar> {
+    pub edge: ResolvedEdgeToleranceSettings<T>,
+    pub shared_tolerance: T,
+}
+
+impl<T: Scalar> ResolvedTopologyToleranceBudget<T> {
+    pub(crate) fn new(edge: ResolvedEdgeToleranceSettings<T>, shared_tolerance: T) -> Self {
+        Self {
+            edge,
+            shared_tolerance,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{ResolvedEdgeToleranceSettings, TopologyToleranceSettings};
+    use super::{
+        ResolvedEdgeToleranceSettings, ResolvedTopologyToleranceBudget, TopologyToleranceSettings,
+    };
 
     #[test]
     fn representative_distance_tolerance_resolves_local_budget_evenly() {
@@ -99,5 +124,19 @@ mod tests {
 
         assert!((settings.distance_tolerance - 0.3).abs() < 1.0e-12);
         assert!((settings.shared_tolerance - 1.0e-6).abs() < 1.0e-12);
+    }
+
+    #[test]
+    fn validator_budget_uses_edge_and_shared_components() {
+        let settings = TopologyToleranceSettings::new(0.3_f64, 1.0e-6);
+        let resolved = settings.resolve_validator_budget();
+
+        assert_eq!(
+            resolved,
+            ResolvedTopologyToleranceBudget::new(
+                ResolvedEdgeToleranceSettings::new(0.1, 0.1, 0.1),
+                1.0e-6,
+            )
+        );
     }
 }

--- a/model/geo_topology/src/tolerance.rs
+++ b/model/geo_topology/src/tolerance.rs
@@ -96,9 +96,7 @@ impl<T: Scalar> ResolvedTopologyToleranceBudget<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        ResolvedEdgeToleranceSettings, ResolvedTopologyToleranceBudget, TopologyToleranceSettings,
-    };
+    use super::{ResolvedEdgeToleranceSettings, TopologyToleranceSettings};
 
     #[test]
     fn representative_distance_tolerance_resolves_local_budget_evenly() {
@@ -131,12 +129,9 @@ mod tests {
         let settings = TopologyToleranceSettings::new(0.3_f64, 1.0e-6);
         let resolved = settings.resolve_validator_budget();
 
-        assert_eq!(
-            resolved,
-            ResolvedTopologyToleranceBudget::new(
-                ResolvedEdgeToleranceSettings::new(0.1, 0.1, 0.1),
-                1.0e-6,
-            )
-        );
+        assert!((resolved.edge.bind_tolerance - 0.1).abs() < 1.0e-12);
+        assert!((resolved.edge.ideal_tolerance - 0.1).abs() < 1.0e-12);
+        assert!((resolved.edge.eval_tolerance - 0.1).abs() < 1.0e-12);
+        assert!((resolved.shared_tolerance - 1.0e-6).abs() < 1.0e-12);
     }
 }

--- a/model/geo_topology/src/topology_validator.rs
+++ b/model/geo_topology/src/topology_validator.rs
@@ -135,7 +135,8 @@ mod tests {
         let start = Point3D::new(0.0, 0.0, 0.1);
         let end = Point3D::new(2.0, 0.0, 0.1);
         let edge = make_offset_support_edge(start, end);
-        let validator = TopologyValidator::new(crate::TopologyToleranceSettings::new(0.31, 1.0e-9));
+        let validator =
+            TopologyValidator::new(crate::TopologyToleranceSettings::new(1.0e-9, 1.0e-9));
 
         let report = validator.validate_edge(&edge);
 

--- a/model/geo_topology/src/topology_validator.rs
+++ b/model/geo_topology/src/topology_validator.rs
@@ -1,0 +1,160 @@
+use crate::tolerance::ResolvedTopologyToleranceBudget;
+use crate::{Edge, TopologyToleranceSettings, Wire};
+use geo_contracts::Scalar;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EdgeValidationReport<T: Scalar> {
+    pub binding_consistent: bool,
+    pub ideal_endpoint_consistent: bool,
+    pub evaluated_endpoint_consistent: bool,
+    pub edge_tolerances: TopologyToleranceSettings<T>,
+}
+
+impl<T: Scalar> EdgeValidationReport<T> {
+    pub fn is_valid(&self) -> bool {
+        self.binding_consistent
+            && self.ideal_endpoint_consistent
+            && self.evaluated_endpoint_consistent
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct WireValidationReport<T: Scalar> {
+    pub edge_reports: Vec<EdgeValidationReport<T>>,
+    pub shared_vertex_consistent: Vec<bool>,
+    pub shared_tolerance: T,
+}
+
+impl<T: Scalar> WireValidationReport<T> {
+    pub fn is_valid(&self) -> bool {
+        self.edge_reports.iter().all(EdgeValidationReport::is_valid)
+            && self.shared_vertex_consistent.iter().all(|status| *status)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TopologyValidator<T: Scalar> {
+    tolerances: TopologyToleranceSettings<T>,
+}
+
+impl<T: Scalar> TopologyValidator<T> {
+    pub fn new(tolerances: TopologyToleranceSettings<T>) -> Self {
+        Self { tolerances }
+    }
+
+    pub fn tolerances(&self) -> TopologyToleranceSettings<T> {
+        self.tolerances
+    }
+
+    pub fn validate_edge(&self, edge: &Edge<T>) -> EdgeValidationReport<T> {
+        let budget = self.tolerances.resolve_validator_budget();
+
+        EdgeValidationReport {
+            binding_consistent: edge.is_binding_consistent(budget.edge.bind_tolerance),
+            ideal_endpoint_consistent: edge
+                .is_ideal_endpoint_consistent(budget.edge.ideal_tolerance),
+            evaluated_endpoint_consistent: edge
+                .is_evaluated_endpoint_consistent(budget.edge.eval_tolerance),
+            edge_tolerances: self.tolerances,
+        }
+    }
+
+    pub fn validate_wire(&self, wire: &Wire<T>) -> WireValidationReport<T> {
+        let budget = self.tolerances.resolve_validator_budget();
+        let edge_reports = wire
+            .edges()
+            .iter()
+            .map(|edge| self.validate_edge(edge))
+            .collect::<Vec<_>>();
+        let shared_vertex_consistent = shared_vertex_consistency(wire, budget);
+
+        WireValidationReport {
+            edge_reports,
+            shared_vertex_consistent,
+            shared_tolerance: budget.shared_tolerance,
+        }
+    }
+}
+
+fn shared_vertex_consistency<T: Scalar>(
+    wire: &Wire<T>,
+    budget: ResolvedTopologyToleranceBudget<T>,
+) -> Vec<bool> {
+    if wire.edges().len() < 2 {
+        return Vec::new();
+    }
+
+    (0..wire.edges().len() - 1)
+        .map(|index| {
+            let end = wire.edges()[index].oriented_constraint_end_point();
+            let next_start = wire.edges()[index + 1].oriented_constraint_start_point();
+            end.distance_to(&next_start) <= budget.shared_tolerance
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TopologyValidator, WireValidationReport};
+    use crate::{CurveRef, Point3D, TopoInfiniteLine3D, TopoLineSegment3D, Vertex, Wire};
+    use std::sync::Arc;
+
+    fn make_edge(start: Point3D<f64>, end: Point3D<f64>) -> crate::Edge<f64> {
+        let v0 = Arc::new(Vertex::new(start));
+        let v1 = Arc::new(Vertex::new(end));
+        let line = TopoLineSegment3D::new(start, end).unwrap();
+
+        crate::Edge::new(
+            v0,
+            v1,
+            CurveRef::Line(line),
+            (line.start_param(), line.end_param()),
+        )
+        .unwrap()
+    }
+
+    fn make_offset_support_edge(start: Point3D<f64>, end: Point3D<f64>) -> crate::Edge<f64> {
+        let support_start = Point3D::new(start.x(), start.y(), 0.0);
+        let support_end = Point3D::new(end.x(), end.y(), 0.0);
+        let support_line = TopoInfiniteLine3D::from_two_points(support_start, support_end).unwrap();
+        let line =
+            TopoLineSegment3D::from_support_line_and_constraint_points(support_line, start, end)
+                .unwrap();
+
+        crate::Edge::new(
+            Arc::new(Vertex::new(start)),
+            Arc::new(Vertex::new(end)),
+            CurveRef::Line(line),
+            (line.start_param(), line.end_param()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn validator_reports_edge_consistency_breakdown() {
+        let start = Point3D::new(0.0, 0.0, 0.1);
+        let end = Point3D::new(2.0, 0.0, 0.1);
+        let edge = make_offset_support_edge(start, end);
+        let validator = TopologyValidator::new(crate::TopologyToleranceSettings::new(0.31, 1.0e-9));
+
+        let report = validator.validate_edge(&edge);
+
+        assert!(report.binding_consistent);
+        assert!(!report.ideal_endpoint_consistent);
+        assert!(!report.evaluated_endpoint_consistent);
+        assert!(!report.is_valid());
+    }
+
+    #[test]
+    fn validator_reports_wire_shared_vertex_failures() {
+        let e1 = make_edge(Point3D::new(0.0, 0.0, 0.0), Point3D::new(1.0, 0.0, 0.0));
+        let e2 = make_edge(Point3D::new(1.1, 0.0, 0.0), Point3D::new(2.0, 0.0, 0.0));
+        let wire = Wire::new_with_tolerances(vec![e1, e2], 1.0e-9, 0.2).unwrap();
+        let validator = TopologyValidator::new(crate::TopologyToleranceSettings::new(1.0e-9, 0.05));
+
+        let report: WireValidationReport<f64> = validator.validate_wire(&wire);
+
+        assert_eq!(report.shared_vertex_consistent, vec![false]);
+        assert!(!report.is_valid());
+    }
+}

--- a/model/geo_topology/src/wire.rs
+++ b/model/geo_topology/src/wire.rs
@@ -1,5 +1,6 @@
 //! Wire: Edge 連続列
 
+use crate::topology_validator::TopologyValidator;
 use crate::{Edge, TopoId, TopologyToleranceSettings};
 use geo_contracts::Scalar;
 
@@ -54,25 +55,9 @@ impl<T: Scalar> Wire<T> {
             return false;
         }
 
-        let edge_tolerances = tolerances.resolve_edge_tolerances();
-
-        if !self
-            .edges
-            .iter()
-            .all(|edge| edge.is_local_consistent_with_tolerances(edge_tolerances))
-        {
-            return false;
-        }
-
-        for i in 0..self.edges.len() - 1 {
-            let end = self.edges[i].oriented_constraint_end_point();
-            let next_start = self.edges[i + 1].oriented_constraint_start_point();
-            if end.distance_to(&next_start) > tolerances.shared_tolerance {
-                return false;
-            }
-        }
-
-        true
+        TopologyValidator::new(tolerances)
+            .validate_wire(self)
+            .is_valid()
     }
 
     pub fn is_continuous_with_tolerances(&self, edge_tolerance: T, shared_tolerance: T) -> bool {


### PR DESCRIPTION
## 概要
- geo_topology に TopologyValidator と Edge/Wire validation report を追加
- TopologyToleranceSettings から validator 用内部解決 budget を導出する入口を追加
- TOPOLOGY_ENTITY_LAYER_DESIGN.md に #606 の validator 入口設計を反映

## 変更内容
- `tolerance.rs` に `ResolvedTopologyToleranceBudget` と `resolve_validator_budget` を追加
- 新規 `topology_validator.rs` で `TopologyValidator`, `EdgeValidationReport`, `WireValidationReport` を追加
- `Wire::is_continuous` は validator を使って bool 判定を返す形へ整理
- `lib.rs` で validator API を再公開
- 設計書に validator 入口の責務分担を追記

## 懸念点
- report は現状 bool breakdown のみで、失敗理由 enum まではまだ持たない
- `Face` / `Shell` / knit 向けの budget 拡張は今後 `ResolvedTopologyToleranceBudget` 側へ積む前提

## 検証
- cargo clippy -- -D warnings
- cargo fmt
- cargo test --workspace

Closes #606