### PR TITLE
refactor: add curve discretization workflow and share knot span search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -209,6 +209,21 @@
   "explorer.decorations.colors": true,
   "explorer.decorations.badges": true,
 
+    "workbench.colorCustomizations": {
+    "editorIndentGuide.background1": "#ff000098",
+    "editorIndentGuide.background2": "#00ff0076",
+    "editorIndentGuide.background3": "#0000ff94",
+    "editorIndentGuide.background4": "#ff00ff9f",
+    "editorIndentGuide.background5": "#00ffff9b",
+    "editorIndentGuide.background6": "#ffff0097",
+    "editorIndentGuide.activeBackground1": "#CCC",
+    "editorIndentGuide.activeBackground2": "#CCC",
+    "editorIndentGuide.activeBackground3": "#CCC",
+    "editorIndentGuide.activeBackground4": "#CCC",
+    "editorIndentGuide.activeBackground5": "#CCC",
+    "editorIndentGuide.activeBackground6": "#CCC"
+  },
+
   // === Workspace-Specific Settings ===
   "workbench.colorTheme": "PowerShell ISE",
   "workbench.iconTheme": "material-icon-theme",

--- a/dev/architecture/GEOMETRY_REFACTOR_ISSUE_DRAFT.md
+++ b/dev/architecture/GEOMETRY_REFACTOR_ISSUE_DRAFT.md
@@ -22,6 +22,7 @@
 
 - 現在方針では `geo_commons` は独立クレートとして維持する
 - `geo_commons` は `analysis` のみに依存する shape 非依存の幾何数値カーネル置き場とする
+- `geo_commons` は暫定退避先ではなく、低依存で再利用可能な数値 kernel 層として残存価値がある
 - 純粋な trait定義は `geo_contracts`、impl entry point は `geo_primitives` / `geo_nurbs`、cross-shape や heavy strategy は `geo_algorithms` に置く
 
 ### 1.3 geo_coreの再定義

--- a/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
+++ b/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
@@ -1164,6 +1164,31 @@ Triangle は面 shape であり、curve endpoint や curve parameter capability 
 - strategy の実装本体は `geo_primitives` の impl entry point または将来的な `geo_algorithms` 側 helper へ置く
 - 近似式・距離計算の数値カーネル自体は `geo_commons` に維持し、`geo_contracts` は数値閾値や比較ロジックを保持しない
 
+`#547` 時点の採用方針:
+
+- 推奨方針は、`EllipseCalculation*` の trait定義を `geo_contracts` に残しつつ、純粋数値カーネルと impl-support を分離して扱う段階整理とする
+- `geo_commons` に残す対象は、楕円周長近似、離心率、焦点距離、焦点座標、shape 型を要求しない ellipse 距離計算のような純粋数値カーネルに限定する
+- `geo_primitives` に残す対象は、`EllipseCalculation<T>` 実装を持つ自 crate 型からのみ利用される非公開 helper とし、現時点では `ellipse_calculation_strategy.rs` と `ellipse_calculation_analysis.rs` のような impl-support をここに含める
+- `geo_primitives` 内 helper は、`geo_commons` の純粋関数へ薄く委譲する構造を優先し、数値式そのものを重複実装しない
+- `geo_algorithms` へ移すのは、cross-shape 化した strategy、solver orchestration を伴う heavy strategy、または ellipse 専用 helper を超えて複数 shape family で共有される高レベル戦略に限る
+- したがって `compare_approximation_methods` のような比較分析 helper や `circumference_adaptive` のような選択ロジックは、将来的な共有需要が確認されるまでは `geo_primitives` の impl-support に留める
+- この分類は ellipse 固有の暫定例外ではなく、後続 shape でも再利用する「trait定義は contracts、純粋数値 kernel は commons、impl entry に閉じた補助は primitives、高レベル戦略は algorithms」という配置判定ルールとして扱う
+
+`#547` の curve discretization 追加方針:
+
+- 曲線を polyline や点列へ落とす離散化は、shape の topology 正規形ではなく幾何アルゴリズム責務として `geo_algorithms` に置く
+- この離散化層は `geo_topology` と同列の所有者にしない。`geo_topology` は接続・向き・trim・binding の正本を保持し、離散化はそれを消費する側として分離する
+- `geo_algorithms` 内では `curve_discretization` を独立モジュールとし、`Edge` / `Wire` / `TrimmedSurface` を直接の正本型として抱え込まない
+- 将来、trim curve、wire、trimmed surface など topology 文脈の入力を受ける必要が生じても、`curve_discretization` 配下の adapter 入口で幾何入力へ正規化してから離散化する
+- したがって topology 入力対応は「topology を離散化する」のではなく、「topology が保持する curve / parameter range / same_sense / 境界情報を離散化向け入力へ解決する補助」として扱う
+- モジュール構成の既定方針は、`curve_discretization/{shape_family}.rs` を core に据え、必要になった時点で `curve_discretization/topology_inputs/` のような補助入口を追加する形とする
+- この方針により、`CompositeCurve` / `Wire` / `TrimmedSurface` のような将来入力が増えても、topology の正本責務と離散化アルゴリズム責務を混同しない
+- shape family ごとの polyline options では、単一の弦誤差だけを正本にせず、少なくとも `chord_tolerance`、`max_angle_step`、`min_divisions`、`max_divisions` を併用できる形を既定とする
+- 既定近似は camera 非依存の world-space 指標で完結させ、screen-space 誤差や拡大率依存の制御は後段の表示専用入口で扱う
+- したがって初期段階では、表示の過剰分割抑制も camera 情報ではなく `max_divisions` 等の geometry 側制約で先に吸収する
+- 表示専用入口を設ける場合でも、UI が `geo_algorithms` の options 型を直接編集する構造にはしない。`viewmodel` / `app` 側に表示設定型を置き、そこから `CircularArcPolylineOptions` へ変換する
+- 切削シミュレーションの replay や snapshot index 整合に使う segment 列は simulation 用 discretization を維持し、表示ワイヤーフレームだけが display 設定を使う
+
 ### 11. `LineSegment3DCollisionDetection` は extension か operations か
 
 判定:

--- a/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
+++ b/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
@@ -103,8 +103,8 @@ Issue #535 では、`geo_contracts` の trait構造を次の最小構造へ再�
 
 設計反映:
 
-- `measure` は単一の意味語彙として新設 capability の中心に置かない
-- `*Measure` を後方互換の集約 trait として残す場合でも、新設 capability の説明単位は `length` / `circumference` / `area` のような具体語彙を優先する
+- `measure` は単一の意味語彙として採用しない
+- quantity capability の説明単位は `length` / `circumference` / `area` のような具体語彙を優先する
 
 ## 2026-04-05 合意更新: Point / Vector / AABB の標準再分類
 
@@ -810,7 +810,7 @@ Triangle は面 shape であり、curve endpoint や curve parameter capability 
 
 この層には、単一 shape に対する追加 capability を置く。
 
-- 全 `*Measure`
+- evaluation / sampling / containment / unary distance / projection / unary derived
 - `Arc2DSampling`
 - `Arc2DContainment`
 - `Bounded<T>`
@@ -884,12 +884,12 @@ Triangle は面 shape であり、curve endpoint や curve parameter capability 
 
 - 全 `*Measure` を shape definition core から分離する
 
-### 4. `contains_point` は `Properties` 側か `Measure` 側か
+### 4. `contains_point` は `Properties` 側か minimal extension 側か
 
 判定:
 
 - shape definition には置かない
-- 単一 shape capability として `Measure` 側または後継 capability trait 側へ置く
+- 単一 shape capability として minimal extension 側の後継 capability trait へ置く
 
 理由:
 
@@ -1189,6 +1189,18 @@ Triangle は面 shape であり、curve endpoint や curve parameter capability 
 - 表示専用入口を設ける場合でも、UI が `geo_algorithms` の options 型を直接編集する構造にはしない。`viewmodel` / `app` 側に表示設定型を置き、そこから `CircularArcPolylineOptions` へ変換する
 - 切削シミュレーションの replay や snapshot index 整合に使う segment 列は simulation 用 discretization を維持し、表示ワイヤーフレームだけが display 設定を使う
 
+`#547` の曲線/曲面離散化 taxonomy:
+
+- `adaptive parameter sampling` は、parameter domain を適応分割して parameter 列または parameter grid を生成する責務を指す。現時点では NURBS evaluation に密着した補助として `geo_nurbs` 側に置く
+- `curve discretization` は、analytic curve / parametric curve を polyline や点列へ落とす上位 taxonomy を指す。shape family ごとの options と離散化入口は `geo_algorithms` 側の責務とする
+- `param-grid tessellation` は、表示や GPU 評価のために parameter grid を生成して wireframe や evaluation 入力へ渡す責務を指す。高品質 meshing と同一語として扱わない
+- `surface meshing` は、surface を三角形群や高品質要素へ落とす責務を指す。表示用の parameter grid 生成とは分離し、CAM / CAE 向け品質要件をここへ含める
+- `facade / orchestration` は、個別 shape family 実装を上位用途へ束ねる入口責務を指す。当面の `geo_algorithms` はこの役割に留め、本体実装の即時移管とは切り分ける
+
+補足:
+
+- `adaptive tessellation` という語は、当面は NURBS の `adaptive parameter sampling` 文脈に限定して使い、汎用 curve discretization の同義語としては使わない
+
 ### 11. `LineSegment3DCollisionDetection` は extension か operations か
 
 判定:
@@ -1262,9 +1274,9 @@ relation 系の代表例:
 
 ### minimal extension
 
-- `*Measure`
 - `Bounded`
 - sampling / evaluation / containment のような単一 shape capability
+- unary distance / projection / unary derived のような単一 shape capability
 - `primitive_kind()` のような lightweight metadata capability
 
 補足:
@@ -1364,7 +1376,7 @@ relation 系の代表例:
 実装 Issue は shape 単位ではなく、責務分離単位で分ける。
 
 - `definition core 縮退`
-- `measure 系 extension 分離`
+- `旧 *Measure 系 capability 分離`
 - `metadata capability 分離`
 - `operations への移送`
 - `AABB 特例整理`
@@ -1383,7 +1395,7 @@ relation 系の代表例:
 
 - [ ] `Constructor` は definition core に残すか確認した
 - [ ] `Properties` の各メソッドが参照系に残せるか確認した
-- [ ] `Measure` 系 API を definition core に残していない
+- [ ] 旧 `*Measure` 系 API を definition core に残していない
 - [ ] `contains_point` / `distance_to_point` / `point_at_parameter` / sampling 系を個別判定した
 - [ ] relation 系メソッド（平行・垂直・交差・同方向・角度・最近点対）を個別判定した
 

--- a/dev/architecture/NURBS_FOUNDATION_PATTERN.md
+++ b/dev/architecture/NURBS_FOUNDATION_PATTERN.md
@@ -171,6 +171,17 @@ geo_nurbs/src/
 - 現在 `geo_nurbs` に `NurbsSurface2D` は存在しないため、`NurbsSurface3D` のみが bounds 対象になっているのは未整備ではなく shape 定義差である
 - 標準 `aabb()` は制御点ベースの保守的な境界ボックスとし、より高精度な境界計算は extension 側へ分離する
 
+## 2026-04-07 合意更新: knot span 探索の共通化
+
+`geo_nurbs::knot` にある knot span 探索のうち、非減少列の区間 index を返す二分探索本体は NURBS 固有責務ではない。
+
+合意事項:
+
+- 非減少列に対する span 探索は `analysis` の numerics 層へ置く
+- `geo_nurbs` 側は、degree に基づく有効範囲の決定と NURBS 用語の薄いラッパーだけを持つ
+- knot vector の妥当性検証、parameter domain、重複度など NURBS 意味論を伴う処理は引き続き `geo_nurbs::knot` に残す
+- GPU shader 側の `find_knot_span` は CPU 側 helper の呼び出し先ではなく、同一意味論を持つ別実装として維持する
+
 ## レガシーコードのクリーンアップ
 
 ### 削除されたモジュール

--- a/dev/architecture/TOPOLOGY_ENTITY_LAYER_DESIGN.md
+++ b/dev/architecture/TOPOLOGY_ENTITY_LAYER_DESIGN.md
@@ -118,6 +118,24 @@ topology で保持する vertex は、shape の拘束点と接続して扱う。
 
 したがって、vertex binding invariant は「母曲線評価端点と vertex が常に一致すること」ではなく、shape 意味論を前提にした binding ルールとして定義し直す。
 
+### 5. curve discretization は topology の正本責務に含めない
+
+curve discretization は、curve を polyline や点列へ落とす幾何アルゴリズム責務であり、topology entity layer の正本責務としては扱わない。
+
+固定方針:
+
+- `geo_topology` は `Edge` / `Wire` / `Loop` / `Face` / `PCurve` などの接続・向き・trim・binding を保持する
+- 離散化アルゴリズムは `geo_algorithms` 側の独立モジュールが担い、topology entity layer の下位概念として配置しない
+- `Wire` や `TrimmedSurface` を入力にした離散化が必要になっても、topology 自身が polyline 生成を所有するのではなく、外部の離散化側が topology 入力を解決して利用する
+- このとき topology から離散化側へ渡す責務は、curve 参照、parameter range、same_sense、boundary 種別、必要な binding 情報の解決までとする
+- 離散化側は、その解決済み入力を受けて polyline / 点列 / パラメータ列を生成する
+
+補足:
+
+- 現時点で `geo_topology` は Edge / Wire の最小位相整合を扱うが、curve discretization 向けの topology adapter 実装を正本としては持たない
+- 将来 `TrimmedSurface` や `PCurve` を導入しても、この非対称な責務分離は維持する
+- したがって、topology 側に `*_to_polyline` のような離散化 API を増やすことは既定方針としない
+
 ## `#567` の設計結論
 
 `#567` では、Arc / EllipseArc の endpoint semantics と topology の拘束端点責務を次のように固定する。

