### PR TITLE
[Phase1] refactor: geo_primitives の tolerance 直接参照を default_* へ統一

### DIFF
--- a/model/geo_primitives/src/infinite_line_3d.rs
+++ b/model/geo_primitives/src/infinite_line_3d.rs
@@ -5,12 +5,13 @@
 
 use crate::{Direction3D, Plane3D, Point3D, Vector3D};
 use geo_contracts::{
-    default_distance_tolerance, default_orthogonality_dot_error_tolerance, AngularRelation,
-    BasicIntersection, ClosestPointPair, CrossDistance, InfiniteLine3DConstructor,
-    InfiniteLine3DContainment, InfiniteLine3DDistance, InfiniteLine3DEvaluation,
-    InfiniteLine3DProjection, InfiniteLine3DProperties, InfiniteLine3DTransform,
-    IntersectsRelation, OnPlaneRelation, ParallelRelation, PerpendicularRelation, PrimitiveKind,
-    PrimitiveMetadata, SameLineRelation, Scalar, SkewRelation,
+    default_distance_tolerance, default_orthogonality_dot_error_tolerance,
+    default_parallel_cross_error_tolerance, AngularRelation, BasicIntersection, ClosestPointPair,
+    CrossDistance, InfiniteLine3DConstructor, InfiniteLine3DContainment, InfiniteLine3DDistance,
+    InfiniteLine3DEvaluation, InfiniteLine3DProjection, InfiniteLine3DProperties,
+    InfiniteLine3DTransform, IntersectsRelation, OnPlaneRelation, ParallelRelation,
+    PerpendicularRelation, PrimitiveKind, PrimitiveMetadata, SameLineRelation, Scalar,
+    SkewRelation,
 };
 
 type LinePointPair3D<T> = ((T, T, T), (T, T, T));
