### PR TITLE
test: align geo_algorithms test tolerance usage rules

### DIFF
--- a/dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md
+++ b/dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md
@@ -141,6 +141,26 @@ Issue #611 では、`geo_algorithms` の tolerance 入口を「明示入力中�
 - `ToleranceSettings` を直接受ける API を追加する場合は、正本 API ではなく wrapper か用途特化設定であることを明示する
 - tests や examples では `ToleranceSettings::<T>::standard()` / `relaxed()` を使ってよいが、その運用を本体 API の既定値へ逆流させない
 
+### tests における使い分け
+
+`geo_algorithms` の tests では、unit テストと integration テストで tolerance の扱いを分ける。
+
+- unit テスト: 原則 `analysis::test_constants` か意味付きローカル定数を使う
+- integration テスト: `ToleranceSettings` を使ってよい
+- examples / docs 相当の確認も `ToleranceSettings` を使ってよい
+
+unit テストで `ToleranceSettings` を常用しない理由は次の通り。
+
+- 失敗理由が「アルゴリズムの退行」か「標準プロファイル値の変更」かを切り分けやすくするため
+- 本体 API が明示 `tolerance` 入力を正本とする方針と整合させるため
+
+integration テストで `ToleranceSettings` を使ってよい理由は次の通り。
+
+- 呼び出し境界で `ToleranceSettings` から値を選んで渡す実利用経路の確認になるため
+- tests 側で `ToleranceSettings` 利用を完全に排除すると、公開入口との接続回帰を拾いにくくなるため
+
+したがって、`ToleranceSettings` を使う tests は「公開入口との接続確認」であることを意図として持ち、アルゴリズム本体の境界条件や数値挙動を検証する unit テストでは `analysis::test_constants` または意味付きローカル定数を優先する。
+
 ## 呼び出し境界ルール
 
 1. API入力トレランスは呼び出し元が `ToleranceSettings` を選択して渡す。

--- a/model/geo_algorithms/src/collision/nurbs_3d.rs
+++ b/model/geo_algorithms/src/collision/nurbs_3d.rs
@@ -975,10 +975,6 @@ impl<T: Scalar> BasicCollision<T, CylindricalSolid3D<T>> for NurbsSurfaceCollide
     }
 }
 
-// ─────────────────────────────────────────────────────────────────────────
-// Public Distance Functions (shared with intersection module)
-// ─────────────────────────────────────────────────────────────────────────
-
 // NurbsCurve3D distance functions
 
 pub fn nurbscurve3d_point3d_distance<T: Scalar>(curve: &NurbsCurve3D<T>, point: &Point3D<T>) -> T {

--- a/model/geo_algorithms/src/collision/nurbs_3d.rs
+++ b/model/geo_algorithms/src/collision/nurbs_3d.rs
@@ -10,7 +10,7 @@
 //! 外部 trait を外部型へ直接実装できないため、
 //! Newtype（NurbsCurveCollider / NurbsSurfaceCollider）経由で BasicCollision を実装します。
 //!
-//! ## 設計方針  
+//! ## 設計方針
 //!
 //! 1. サンプリング + 数値最適化で距離を評価
 //! 2. 形状ペアごとに BasicCollision を実装
@@ -39,10 +39,6 @@ const NURBS_CURVE_POINT_BOOTSTRAP_SAMPLES: usize = 20;
 const NURBS_CURVE_DISTANCE_SAMPLES: usize = 100;
 const NURBS_SURFACE_DISTANCE_SAMPLES_U: usize = 24;
 const NURBS_SURFACE_DISTANCE_SAMPLES_V: usize = 24;
-
-// ─────────────────────────────────────────────────────────────────────────
-// NurbsCurveCollider Newtype Wrapper
-// ─────────────────────────────────────────────────────────────────────────
 
 /// NURBS曲線の衝突判定アダプタ（Newtype パターン）
 ///
@@ -537,10 +533,6 @@ impl<T: Scalar> BasicCollision<T, CylindricalSolid3D<T>> for NurbsCurveCollider<
         min_distance
     }
 }
-
-// ─────────────────────────────────────────────────────────────────────────
-// NurbsSurfaceCollider Newtype Wrapper
-// ─────────────────────────────────────────────────────────────────────────
 
 #[repr(transparent)]
 #[derive(Debug, Clone)]