--- a/dev/architecture/issues/2026-03-geometry-refactor-03-retire-geo-commons.md
+++ b/dev/architecture/issues/2026-03-geometry-refactor-03-retire-geo-commons.md
@@ -1,10 +1,18 @@
-# geo_commons 撤去メモ（旧方針）
+# geo_commons 旧撤去案アーカイブメモ
 
 ## 概要
 
 この文書は旧方針メモであり、**現在の正本方針では `geo_commons` は廃止対象ではない**。
 
 現行方針では、`geo_commons` は `analysis` のみに依存する再利用可能な幾何数値カーネル層として意図的に維持する。したがって本メモの「撤去計画」は実施対象ではなく、旧検討経緯としてのみ参照する。
+
+## 現在の結論
+
+- `geo_commons` は削除対象ではなく、残存する価値がある
+- 価値の中心は、shape 非依存の純粋数値 kernel を `analysis` 直上で再利用できる点にある
+- `geo_contracts` の trait定義、`geo_primitives` / `geo_nurbs` の impl entry point、`geo_algorithms` の高レベル戦略と責務分離できること自体が `geo_commons` の設計上の価値である
+- ellipse 周長近似、離心率、焦点距離、焦点座標、shape 型を要求しない距離 helper のような共通数値処理は、今後も `geo_commons` に残す前提で扱う
+- 本ファイルに残る撤去チェックリストは履歴情報であり、現行タスクや完了条件として読まない
 
 ## 背景
 
@@ -18,8 +26,9 @@
 - ellipse 周長近似、焦点、離心率、ellipse 距離計算のような shape 非依存カーネルは `geo_commons` に残す
 - `geo_contracts` は trait定義の正本、`geo_primitives` は impl entry point、`geo_algorithms` は cross-shape / heavy strategy を担う
 - したがって本メモにある「物理削除と痕跡整理」は現行タスクではなく、旧案の記録として扱う
+- `geo_commons` の価値は「残しても害がない」ではなく、「低依存の共通数値 kernel 層として残す意味がある」点にある
 
-## 旧タスク（現行では非採用）
+## 旧タスク（履歴情報。現行では非採用）
 
 ### Phase A: API棚卸し
 
@@ -52,7 +61,7 @@
 - [ ] `cargo test --workspace`
 - [ ] `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\check_architecture_dependencies.ps1 -ExitOnError`
 
-## 旧受け入れ条件（現行では非採用）
+## 旧受け入れ条件（履歴情報。現行では非採用）
 
 - [x] ワークスペースに `geo_commons` 依存が存在しない
 - [x] `analysis` は形状を含まない純粋数値計算のみを保持
@@ -62,6 +71,12 @@
 - [ ] `cargo clippy --workspace --all-targets -- -D warnings` が通る
 - [ ] `cargo check --workspace` が通る
 - [ ] `cargo test --workspace` が通る
+
+## 現行運用メモ
+
+- `geo_commons` に残すかどうかは、「shape 型や orchestration を必要とせず、純粋関数として再利用できるか」で判定する
+- `geo_commons` から外す候補は、cross-shape capability、solver orchestration、高レベル strategy、trait定義そのもの
+- ellipse calculation 系の詳細な配置ルールは [dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md](../GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md) の `#547` 節を正本とする
 
 ## 備考
 

--- a/foundation/analysis/src/lib.rs
+++ b/foundation/analysis/src/lib.rs
@@ -31,7 +31,9 @@ pub use crate::linalg::solver::newton::{
     newton_inverse, newton_solve, newton_solve_bounded,
     newton_solve_with_numeric_derivative_bounded,
 };
-pub use crate::numerics::{newton_arc_length, trapezoidal_rule, NormedVector};
+pub use crate::numerics::{
+    find_span_in_non_decreasing_sequence, newton_arc_length, trapezoidal_rule, NormedVector,
+};
 
 // 単位系の再エクスポート
 pub use units::{LengthUnit, Tolerance};

--- a/foundation/analysis/src/numerics/mod.rs
+++ b/foundation/analysis/src/numerics/mod.rs
@@ -5,15 +5,19 @@
 //! 特殊数学定数は `crate::consts::special` モジュールを使用してください。
 
 pub mod integration;
+pub mod partition;
 pub mod vector_distance;
 
 #[cfg(test)]
 pub mod integration_tests;
 #[cfg(test)]
+pub mod partition_tests;
+#[cfg(test)]
 pub mod vector_distance_tests;
 
 // 数値積分の再エクスポート
 pub use integration::{newton_arc_length, trapezoidal_rule, NormedVector};
+pub use partition::find_span_in_non_decreasing_sequence;
 
 // 非線形方程式ソルバーは linalg::solver::newton を使用してください
 // pub use crate::linalg::solver::newton::{newton_solve, newton_inverse};

--- a/foundation/analysis/src/numerics/partition.rs
+++ b/foundation/analysis/src/numerics/partition.rs
@@ -1,0 +1,59 @@
+//! 非減少列に対する区間探索ユーティリティ。
+//!
+//! knot vector のような重複を含み得る非減少列に対し、
+//! 指定値が属する span の左 index を返す。
+
+use crate::Scalar;
+
+/// 非減少列上で、`sequence[i] <= value < sequence[i + 1]` を満たす span の左 index を返す。
+///
+/// `lower_bound` と `upper_bound` は探索対象の有効範囲を表す。
+/// `value <= sequence[lower_bound]` のときは `lower_bound`、
+/// `value >= sequence[upper_bound]` のときは `upper_bound - 1` を返す。
+///
+/// # Panics
+///
+/// - `sequence.len() < 2` の場合
+/// - `lower_bound >= upper_bound` の場合
+/// - `upper_bound >= sequence.len()` の場合
+pub fn find_span_in_non_decreasing_sequence<T: Scalar>(
+    value: T,
+    sequence: &[T],
+    lower_bound: usize,
+    upper_bound: usize,
+) -> usize {
+    assert!(
+        sequence.len() >= 2,
+        "sequence must contain at least two elements"
+    );
+    assert!(
+        lower_bound < upper_bound,
+        "lower_bound must be smaller than upper_bound"
+    );
+    assert!(
+        upper_bound < sequence.len(),
+        "upper_bound must be within sequence"
+    );
+
+    if value <= sequence[lower_bound] {
+        return lower_bound;
+    }
+
+    if value >= sequence[upper_bound] {
+        return upper_bound - 1;
+    }
+
+    let mut low = lower_bound;
+    let mut high = upper_bound;
+
+    while low < high {
+        let mid = usize::midpoint(low, high);
+        if value < sequence[mid] {
+            high = mid;
+        } else {
+            low = mid + 1;
+        }
+    }
+
+    low - 1
+}

--- a/foundation/analysis/src/numerics/partition_tests.rs
+++ b/foundation/analysis/src/numerics/partition_tests.rs
@@ -1,0 +1,44 @@
+use super::partition::find_span_in_non_decreasing_sequence;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_interior_span_in_non_decreasing_sequence() {
+        let sequence = [0.0_f64, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0];
+
+        assert_eq!(
+            find_span_in_non_decreasing_sequence(0.25, &sequence, 2, 4),
+            2
+        );
+        assert_eq!(
+            find_span_in_non_decreasing_sequence(0.5, &sequence, 2, 4),
+            3
+        );
+    }
+
+    #[test]
+    fn clamps_to_search_bounds_for_boundary_values() {
+        let sequence = [0.0_f64, 0.0, 0.0, 1.0, 1.0, 1.0];
+
+        assert_eq!(
+            find_span_in_non_decreasing_sequence(0.0, &sequence, 2, 3),
+            2
+        );
+        assert_eq!(
+            find_span_in_non_decreasing_sequence(1.0, &sequence, 2, 3),
+            2
+        );
+    }
+
+    #[test]
+    fn handles_repeated_values_inside_sequence() {
+        let sequence = [0.0_f64, 0.0, 0.25, 0.25, 0.5, 1.0];
+
+        assert_eq!(
+            find_span_in_non_decreasing_sequence(0.25, &sequence, 1, 5),
+            3
+        );
+    }
+}

--- a/model/cam_sim/src/lib.rs
+++ b/model/cam_sim/src/lib.rs
@@ -16,6 +16,7 @@ pub use job_adapter::CamJobExecutorAdapter;
 /// シミュレーション実行APIとスナップショット関連型。
 pub use simulator::{
     CuttingSimulator, PathPosition, SimulationSnapshot, SimulationSnapshotExport, SnapshotInterval,
+    collect_toolpath_line_segments, collect_toolpath_line_segments_with_arc_options,
 };
 /// CAM工程向けワークフロー制約ファサード。
 pub use workflow::{CamWorkflowError, CamWorkflowSubmitter};

--- a/model/cam_sim/src/simulator.rs
+++ b/model/cam_sim/src/simulator.rs
@@ -1,6 +1,6 @@
 use cam_core::{Tool, ToolPath};
 use geo_algorithms::octree::VoxelOctree;
-use geo_algorithms::{LineSegment3D, Scalar};
+use geo_algorithms::{DEFAULT_CIRCULAR_ARC_CHORD_TOLERANCE_MM, LineSegment3D, Scalar};
 
 use crate::error::SimulationError;
 
@@ -10,6 +10,10 @@ mod engine;
 mod segments;
 
 use behavior::{FlatEndMillBehavior, tool_cutting_behavior};
+
+pub use segments::{
+    collect_toolpath_line_segments, collect_toolpath_line_segments_with_arc_options,
+};
 
 /// スナップショット保存間隔の指定方法。
 #[derive(Debug, Clone)]
@@ -84,7 +88,7 @@ impl<T: Scalar> CuttingSimulator<T> {
             voxel_tree,
             interval,
             snapshots: Vec::new(),
-            arc_chord_tolerance_mm: segments::DEFAULT_ARC_CHORD_TOLERANCE_MM,
+            arc_chord_tolerance_mm: DEFAULT_CIRCULAR_ARC_CHORD_TOLERANCE_MM,
         }
     }
 

--- a/model/cam_sim/src/simulator/segments.rs
+++ b/model/cam_sim/src/simulator/segments.rs
@@ -1,16 +1,83 @@
 use cam_core::{ArcDirection, PathGeometry, PathSegment, ToolPath};
+use geo_algorithms::{
+    CircularArcDirection, CircularArcPolylineOptions, LineSegment3D, Scalar,
+    circular_arc_to_polyline,
+};
 
 use crate::error::SimulationError;
 
-/// Arc を polyline 近似する際のデフォルト弦誤差上限（mm）。
-pub(super) const DEFAULT_ARC_CHORD_TOLERANCE_MM: f64 = 0.1;
+/// ToolPathから線分セグメントを抽出し、切削フラグ付きで返す。
+///
+/// Arc は polyline 近似して展開する。
+pub fn collect_toolpath_line_segments<T: Scalar>(
+    toolpath: &ToolPath<T>,
+    arc_chord_tolerance_mm: f64,
+) -> Vec<(LineSegment3D<T>, bool)> {
+    collect_toolpath_line_segments_with_arc_options(
+        toolpath,
+        CircularArcPolylineOptions::simulation_default()
+            .with_chord_tolerance_mm(arc_chord_tolerance_mm),
+    )
+}
 