@@ -158,7 +159,7 @@ impl<T: Scalar> InfiniteLine3D<T> {
         let e = d2.dot(&w);
 
         let denom = a * c - b * b;
-        if denom.abs() <= T::PARALLEL_CROSS_ERROR_TOLERANCE {
+        if denom.abs() <= default_parallel_cross_error_tolerance::<T>() {
             return None;
         }
 
@@ -278,7 +279,7 @@ impl<T: Scalar> InfiniteLine3D<T> {
         let line_dir = Vector3D::new(self.direction.x(), self.direction.y(), self.direction.z());
         let denom = line_dir.dot(plane_normal);
 
-        if denom.abs() <= T::ORTHOGONALITY_DOT_ERROR_TOLERANCE {
+        if denom.abs() <= default_orthogonality_dot_error_tolerance::<T>() {
             return None; // 直線が平面と平行
         }
 
@@ -435,32 +436,32 @@ impl<T: Scalar> InfiniteLine3DProperties<T> for InfiniteLine3D<T> {
     }
 
     fn is_x_parallel(&self) -> bool {
-        let tolerance = T::PARALLEL_CROSS_ERROR_TOLERANCE;
+        let tolerance = default_parallel_cross_error_tolerance::<T>();
         self.direction.y().abs() <= tolerance && self.direction.z().abs() <= tolerance
     }
 
     fn is_y_parallel(&self) -> bool {
-        let tolerance = T::PARALLEL_CROSS_ERROR_TOLERANCE;
+        let tolerance = default_parallel_cross_error_tolerance::<T>();
         self.direction.x().abs() <= tolerance && self.direction.z().abs() <= tolerance
     }
 
     fn is_z_parallel(&self) -> bool {
-        let tolerance = T::PARALLEL_CROSS_ERROR_TOLERANCE;
+        let tolerance = default_parallel_cross_error_tolerance::<T>();
         self.direction.x().abs() <= tolerance && self.direction.y().abs() <= tolerance
     }
 
     fn is_xy_parallel(&self) -> bool {
-        let tolerance = T::PARALLEL_CROSS_ERROR_TOLERANCE;
+        let tolerance = default_parallel_cross_error_tolerance::<T>();
         self.direction.z().abs() <= tolerance
     }
 
     fn is_xz_parallel(&self) -> bool {
-        let tolerance = T::PARALLEL_CROSS_ERROR_TOLERANCE;
+        let tolerance = default_parallel_cross_error_tolerance::<T>();
         self.direction.y().abs() <= tolerance
     }
 
     fn is_yz_parallel(&self) -> bool {
-        let tolerance = T::PARALLEL_CROSS_ERROR_TOLERANCE;
+        let tolerance = default_parallel_cross_error_tolerance::<T>();
         self.direction.x().abs() <= tolerance
     }
 

--- a/model/geo_primitives/src/plane_3d.rs
+++ b/model/geo_primitives/src/plane_3d.rs
@@ -5,9 +5,9 @@
 
 use crate::{Direction3D, Point3D, Vector3D};
 use geo_contracts::{
-    default_distance_tolerance, BasicIntersection, Plane3DConstructor, Plane3DContainment,
-    Plane3DDerived, Plane3DDistance, Plane3DEvaluation, Plane3DProjection, Plane3DProperties,
-    Plane3DTransform, Scalar,
+    default_distance_tolerance, default_orthogonality_dot_error_tolerance, BasicIntersection,
+    Plane3DConstructor, Plane3DContainment, Plane3DDerived, Plane3DDistance, Plane3DEvaluation,
+    Plane3DProjection, Plane3DProperties, Plane3DTransform, Scalar,
 };
 
 /// CAD用3次元平面（座標系付き）
@@ -242,7 +242,7 @@ impl<T: Scalar> Plane3D<T> {
         let dot_un = self.u_axis.as_vector().dot(&self.normal.as_vector()).abs();
         let dot_vn = self.v_axis.as_vector().dot(&self.normal.as_vector()).abs();
 
-        let tolerance = T::ORTHOGONALITY_DOT_ERROR_TOLERANCE;
+        let tolerance = default_orthogonality_dot_error_tolerance::<T>();
         dot_uv < tolerance && dot_un < tolerance && dot_vn < tolerance
     }
 }
@@ -365,7 +365,7 @@ impl<T: Scalar> Plane3DProperties<T> for Plane3D<T> {
     }
 
     fn is_xy_plane(&self) -> bool {
-        let angle_tolerance = T::ORTHOGONALITY_DOT_ERROR_TOLERANCE;
+        let angle_tolerance = default_orthogonality_dot_error_tolerance::<T>();
         let distance_tolerance = default_distance_tolerance::<T>();
         let z_axis = Vector3D::new(T::ZERO, T::ZERO, T::ONE);
         (self.normal.as_vector().dot(&z_axis) - T::ONE).abs() <= angle_tolerance
@@ -373,7 +373,7 @@ impl<T: Scalar> Plane3DProperties<T> for Plane3D<T> {
     }
 
     fn is_xz_plane(&self) -> bool {
-        let angle_tolerance = T::ORTHOGONALITY_DOT_ERROR_TOLERANCE;
+        let angle_tolerance = default_orthogonality_dot_error_tolerance::<T>();
         let distance_tolerance = default_distance_tolerance::<T>();
         let y_axis = Vector3D::new(T::ZERO, T::ONE, T::ZERO);
         (self.normal.as_vector().dot(&y_axis) - T::ONE).abs() <= angle_tolerance
@@ -381,7 +381,7 @@ impl<T: Scalar> Plane3DProperties<T> for Plane3D<T> {
     }
 
     fn is_yz_plane(&self) -> bool {
-        let angle_tolerance = T::ORTHOGONALITY_DOT_ERROR_TOLERANCE;
+        let angle_tolerance = default_orthogonality_dot_error_tolerance::<T>();
         let distance_tolerance = default_distance_tolerance::<T>();
         let x_axis = Vector3D::new(T::ONE, T::ZERO, T::ZERO);
         (self.normal.as_vector().dot(&x_axis) - T::ONE).abs() <= angle_tolerance


### PR DESCRIPTION
## 概要

- `geo_primitives` の公開 operations で残っていた `T::*` 直接参照を `default_*` へ統一
- `InfiniteLine3D` と `Plane3D` の tolerance 参照スタイルを #548 の設計方針に揃えた
- 低レベル kernel として残す `geo_core` 側の直接参照には手を入れていない

## 変更内容

- `model/geo_primitives/src/infinite_line_3d.rs`
  - `default_parallel_cross_error_tolerance::<T>()` を利用するよう変更
  - `default_orthogonality_dot_error_tolerance::<T>()` を利用するよう変更
- `model/geo_primitives/src/plane_3d.rs`
  - `is_valid` と各軸平面判定で `default_orthogonality_dot_error_tolerance::<T>()` を利用するよう変更

## 設計整合

- 公開面の既定値選択は `geo_contracts` の `default_*` を正本とする
- `Scalar` 関連定数の直接参照は低レベル kernel に閉じる範囲へ限定する
- 今回は `geo_primitives` の公開 operations だけを対象にし、`geo_core` の基礎ベクトル演算は変更していない

## 検証

- `cargo clippy -p geo_primitives -- -D warnings`
- `cargo fmt`
- `cargo test -p geo_primitives`
- `cargo test --workspace`

Closes #608