@@ -1109,10 +1101,11 @@ pub fn nurbssurface3d_cylindrical_solid3d_distance<T: Scalar>(
 mod tests {
     use super::*;
     use crate::Vector3D;
+    use analysis::test_constants;
     use geo_contracts::NurbsSurface3DConstructor;
     use geo_nurbs::NurbsCurve3D;
 
-    const TEST_TOLERANCE: f64 = 1e-6;
+    const TEST_TOLERANCE: f64 = test_constants::DISTANCE_TOLERANCE_F64;
     const TEST_FAR_POINT_COORD: f64 = 10.0;
     const TEST_MIN_FAR_DISTANCE: f64 = 10.0;
 

--- a/model/geo_algorithms/src/collision/primitive_3d.rs
+++ b/model/geo_algorithms/src/collision/primitive_3d.rs
@@ -1026,10 +1026,10 @@ mod tests {
         InfiniteLine3D, LineSegment3D, Plane3D, Point3D, Ray3D, SphericalSolid3D, TorusSolid3D,
         TorusSurface3D, Triangle3D, TriangleMesh3D, Vector3D,
     };
-    use geo_contracts::ToleranceSettings;
+    use analysis::test_constants;
 
     fn standard_distance_tol() -> f64 {
-        ToleranceSettings::<f64>::standard().distance_tolerance
+        test_constants::DISTANCE_TOLERANCE_F64
     }
 
     #[test]

--- a/model/geo_algorithms/src/distance/primitive_3d.rs
+++ b/model/geo_algorithms/src/distance/primitive_3d.rs
@@ -81,10 +81,10 @@ pub fn point3d_circle3d_distance<T: Scalar>(point: &Point3D<T>, circle: &Circle3
 #[cfg(test)]
 mod tests {
     use super::*;
-    use geo_contracts::ToleranceSettings;
+    use analysis::test_constants;
 
     fn standard_distance_tol() -> f64 {
-        ToleranceSettings::<f64>::standard().distance_tolerance
+        test_constants::DISTANCE_TOLERANCE_F64
     }
 
     #[test]

--- a/model/geo_algorithms/src/intersection/nurbs_3d.rs
+++ b/model/geo_algorithms/src/intersection/nurbs_3d.rs
@@ -46,10 +46,6 @@ fn representative_surface_domain_start_point<T: Scalar>(surface: &NurbsSurface3D
     Point3D::new(point.x(), point.y(), point.z())
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// NurbsCurve3D × Primitives
-// ─────────────────────────────────────────────────────────────────────────────
-
 pub fn nurbscurve3d_point3d_intersection<T: Scalar>(
     curve: &NurbsCurve3D<T>,
     point: &Point3D<T>,
@@ -180,10 +176,6 @@ pub fn nurbscurve3d_cylindrical_solid3d_intersection<T: Scalar>(
         None
     }
 }
-
-// ─────────────────────────────────────────────────────────────────────────────
-// NurbsSurface3D × Primitives
-// ─────────────────────────────────────────────────────────────────────────────
 
 pub fn nurbssurface3d_point3d_intersection<T: Scalar>(
     surface: &NurbsSurface3D<T>,
@@ -321,7 +313,10 @@ pub fn nurbssurface3d_cylindrical_solid3d_intersection<T: Scalar>(
 mod tests {
     use super::*;
     use crate::{Direction3D, Vector3D};
+    use analysis::test_constants;
     use geo_contracts::{NurbsCurve3DConstructor, NurbsSurface3DConstructor};
+
+    const TEST_TOLERANCE: f64 = test_constants::DISTANCE_TOLERANCE_F64;
 
     fn create_test_curve<T: Scalar>() -> NurbsCurve3D<T> {
         use analysis::linalg::vector::vector3::Vector3;
@@ -367,7 +362,7 @@ mod tests {
     fn test_nurbscurve3d_point3d_intersection_on_curve() {
         let curve = create_test_curve::<f64>();
         let point = Point3D::new(0.0, 0.0, 0.0);
-        let tolerance = 1e-6;
+        let tolerance = TEST_TOLERANCE;
 
         let result = nurbscurve3d_point3d_intersection(&curve, &point, tolerance);
         assert!(result.is_some());
@@ -377,7 +372,7 @@ mod tests {
     fn test_nurbscurve3d_point3d_no_intersection() {
         let curve = create_test_curve::<f64>();
         let point = Point3D::new(10.0, 10.0, 10.0);
-        let tolerance = 1e-6;
+        let tolerance = TEST_TOLERANCE;
 
         let result = nurbscurve3d_point3d_intersection(&curve, &point, tolerance);
         assert!(result.is_none());
@@ -409,7 +404,7 @@ mod tests {
     fn test_nurbscurve3d_ray3d_intersection() {
         let curve = create_test_curve::<f64>();
         let ray = Ray3D::new(Point3D::new(0.0, 0.0, 0.0), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
-        let tolerance = 1e-6;
+        let tolerance = TEST_TOLERANCE;
 
         let result = nurbscurve3d_ray3d_intersection(&curve, &ray, tolerance);
         assert!(result.is_some());
@@ -420,7 +415,7 @@ mod tests {
         let curve = create_test_curve::<f64>();
         let ray = Ray3D::new(Point3D::new(0.0, 0.0, 0.0), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
 
-        let result = nurbscurve3d_ray3d_intersection(&curve, &ray, 1e-6);
+        let result = nurbscurve3d_ray3d_intersection(&curve, &ray, TEST_TOLERANCE);
         assert_eq!(result, Some(ray.origin()));
     }
 
@@ -435,7 +430,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = nurbscurve3d_spherical_solid3d_intersection(&curve, &sphere, 1e-6);
+        let result = nurbscurve3d_spherical_solid3d_intersection(&curve, &sphere, TEST_TOLERANCE);
         assert_eq!(
             result,
             Some(representative_curve_domain_start_point(&curve))
@@ -446,7 +441,7 @@ mod tests {
     fn test_nurbssurface3d_point3d_intersection_on_surface() {
         let surface = create_test_surface::<f64>();
         let point = Point3D::new(0.5, 0.5, 0.0);
-        let result = nurbssurface3d_point3d_intersection(&surface, &point, 1e-6);
+        let result = nurbssurface3d_point3d_intersection(&surface, &point, TEST_TOLERANCE);
         assert!(result.is_some());
     }
 
@@ -454,7 +449,7 @@ mod tests {
     fn test_nurbssurface3d_plane3d_intersection_on_same_plane() {
         let surface = create_test_surface::<f64>();
         let plane = Plane3D::xy_plane(0.0);
-        let result = nurbssurface3d_plane3d_intersection(&surface, &plane, 1e-6);
+        let result = nurbssurface3d_plane3d_intersection(&surface, &plane, TEST_TOLERANCE);
         assert!(result.is_some());
     }
 
@@ -463,7 +458,7 @@ mod tests {
         let surface = create_test_surface::<f64>();
         let plane = Plane3D::xy_plane(0.0);
 
-        let result = nurbssurface3d_plane3d_intersection(&surface, &plane, 1e-6);
+        let result = nurbssurface3d_plane3d_intersection(&surface, &plane, TEST_TOLERANCE);
         assert_eq!(result, Some(plane.origin()));
     }
 
@@ -471,7 +466,7 @@ mod tests {
     fn test_nurbssurface3d_ray3d_intersection_vertical_hit() {
         let surface = create_test_surface::<f64>();
         let ray = Ray3D::new(Point3D::new(0.5, 0.5, -1.0), Vector3D::new(0.0, 0.0, 1.0)).unwrap();
-        let result = nurbssurface3d_ray3d_intersection(&surface, &ray, 1e-6);
+        let result = nurbssurface3d_ray3d_intersection(&surface, &ray, TEST_TOLERANCE);
         assert!(result.is_some());
     }
 
@@ -480,7 +475,7 @@ mod tests {
         let surface = create_test_surface::<f64>();
         let segment =
             LineSegment3D::new(Point3D::new(0.5, 0.5, -1.0), Point3D::new(0.5, 0.5, 1.0)).unwrap();
-        let result = nurbssurface3d_line_segment3d_intersection(&surface, &segment, 1e-6);
+        let result = nurbssurface3d_line_segment3d_intersection(&surface, &segment, TEST_TOLERANCE);
         assert!(result.is_some());
     }
 
@@ -492,7 +487,7 @@ mod tests {
             Point3D::new(0.5, 0.5, 1.0),
         )
         .unwrap();
-        let result = nurbssurface3d_infinite_line3d_intersection(&surface, &line, 1e-6);
+        let result = nurbssurface3d_infinite_line3d_intersection(&surface, &line, TEST_TOLERANCE);
         assert!(result.is_some());
     }
 
@@ -505,7 +500,7 @@ mod tests {
             0.25,
         )
         .unwrap();
-        let result = nurbssurface3d_circle3d_intersection(&surface, &circle, 1e-6);
+        let result = nurbssurface3d_circle3d_intersection(&surface, &circle, TEST_TOLERANCE);
         assert!(result.is_some());
     }
 
@@ -519,7 +514,8 @@ mod tests {
             2.0,
         )
         .unwrap();
-        let result = nurbssurface3d_spherical_solid3d_intersection(&surface, &sphere, 1e-6);
+        let result =
+            nurbssurface3d_spherical_solid3d_intersection(&surface, &sphere, TEST_TOLERANCE);
         assert!(result.is_some());
     }
 
@@ -534,7 +530,8 @@ mod tests {
         )
         .unwrap();
 
-        let result = nurbssurface3d_spherical_solid3d_intersection(&surface, &sphere, 1e-6);
+        let result =
+            nurbssurface3d_spherical_solid3d_intersection(&surface, &sphere, TEST_TOLERANCE);
         assert_eq!(
             result,
             Some(representative_surface_domain_start_point(&surface))

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -2176,10 +2176,10 @@ mod tests {
         IntersectionGeometry, IntersectionTopology, LineSegment3D, Plane3D, Point3D, Ray3D,
         SphericalSurface3D, TorusSurface3D, Triangle3D, TriangleMesh3D, Vector3D,
     };
-    use geo_contracts::ToleranceSettings;
+    use analysis::test_constants;
 
     fn standard_distance_tol() -> f64 {
-        ToleranceSettings::<f64>::standard().distance_tolerance
+        test_constants::DISTANCE_TOLERANCE_F64
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- clarify the unit/integration test tolerance rules in the geometry tolerance design doc
- replace geo_algorithms unit-test usage of ToleranceSettings with analysis::test_constants
- align NURBS collision/intersection tests to the shared distance tolerance constant

## Validation
- cargo clippy -p geo_algorithms -- -D warnings
- cargo fmt
- cargo test -p geo_algorithms

Closes #613