-/// Arc を polyline 近似する際の最小分割数。
-const MIN_ARC_DIVISIONS: usize = 4;
+/// ToolPathから線分セグメントを抽出し、切削フラグ付きで返す。
+///
+/// Arc の polyline 近似設定を呼び出し側から明示したい用途向けの入口。
+pub fn collect_toolpath_line_segments_with_arc_options<T: Scalar>(
+    toolpath: &ToolPath<T>,
+    arc_options: CircularArcPolylineOptions,
+) -> Vec<(LineSegment3D<T>, bool)> {
+    let mut out = Vec::new();
 
-impl<T: geo_algorithms::Scalar> super::CuttingSimulator<T> {
+    for segment in &toolpath.approach_segments {
+        push_path_segment_lines(segment, false, arc_options, &mut out);
+    }
+
+    for contour in &toolpath.contour_levels {
+        for segment in &contour.segments {
+            push_path_segment_lines(segment, segment.is_cutting(), arc_options, &mut out);
+        }
+    }
+
+    for segment in &toolpath.retract_segments {
+        push_path_segment_lines(segment, false, arc_options, &mut out);
+    }
+
+    out
+}
+
+fn push_path_segment_lines<T: Scalar>(
+    segment: &PathSegment<T>,
+    is_cutting: bool,
+    arc_options: CircularArcPolylineOptions,
+    out: &mut Vec<(LineSegment3D<T>, bool)>,
+) {
+    match segment.geometry {
+        PathGeometry::Line { end } => {
+            if let Some(line_segment) = LineSegment3D::new(segment.start, end) {
+                out.push((line_segment, is_cutting));
+            }
+        }
+        PathGeometry::Arc {
+            end,
+            center,
+            direction,
+        } => {
+            let direction = match direction {
+                ArcDirection::Clockwise => CircularArcDirection::Clockwise,
+                ArcDirection::CounterClockwise => CircularArcDirection::CounterClockwise,
+            };
+            for line in circular_arc_to_polyline(segment.start, end, center, direction, arc_options)
+            {
+                out.push((line, is_cutting));
+            }
+        }
+    }
+}
+
+impl<T: Scalar> super::CuttingSimulator<T> {
     /// 線分長を `f64` で計算する（距離ベース間隔計算用）。
-    pub(super) fn segment_length(&self, segment: &geo_algorithms::LineSegment3D<T>) -> f64 {
+    pub(super) fn segment_length(&self, segment: &LineSegment3D<T>) -> f64 {
         let start = segment.start();
         let end = segment.end();
         start.distance_to(&end).to_f64()
@@ -22,135 +89,79 @@ impl<T: geo_algorithms::Scalar> super::CuttingSimulator<T> {
     pub(super) fn collect_line_segments(
         &self,
         toolpath: &ToolPath<T>,
-    ) -> Result<Vec<(geo_algorithms::LineSegment3D<T>, bool)>, SimulationError> {
-        let mut out = Vec::new();
-
-        for segment in &toolpath.approach_segments {
-            self.push_segment(segment, false, &mut out)?;
-        }
-
-        for contour in &toolpath.contour_levels {
-            for segment in &contour.segments {
-                self.push_segment(segment, segment.is_cutting(), &mut out)?;
-            }
-        }
-
-        for segment in &toolpath.retract_segments {
-            self.push_segment(segment, false, &mut out)?;
-        }
-
-        Ok(out)
-    }
-
-    /// PathSegmentをLineSegmentへ変換して出力に追加する。
-    fn push_segment(
-        &self,
-        segment: &PathSegment<T>,
-        is_cutting: bool,
-        out: &mut Vec<(geo_algorithms::LineSegment3D<T>, bool)>,
-    ) -> Result<(), SimulationError> {
-        match segment.geometry {
-            PathGeometry::Line { end } => {
-                if let Some(line_segment) = geo_algorithms::LineSegment3D::new(segment.start, end) {
-                    out.push((line_segment, is_cutting));
-                }
-                Ok(())
-            }
-            PathGeometry::Arc {
-                end,
-                center,
-                direction,
-            } => {
-                for line in arc_to_polyline(
-                    segment.start,
-                    end,
-                    center,
-                    direction,
-                    self.arc_chord_tolerance_mm,
-                ) {
-                    out.push((line, is_cutting));
-                }
-                Ok(())
-            }
-        }
+    ) -> Result<Vec<(LineSegment3D<T>, bool)>, SimulationError> {
+        Ok(collect_toolpath_line_segments(
+            toolpath,
+            self.arc_chord_tolerance_mm,
+        ))
     }
 }
 
-/// Arc セグメントを polyline 近似して LineSegment3D の Vec に変換する。
-///
-/// XY 平面上の円弧を想定し、Z は始点・終点間で線形補間する（ヘリカル対応）。
-/// 弦誤差 `chord_tolerance_mm` に基づいて分割数を決定する。
-fn arc_to_polyline<T: geo_algorithms::Scalar>(
-    start: geo_algorithms::Point3D<T>,
-    end: geo_algorithms::Point3D<T>,
-    center: geo_algorithms::Point3D<T>,
-    direction: ArcDirection,
-    chord_tolerance_mm: f64,
-) -> Vec<geo_algorithms::LineSegment3D<T>> {
-    let dx1 = (start.x() - center.x()).to_f64();
-    let dy1 = (start.y() - center.y()).to_f64();
-    let dx2 = (end.x() - center.x()).to_f64();
-    let dy2 = (end.y() - center.y()).to_f64();
-
-    let r = (dx1 * dx1 + dy1 * dy1).sqrt();
-    if r < f64::EPSILON {
-        return Vec::new();
-    }
-
-    let angle_start = dy1.atan2(dx1);
-    let angle_end = dy2.atan2(dx2);
-
-    // 方向に従い弧角を [0, 2π] の範囲で計算する（0 は全周として扱う）。
-    let sweep = match direction {
-        ArcDirection::CounterClockwise => {
-            let mut s = angle_end - angle_start;
-            if s < f64::EPSILON {
-                s += std::f64::consts::TAU;
-            }
-            s
-        }
-        ArcDirection::Clockwise => {
-            let mut s = angle_start - angle_end;
-            if s < f64::EPSILON {
-                s += std::f64::consts::TAU;
-            }
-            s
-        }
+#[cfg(test)]
+mod tests {
+    use super::{collect_toolpath_line_segments, collect_toolpath_line_segments_with_arc_options};
+    use cam_core::{
+        ArcDirection, ContourLevelPath, CuttingDirection, PathSegment, SegmentType, ToolPath,
+    };
+    use geo_algorithms::{
+        CircularArcPolylineOptions, DEFAULT_CIRCULAR_ARC_CHORD_TOLERANCE_MM, Point3D,
     };
 
-    let n = if chord_tolerance_mm > f64::EPSILON {
-        let cos_val = (1.0 - chord_tolerance_mm / r).clamp(-1.0, 1.0);
-        let half_angle = cos_val.acos();
-        let divisions = (sweep / (2.0 * half_angle)).ceil() as usize;
-        divisions.max(MIN_ARC_DIVISIONS)
-    } else {
-        MIN_ARC_DIVISIONS
-    };
+    #[test]
+    fn collect_toolpath_line_segments_expands_arc_and_keeps_flags() {
+        let cutting_arc = PathSegment {
+            start: Point3D::new(1.0_f64, 0.0, 0.0),
+            geometry: cam_core::PathGeometry::Arc {
+                end: Point3D::new(0.0_f64, 1.0, 0.0),
+                center: Point3D::new(0.0_f64, 0.0, 0.0),
+                direction: ArcDirection::CounterClockwise,
+            },
+            segment_type: SegmentType::Cutting { feed_rate: 100.0 },
+            ext_attributes: Vec::new(),
+        };
 
-    let cx = center.x().to_f64();
-    let cy = center.y().to_f64();
-    let z_start = start.z().to_f64();
-    let z_end = end.z().to_f64();
-
-    let sign = match direction {
-        ArcDirection::CounterClockwise => 1.0_f64,
-        ArcDirection::Clockwise => -1.0_f64,
-    };
-    let angle_step = sign * sweep / n as f64;
-
-    let mut segments = Vec::with_capacity(n);
-    let mut prev = start;
-    for i in 1..=n {
-        let angle = angle_start + angle_step * i as f64;
-        let next = geo_algorithms::Point3D::new(
-            T::from_f64(cx + r * angle.cos()),
-            T::from_f64(cy + r * angle.sin()),
-            T::from_f64(z_start + (z_end - z_start) * (i as f64 / n as f64)),
+        let toolpath = ToolPath::new(
+            "tool".to_string(),
+            CuttingDirection::Down,
+            Vec::new(),
+            vec![ContourLevelPath::new(0, 0.0, vec![cutting_arc])],
+            Vec::new(),
         );
-        if let Some(line) = geo_algorithms::LineSegment3D::new(prev, next) {
-            segments.push(line);
-        }
-        prev = next;
+
+        let segments =
+            collect_toolpath_line_segments(&toolpath, DEFAULT_CIRCULAR_ARC_CHORD_TOLERANCE_MM);
+
+        assert!(!segments.is_empty());
+        assert!(segments.iter().all(|(_, is_cutting)| *is_cutting));
     }
-    segments
+
+    #[test]
+    fn collect_toolpath_line_segments_with_arc_options_accepts_display_default() {
+        let cutting_arc = PathSegment {
+            start: Point3D::new(1.0_f64, 0.0, 0.0),
+            geometry: cam_core::PathGeometry::Arc {
+                end: Point3D::new(0.0_f64, 1.0, 0.0),
+                center: Point3D::new(0.0_f64, 0.0, 0.0),
+                direction: ArcDirection::CounterClockwise,
+            },
+            segment_type: SegmentType::Cutting { feed_rate: 100.0 },
+            ext_attributes: Vec::new(),
+        };
+
+        let toolpath = ToolPath::new(
+            "tool".to_string(),
+            CuttingDirection::Down,
+            Vec::new(),
+            vec![ContourLevelPath::new(0, 0.0, vec![cutting_arc])],
+            Vec::new(),
+        );
+
+        let segments = collect_toolpath_line_segments_with_arc_options(
+            &toolpath,
+            CircularArcPolylineOptions::default(),
+        );
+
+        assert!(!segments.is_empty());
+        assert!(segments.iter().all(|(_, is_cutting)| *is_cutting));
+    }
 }

--- a/model/geo_algorithms/src/curve_discretization/circular_arc.rs
+++ b/model/geo_algorithms/src/curve_discretization/circular_arc.rs
@@ -1,0 +1,302 @@
+use crate::{LineSegment3D, Point3D, Scalar};
+
+/// 円弧を polyline 近似する際のデフォルト弦誤差上限（mm）。
+pub const DEFAULT_CIRCULAR_ARC_CHORD_TOLERANCE_MM: f64 = 0.1;
+
+/// 汎用用途での円弧 1 セグメントあたりの最大角度ステップ。
+pub const DEFAULT_CIRCULAR_ARC_MAX_ANGLE_STEP_RAD: f64 = std::f64::consts::PI / 12.0;
+
+/// 円弧を polyline 近似する際の最小分割数。
+const MIN_CIRCULAR_ARC_DIVISIONS: usize = 4;
+
+/// 汎用用途での円弧 polyline 近似の最大分割数。
+pub const DEFAULT_MAX_CIRCULAR_ARC_DIVISIONS: usize = 128;
+
+/// XY 平面上の円弧方向。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CircularArcDirection {
+    Clockwise,
+    CounterClockwise,
+}
+
+/// 円弧を polyline 近似する際の設定。
+///
+/// 将来 `ellipse_arc` や `composite_curve` にも同系統の options 型を並べる前提で、
+/// shape family ごとに閉じた設定型として扱う。
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CircularArcPolylineOptions {
+    chord_tolerance_mm: f64,
+    max_angle_step_rad: Option<f64>,
+    min_divisions: usize,
+    max_divisions: Option<usize>,
+}
+
+impl CircularArcPolylineOptions {
+    pub const fn new(chord_tolerance_mm: f64) -> Self {
+        Self {
+            chord_tolerance_mm,
+            max_angle_step_rad: Some(DEFAULT_CIRCULAR_ARC_MAX_ANGLE_STEP_RAD),
+            min_divisions: MIN_CIRCULAR_ARC_DIVISIONS,
+            max_divisions: Some(DEFAULT_MAX_CIRCULAR_ARC_DIVISIONS),
+        }
+    }
+
+    /// CAM シミュレーションのように chord tolerance を正本とし、
+    /// 追加の角度制約や上限分割を持ち込まない既定値。
+    pub const fn simulation_default() -> Self {
+        Self {
+            chord_tolerance_mm: DEFAULT_CIRCULAR_ARC_CHORD_TOLERANCE_MM,
+            max_angle_step_rad: None,
+            min_divisions: MIN_CIRCULAR_ARC_DIVISIONS,
+            max_divisions: None,
+        }
+    }
+
+    pub const fn chord_tolerance_mm(&self) -> f64 {
+        self.chord_tolerance_mm
+    }
+
+    pub const fn with_chord_tolerance_mm(mut self, chord_tolerance_mm: f64) -> Self {
+        self.chord_tolerance_mm = chord_tolerance_mm;
+        self
+    }
+
+    pub const fn max_angle_step_rad(&self) -> Option<f64> {
+        self.max_angle_step_rad
+    }
+
+    pub const fn with_max_angle_step_rad(mut self, max_angle_step_rad: f64) -> Self {
+        self.max_angle_step_rad = Some(max_angle_step_rad);
+        self
+    }
+
+    pub const fn without_max_angle_step(mut self) -> Self {
+        self.max_angle_step_rad = None;
+        self
+    }
+
+    pub const fn min_divisions(&self) -> usize {
+        self.min_divisions
+    }
+
+    pub const fn with_min_divisions(mut self, min_divisions: usize) -> Self {
+        self.min_divisions = min_divisions;
+        self
+    }
+
+    pub const fn max_divisions(&self) -> Option<usize> {
+        self.max_divisions
+    }
+
+    pub const fn with_max_divisions(mut self, max_divisions: usize) -> Self {
+        self.max_divisions = Some(max_divisions);
+        self
+    }
+
+    pub const fn without_max_divisions(mut self) -> Self {
+        self.max_divisions = None;
+        self
+    }
+}
+
+impl Default for CircularArcPolylineOptions {
+    fn default() -> Self {
+        Self::new(DEFAULT_CIRCULAR_ARC_CHORD_TOLERANCE_MM)
+    }
+}
+
+/// XY 平面上の円弧を polyline 近似して線分列へ展開する。
+///
+/// Z は始点・終点間で線形補間するため、ヘリカルな円弧にも利用できる。
+pub fn circular_arc_to_polyline<T: Scalar>(
+    start: Point3D<T>,
+    end: Point3D<T>,
+    center: Point3D<T>,
+    direction: CircularArcDirection,
+    options: CircularArcPolylineOptions,
+) -> Vec<LineSegment3D<T>> {
+    let chord_tolerance_mm = options.chord_tolerance_mm();
+    let dx1 = (start.x() - center.x()).to_f64();
+    let dy1 = (start.y() - center.y()).to_f64();
+    let dx2 = (end.x() - center.x()).to_f64();
+    let dy2 = (end.y() - center.y()).to_f64();
+
+    let radius = (dx1 * dx1 + dy1 * dy1).sqrt();
+    if radius < f64::EPSILON {
+        return Vec::new();
+    }
+
+    let angle_start = dy1.atan2(dx1);
+    let angle_end = dy2.atan2(dx2);
+
+    let sweep = match direction {
+        CircularArcDirection::CounterClockwise => {
+            let mut value = angle_end - angle_start;
+            if value < f64::EPSILON {
+                value += std::f64::consts::TAU;
+            }
+            value
+        }
+        CircularArcDirection::Clockwise => {
+            let mut value = angle_start - angle_end;
+            if value < f64::EPSILON {
+                value += std::f64::consts::TAU;
+            }
+            value
+        }
+    };
+
+    let chord_based_divisions = if chord_tolerance_mm > f64::EPSILON {
+        let cos_val = (1.0 - chord_tolerance_mm / radius).clamp(-1.0, 1.0);
+        let half_angle = cos_val.acos();
+        if half_angle > f64::EPSILON {
+            (sweep / (2.0 * half_angle)).ceil() as usize
+        } else {
+            1
+        }
+    } else {
+        1
+    };
+
+    let angle_based_divisions = match options.max_angle_step_rad() {
+        Some(max_angle_step_rad) if max_angle_step_rad > f64::EPSILON => {
+            (sweep / max_angle_step_rad).ceil() as usize
+        }
+        _ => 1,
+    };
+
+    let min_divisions = options.min_divisions().max(MIN_CIRCULAR_ARC_DIVISIONS);
+    let mut divisions = chord_based_divisions
+        .max(angle_based_divisions)
+        .max(min_divisions);
+
+    if let Some(max_divisions) = options.max_divisions() {
+        divisions = divisions.min(max_divisions.max(min_divisions));
+    }
+
+    let cx = center.x().to_f64();
+    let cy = center.y().to_f64();
+    let z_start = start.z().to_f64();
+    let z_end = end.z().to_f64();
+    let direction_sign = match direction {
+        CircularArcDirection::CounterClockwise => 1.0_f64,
+        CircularArcDirection::Clockwise => -1.0_f64,
+    };
+    let angle_step = direction_sign * sweep / divisions as f64;
+
+    let mut segments = Vec::with_capacity(divisions);
+    let mut prev = start;
+    for index in 1..=divisions {
+        let next = if index == divisions {
+            end
+        } else {
+            let angle = angle_start + angle_step * index as f64;
+            Point3D::new(
+                T::from_f64(cx + radius * angle.cos()),
+                T::from_f64(cy + radius * angle.sin()),
+                T::from_f64(z_start + (z_end - z_start) * (index as f64 / divisions as f64)),
+            )
+        };
+        if let Some(line) = LineSegment3D::new(prev, next) {
+            segments.push(line);
+        }
+        prev = next;
+    }
+
+    segments
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        circular_arc_to_polyline, CircularArcDirection, CircularArcPolylineOptions,
+        DEFAULT_CIRCULAR_ARC_CHORD_TOLERANCE_MM, DEFAULT_CIRCULAR_ARC_MAX_ANGLE_STEP_RAD,
+        DEFAULT_MAX_CIRCULAR_ARC_DIVISIONS,
+    };
+    use crate::Point3D;
+
+    #[test]
+    fn circular_arc_to_polyline_preserves_endpoints() {
+        let start = Point3D::new(1.0_f64, 0.0, 0.0);
+        let end = Point3D::new(0.0_f64, 1.0, 1.0);
+        let center = Point3D::new(0.0_f64, 0.0, 0.0);
+
+        let segments = circular_arc_to_polyline(
+            start,
+            end,
+            center,
+            CircularArcDirection::CounterClockwise,
+            CircularArcPolylineOptions::default(),
+        );
+
+        assert!(!segments.is_empty());
+        assert_eq!(segments.first().unwrap().constraint_start_point(), start);
+        assert_eq!(segments.last().unwrap().constraint_end_point(), end);
+    }
+
+    #[test]
+    fn circular_arc_polyline_options_default_uses_current_tolerance() {
+        assert_eq!(
+            CircularArcPolylineOptions::default().chord_tolerance_mm(),
+            DEFAULT_CIRCULAR_ARC_CHORD_TOLERANCE_MM,
+        );
+        assert_eq!(
+            CircularArcPolylineOptions::default().max_angle_step_rad(),
+            Some(DEFAULT_CIRCULAR_ARC_MAX_ANGLE_STEP_RAD),
+        );
+        assert_eq!(
+            CircularArcPolylineOptions::default().max_divisions(),
+            Some(DEFAULT_MAX_CIRCULAR_ARC_DIVISIONS),
+        );
+    }
+
+    #[test]
+    fn circular_arc_polyline_options_simulation_default_disables_angle_and_cap() {
+        assert_eq!(
+            CircularArcPolylineOptions::simulation_default().max_angle_step_rad(),
+            None,
+        );
+        assert_eq!(
+            CircularArcPolylineOptions::simulation_default().max_divisions(),
+            None,
+        );
+    }
+
+    #[test]
+    fn circular_arc_to_polyline_respects_max_divisions_cap() {
+        let start = Point3D::new(100.0_f64, 0.0, 0.0);
+        let end = Point3D::new(-100.0_f64, 0.0, 0.0);
+        let center = Point3D::new(0.0_f64, 0.0, 0.0);
+
+        let segments = circular_arc_to_polyline(
+            start,
+            end,
+            center,
+            CircularArcDirection::CounterClockwise,
+            CircularArcPolylineOptions::simulation_default()
+                .with_chord_tolerance_mm(0.001)
+                .with_max_divisions(12),
+        );
+
+        assert_eq!(segments.len(), 12);
+    }
+
+    #[test]
+    fn circular_arc_to_polyline_respects_max_angle_step() {
+        let start = Point3D::new(1.0_f64, 0.0, 0.0);
+        let end = Point3D::new(0.0_f64, 1.0, 0.0);
+        let center = Point3D::new(0.0_f64, 0.0, 0.0);
+
+        let segments = circular_arc_to_polyline(
+            start,
+            end,
+            center,
+            CircularArcDirection::CounterClockwise,
+            CircularArcPolylineOptions::simulation_default()
+                .with_max_angle_step_rad(std::f64::consts::FRAC_PI_4)
+                .without_max_divisions(),
+        );
+
+        assert_eq!(segments.len(), 4);
+    }
+}

--- a/model/geo_algorithms/src/curve_discretization/mod.rs
+++ b/model/geo_algorithms/src/curve_discretization/mod.rs
@@ -1,0 +1,6 @@
+pub mod circular_arc;
+
+pub use circular_arc::{
+    circular_arc_to_polyline, CircularArcDirection, CircularArcPolylineOptions,
+    DEFAULT_CIRCULAR_ARC_CHORD_TOLERANCE_MM,
+};

--- a/model/geo_algorithms/src/lib.rs
+++ b/model/geo_algorithms/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod angle_utils;
 pub mod collision;
 pub mod constraint_validation;
+pub mod curve_discretization;
 pub mod distance;
 pub mod intersection;
 pub mod nurbs_fixtures;
@@ -30,6 +31,10 @@ pub use constraint_validation::{
     validate_linear_speed_mm_per_min, validate_linear_travel, validate_linear_travel_mm,
     validate_rotary_acceleration_deg_per_s2, validate_rotary_angle, validate_rotary_angle_deg,
     validate_rotary_speed_deg_per_min, ConstraintViolation, ValidationResult,
+};
+pub use curve_discretization::{
+    circular_arc_to_polyline, CircularArcDirection, CircularArcPolylineOptions,
+    DEFAULT_CIRCULAR_ARC_CHORD_TOLERANCE_MM,
 };
 
 // geo_algorithms が提供する交差結果型

--- a/model/geo_nurbs/src/knot.rs
+++ b/model/geo_nurbs/src/knot.rs
@@ -1,6 +1,7 @@
 //! ノットベクトル操作とバリデーション
 
 use crate::{NurbsError, Result};
+use analysis::find_span_in_non_decreasing_sequence;
 use geo_contracts::Scalar;
 
 /// ノットベクトルの型エイリアス
@@ -166,29 +167,7 @@ pub fn get_parameter_domain<T: Scalar>(knots: &[T], degree: usize) -> (T, T) {
 pub fn find_knot_span<T: Scalar>(t: T, knots: &[T], degree: usize) -> usize {
     let n = knots.len() - degree - 1;
 
-    // 境界値の処理
-    if t >= knots[n] {
-        return n - 1;
-    }
-
-    if t <= knots[degree] {
-        return degree;
-    }
-
-    // バイナリサーチ
-    let mut low = degree;
-    let mut high = n;
-
-    while low < high {
-        let mid = usize::midpoint(low, high);
-        if t < knots[mid] {
-            high = mid;
-        } else {
-            low = mid + 1;
-        }
-    }
-
-    low - 1
+    find_span_in_non_decreasing_sequence(t, knots, degree, n)
 }
 
 /// 開始位置での重複度を数える

--- a/view/app/src/app_state.rs
+++ b/view/app/src/app_state.rs
@@ -3,6 +3,7 @@ use crate::entity_manager::EntityManager;
 use crate::graphic::{init_graphic, Graphic};
 use crate::mouse_input::MouseInput;
 use crate::selection_rect::SelectionRect;
+use crate::settings_panel_ui::SettingsPanelTab;
 use crate::snapshot_overlay_renderer::SnapshotOverlayStyle;
 use analysis::{LengthUnit, Tolerance};
 use debug_snapshot_state::DebugSnapshotState;
@@ -10,7 +11,9 @@ use std::sync::Arc;
 use viewmodel::cam_sim_visualization_converter::{
     CamSimulationDemoScenario, ToolWireframeVisualizationSettings,
 };
+use viewmodel::message_catalog::UiLocale;
 use viewmodel::octree_converter::OctreeVisualizationSettings;
+use viewmodel::toolpath_converter::ToolPathVisualizationSettings;
 use viewmodel_graphics::{Camera, CameraControlSensitivity};
 use winit::window::Window;
 
@@ -98,11 +101,20 @@ pub struct AppState {
     /// Toolワイヤーフレーム可視化設定
     tool_wireframe_visualization_settings: ToolWireframeVisualizationSettings,
 
+    /// ToolPath表示設定
+    toolpath_visualization_settings: ToolPathVisualizationSettings,
+
     /// 最後に表示したCAMデモの種別
     current_cam_demo_scenario: Option<CamSimulationDemoScenario>,
 
     /// 設定パネル表示状態
     settings_panel_open: bool,
+
+    /// 設定パネルの選択中タブ
+    settings_panel_active_tab: SettingsPanelTab,
+
+    /// 設定パネルの表示言語
+    settings_panel_locale: UiLocale,
 
     /// デバッグ用: シミュレーションスナップショット状態
     debug_snapshot: DebugSnapshotState,
@@ -143,8 +155,11 @@ impl AppState {
             snapshot_overlay_style: SnapshotOverlayStyle::default(),
             snapshot_shaded_color_settings: SnapshotShadedColorSettings::default(),
             tool_wireframe_visualization_settings: ToolWireframeVisualizationSettings::default(),
+            toolpath_visualization_settings: ToolPathVisualizationSettings::default(),
             current_cam_demo_scenario: None,
             settings_panel_open: false,
+            settings_panel_active_tab: SettingsPanelTab::default(),
+            settings_panel_locale: UiLocale::Ja,
             debug_snapshot: DebugSnapshotState::default(),
             snapshot_scrub_active: false,
             cursor_position: None,

--- a/view/app/src/app_state/debug_scene/toolpath.rs
+++ b/view/app/src/app_state/debug_scene/toolpath.rs
@@ -37,6 +37,7 @@ impl AppState {
         let bundle = build_demo_cam_simulation_visualization_bundle_with_tool_settings(
             &self.octree_visualization_settings,
             &self.tool_wireframe_visualization_settings,
+            &self.toolpath_visualization_settings,
             scenario,
         )
         .map_err(ToolPathBuildError::Converter)?;
@@ -209,15 +210,13 @@ impl AppState {
 
     /// サンプル表示用：カッターパスのみを表示（pキー）
     pub fn load_sample_toolpath_only(&mut self) {
-        use viewmodel::toolpath_converter::{
-            load_demo_toolpath, toolpath_to_vertices, ToolPathVisualizationSettings,
-        };
+        use viewmodel::toolpath_converter::{load_demo_toolpath, toolpath_to_vertices};
 
         tracing::info!("カッターパス表示デバッグ開始（pキー）");
 
         let toolpath = load_demo_toolpath();
-        let settings = ToolPathVisualizationSettings::default();
-        let toolpath_vertices = toolpath_to_vertices(&toolpath, &settings);
+        let toolpath_vertices =
+            toolpath_to_vertices(&toolpath, &self.toolpath_visualization_settings);
 
         let vertices: Vec<MeshVertex> = toolpath_vertices
             .vertices

--- a/view/app/src/app_state/settings_panel.rs
+++ b/view/app/src/app_state/settings_panel.rs
@@ -35,11 +35,14 @@ impl AppState {
     pub(crate) fn prepare_settings_panel_state(&self) -> SettingsPanelUiState {
         SettingsPanelUiState {
             open: self.settings_panel_open,
+            active_tab: self.settings_panel_active_tab,
+            locale: self.settings_panel_locale,
             camera_control_sensitivity: self.viewing_operation_settings.camera_control_sensitivity,
             octree_settings: self.octree_visualization_settings.clone(),
             snapshot_overlay_style: self.snapshot_overlay_style,
             snapshot_shaded_colors: self.snapshot_shaded_color_settings,
             tool_wireframe_settings: self.tool_wireframe_visualization_settings,
+            toolpath_settings: self.toolpath_visualization_settings.clone(),
             current_demo_label: self.current_cam_demo_scenario.map(demo_scenario_label),
             reload_demo_requested: false,
         }
@@ -47,7 +50,10 @@ impl AppState {
 
     pub(crate) fn apply_settings_panel_state(&mut self, panel_state: SettingsPanelUiState) {
         self.settings_panel_open = panel_state.open;
+        self.settings_panel_active_tab = panel_state.active_tab;
+        self.settings_panel_locale = panel_state.locale;
         self.tool_wireframe_visualization_settings = panel_state.tool_wireframe_settings;
+        self.toolpath_visualization_settings = panel_state.toolpath_settings;
 
         if panel_state.reload_demo_requested {
             // 設定反映後も表示状態の整合を保つため、共通のstage復元経路で再読込する。

--- a/view/app/src/lib.rs
+++ b/view/app/src/lib.rs
@@ -9,6 +9,7 @@ pub mod mouse_input;
 pub mod overlay_coords;
 pub mod selection_rect;
 pub mod selection_rect_renderer;
+pub(crate) mod settings_panel_messages;
 pub(crate) mod settings_panel_renderer;
 pub(crate) mod settings_panel_ui;
 pub mod snapshot_overlay_renderer;

--- a/view/app/src/settings_panel_messages.rs
+++ b/view/app/src/settings_panel_messages.rs
@@ -1,0 +1,212 @@
+use viewmodel::message_catalog::{
+    resolve_message, TableMessageCatalog, UiLocale, UiMessage, UiMessageArg,
+};
+
+const SETTINGS_PANEL_TEMPLATE_JA: &[(&str, &str)] = &[
+    ("settings.window.title", "設定"),
+    ("settings.intro", "カテゴリごとに設定を確認・調整します。"),
+    ("settings.tab.display", "表示"),
+    ("settings.tab.tool", "工具"),
+    ("settings.current_demo", "現在のデモ: {label}"),
+    ("settings.apply", "設定を反映"),
+    (
+        "settings.no_active_demo",
+        "現在アクティブな切削デモはありません。変更は次回のデモ開始時に反映されます。",
+    ),
+    ("settings.header.view_controls", "View 操作設定"),
+    (
+        "settings.view.controls_summary",
+        "rotate={rotate}, arcball={arcball}, pan={pan}",
+    ),
+    (
+        "settings.view.zoom_summary",
+        "zoom_drag={zoom_drag}, zoom_wheel={zoom_wheel}, pixel_to_line={pixel_to_line}",
+    ),
+    ("settings.header.octree", "Octree 可視化設定"),
+    ("settings.octree.max_depth", "max_depth={max_depth}"),
+    (
+        "settings.octree.gradient_start",
+        "gradient_start=({r}, {g}, {b})",
+    ),
+    (
+        "settings.octree.gradient_end",
+        "gradient_end=({r}, {g}, {b})",
+    ),
+    (
+        "settings.octree.tolerance",
+        "tol: point={point}, query={query}, nearest={nearest}",
+    ),
+    ("settings.header.snapshot_overlay", "Snapshot Overlay 設定"),
+    ("settings.snapshot_overlay.block_count", "block_count={count}"),
+    (
+        "settings.snapshot_overlay.track",
+        "track=({r}, {g}, {b}, {a})",
+    ),
+    (
+        "settings.snapshot_overlay.done",
+        "done=({r}, {g}, {b}, {a})",
+    ),
+    ("settings.header.snapshot_shading", "Snapshot Shading 設定"),
+    ("settings.snapshot_shading.work", "work=({r}, {g}, {b}, {a})"),
+    ("settings.snapshot_shading.tool", "tool=({r}, {g}, {b})"),
+    ("settings.header.tool_wireframe", "Tool Wireframe 設定"),
+    ("settings.tool.manual_apply", "このタブの設定は手動で反映します"),
+    ("settings.tool.flat_circle_divisions", "flat 円周分割"),
+    ("settings.tool.ball_circle_divisions", "ball 円周分割"),
+    ("settings.tool.ball_latitudes", "ball 半球緯線分割"),
+    ("settings.tool.ball_meridians", "ball 半球経線本数"),
+    (
+        "settings.header.toolpath_discretization",
+        "ToolPath 離散化設定",
+    ),
+    ("settings.toolpath.display_only", "表示ワイヤーフレーム専用"),
+    ("settings.toolpath.preset", "プリセット"),
+    ("settings.toolpath.preset.performance", "軽量"),
+    ("settings.toolpath.preset.balanced", "標準"),
+    ("settings.toolpath.preset.fine", "精細"),
+    (
+        "settings.toolpath.current_values",
+        "現在値: 弦誤差 {chord_tolerance_mm} mm / 最大角度 {max_angle_deg} 度 / 分割 {min_divisions}..{max_divisions}",
+    ),
+    ("settings.toolpath.chord_tolerance", "弦誤差(mm)"),
+    ("settings.toolpath.max_angle_deg", "最大角度(度)"),
+    ("settings.toolpath.min_divisions", "最小分割数"),
+    ("settings.toolpath.max_divisions", "最大分割数"),
+];
+
+const SETTINGS_PANEL_TEMPLATE_EN: &[(&str, &str)] = &[
+    ("settings.window.title", "Settings"),
+    ("settings.intro", "Review and adjust settings by category."),
+    ("settings.tab.display", "Display"),
+    ("settings.tab.tool", "Tool"),
+    ("settings.current_demo", "Current demo: {label}"),
+    ("settings.apply", "Apply Settings"),
+    (
+        "settings.no_active_demo",
+        "No CAM demo is active. Changes will be applied the next time a demo starts.",
+    ),
+    ("settings.header.view_controls", "View Controls"),
+    (
+        "settings.view.controls_summary",
+        "rotate={rotate}, arcball={arcball}, pan={pan}",
+    ),
+    (
+        "settings.view.zoom_summary",
+        "zoom_drag={zoom_drag}, zoom_wheel={zoom_wheel}, pixel_to_line={pixel_to_line}",
+    ),
+    ("settings.header.octree", "Octree Visualization"),
+    ("settings.octree.max_depth", "max_depth={max_depth}"),
+    (
+        "settings.octree.gradient_start",
+        "gradient_start=({r}, {g}, {b})",
+    ),
+    (
+        "settings.octree.gradient_end",
+        "gradient_end=({r}, {g}, {b})",
+    ),
+    (
+        "settings.octree.tolerance",
+        "tol: point={point}, query={query}, nearest={nearest}",
+    ),
+    ("settings.header.snapshot_overlay", "Snapshot Overlay"),
+    ("settings.snapshot_overlay.block_count", "block_count={count}"),
+    (
+        "settings.snapshot_overlay.track",
+        "track=({r}, {g}, {b}, {a})",
+    ),
+    (
+        "settings.snapshot_overlay.done",
+        "done=({r}, {g}, {b}, {a})",
+    ),
+    ("settings.header.snapshot_shading", "Snapshot Shading"),
+    ("settings.snapshot_shading.work", "work=({r}, {g}, {b}, {a})"),
+    ("settings.snapshot_shading.tool", "tool=({r}, {g}, {b})"),
+    ("settings.header.tool_wireframe", "Tool Wireframe"),
+    ("settings.tool.manual_apply", "Changes on this tab are applied manually."),
+    ("settings.tool.flat_circle_divisions", "flat circle divisions"),
+    ("settings.tool.ball_circle_divisions", "ball circle divisions"),
+    ("settings.tool.ball_latitudes", "ball hemisphere latitude divisions"),
+    ("settings.tool.ball_meridians", "ball hemisphere meridian count"),
+    (
+        "settings.header.toolpath_discretization",
+        "ToolPath Discretization",
+    ),
+    ("settings.toolpath.display_only", "For display wireframe only"),
+    ("settings.toolpath.preset", "Preset"),
+    ("settings.toolpath.preset.performance", "Light"),
+    ("settings.toolpath.preset.balanced", "Balanced"),
+    ("settings.toolpath.preset.fine", "Fine"),
+    (
+        "settings.toolpath.current_values",
+        "Current: chord {chord_tolerance_mm} mm / max angle {max_angle_deg} deg / divisions {min_divisions}..{max_divisions}",
+    ),
+    ("settings.toolpath.chord_tolerance", "Chord tolerance (mm)"),
+    ("settings.toolpath.max_angle_deg", "Max angle (deg)"),
+    ("settings.toolpath.min_divisions", "Min divisions"),
+    ("settings.toolpath.max_divisions", "Max divisions"),
+];
+
+pub const SETTINGS_PANEL_MESSAGE_CATALOG: TableMessageCatalog = TableMessageCatalog::new(
+    SETTINGS_PANEL_TEMPLATE_JA,
+    SETTINGS_PANEL_TEMPLATE_EN,
+    "__missing__",
+    "__missing__",
+);
+
+pub fn resolve_settings_panel_text(locale: UiLocale, key: &str) -> String {
+    resolve_settings_panel_text_with_args(locale, key, &[])
+}
+
+pub fn resolve_settings_panel_text_with_args(
+    locale: UiLocale,
+    key: &str,
+    args: &[(&str, String)],
+) -> String {
+    let message = UiMessage {
+        key: key.to_string(),
+        args: args
+            .iter()
+            .map(|(name, value)| UiMessageArg {
+                name: (*name).to_string(),
+                value: value.clone(),
+            })
+            .collect(),
+    };
+
+    resolve_message(&SETTINGS_PANEL_MESSAGE_CATALOG, locale, &message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_settings_panel_text, resolve_settings_panel_text_with_args};
+    use viewmodel::message_catalog::UiLocale;
+
+    #[test]
+    fn resolves_settings_panel_text_for_ja_and_en() {
+        assert_eq!(
+            resolve_settings_panel_text(UiLocale::Ja, "settings.window.title"),
+            "設定"
+        );
+        assert_eq!(
+            resolve_settings_panel_text(UiLocale::En, "settings.window.title"),
+            "Settings"
+        );
+    }
+
+    #[test]
+    fn resolves_settings_panel_text_with_args() {
+        let ja = resolve_settings_panel_text_with_args(
+            UiLocale::Ja,
+            "settings.current_demo",
+            &[("label", "ボールエンドミル".to_string())],
+        );
+        let en = resolve_settings_panel_text_with_args(
+            UiLocale::En,
+            "settings.current_demo",
+            &[("label", "Ball End Mill".to_string())],
+        );
+
+        assert_eq!(ja, "現在のデモ: ボールエンドミル");
+        assert_eq!(en, "Current demo: Ball End Mill");
+    }
+}

--- a/view/app/src/settings_panel_ui.rs
+++ b/view/app/src/settings_panel_ui.rs
@@ -1,168 +1,561 @@
 use crate::app_state::SnapshotShadedColorSettings;
+use crate::settings_panel_messages::{
+    resolve_settings_panel_text, resolve_settings_panel_text_with_args,
+};
 use crate::snapshot_overlay_renderer::SnapshotOverlayStyle;
 use egui::{Align2, CollapsingHeader, Context, RichText, Slider, Window};
 use viewmodel::cam_sim_visualization_converter::ToolWireframeVisualizationSettings;
+use viewmodel::message_catalog::UiLocale;
 use viewmodel::octree_converter::OctreeVisualizationSettings;
+use viewmodel::toolpath_converter::{
+    DisplayCurveDiscretizationSettings, ToolPathVisualizationSettings,
+};
 use viewmodel_graphics::CameraControlSensitivity;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SettingsPanelTab {
+    #[default]
+    Display,
+    Tool,
+}
 
 #[derive(Debug, Clone)]
 pub struct SettingsPanelUiState {
     pub open: bool,
+    pub active_tab: SettingsPanelTab,
+    pub locale: UiLocale,
     pub camera_control_sensitivity: CameraControlSensitivity,
     pub octree_settings: OctreeVisualizationSettings,
     pub snapshot_overlay_style: SnapshotOverlayStyle,
     pub snapshot_shaded_colors: SnapshotShadedColorSettings,
     pub tool_wireframe_settings: ToolWireframeVisualizationSettings,
+    pub toolpath_settings: ToolPathVisualizationSettings,
     pub current_demo_label: Option<String>,
     pub reload_demo_requested: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CurveDiscretizationPreset {
+    Performance,
+    Balanced,
+    Fine,
+}
+
+fn apply_curve_discretization_preset(
+    settings: &mut ToolPathVisualizationSettings,
+    preset: CurveDiscretizationPreset,
+) {
+    settings.curve_discretization = match preset {
+        CurveDiscretizationPreset::Performance => {
+            DisplayCurveDiscretizationSettings::performance_preset()
+        }
+        CurveDiscretizationPreset::Balanced => {
+            DisplayCurveDiscretizationSettings::balanced_preset()
+        }
+        CurveDiscretizationPreset::Fine => DisplayCurveDiscretizationSettings::fine_preset(),
+    };
+}
+
+fn set_curve_discretization_max_angle_deg(
+    settings: &mut ToolPathVisualizationSettings,
+    max_angle_deg: f64,
+) {
+    settings.curve_discretization.max_angle_step_rad = max_angle_deg.to_radians();
+}
+
+fn set_curve_discretization_min_divisions(
+    settings: &mut ToolPathVisualizationSettings,
+    min_divisions: usize,
+) {
+    settings.curve_discretization.min_divisions = min_divisions;
+    settings.curve_discretization.max_divisions = settings
+        .curve_discretization
+        .max_divisions
+        .max(min_divisions);
+}
+
+fn set_curve_discretization_max_divisions(
+    settings: &mut ToolPathVisualizationSettings,
+    max_divisions: usize,
+) {
+    settings.curve_discretization.max_divisions = max_divisions;
+}
+
 impl SettingsPanelUiState {
+    fn text(&self, key: &str) -> String {
+        resolve_settings_panel_text(self.locale, key)
+    }
+
+    fn text_with_args(&self, key: &str, args: &[(&str, String)]) -> String {
+        resolve_settings_panel_text_with_args(self.locale, key, args)
+    }
+
     pub fn show(&mut self, ctx: &Context) {
         if !self.open {
             return;
         }
 
-        Window::new("Settings")
+        let mut open = self.open;
+
+        Window::new(self.text("settings.window.title"))
             .anchor(Align2::RIGHT_TOP, [-16.0, 16.0])
             .default_width(360.0)
             .resizable(true)
-            .open(&mut self.open)
+            .open(&mut open)
             .show(ctx, |ui| {
-                ui.label("登録済み設定の棚卸しと、工具ワイヤーフレーム分割数の調整を行います。");
+                let display_tab_label = self.text("settings.tab.display");
+                let tool_tab_label = self.text("settings.tab.tool");
+
+                ui.label(self.text("settings.intro"));
                 ui.separator();
 
-                CollapsingHeader::new("View 操作設定")
-                    .default_open(true)
-                    .show(ui, |ui| {
-                        ui.label(format!(
-                            "rotate={:.3}, arcball={:.3}, pan={:.3}",
-                            self.camera_control_sensitivity.rotate,
-                            self.camera_control_sensitivity.arcball,
-                            self.camera_control_sensitivity.pan,
-                        ));
-                        ui.label(format!(
-                            "zoom_drag={:.3}, zoom_wheel={:.3}, pixel_to_line={:.3}",
-                            self.camera_control_sensitivity.zoom_drag,
-                            self.camera_control_sensitivity.zoom_wheel,
-                            self.camera_control_sensitivity.wheel_pixel_to_line,
-                        ));
-                    });
+                ui.horizontal(|ui| {
+                    ui.selectable_value(
+                        &mut self.active_tab,
+                        SettingsPanelTab::Display,
+                        display_tab_label,
+                    );
+                    ui.selectable_value(
+                        &mut self.active_tab,
+                        SettingsPanelTab::Tool,
+                        tool_tab_label,
+                    );
+                });
+                ui.separator();
 
-                CollapsingHeader::new("Octree 可視化設定")
-                    .default_open(true)
-                    .show(ui, |ui| {
-                        ui.label(format!("max_depth={}", self.octree_settings.max_depth));
-                        ui.label(format!(
-                            "gradient_start=({:.2}, {:.2}, {:.2})",
-                            self.octree_settings.gradient_start[0],
-                            self.octree_settings.gradient_start[1],
-                            self.octree_settings.gradient_start[2],
-                        ));
-                        ui.label(format!(
-                            "gradient_end=({:.2}, {:.2}, {:.2})",
-                            self.octree_settings.gradient_end[0],
-                            self.octree_settings.gradient_end[1],
-                            self.octree_settings.gradient_end[2],
-                        ));
-                        ui.label(format!(
-                            "tol: point={:.4}, query={:.4}, nearest={:.4}",
-                            self.octree_settings.octree_tolerance.point_aabb_half_extent,
-                            self.octree_settings.octree_tolerance.query_expand,
-                            self.octree_settings.octree_tolerance.nearest_prune_margin,
-                        ));
-                    });
+                match self.active_tab {
+                    SettingsPanelTab::Display => self.show_display_tab(ui),
+                    SettingsPanelTab::Tool => self.show_tool_tab(ui),
+                }
 
-                CollapsingHeader::new("Snapshot Overlay 設定")
-                    .default_open(false)
-                    .show(ui, |ui| {
-                        ui.label(format!("block_count={}", self.snapshot_overlay_style.block_count));
-                        ui.label(format!(
-                            "track=({:.2}, {:.2}, {:.2}, {:.2})",
-                            self.snapshot_overlay_style.track_color[0],
-                            self.snapshot_overlay_style.track_color[1],
-                            self.snapshot_overlay_style.track_color[2],
-                            self.snapshot_overlay_style.track_color[3],
-                        ));
-                        ui.label(format!(
-                            "done=({:.2}, {:.2}, {:.2}, {:.2})",
-                            self.snapshot_overlay_style.done_color[0],
-                            self.snapshot_overlay_style.done_color[1],
-                            self.snapshot_overlay_style.done_color[2],
-                            self.snapshot_overlay_style.done_color[3],
-                        ));
-                    });
-
-                CollapsingHeader::new("Snapshot Shading 設定")
-                    .default_open(false)
-                    .show(ui, |ui| {
-                        ui.label(format!(
-                            "work=({:.2}, {:.2}, {:.2}, {:.2})",
-                            self.snapshot_shaded_colors.work_solid_color[0],
-                            self.snapshot_shaded_colors.work_solid_color[1],
-                            self.snapshot_shaded_colors.work_solid_color[2],
-                            self.snapshot_shaded_colors.work_solid_color[3],
-                        ));
-                        ui.label(format!(
-                            "tool=({:.2}, {:.2}, {:.2})",
-                            self.snapshot_shaded_colors.tool_wire_color[0],
-                            self.snapshot_shaded_colors.tool_wire_color[1],
-                            self.snapshot_shaded_colors.tool_wire_color[2],
-                        ));
-                    });
-
-                CollapsingHeader::new("Tool Wireframe 設定")
-                    .default_open(true)
-                    .show(ui, |ui| {
-                        ui.label(RichText::new("このセクションのみ編集可能").strong());
-
-                        let mut flat_circle = self.tool_wireframe_settings.flat_circle_divisions as u32;
-                        if ui
-                            .add(Slider::new(&mut flat_circle, 8..=96).text("flat 円周分割"))
-                            .changed()
-                        {
-                            self.tool_wireframe_settings.flat_circle_divisions = flat_circle as usize;
+                ui.separator();
+                match &self.current_demo_label {
+                    Some(label) => {
+                        ui.label(
+                            self.text_with_args(
+                                "settings.current_demo",
+                                &[("label", label.clone())],
+                            ),
+                        );
+                        if ui.button(self.text("settings.apply")).clicked() {
+                            self.reload_demo_requested = true;
                         }
-
-                        let mut ball_circle = self.tool_wireframe_settings.ball_circle_divisions as u32;
-                        if ui
-                            .add(Slider::new(&mut ball_circle, 8..=128).text("ball 円周分割"))
-                            .changed()
-                        {
-                            self.tool_wireframe_settings.ball_circle_divisions = ball_circle as usize;
-                        }
-
-                        let mut ball_latitudes =
-                            self.tool_wireframe_settings.ball_hemisphere_divisions as u32;
-                        if ui
-                            .add(Slider::new(&mut ball_latitudes, 2..=24).text("ball 半球緯線分割"))
-                            .changed()
-                        {
-                            self.tool_wireframe_settings.ball_hemisphere_divisions =
-                                ball_latitudes as usize;
-                        }
-
-                        let mut ball_meridians = self.tool_wireframe_settings.ball_meridian_count as u32;
-                        if ui
-                            .add(Slider::new(&mut ball_meridians, 4..=32).text("ball 半球経線本数"))
-                            .changed()
-                        {
-                            self.tool_wireframe_settings.ball_meridian_count = ball_meridians as usize;
-                        }
-
-                        ui.separator();
-                        match &self.current_demo_label {
-                            Some(label) => {
-                                ui.label(format!("現在のデモ: {}", label));
-                                if ui.button(format!("現在の{}デモを再読込", label)).clicked() {
-                                    self.reload_demo_requested = true;
-                                }
-                            }
-                            None => {
-                                ui.label("現在アクティブな切削デモはありません。変更は次回のデモ開始時に反映されます。");
-                            }
-                        }
-                    });
+                    }
+                    None => {
+                        ui.label(self.text("settings.no_active_demo"));
+                    }
+                }
             });
+
+        self.open = open;
+    }
+
+    fn show_display_tab(&mut self, ui: &mut egui::Ui) {
+        CollapsingHeader::new(self.text("settings.header.view_controls"))
+            .default_open(true)
+            .show(ui, |ui| {
+                ui.label(self.text_with_args(
+                    "settings.view.controls_summary",
+                    &[
+                        (
+                            "rotate",
+                            format!("{:.3}", self.camera_control_sensitivity.rotate),
+                        ),
+                        (
+                            "arcball",
+                            format!("{:.3}", self.camera_control_sensitivity.arcball),
+                        ),
+                        ("pan", format!("{:.3}", self.camera_control_sensitivity.pan)),
+                    ],
+                ));
+                ui.label(self.text_with_args(
+                    "settings.view.zoom_summary",
+                    &[
+                        (
+                            "zoom_drag",
+                            format!("{:.3}", self.camera_control_sensitivity.zoom_drag),
+                        ),
+                        (
+                            "zoom_wheel",
+                            format!("{:.3}", self.camera_control_sensitivity.zoom_wheel),
+                        ),
+                        (
+                            "pixel_to_line",
+                            format!("{:.3}", self.camera_control_sensitivity.wheel_pixel_to_line),
+                        ),
+                    ],
+                ));
+            });
+
+        CollapsingHeader::new(self.text("settings.header.octree"))
+            .default_open(true)
+            .show(ui, |ui| {
+                ui.label(self.text_with_args(
+                    "settings.octree.max_depth",
+                    &[("max_depth", self.octree_settings.max_depth.to_string())],
+                ));
+                ui.label(self.text_with_args(
+                    "settings.octree.gradient_start",
+                    &[
+                        (
+                            "r",
+                            format!("{:.2}", self.octree_settings.gradient_start[0]),
+                        ),
+                        (
+                            "g",
+                            format!("{:.2}", self.octree_settings.gradient_start[1]),
+                        ),
+                        (
+                            "b",
+                            format!("{:.2}", self.octree_settings.gradient_start[2]),
+                        ),
+                    ],
+                ));
+                ui.label(self.text_with_args(
+                    "settings.octree.gradient_end",
+                    &[
+                        ("r", format!("{:.2}", self.octree_settings.gradient_end[0])),
+                        ("g", format!("{:.2}", self.octree_settings.gradient_end[1])),
+                        ("b", format!("{:.2}", self.octree_settings.gradient_end[2])),
+                    ],
+                ));
+                ui.label(self.text_with_args(
+                    "settings.octree.tolerance",
+                    &[
+                        (
+                            "point",
+                            format!(
+                                "{:.4}",
+                                self.octree_settings.octree_tolerance.point_aabb_half_extent
+                            ),
+                        ),
+                        (
+                            "query",
+                            format!("{:.4}", self.octree_settings.octree_tolerance.query_expand),
+                        ),
+                        (
+                            "nearest",
+                            format!(
+                                "{:.4}",
+                                self.octree_settings.octree_tolerance.nearest_prune_margin
+                            ),
+                        ),
+                    ],
+                ));
+            });
+
+        CollapsingHeader::new(self.text("settings.header.snapshot_overlay"))
+            .default_open(false)
+            .show(ui, |ui| {
+                ui.label(self.text_with_args(
+                    "settings.snapshot_overlay.block_count",
+                    &[("count", self.snapshot_overlay_style.block_count.to_string())],
+                ));
+                ui.label(self.text_with_args(
+                    "settings.snapshot_overlay.track",
+                    &[
+                        (
+                            "r",
+                            format!("{:.2}", self.snapshot_overlay_style.track_color[0]),
+                        ),
+                        (
+                            "g",
+                            format!("{:.2}", self.snapshot_overlay_style.track_color[1]),
+                        ),
+                        (
+                            "b",
+                            format!("{:.2}", self.snapshot_overlay_style.track_color[2]),
+                        ),
+                        (
+                            "a",
+                            format!("{:.2}", self.snapshot_overlay_style.track_color[3]),
+                        ),
+                    ],
+                ));
+                ui.label(self.text_with_args(
+                    "settings.snapshot_overlay.done",
+                    &[
+                        (
+                            "r",
+                            format!("{:.2}", self.snapshot_overlay_style.done_color[0]),
+                        ),
+                        (
+                            "g",
+                            format!("{:.2}", self.snapshot_overlay_style.done_color[1]),
+                        ),
+                        (
+                            "b",
+                            format!("{:.2}", self.snapshot_overlay_style.done_color[2]),
+                        ),
+                        (
+                            "a",
+                            format!("{:.2}", self.snapshot_overlay_style.done_color[3]),
+                        ),
+                    ],
+                ));
+            });
+
+        CollapsingHeader::new(self.text("settings.header.snapshot_shading"))
+            .default_open(false)
+            .show(ui, |ui| {
+                ui.label(self.text_with_args(
+                    "settings.snapshot_shading.work",
+                    &[
+                        (
+                            "r",
+                            format!("{:.2}", self.snapshot_shaded_colors.work_solid_color[0]),
+                        ),
+                        (
+                            "g",
+                            format!("{:.2}", self.snapshot_shaded_colors.work_solid_color[1]),
+                        ),
+                        (
+                            "b",
+                            format!("{:.2}", self.snapshot_shaded_colors.work_solid_color[2]),
+                        ),
+                        (
+                            "a",
+                            format!("{:.2}", self.snapshot_shaded_colors.work_solid_color[3]),
+                        ),
+                    ],
+                ));
+                ui.label(self.text_with_args(
+                    "settings.snapshot_shading.tool",
+                    &[
+                        (
+                            "r",
+                            format!("{:.2}", self.snapshot_shaded_colors.tool_wire_color[0]),
+                        ),
+                        (
+                            "g",
+                            format!("{:.2}", self.snapshot_shaded_colors.tool_wire_color[1]),
+                        ),
+                        (
+                            "b",
+                            format!("{:.2}", self.snapshot_shaded_colors.tool_wire_color[2]),
+                        ),
+                    ],
+                ));
+            });
+    }
+
+    fn show_tool_tab(&mut self, ui: &mut egui::Ui) {
+        let flat_circle_label = self.text("settings.tool.flat_circle_divisions");
+        let ball_circle_label = self.text("settings.tool.ball_circle_divisions");
+        let ball_latitudes_label = self.text("settings.tool.ball_latitudes");
+        let ball_meridians_label = self.text("settings.tool.ball_meridians");
+        let preset_label = self.text("settings.toolpath.preset");
+        let preset_performance_label = self.text("settings.toolpath.preset.performance");
+        let preset_balanced_label = self.text("settings.toolpath.preset.balanced");
+        let preset_fine_label = self.text("settings.toolpath.preset.fine");
+        let chord_tolerance_label = self.text("settings.toolpath.chord_tolerance");
+        let max_angle_deg_label = self.text("settings.toolpath.max_angle_deg");
+        let min_divisions_label = self.text("settings.toolpath.min_divisions");
+        let max_divisions_label = self.text("settings.toolpath.max_divisions");
+
+        CollapsingHeader::new(self.text("settings.header.tool_wireframe"))
+            .default_open(true)
+            .show(ui, |ui| {
+                ui.label(RichText::new(self.text("settings.tool.manual_apply")).strong());
+
+                let mut flat_circle = self.tool_wireframe_settings.flat_circle_divisions as u32;
+                if ui
+                    .add(Slider::new(&mut flat_circle, 8..=96).text(flat_circle_label))
+                    .changed()
+                {
+                    self.tool_wireframe_settings.flat_circle_divisions = flat_circle as usize;
+                }
+
+                let mut ball_circle = self.tool_wireframe_settings.ball_circle_divisions as u32;
+                if ui
+                    .add(Slider::new(&mut ball_circle, 8..=128).text(ball_circle_label))
+                    .changed()
+                {
+                    self.tool_wireframe_settings.ball_circle_divisions = ball_circle as usize;
+                }
+
+                let mut ball_latitudes =
+                    self.tool_wireframe_settings.ball_hemisphere_divisions as u32;
+                if ui
+                    .add(Slider::new(&mut ball_latitudes, 2..=24).text(ball_latitudes_label))
+                    .changed()
+                {
+                    self.tool_wireframe_settings.ball_hemisphere_divisions =
+                        ball_latitudes as usize;
+                }
+
+                let mut ball_meridians = self.tool_wireframe_settings.ball_meridian_count as u32;
+                if ui
+                    .add(Slider::new(&mut ball_meridians, 4..=32).text(ball_meridians_label))
+                    .changed()
+                {
+                    self.tool_wireframe_settings.ball_meridian_count = ball_meridians as usize;
+                }
+            });
+
+        CollapsingHeader::new(self.text("settings.header.toolpath_discretization"))
+            .default_open(true)
+            .show(ui, |ui| {
+                ui.label(RichText::new(self.text("settings.toolpath.display_only")).strong());
+
+                ui.horizontal(|ui| {
+                    ui.label(preset_label);
+                    if ui.button(preset_performance_label).clicked() {
+                        apply_curve_discretization_preset(
+                            &mut self.toolpath_settings,
+                            CurveDiscretizationPreset::Performance,
+                        );
+                    }
+                    if ui.button(preset_balanced_label).clicked() {
+                        apply_curve_discretization_preset(
+                            &mut self.toolpath_settings,
+                            CurveDiscretizationPreset::Balanced,
+                        );
+                    }
+                    if ui.button(preset_fine_label).clicked() {
+                        apply_curve_discretization_preset(
+                            &mut self.toolpath_settings,
+                            CurveDiscretizationPreset::Fine,
+                        );
+                    }
+                });
+
+                let angle_deg = self
+                    .toolpath_settings
+                    .curve_discretization
+                    .max_angle_step_rad
+                    .to_degrees();
+                ui.label(
+                    self.text_with_args(
+                        "settings.toolpath.current_values",
+                        &[
+                            (
+                                "chord_tolerance_mm",
+                                format!(
+                                    "{:.3}",
+                                    self.toolpath_settings
+                                        .curve_discretization
+                                        .chord_tolerance_mm
+                                ),
+                            ),
+                            ("max_angle_deg", format!("{:.1}", angle_deg)),
+                            (
+                                "min_divisions",
+                                self.toolpath_settings
+                                    .curve_discretization
+                                    .min_divisions
+                                    .to_string(),
+                            ),
+                            (
+                                "max_divisions",
+                                self.toolpath_settings
+                                    .curve_discretization
+                                    .max_divisions
+                                    .to_string(),
+                            ),
+                        ],
+                    ),
+                );
+
+                ui.add(
+                    Slider::new(
+                        &mut self
+                            .toolpath_settings
+                            .curve_discretization
+                            .chord_tolerance_mm,
+                        0.01..=1.0,
+                    )
+                    .text(chord_tolerance_label),
+                );
+
+                let mut max_angle_deg = self
+                    .toolpath_settings
+                    .curve_discretization
+                    .max_angle_step_rad
+                    .to_degrees();
+                ui.add(Slider::new(&mut max_angle_deg, 3.0..=90.0).text(max_angle_deg_label));
+                set_curve_discretization_max_angle_deg(&mut self.toolpath_settings, max_angle_deg);
+
+                let mut min_divisions =
+                    self.toolpath_settings.curve_discretization.min_divisions as u32;
+                if ui
+                    .add(Slider::new(&mut min_divisions, 4..=64).text(min_divisions_label))
+                    .changed()
+                {
+                    set_curve_discretization_min_divisions(
+                        &mut self.toolpath_settings,
+                        min_divisions as usize,
+                    );
+                }
+
+                let min_max = self.toolpath_settings.curve_discretization.min_divisions as u32;
+                let mut max_divisions =
+                    self.toolpath_settings.curve_discretization.max_divisions as u32;
+                if ui
+                    .add(Slider::new(&mut max_divisions, min_max..=256).text(max_divisions_label))
+                    .changed()
+                {
+                    set_curve_discretization_max_divisions(
+                        &mut self.toolpath_settings,
+                        max_divisions as usize,
+                    );
+                }
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        apply_curve_discretization_preset, set_curve_discretization_max_angle_deg,
+        set_curve_discretization_max_divisions, set_curve_discretization_min_divisions,
+        CurveDiscretizationPreset,
+    };
+    use viewmodel::toolpath_converter::ToolPathVisualizationSettings;
+
+    #[test]
+    fn curve_discretization_preset_updates_settings() {
+        let mut settings = ToolPathVisualizationSettings::default();
+
+        apply_curve_discretization_preset(&mut settings, CurveDiscretizationPreset::Performance);
+        let performance = settings.curve_discretization;
+
+        apply_curve_discretization_preset(&mut settings, CurveDiscretizationPreset::Fine);
+        let fine = settings.curve_discretization;
+
+        assert!(performance.chord_tolerance_mm > fine.chord_tolerance_mm);
+        assert!(performance.max_divisions < fine.max_divisions);
+    }
+
+    #[test]
+    fn set_curve_discretization_max_angle_deg_converts_to_radians() {
+        let mut settings = ToolPathVisualizationSettings::default();
+
+        set_curve_discretization_max_angle_deg(&mut settings, 45.0);
+
+        assert!(
+            (settings.curve_discretization.max_angle_step_rad - std::f64::consts::FRAC_PI_4).abs()
+                < 1e-12
+        );
+    }
+
+    #[test]
+    fn set_curve_discretization_min_divisions_clamps_max_divisions() {
+        let mut settings = ToolPathVisualizationSettings::default();
+        settings.curve_discretization.max_divisions = 12;
+
+        set_curve_discretization_min_divisions(&mut settings, 24);
+
+        assert_eq!(settings.curve_discretization.min_divisions, 24);
+        assert_eq!(settings.curve_discretization.max_divisions, 24);
+    }
+
+    #[test]
+    fn set_curve_discretization_max_divisions_updates_value() {
+        let mut settings = ToolPathVisualizationSettings::default();
+
+        set_curve_discretization_max_divisions(&mut settings, 72);
+
+        assert_eq!(settings.curve_discretization.max_divisions, 72);
     }
 }

--- a/viewmodel/converter/src/cam_sim_visualization_converter.rs
+++ b/viewmodel/converter/src/cam_sim_visualization_converter.rs
@@ -11,13 +11,13 @@ use application::cam_orchestration::{
     ToolEntityManagementOrchestrator,
 };
 use cam_core::{
-    validate_toolpath_machine_constraints, ArcDirection, CamTolerance, MachineConstraint,
-    PathGeometry, Tool, ToolPath, ValidationError,
+    validate_toolpath_machine_constraints, CamTolerance, MachineConstraint, Tool, ToolPath,
+    ValidationError,
 };
-use cam_sim::{SimulationError, SnapshotInterval};
+use cam_sim::{collect_toolpath_line_segments_with_arc_options, SimulationError, SnapshotInterval};
 use geo_algorithms::{
     octree::{VoxelOctree, VoxelState},
-    LineSegment3D, Point3D,
+    CircularArcPolylineOptions, LineSegment3D, Point3D,
 };
 use std::collections::HashMap;
 use std::f64::consts::TAU;
@@ -269,150 +269,13 @@ fn build_solid_mesh_from_voxel_tree(
     (vertices, indices)
 }
 
-fn collect_line_segments_with_flags(
+fn collect_simulation_line_segments_with_flags(
     toolpath: &ToolPath<f64>,
 ) -> Result<Vec<(LineSegment3D<f64>, bool)>, SimulationError> {
-    let mut out = Vec::new();
-
-    for segment in &toolpath.approach_segments {
-        match segment.geometry {
-            PathGeometry::Line { end } => {
-                if let Some(line_segment) = LineSegment3D::new(segment.start, end) {
-                    out.push((line_segment, false));
-                }
-            }
-            PathGeometry::Arc {
-                end,
-                center,
-                direction,
-            } => {
-                for line in arc_to_lines_f64(segment.start, end, center, direction) {
-                    out.push((line, false));
-                }
-            }
-        }
-    }
-
-    for contour in &toolpath.contour_levels {
-        for segment in &contour.segments {
-            match segment.geometry {
-                PathGeometry::Line { end } => {
-                    if let Some(line_segment) = LineSegment3D::new(segment.start, end) {
-                        out.push((line_segment, segment.is_cutting()));
-                    }
-                }
-                PathGeometry::Arc {
-                    end,
-                    center,
-                    direction,
-                } => {
-                    let is_cutting = segment.is_cutting();
-                    for line in arc_to_lines_f64(segment.start, end, center, direction) {
-                        out.push((line, is_cutting));
-                    }
-                }
-            }
-        }
-    }
-
-    for segment in &toolpath.retract_segments {
-        match segment.geometry {
-            PathGeometry::Line { end } => {
-                if let Some(line_segment) = LineSegment3D::new(segment.start, end) {
-                    out.push((line_segment, false));
-                }
-            }
-            PathGeometry::Arc {
-                end,
-                center,
-                direction,
-            } => {
-                for line in arc_to_lines_f64(segment.start, end, center, direction) {
-                    out.push((line, false));
-                }
-            }
-        }
-    }
-
-    Ok(out)
-}
-
-/// Arc を polyline 近似する（可視化側の f64 専用版）。
-///
-/// 弦誤差 0.1mm 基準、最小分割数 4。
-fn arc_to_lines_f64(
-    start: Point3D<f64>,
-    end: Point3D<f64>,
-    center: Point3D<f64>,
-    direction: ArcDirection,
-) -> Vec<LineSegment3D<f64>> {
-    const CHORD_TOLERANCE: f64 = 0.1;
-    const MIN_DIVISIONS: usize = 4;
-
-    let dx1 = start.x() - center.x();
-    let dy1 = start.y() - center.y();
-    let r = (dx1 * dx1 + dy1 * dy1).sqrt();
-    if r < f64::EPSILON {
-        return Vec::new();
-    }
-
-    let dx2 = end.x() - center.x();
-    let dy2 = end.y() - center.y();
-    let angle_start = dy1.atan2(dx1);
-    let angle_end = dy2.atan2(dx2);
-
-    let sweep = match direction {
-        ArcDirection::CounterClockwise => {
-            let mut s = angle_end - angle_start;
-            if s < f64::EPSILON {
-                s += TAU;
-            }
-            s
-        }
-        ArcDirection::Clockwise => {
-            let mut s = angle_start - angle_end;
-            if s < f64::EPSILON {
-                s += TAU;
-            }
-            s
-        }
-    };
-
-    let n = if CHORD_TOLERANCE > f64::EPSILON {
-        let cos_val = (1.0 - CHORD_TOLERANCE / r).clamp(-1.0, 1.0);
-        let half_angle = cos_val.acos();
-        let divisions = (sweep / (2.0 * half_angle)).ceil() as usize;
-        divisions.max(MIN_DIVISIONS)
-    } else {
-        MIN_DIVISIONS
-    };
-
-    let cx = center.x();
-    let cy = center.y();
-    let z_start = start.z();
-    let z_end = end.z();
-
-    let sign = match direction {
-        ArcDirection::CounterClockwise => 1.0_f64,
-        ArcDirection::Clockwise => -1.0_f64,
-    };
-    let angle_step = sign * sweep / n as f64;
-
-    let mut segments = Vec::with_capacity(n);
-    let mut prev = start;
-    for i in 1..=n {
-        let angle = angle_start + angle_step * i as f64;
-        let next = Point3D::new(
-            cx + r * angle.cos(),
-            cy + r * angle.sin(),
-            z_start + (z_end - z_start) * (i as f64 / n as f64),
-        );
-        if let Some(line) = LineSegment3D::new(prev, next) {
-            segments.push(line);
-        }
-        prev = next;
-    }
-    segments
+    Ok(collect_toolpath_line_segments_with_arc_options(
+        toolpath,
+        CircularArcPolylineOptions::default(),
+    ))
 }
 
 fn lerp_point_on_segment(segment: &LineSegment3D<f64>, t: f64) -> Point3D<f64> {
@@ -440,9 +303,11 @@ fn tool_tip_position(
     Some(lerp_point_on_segment(segment, segment_t))
 }
 
-fn create_toolpath_wireframe_vertices(toolpath: &ToolPath<f64>) -> Vec<WireframeVertex> {
-    let settings = ToolPathVisualizationSettings::default();
-    let toolpath_vertices = toolpath_to_vertices(toolpath, &settings);
+fn create_toolpath_wireframe_vertices(
+    toolpath: &ToolPath<f64>,
+    settings: &ToolPathVisualizationSettings,
+) -> Vec<WireframeVertex> {
+    let toolpath_vertices = toolpath_to_vertices(toolpath, settings);
 
     toolpath_vertices
         .vertices
@@ -789,6 +654,7 @@ pub fn build_demo_cam_simulation_visualization_bundle(
     build_demo_cam_simulation_visualization_bundle_with_tool_settings(
         settings,
         &ToolWireframeVisualizationSettings::default(),
+        &ToolPathVisualizationSettings::default(),
         scenario,
     )
 }
@@ -798,6 +664,7 @@ pub fn build_demo_cam_simulation_visualization_bundle(
 pub fn build_demo_cam_simulation_visualization_bundle_with_tool_settings(
     settings: &OctreeVisualizationSettings,
     tool_wireframe_settings: &ToolWireframeVisualizationSettings,
+    toolpath_settings: &ToolPathVisualizationSettings,
     scenario: CamSimulationDemoScenario,
 ) -> Result<CamSimulationVisualizationBundle, CamSimulationVisualizationError> {
     let demo = build_demo_artifacts_for_cam_simulation(scenario);
@@ -816,7 +683,7 @@ pub fn build_demo_cam_simulation_visualization_bundle_with_tool_settings(
     let machine_constraint = MachineConstraint::empty();
     validate_toolpath_machine_constraints(&toolpath, &machine_constraint, &tolerance)?;
 
-    let segments = collect_line_segments_with_flags(&toolpath)?;
+    let segments = collect_simulation_line_segments_with_flags(&toolpath)?;
 
     let work_bounds = compute_toolpath_work_bounds(&segments, behavior.radius());
     let non_cutting_interference_count =
@@ -841,7 +708,7 @@ pub fn build_demo_cam_simulation_visualization_bundle_with_tool_settings(
     let snapshot_inputs = cam_snapshot_exports_to_inputs(&exports);
     let snapshot_series = cam_snapshot_inputs_to_domain_series("cam_sim", &snapshot_inputs);
 
-    let toolpath_wireframe = create_toolpath_wireframe_vertices(&toolpath);
+    let toolpath_wireframe = create_toolpath_wireframe_vertices(&toolpath, toolpath_settings);
 
     let mut replay_tree = VoxelOctree::new(work_bounds, settings.max_depth);
     let mut replay_segment_index = 0usize;

--- a/viewmodel/converter/src/toolpath_converter.rs
+++ b/viewmodel/converter/src/toolpath_converter.rs
@@ -13,7 +13,9 @@ use cam_core::{
     ArcDirection, ContourLevelPath, CuttingDirection, PathGeometry, PathSegment, SegmentType,
     ToolPath,
 };
-use geo_algorithms::Point3D;
+use geo_algorithms::{
+    circular_arc_to_polyline, CircularArcDirection, CircularArcPolylineOptions, Point3D,
+};
 
 /// 工具経路の色設定（App層から注入）
 #[derive(Debug, Clone, Copy)]
@@ -54,22 +56,63 @@ impl Default for ToolPathColorScheme {
     }
 }
 
-/// テッセレーション設定（App層から注入）
+/// 表示用の曲線離散化設定（App層から注入）
 #[derive(Debug, Clone, Copy)]
-pub struct TessellationSettings {
-    /// 円弧の分割数（セグメント数）
-    pub arc_segments: u32,
+pub struct DisplayCurveDiscretizationSettings {
+    /// 円弧 polyline 近似の弦誤差上限（mm）
+    pub chord_tolerance_mm: f64,
 
-    /// 最小セグメント長（これ以下の細分化は行わない）
-    pub min_segment_length: f64,
+    /// 1 セグメントあたりの最大角度ステップ（rad）
+    pub max_angle_step_rad: f64,
+
+    /// 最小分割数
+    pub min_divisions: usize,
+
+    /// 最大分割数
+    pub max_divisions: usize,
 }
 
-impl Default for TessellationSettings {
+impl Default for DisplayCurveDiscretizationSettings {
     fn default() -> Self {
+        let options = CircularArcPolylineOptions::default();
         Self {
-            arc_segments: 32,
-            min_segment_length: 0.1, // 0.1mm
+            chord_tolerance_mm: options.chord_tolerance_mm(),
+            max_angle_step_rad: options.max_angle_step_rad().unwrap_or(std::f64::consts::PI),
+            min_divisions: options.min_divisions(),
+            max_divisions: options.max_divisions().unwrap_or(usize::MAX),
         }
+    }
+}
+
+impl DisplayCurveDiscretizationSettings {
+    pub fn performance_preset() -> Self {
+        Self {
+            chord_tolerance_mm: 0.25,
+            max_angle_step_rad: std::f64::consts::PI / 6.0,
+            min_divisions: 4,
+            max_divisions: 48,
+        }
+    }
+
+    pub fn balanced_preset() -> Self {
+        Self::default()
+    }
+
+    pub fn fine_preset() -> Self {
+        Self {
+            chord_tolerance_mm: 0.03,
+            max_angle_step_rad: std::f64::consts::PI / 24.0,
+            min_divisions: 8,
+            max_divisions: 192,
+        }
+    }
+
+    pub fn to_circular_arc_polyline_options(&self) -> CircularArcPolylineOptions {
+        CircularArcPolylineOptions::simulation_default()
+            .with_chord_tolerance_mm(self.chord_tolerance_mm)
+            .with_max_angle_step_rad(self.max_angle_step_rad)
+            .with_min_divisions(self.min_divisions)
+            .with_max_divisions(self.max_divisions)
     }
 }
 
@@ -79,8 +122,8 @@ pub struct ToolPathVisualizationSettings {
     /// 色設定
     pub color_scheme: ToolPathColorScheme,
 
-    /// テッセレーション設定
-    pub tessellation: TessellationSettings,
+    /// 表示用の曲線離散化設定
+    pub curve_discretization: DisplayCurveDiscretizationSettings,
 
     /// 切削方向による色分けを有効化
     pub color_by_cutting_direction: bool,
@@ -99,7 +142,7 @@ impl Default for ToolPathVisualizationSettings {
     fn default() -> Self {
         Self {
             color_scheme: ToolPathColorScheme::default(),
-            tessellation: TessellationSettings::default(),
+            curve_discretization: DisplayCurveDiscretizationSettings::default(),
             color_by_cutting_direction: false,
             show_rapid: true,
             show_approach: true,
@@ -168,7 +211,9 @@ pub fn toolpath_to_vertices(
             convert_segment(
                 segment,
                 &settings.color_scheme,
-                &settings.tessellation,
+                settings
+                    .curve_discretization
+                    .to_circular_arc_polyline_options(),
                 toolpath.cutting_direction,
                 settings.color_by_cutting_direction,
                 &mut vertices,
@@ -219,7 +264,9 @@ pub fn toolpath_to_vertices(
             convert_segment(
                 segment,
                 &settings.color_scheme,
-                &settings.tessellation,
+                settings
+                    .curve_discretization
+                    .to_circular_arc_polyline_options(),
                 toolpath.cutting_direction,
                 settings.color_by_cutting_direction,
                 &mut vertices,
@@ -272,7 +319,9 @@ fn convert_contour_level(
         convert_segment(
             segment,
             &settings.color_scheme,
-            &settings.tessellation,
+            settings
+                .curve_discretization
+                .to_circular_arc_polyline_options(),
             cutting_direction,
             settings.color_by_cutting_direction,
             vertices,
@@ -285,7 +334,7 @@ fn convert_contour_level(
 fn convert_segment(
     segment: &PathSegment<f64>,
     color_scheme: &ToolPathColorScheme,
-    tessellation: &TessellationSettings,
+    arc_options: CircularArcPolylineOptions,
     cutting_direction: CuttingDirection,
     color_by_direction: bool,
     vertices: &mut Vec<Vertex3D>,
@@ -311,19 +360,23 @@ fn convert_segment(
             center,
             direction,
         } => {
-            // 円弧セグメント: テッセレーション
-            let arc_vertices = tessellate_arc(
-                &segment.start,
-                end,
-                center,
-                *direction,
-                tessellation.arc_segments,
+            let circular_direction = match direction {
+                ArcDirection::Clockwise => CircularArcDirection::Clockwise,
+                ArcDirection::CounterClockwise => CircularArcDirection::CounterClockwise,
+            };
+
+            let arc_segments = circular_arc_to_polyline(
+                segment.start,
+                *end,
+                *center,
+                circular_direction,
+                arc_options,
             );
 
             // 線分列として頂点追加
-            for i in 0..arc_vertices.len().saturating_sub(1) {
-                vertices.push(arc_vertices[i]);
-                vertices.push(arc_vertices[i + 1]);
+            for line in arc_segments {
+                vertices.push(point_to_vertex(&line.constraint_start_point()));
+                vertices.push(point_to_vertex(&line.constraint_end_point()));
                 colors.push(color);
             }
         }
@@ -364,75 +417,6 @@ fn point_to_vertex(point: &Point3D<f64>) -> Vertex3D {
     }
 }
 
-/// 円弧をテッセレーション（線分分割）
-///
-/// # 引数
-///
-/// - `start`: 円弧始点
-/// - `end`: 円弧終点
-/// - `center`: 円弧中心点
-/// - `direction`: 円弧方向（時計回り/反時計回り）
-/// - `segments`: 分割数
-///
-/// # 戻り値
-///
-/// テッセレーション後の頂点配列
-fn tessellate_arc(
-    start: &Point3D<f64>,
-    end: &Point3D<f64>,
-    center: &Point3D<f64>,
-    direction: ArcDirection,
-    segments: u32,
-) -> Vec<Vertex3D> {
-    let mut result = Vec::with_capacity((segments + 1) as usize);
-
-    // 半径計算
-    let radius = {
-        let dx = start.x() - center.x();
-        let dy = start.y() - center.y();
-        let dz = start.z() - center.z();
-        (dx * dx + dy * dy + dz * dz).sqrt()
-    };
-
-    // 始点・終点の角度計算
-    let start_angle = (start.y() - center.y()).atan2(start.x() - center.x());
-    let end_angle = (end.y() - center.y()).atan2(end.x() - center.x());
-
-    // 中心角計算（方向を考慮）
-    let sweep_angle = match direction {
-        ArcDirection::CounterClockwise => {
-            if end_angle >= start_angle {
-                end_angle - start_angle
-            } else {
-                end_angle - start_angle + 2.0 * std::f64::consts::PI
-            }
-        }
-        ArcDirection::Clockwise => {
-            if end_angle <= start_angle {
-                end_angle - start_angle
-            } else {
-                end_angle - start_angle - 2.0 * std::f64::consts::PI
-            }
-        }
-    };
-
-    // 分割点を生成
-    for i in 0..=segments {
-        let t = i as f64 / segments as f64;
-        let angle = start_angle + sweep_angle * t;
-
-        let x = center.x() + radius * angle.cos();
-        let y = center.y() + radius * angle.sin();
-        let z = start.z() + (end.z() - start.z()) * t; // Z方向は線形補間
-
-        result.push(Vertex3D {
-            position: [x as f32, y as f32, z as f32],
-        });
-    }
-
-    result
-}
-
 /// デバッグ用：サンプル工具経路を取得
 ///
 /// 生成本体は `cam_core::fixtures` に置き、ViewModel は層境界の薄い中継だけを担う。
@@ -453,10 +437,28 @@ mod tests {
     }
 
     #[test]
-    fn test_default_tessellation() {
-        let settings = TessellationSettings::default();
-        assert_eq!(settings.arc_segments, 32);
-        assert_eq!(settings.min_segment_length, 0.1);
+    fn test_default_curve_discretization() {
+        let settings = DisplayCurveDiscretizationSettings::default();
+        assert!(settings.chord_tolerance_mm > 0.0);
+        assert!(settings.max_angle_step_rad > 0.0);
+        assert!(settings.min_divisions >= 4);
+        assert!(settings.max_divisions >= settings.min_divisions);
+    }
+
+    #[test]
+    fn test_curve_discretization_presets_are_ordered_by_quality() {
+        let performance = DisplayCurveDiscretizationSettings::performance_preset();
+        let balanced = DisplayCurveDiscretizationSettings::balanced_preset();
+        let fine = DisplayCurveDiscretizationSettings::fine_preset();
+
+        assert!(performance.chord_tolerance_mm > balanced.chord_tolerance_mm);
+        assert!(balanced.chord_tolerance_mm > fine.chord_tolerance_mm);
+
+        assert!(performance.max_angle_step_rad > balanced.max_angle_step_rad);
+        assert!(balanced.max_angle_step_rad > fine.max_angle_step_rad);
+
+        assert!(performance.max_divisions < balanced.max_divisions);
+        assert!(balanced.max_divisions < fine.max_divisions);
     }
 
     #[test]
@@ -556,23 +558,44 @@ mod tests {
 
     #[test]
     fn test_arc_tessellation() {
-        // 半円（180度）のテッセレーション
         let start = Point3D::new(10.0, 0.0, 0.0);
         let end = Point3D::new(-10.0, 0.0, 0.0);
         let center = Point3D::new(0.0, 0.0, 0.0);
 
-        let vertices = tessellate_arc(&start, &end, &center, ArcDirection::CounterClockwise, 8);
+        let settings = ToolPathVisualizationSettings {
+            curve_discretization: DisplayCurveDiscretizationSettings {
+                chord_tolerance_mm: 1.0,
+                max_angle_step_rad: std::f64::consts::PI / 8.0,
+                min_divisions: 8,
+                max_divisions: 8,
+            },
+            ..Default::default()
+        };
+        let segment = PathSegment::new_arc(
+            start,
+            end,
+            center,
+            ArcDirection::CounterClockwise,
+            SegmentType::Cutting { feed_rate: 500.0 },
+        );
+        let contour = ContourLevelPath::new(0, 0.0, vec![segment]);
+        let toolpath = ToolPath::new(
+            "tool1".to_string(),
+            CuttingDirection::Down,
+            vec![],
+            vec![contour],
+            vec![],
+        );
+        let result = toolpath_to_vertices(&toolpath, &settings);
 
-        // 9頂点（8セグメント + 1）
-        assert_eq!(vertices.len(), 9);
+        assert_eq!(result.vertices.len(), 16);
 
-        // 始点確認
-        assert!((vertices[0].position[0] - 10.0).abs() < 0.01);
-        assert!((vertices[0].position[1] - 0.0).abs() < 0.01);
+        assert!((result.vertices[0].position[0] - 10.0).abs() < 0.01);
+        assert!((result.vertices[0].position[1] - 0.0).abs() < 0.01);
 
-        // 終点確認
-        assert!((vertices[8].position[0] - (-10.0)).abs() < 0.01);
-        assert!((vertices[8].position[1] - 0.0).abs() < 0.01);
+        let last = result.vertices.last().unwrap();
+        assert!((last.position[0] - (-10.0)).abs() < 0.01);
+        assert!((last.position[1] - 0.0).abs() < 0.01);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add circular arc curve discretization workflow and move toolpath polyline expansion to geo_algorithms
- share NURBS knot span search logic in analysis and update geo_nurbs to use the common helper
- document Issue #547 curve/surface discretization taxonomy and align the design wording with the Measure廃止方針
- include workspace indent guide color settings used during this work

## Details
- add `geo_algorithms::curve_discretization` with `circular_arc_to_polyline` and shape-family options
- route `cam_sim` and `viewmodel` toolpath conversion through the new curve discretization settings flow
- add `analysis::numerics::partition` and reuse it from `geo_nurbs::knot`
- update `GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md` with the `adaptive parameter sampling` / `curve discretization` / `param-grid tessellation` / `surface meshing` taxonomy

## Validation
- `cargo fmt --all -- --check`
- `cargo test --workspace`

## Related
- Related #547