### PR TITLE
refactor: unify parameter semantics across curve families

### DIFF
--- a/dev/architecture/GEOMETRY_SHAPE_SEMANTICS_DESIGN.md
+++ b/dev/architecture/GEOMETRY_SHAPE_SEMANTICS_DESIGN.md
@@ -31,23 +31,23 @@
 
 ただし本論点は `LineSegment` 固有ではなく、shape 横断で再発しうる意味論項目を先に `LineSegment` で明文化する位置付けとする。
 
-Arc / EllipseArc / Circle / Triangle などを含む shape 横断の `Measure / parameter / endpoint` capability 論点は `#558` で別途整理する。
+Arc / EllipseArc / Circle / Triangle などを含む shape 横断の quantity / parameter / endpoint capability 論点は `#558` で別途整理する。
 
 ## `#558` の現状棚卸し
 
-`#558` 着手時点の `geo_contracts` では、Arc / EllipseArc / Circle / Triangle / LineSegment の各 trait が、shape ごとに異なる粒度で `Measure / endpoint / evaluation / containment / distance` を抱えている。
+`#558` 着手時点の `geo_contracts` では、旧 `*Measure` 集約 trait 自体はかなり解体済みだが、Arc / EllipseArc / Circle / Triangle / LineSegment の capability 分解粒度と、`Properties` に何を残すかが shape ごとにまだ揃っていない。
 
 少なくとも、次の非対称が存在する。
 
-| Shape | 現状の主な意味要素 | 現状の混在状況 |
+| Shape | 現状の主な意味要素 | 現状の capability 状況 |
 | --- | --- | --- |
-| `LineSegment` | support line、理想端点、長さ、parameter 評価 | endpoint は `Properties`、拘束端点は topology 側責務として分離対象 |
-| `Arc` | 中心、半径、角度区間、始終点、parameter 評価 | `Measure` に始終点、midpoint、angle 評価、distance、containment が同居 |
-| `EllipseArc` | 中心、主軸情報、角度区間、始終点、parameter 評価 | `Measure` に始終点、midpoint、angle 評価、containment、bounding box が同居 |
-| `Circle` | 中心、半径、周回 parameter 評価、閉曲線性 | `Measure` に circumference、area、containment、distance、projection、parameter 評価が同居 |
-| `Triangle` | 3頂点、面積、`perimeter`、面内判定 | `Measure` に edge length、perimeter、containment、distance、向き/planarity 判定が同居 |
+| `LineSegment` | support line、理想端点、長さ、parameter 評価 | `start/end/length` を `Properties` に残しつつ、distance / containment / evaluation / projection は別 trait 化済み |
+| `Arc` | 中心、半径、角度区間、始終点、parameter 評価 | endpoint / evaluation / trim-range / distance / containment は分離済みだが、`LineSegment` と違って endpoint は `Properties` ではなく独立 trait にある |
+| `EllipseArc` | 中心、主軸情報、角度区間、始終点、parameter 評価 | Arc 同様に endpoint / evaluation / trim-range / containment は分離済みで、`bounding_box` は `Derived` に残る |
+| `Circle` | 中心、半径、周回 parameter 評価、閉曲線性 | endpoint は導入せず、derived / evaluation / containment / distance / projection の分離は済んでいる |
+| `Triangle` | 3頂点、面積、`perimeter`、面内判定 | `BoundaryAccess` / `BoundaryQuantity` / `Derived` / `Containment` / `Distance` へ分離済みだが、`Properties` は互換 alias として残っている |
 
-この棚卸しから、現状の `Measure` は単なる測度ではなく、shape ごとに次の異種 capability を束ねていることが分かる。
+この棚卸しから見えるのは、問題の中心が「`Measure` を残すかどうか」ではなく、shape ごとに必要な capability 軸と公開位置がまだ不均一だという点である。
 
 - primary quantity: 単独線 shape の `length` / 閉曲線 shape の `circumference` / 面の `area`
 - boundary quantity: 複数辺境界 shape の `perimeter` / edge length
@@ -56,8 +56,9 @@ Arc / EllipseArc / Circle / Triangle などを含む shape 横断の `Measure / 
 - 関係判定: `contains_point`
 - 距離・射影: `distance_to_point` / `closest_point_to`
 - 形状固有派生: `direction_vector` / `bounding_box` / `is_clockwise` / `is_planar`
+- 互換経路: `Properties` alias や旧語彙をどこまで残すか
 
-重要なのは、これは trait 分割の問題である前に、shape ごとに「どの capability が本質的に存在するか」が揃っていない問題だという点である。
+重要なのは、これは単なる trait 分割の問題ではなく、shape ごとに「どの capability が本質的に存在し、definition に近いのか」が揃っていない問題だという点である。
 
 ## `#558` で固定したい shape 横断分類
 
@@ -142,6 +143,73 @@ shape 横断で `measure` だけを共通語彙にすると、長さ、面積、
 `start/end`、頂点参照、edge 長などの「境界の語彙」と、`point_at_parameter` や `point_at_angle` のような「評価の語彙」は同じではない。
 
 今後の capability 分離では、少なくともこの 2 系統を別物として扱う。
+
+## `#558` parameter semantics の正本
+
+`#558` で整理した parameter semantics は、本節を shape family 横断の正本とする。
+
+ここでいう parameter semantics は、少なくとも次を含む。
+
+- `point_at_parameter` が受け取る値域
+- `point_at_angle` が存在する場合の役割
+- `parameter_range()` が返す範囲の意味
+- `start/end` と evaluation の関係
+
+### family 別の原則
+
+| Shape family | `point_at_parameter` の意味 | `point_at_angle` の意味 | `parameter_range()` の意味 |
+| --- | --- | --- | --- |
+| `LineSegment` | bounded support 上の trim-local parameter | 原則として持たない | bounded curve の局所 parameter 範囲 |
+| `Arc` | trim-local parameter `0..=1` | 母円の native angle parameter | trim-local 範囲 `0..=1` |
+| `EllipseArc` | trim-local parameter `0..=1` | 母楕円の native angle parameter | trim-local 範囲 `0..=1` |
+| `Circle` | local angle parameter | convenience angle API があっても canonical 意味は `point_at_parameter` 側 | closed curve の local angle 範囲 |
+| `Ellipse` | local angle parameter | convenience angle API は同じ意味の別入口 | closed curve の local angle 範囲 |
+
+### bounded curve family: `LineSegment` / `Arc` / `EllipseArc`
+
+bounded curve family では、`point_at_parameter` は support shape 全体の native parameter ではなく、その shape 自身の有効区間を `0..=1` へ正規化した trim-local parameter として扱う。
+
+意味論上の帰結:
+
+- `point_at_parameter(0)` は ideal start endpoint に対応する
+- `point_at_parameter(1)` は ideal end endpoint に対応する
+- `point_at_parameter(0.5)` は中間評価であり、endpoint capability ではない
+- `parameter_range()` を持つ場合、その返り値は trim-local range を表す
+
+補足:
+
+- `LineSegment` は angle を持たないため、`point_at_angle` を導入しない
+- `Arc` / `EllipseArc` の `point_at_angle` は母曲線の native angle parameter を直接指定する evaluation convenience として扱う
+- `contains_angle` は trim 判定の責務であり、`point_at_angle` 自体は total な support evaluation として扱う
+
+### closed curve family: `Circle` / `Ellipse`
+
+closed curve family では、`point_at_parameter` を local angle semantics に統一する。
+
+意味論上の帰結:
+
+- `Circle` / `Ellipse` の `point_at_parameter` はともに local angle parameter を受け取る
+- `Circle` / `Ellipse` に endpoint capability は導入しない
+- `parameter_range()` を持つ場合、その返り値は local angle domain を表す
+- periodic shape に convenience として `point_at_angle` を置く場合も、canonical な意味は `point_at_parameter` 側に置く
+
+補足:
+
+- `Circle` では `point_at_parameter` を正本とし、`point_at_angle` は同じ angle domain を渡す convenience API として扱う
+- `Ellipse` でも同様に local angle semantics を正本とする
+- 正規化 phase や周回率が必要であれば、それは別 API で表現し、`point_at_parameter` の意味へ混入させない
+
+### topology との接続
+
+topology は primitive / mother curve の native parameter semantics を保存し、edge 側でのみ局所 parameter を導入する。
+
+この原則は次のように読む。
+
+- `Circle` / `Ellipse` の mother curve parameter は local angle domain のまま保持する
+- `Arc` / `EllipseArc` は primitive 自身が trim-local parameter shape なので、`0..=1` を shape semantics として持つ
+- topology の edge-local `0..=1` は mother curve の native domain とは別層の parameter である
+
+したがって、primitive 側の `point_at_parameter` と topology 側の edge-local parameter を同一視しない。
 
 ## 今回の棚卸しで見えた #558 の設計対象
 
@@ -317,6 +385,8 @@ topology 側の Edge 正規形は、primitive の ideal endpoint を前提に、
 
 ### 1. Arc / EllipseArc の endpoint は ideal endpoint として扱う
 
+parameter semantics の正本は「`#558` parameter semantics の正本」を参照する。
+
 - `Arc` / `EllipseArc` の `start_point` / `end_point` は、母曲線上の ideal endpoint を返す語彙として扱う
 - `midpoint` / `mid_point` は endpoint capability の正本語彙としては採用しない
 - 利用者が中間点を必要とする場合は、parameter 評価か、将来の弧長比評価のような明示 API を使う
@@ -324,7 +394,12 @@ topology 側の Edge 正規形は、primitive の ideal endpoint を前提に、
 
 ### 2. Circle / Ellipse は endpoint capability を持たない
 
+parameter semantics の正本は「`#558` parameter semantics の正本」を参照する。
+
 - `Circle` / `Ellipse` は閉曲線として `point_at_parameter` を持てる
+- periodic parameter は closed curve family 内で局所角度 parameter に揃える
+- `Circle` / `Ellipse` ともに `point_at_parameter` は `0 <= t <= 2π` を基本 domain とする
+- `2π` は周期端であり、`0` と同じ幾何点へ戻る
 - ただし parameter 原点を与える `ref_direction` や `rotation` は endpoint の根拠にしない
 - 閉曲線では `start` / `end` を正本語彙として導入しない
 
@@ -347,15 +422,19 @@ topology 側の Edge 正規形は、primitive の ideal endpoint を前提に、
 - `start_point` / `end_point` は境界付き曲線に限って endpoint capability に置く
 - `point_at_parameter(0.5)` のような parameter midpoint は evaluation の一例であり、endpoint 語彙へ昇格させない
 - 将来的に support curve evaluation と拘束点補間を併存させる場合は、同じ `point_at_parameter` 名に押し込めず名称で分ける
+- closed curve family の `point_at_parameter` は local angle domain を前提にし、shape ごとの差は parameter 原点の定義側へ限定する
 
 補足:
 
 - 中点が重要なユースケースでも、`midpoint` のような convenience 名ではなく、何の中点かを API 名で明示する
 - 特に楕円弧や NURBS では、parameter 中点と弧長中点が一致しないため、曖昧な `midpoint` は導入しない
+- Circle と Ellipse の periodic parameter は local angle domain へ統一し、closed curve family の可読性を優先する
 
 ## `#558` 実装単位 A の詳細設計
 
 実装単位 A では、`Arc` / `EllipseArc` に対して「primitive の endpoint semantics を維持したまま、topology の拘束端点要求と衝突しないこと」を設計目標とする。
+
+parameter semantics の具体値域と family 別ルールは「`#558` parameter semantics の正本」を参照し、本節では Arc / EllipseArc に必要な責務分離だけを扱う。
 
 ### primitive 側で固定すること
 

--- a/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
+++ b/dev/architecture/GEO_CONTRACTS_TRAIT_STRUCTURE_MINIMIZATION_DESIGN.md
@@ -68,16 +68,24 @@ Issue #535 では、`geo_contracts` の trait構造を次の最小構造へ再�
 - `Triangle` のような面 shape に、curve parameter capability を横展開しない
 - surface family を扱う場合は、curve parameter と surface parameter を同一 trait に混在させない
 
+補足:
+
+- `point_at_parameter` / `point_at_angle` / `parameter_range()` の具体的な意味は `GEOMETRY_SHAPE_SEMANTICS_DESIGN.md` の「`#558` parameter semantics の正本」を参照する
+- 本書では capability の所属だけを扱い、trim-local parameter と mother curve native angle の語彙定義自体は shape semantics 側へ集約する
+
 ### 3. periodic parameter は閉曲線 shape の個別論点として扱う
 
 対象:
 
 - `Circle`
+- `Ellipse`
 
 設計反映:
 
 - 閉曲線の parameter capability は、境界付き曲線と同一視しない
 - `Circle` の parameter は評価 capability として許容するが、`start/end` を導く根拠には使わない
+- `Ellipse` も同様に評価 capability として許容するが、`start/end` を導く根拠には使わない
+- closed curve family の periodic parameter は local angle semantics へ揃える
 - periodic curve を導入する場合、endpoint capability とは別の分岐として扱う
 
 ### 4. boundary access は curve endpoint と polygon vertex を分ける
@@ -457,8 +465,8 @@ Arc はもともと `Measure` に endpoint / evaluation / containment / distance
 | `Arc2DConstructor` / `Arc3DConstructor` | `definition` |
 | `Arc2DProperties::center/radius/start_angle/end_angle/dimension/angle_span/is_full_circle/is_semicircle` | `definition` |
 | `Arc3DProperties::center/radius/start_angle/end_angle/dimension/angle_span/is_full_circle/is_on_xy_plane` | `definition` |
-| `Arc2DDerived::measure` | `derived` |
-| `Arc3DDerived::measure` | `derived` |
+| `Arc2DDerived::length` | `derived` |
+| `Arc3DDerived::length` | `derived` |
 | `Arc2DEndpoint::start_point/end_point` | `endpoint` |
 | `Arc3DEndpoint::start_point/end_point` | `endpoint` |
 | `Arc2DEvaluation::point_at_parameter` | `evaluation` |
@@ -491,8 +499,8 @@ EllipseArc も Arc と同系統だが、`bounding_box` と tolerance 付き cont
 | `EllipseArc2DConstructor` / `EllipseArc3DConstructor` | `definition` |
 | `EllipseArc2DProperties::center/semi_major_axis/semi_minor_axis/start_angle/end_angle/rotation/sweep_angle/eccentricity` | `definition` |
 | `EllipseArc3DProperties::center/semi_major_axis/semi_minor_axis/start_angle/end_angle/normal/sweep_angle/eccentricity` | `definition` |
-| `EllipseArc2DDerived::measure/bounding_box` | `derived` |
-| `EllipseArc3DDerived::measure/bounding_box` | `derived` |
+| `EllipseArc2DDerived::length/bounding_box` | `derived` |
+| `EllipseArc3DDerived::length/bounding_box` | `derived` |
 | `EllipseArc2DEndpoint::start_point/end_point` | `endpoint` |
 | `EllipseArc3DEndpoint::start_point/end_point` | `endpoint` |
 | `EllipseArc2DEvaluation::point_at_parameter/point_at_angle` | `evaluation` |
@@ -514,10 +522,10 @@ EllipseArc も Arc と同系統だが、`bounding_box` と tolerance 付き cont
 ### Ellipse の再分類
 
 Ellipse は閉曲線 shape であり、Circle と同様に endpoint capability は持たない。
-一方で、現行 API は `perimeter` と `measure` を併存させており、閉曲線の主語彙が曖昧である。
+一方で、現行 core API 自体は `circumference` を主語彙としているが、旧補助層や一部 downstream テストには `perimeter` / `length` 由来の語彙が残っている。
 
 本整理では、Ellipse の周回長語彙は `length` へ寄せず、閉曲線 family の primary vocabulary として `circumference` を採用する。
-`perimeter` は既存 API との互換語彙、`measure` は集約互換 API として後退させる。
+`perimeter` や `length` は旧補助層の互換語彙としてのみ扱い、core / derived の正本語彙は `circumference` に揃える。
 
 | 現行 trait / API | 再分類 |
 | --- | --- |
@@ -660,24 +668,24 @@ Circle は閉曲線であり、parameter evaluation を持っても endpoint cap
 | `Circle2DConstructor` / `Circle3DConstructor` | `definition` |
 | `Circle2DProperties::center/radius/ref_direction/diameter/dimension/is_unit_circle/is_centered_at_origin/is_degenerate` | `definition` |
 | `Circle3DProperties::center/radius/axis/ref_direction/dimension/is_unit_circle/is_centered_at_origin/is_degenerate/is_on_xy_plane` | `definition` |
-| `Circle2DMeasure::circumference` | `derived` |
-| `Circle3DMeasure::circumference` | `derived` |
-| `Circle2DMeasure::area` | `derived` |
-| `Circle3DMeasure::area` | `derived` |
-| `Circle2DMeasure::point_at_parameter` | `evaluation` |
-| `Circle3DMeasure::point_at_parameter` | `evaluation` |
-| `Circle2DMeasure::contains_point/point_on_circumference` | `containment` |
-| `Circle3DMeasure::contains_point/point_on_circumference` | `containment` |
-| `Circle2DMeasure::distance_to_point` | `distance` |
-| `Circle3DMeasure::distance_to_point` | `distance` |
-| `Circle2DMeasure::closest_point_to` | `projection` |
-| `Circle3DMeasure::closest_point_to` | `projection` |
+| `Circle2DDerived::circumference/area` | `derived` |
+| `Circle3DDerived::circumference/area` | `derived` |
+| `Circle2DEvaluation::point_at_parameter` | `evaluation` |
+| `Circle3DEvaluation::point_at_parameter` | `evaluation` |
+| `Circle2DContainment::contains_point/point_on_circumference` | `containment` |
+| `Circle3DContainment::contains_point/point_on_circumference` | `containment` |
+| `Circle2DDistance::distance_to_point` | `distance` |
+| `Circle3DDistance::distance_to_point` | `distance` |
+| `Circle2DProjection::closest_point_to` | `projection` |
+| `Circle3DProjection::closest_point_to` | `projection` |
 | `Circle2DCore` / `Circle3DCore` | `Constructor + Properties` へ縮退候補 |
 
 補足:
 
 - `area` は閉曲線そのものの評価というより、その interior を伴う派生量として扱う
 - `ref_direction` は parameter 原点の便宜的基準として使えても、endpoint capability の根拠には使わない
+- `Circle` / `Ellipse` の `point_at_parameter` はともに局所角度 parameter を使う
+- closed curve family では `point_at_parameter` を angle domain に揃え、必要なら正規化 phase は別 API で表す
 - 実装進捗として `Circle2DMeasure` / `Circle3DMeasure` は削除済みで、capability trait のみを export する
 - 実装進捗として `Ellipse2DMeasure` / `Ellipse3DMeasure` も削除済みで、派生量・評価・包含・距離を個別 trait で公開する
 
@@ -688,22 +696,17 @@ Triangle は面 shape であり、curve endpoint や curve parameter capability 
 | 現行 trait / API | 再分類 |
 | --- | --- |
 | `Triangle2DConstructor` / `Triangle3DConstructor` | `definition` |
-| `Triangle2DProperties::vertex_a/vertex_b/vertex_c` | `definition` |
-| `Triangle3DProperties::vertex_a/vertex_b/vertex_c` | `definition` |
-| `Triangle2DProperties::centroid/circumcenter/incenter/circumradius/inradius` | `derived` |
-| `Triangle3DProperties::centroid/normal/circumcenter/circumradius/inradius` | `derived` |
-| `Triangle2DDerived::measure` | `derived` |
-| `Triangle3DDerived::measure` | `derived` |
-| `Triangle2DDerived::edge_ab_length/edge_bc_length/edge_ca_length` | `derived` |
-| `Triangle3DDerived::edge_ab_length/edge_bc_length/edge_ca_length` | `derived` |
-| `Triangle2DDerived::perimeter` | `derived` |
-| `Triangle3DDerived::perimeter` | `derived` |
+| `Triangle2DBoundaryAccess::vertex_a/vertex_b/vertex_c` | `boundary-access` |
+| `Triangle3DBoundaryAccess::vertex_a/vertex_b/vertex_c` | `boundary-access` |
+| `Triangle2DProperties` / `Triangle3DProperties` | 互換 alias |
+| `Triangle2DDerived::centroid/circumcenter/incenter/circumradius/inradius/area/is_clockwise` | `derived` |
+| `Triangle3DDerived::centroid/normal/circumcenter/circumradius/inradius/area/is_planar` | `derived` |
+| `Triangle2DBoundaryQuantity::edge_ab_length/edge_bc_length/edge_ca_length/perimeter` | `boundary-quantity` |
+| `Triangle3DBoundaryQuantity::edge_ab_length/edge_bc_length/edge_ca_length/perimeter` | `boundary-quantity` |
 | `Triangle2DContainment::contains_point` | `containment` |
 | `Triangle3DContainment::contains_point` | `containment` |
 | `Triangle2DDistance::distance_to_point` | `distance` |
 | `Triangle3DDistance::distance_to_point` | `distance` |
-| `Triangle2DDerived::is_clockwise` | `derived` |
-| `Triangle3DDerived::is_planar` | `derived` |
 | `Triangle2DCore` / `Triangle3DCore` | `Constructor + Properties` へ縮退候補 |
 
 補足:
@@ -986,6 +989,7 @@ Triangle は面 shape であり、curve endpoint や curve parameter capability 
 
 - `ref_direction` / `rotation` は parameter 原点の基準に限定する
 - `point_at_parameter` は evaluation に置く
+- periodic parameter の具体的な規約は Circle / Ellipse とも local angle semantics に統一する
 - `circumference` / `area` は derived に置く
 - endpoint 語彙は追加しない
 

--- a/model/geo_contracts/src/geometry/core/arc_traits.rs
+++ b/model/geo_contracts/src/geometry/core/arc_traits.rs
@@ -95,12 +95,13 @@ pub trait Arc2DEndpoint<T: Scalar> {
 }
 
 pub trait Arc2DEvaluation<T: Scalar> {
-    /// 正規化 parameter `t` (`0 <= t <= 1`) に対応する ideal evaluation point を取得
+    /// Arc trim-local parameter `t` (`0 <= t <= 1`) に対応する ideal evaluation point を取得
     ///
     /// `t=0/1` は Arc のトリム区間の両端を指すが、拘束端点補間を意味しない。
+    /// 評価時には母円の local angle parameter へ線形写像される。
     fn point_at_parameter(&self, t: T) -> (T, T);
 
-    /// Primitive 局所角度系の角度で ideal evaluation point を取得
+    /// 母円の native angle parameter を直接指定して ideal evaluation point を取得
     ///
     /// 角度範囲内かどうかの判定は `contains_angle` 側の責務とし、この API は角度指定評価を表す。
     fn point_at_angle(&self, angle: T) -> (T, T);
@@ -131,12 +132,13 @@ pub trait Arc3DEndpoint<T: Scalar> {
 }
 
 pub trait Arc3DEvaluation<T: Scalar> {
-    /// 正規化 parameter `t` (`0 <= t <= 1`) に対応する ideal evaluation point を取得
+    /// Arc trim-local parameter `t` (`0 <= t <= 1`) に対応する ideal evaluation point を取得
     ///
     /// `t=0/1` は Arc のトリム区間の両端を指すが、拘束端点補間を意味しない。
+    /// 評価時には母円の local angle parameter へ線形写像される。
     fn point_at_parameter(&self, t: T) -> (T, T, T);
 
-    /// Primitive 局所角度系の角度で ideal evaluation point を取得
+    /// 母円の native angle parameter を直接指定して ideal evaluation point を取得
     fn point_at_angle(&self, angle: T) -> (T, T, T);
 }
 

--- a/model/geo_contracts/src/geometry/core/circle_traits.rs
+++ b/model/geo_contracts/src/geometry/core/circle_traits.rs
@@ -90,11 +90,15 @@ pub trait Circle3DProperties<T: Scalar> {
 }
 
 pub trait Circle2DDerived<T: Scalar> {
+    /// 閉曲線 shape の primary quantity としての周回長を返す
     fn circumference(&self) -> T;
+
+    /// 円が張る interior を含めた派生量を返す
     fn area(&self) -> T;
 }
 
 pub trait Circle2DEvaluation<T: Scalar> {
+    /// Primitive 局所座標系の local angle parameter `t` (`0 <= t <= 2π`) に対応する円周上の点を返す
     fn point_at_parameter(&self, t: T) -> (T, T);
 }
 
@@ -112,11 +116,15 @@ pub trait Circle2DProjection<T: Scalar> {
 }
 
 pub trait Circle3DDerived<T: Scalar> {
+    /// 閉曲線 shape の primary quantity としての周回長を返す
     fn circumference(&self) -> T;
+
+    /// 円が張る interior を含めた派生量を返す
     fn area(&self) -> T;
 }
 
 pub trait Circle3DEvaluation<T: Scalar> {
+    /// Primitive 局所座標系の local angle parameter `t` (`0 <= t <= 2π`) に対応する円周上の点を返す
     fn point_at_parameter(&self, t: T) -> (T, T, T);
 }
 

--- a/model/geo_contracts/src/geometry/core/direction_traits.rs
+++ b/model/geo_contracts/src/geometry/core/direction_traits.rs
@@ -1,7 +1,7 @@
 //! Direction Core Traits - Direction形状の3つのCore機能統合
 //!
 //! Foundation ハイブリッド実装方針に基づく
-//! Core機能（Constructor/Properties/Measure）を形状別に統合
+//! Core機能（Constructor/Properties）を統合し、relation 系 capability は分離する
 //! Transform機能は共通のAnalysisTransformトレイトを使用
 
 use analysis::abstract_types::Scalar;

--- a/model/geo_contracts/src/geometry/core/ellipse_arc_traits.rs
+++ b/model/geo_contracts/src/geometry/core/ellipse_arc_traits.rs
@@ -185,12 +185,13 @@ pub trait EllipseArc2DEndpoint<T: Scalar> {
 }
 
 pub trait EllipseArc2DEvaluation<T: Scalar> {
-    /// 正規化 parameter `t` (`0 <= t <= 1`) に対応する ideal evaluation point を取得
+    /// EllipseArc trim-local parameter `t` (`0 <= t <= 1`) に対応する ideal evaluation point を取得
     ///
     /// `t=0/1` は EllipseArc のトリム区間の両端を指すが、拘束端点補間を意味しない。
+    /// 評価時には母楕円の local angle parameter へ線形写像される。
     fn point_at_parameter(&self, t: T) -> (T, T);
 
-    /// Primitive 局所角度系の角度で ideal evaluation point を取得
+    /// 母楕円の native angle parameter を直接指定して ideal evaluation point を取得
     fn point_at_angle(&self, angle: T) -> (T, T);
 }
 
@@ -222,12 +223,13 @@ pub trait EllipseArc3DEndpoint<T: Scalar> {
 }
 
 pub trait EllipseArc3DEvaluation<T: Scalar> {
-    /// 正規化 parameter `t` (`0 <= t <= 1`) に対応する ideal evaluation point を取得
+    /// EllipseArc trim-local parameter `t` (`0 <= t <= 1`) に対応する ideal evaluation point を取得
     ///
     /// `t=0/1` は EllipseArc のトリム区間の両端を指すが、拘束端点補間を意味しない。
+    /// 評価時には母楕円の local angle parameter へ線形写像される。
     fn point_at_parameter(&self, t: T) -> (T, T, T);
 
-    /// Primitive 局所角度系の角度で ideal evaluation point を取得
+    /// 母楕円の native angle parameter を直接指定して ideal evaluation point を取得
     fn point_at_angle(&self, angle: T) -> (T, T, T);
 }
 

--- a/model/geo_contracts/src/geometry/core/ellipse_traits.rs
+++ b/model/geo_contracts/src/geometry/core/ellipse_traits.rs
@@ -42,10 +42,10 @@ pub trait Ellipse2DProperties<T: Scalar> {
 
 /// Ellipse2D の派生量
 pub trait Ellipse2DDerived<T: Scalar> {
-    /// 面積を返す
+    /// 楕円が張る interior を含めた派生量を返す
     fn area(&self) -> T;
 
-    /// 閉曲線の主語彙としての周回長を返す
+    /// 閉曲線 shape の primary quantity としての周回長を返す
     fn circumference(&self) -> T;
 
     /// 離心率を返す
@@ -69,6 +69,7 @@ pub trait Ellipse2DDerived<T: Scalar> {
 
 /// Ellipse2D の評価
 pub trait Ellipse2DEvaluation<T: Scalar> {
+    /// Primitive 局所座標系の周期 angle parameter `t` (`0 <= t < 2π`) に対応する evaluation point を返す
     fn point_at_parameter(&self, t: T) -> (T, T);
 }
 
@@ -165,10 +166,10 @@ pub trait Ellipse3DProperties<T: Scalar> {
 
 /// Ellipse3D の派生量
 pub trait Ellipse3DDerived<T: Scalar> {
-    /// 面積を返す
+    /// 楕円が張る interior を含めた派生量を返す
     fn area(&self) -> T;
 
-    /// 閉曲線の主語彙としての周回長を返す
+    /// 閉曲線 shape の primary quantity としての周回長を返す
     fn circumference(&self) -> T;
 
     /// 離心率を返す
@@ -183,6 +184,7 @@ pub trait Ellipse3DDerived<T: Scalar> {
 
 /// Ellipse3D の評価
 pub trait Ellipse3DEvaluation<T: Scalar> {
+    /// Primitive 局所座標系の周期 angle parameter `t` (`0 <= t < 2π`) に対応する evaluation point を返す
     fn point_at_parameter(&self, t: T) -> (T, T, T);
 }
 

--- a/model/geo_contracts/src/geometry/core/infinite_line_traits.rs
+++ b/model/geo_contracts/src/geometry/core/infinite_line_traits.rs
@@ -134,7 +134,10 @@ pub trait InfiniteLine3DProperties<T: Scalar> {
 }
 
 pub trait InfiniteLine2DEvaluation<T: Scalar> {
+    /// 基準点 `point()` を原点とし、正規化方向 `direction()` に沿う signed support parameter `t` の evaluation point を返す
     fn point_at_parameter(&self, t: T) -> (T, T);
+
+    /// 点を同じ signed support parameter 系へ写像する
     fn parameter_for_point(&self, point: (T, T)) -> T;
 }
 
@@ -167,7 +170,10 @@ pub trait InfiniteLine2DTransform<T: Scalar> {
 }
 
 pub trait InfiniteLine3DEvaluation<T: Scalar> {
+    /// 基準点 `point()` を原点とし、正規化方向 `direction()` に沿う signed support parameter `t` の evaluation point を返す
     fn point_at_parameter(&self, t: T) -> (T, T, T);
+
+    /// 点を同じ signed support parameter 系へ写像する
     fn parameter_for_point(&self, point: (T, T, T)) -> T;
 }
 

--- a/model/geo_contracts/src/geometry/core/linesegment_traits.rs
+++ b/model/geo_contracts/src/geometry/core/linesegment_traits.rs
@@ -148,7 +148,9 @@ pub trait LineSegment2DContainment<T: Scalar> {
 }
 
 pub trait LineSegment2DEvaluation<T: Scalar> {
-    /// 正規化パラメータt（0<=t<=1）で support line 上の評価点を取得
+    /// 正規化 parameter `t` (`0 <= t <= 1`) に対応する support line 上の evaluation point を取得
+    ///
+    /// `t=0/1` は bounded curve primitive の ideal start/end endpoint と整合する。
     fn point_at_parameter(&self, t: T) -> (T, T);
 }
 
@@ -176,7 +178,9 @@ pub trait LineSegment3DContainment<T: Scalar> {
 }
 
 pub trait LineSegment3DEvaluation<T: Scalar> {
-    /// 正規化パラメータt（0<=t<=1）で support line 上の評価点を取得
+    /// 正規化 parameter `t` (`0 <= t <= 1`) に対応する support line 上の evaluation point を取得
+    ///
+    /// `t=0/1` は bounded curve primitive の ideal start/end endpoint と整合する。
     fn point_at_parameter(&self, t: T) -> (T, T, T);
 }
 

--- a/model/geo_contracts/src/geometry/core/ray_traits.rs
+++ b/model/geo_contracts/src/geometry/core/ray_traits.rs
@@ -144,8 +144,15 @@ pub trait Ray3DProperties<T: Scalar> {
 }
 
 pub trait Ray2DEvaluation<T: Scalar> {
+    /// Ray origin を原点とし、正規化方向に沿う support parameter `t` の evaluation point を返す
+    ///
+    /// Ray の有効 domain は `t >= 0` だが、この API は support line evaluation を表し、clamp は行わない。
     fn point_at_parameter(&self, t: T) -> (T, T);
+
+    /// 点を同じ support parameter 系へ写像する
     fn parameter_for_point(&self, point: (T, T)) -> T;
+
+    /// 幾何学的距離を parameter に対応づけた evaluation point を返す
     fn point_at_distance(&self, distance: T) -> (T, T);
 }
 
@@ -174,8 +181,15 @@ pub trait Ray2DTransform<T: Scalar> {
 }
 
 pub trait Ray3DEvaluation<T: Scalar> {
+    /// Ray origin を原点とし、正規化方向に沿う support parameter `t` の evaluation point を返す
+    ///
+    /// Ray の有効 domain は `t >= 0` だが、この API は support line evaluation を表し、clamp は行わない。
     fn point_at_parameter(&self, t: T) -> (T, T, T);
+
+    /// 点を同じ support parameter 系へ写像する
     fn parameter_for_point(&self, point: (T, T, T)) -> T;
+
+    /// 幾何学的距離を parameter に対応づけた evaluation point を返す
     fn point_at_distance(&self, distance: T) -> (T, T, T);
 }
 

--- a/model/geo_contracts/src/geometry/core/triangle_traits.rs
+++ b/model/geo_contracts/src/geometry/core/triangle_traits.rs
@@ -1,7 +1,7 @@
 //! Triangle Core Traits - 三角形の基本機能トレイト
 //!
 //! Foundation Pattern Phase 1 + Phase 2 実装
-//! 3-5-4 パターン: Constructor(3+3) + Properties(5+3) + Measure(4+4)
+//! face boundary access / boundary quantity / derived capability を分離する
 
 use crate::Scalar;
 
@@ -40,7 +40,7 @@ pub trait Triangle2DBoundaryAccess<T: Scalar> {
     fn vertex_c(&self) -> (T, T);
 }
 
-/// Triangle2D の互換 Properties trait
+/// Triangle2D の互換 boundary access alias
 pub trait Triangle2DProperties<T: Scalar>: Triangle2DBoundaryAccess<T> {}
 
 pub trait Triangle2DDerived<T: Scalar> {
@@ -131,7 +131,7 @@ pub trait Triangle3DBoundaryAccess<T: Scalar> {
     fn vertex_c(&self) -> (T, T, T);
 }
 
-/// Triangle3D の互換 Properties trait
+/// Triangle3D の互換 boundary access alias
 pub trait Triangle3DProperties<T: Scalar>: Triangle3DBoundaryAccess<T> {}
 
 pub trait Triangle3DDerived<T: Scalar> {

--- a/model/geo_primitives/src/arc_2d_extensions.rs
+++ b/model/geo_primitives/src/arc_2d_extensions.rs
@@ -3,11 +3,26 @@
 //! Core Foundation パターンに基づく Arc2D の拡張機能
 //! 基本機能は arc_2d.rs を参照
 
-use crate::{arc_2d::Arc2D, Circle2D, Point2D};
+use crate::{arc_2d::Arc2D, Circle2D, Point2D, Vector2D};
 use geo_contracts::{default_angle_tolerance, default_distance_tolerance};
 use geo_contracts::{Angle, Scalar};
 
 impl<T: Scalar> Arc2D<T> {
+    /// Arc trim-local parameter `t` (`0 <= t <= 1`) で円弧上の点を計算
+    ///
+    /// 母円の local angle parameter へ線形写像して評価する。
+    pub fn point_at_parameter(&self, t: T) -> Point2D<T> {
+        let angle = self.start_angle().to_radians() + self.angular_span() * t;
+        self.point_at_angle(angle)
+    }
+
+    /// Primitive 局所角度系の角度で円弧上の点を計算する convenience API
+    pub fn point_at_angle(&self, angle: T) -> Point2D<T> {
+        let x = self.radius_internal() * angle.cos();
+        let y = self.radius_internal() * angle.sin();
+        self.center_internal() + Vector2D::new(x, y)
+    }
+
     /// 3点を通る円弧を作成
     ///
     /// # 引数

--- a/model/geo_primitives/src/arc_2d_tests.rs
+++ b/model/geo_primitives/src/arc_2d_tests.rs
@@ -171,6 +171,24 @@ mod tests {
     }
 
     #[test]
+    fn test_parameter_and_angle_apis_are_distinct_but_consistent() {
+        let center = Point2D::origin();
+        let arc = Arc2D::xy_arc(
+            center,
+            3.0_f64,
+            angle(0.0),
+            angle(std::f64::consts::PI / 2.0),
+        )
+        .unwrap();
+
+        let from_parameter = arc.point_at_parameter(0.5);
+        let from_angle = arc.point_at_angle(std::f64::consts::PI / 4.0);
+
+        assert!((from_parameter.x() - from_angle.x()).abs() < 1e-10);
+        assert!((from_parameter.y() - from_angle.y()).abs() < 1e-10);
+    }
+
+    #[test]
     fn test_angle_containment() {
         let center = Point2D::origin();
         let arc = Arc2D::xy_arc(center, 2.0_f64, angle(0.0), angle(std::f64::consts::PI)).unwrap();

--- a/model/geo_primitives/src/arc_3d_extensions.rs
+++ b/model/geo_primitives/src/arc_3d_extensions.rs
@@ -76,14 +76,15 @@ impl<T: Scalar> Arc3D<T> {
             || self.angle_span().to_radians() <= default_angle_tolerance::<T>()
     }
 
-    /// パラメータ t での円弧上の点を計算
-    /// t ∈ [0, 1] で正規化
+    /// Arc trim-local parameter `t` (`0 <= t <= 1`) で円弧上の点を計算
+    ///
+    /// 母円の local angle parameter へ線形写像して評価する。
     pub fn point_at_parameter(&self, t: T) -> Point3D<T> {
         let angle = self.start_angle().to_radians() + self.angle_span().to_radians() * t;
         self.point_at_angle(angle)
     }
 
-    /// 角度 θ での円弧上の点を計算
+    /// Primitive 局所角度系の角度で円弧上の点を計算する convenience API
     pub fn point_at_angle(&self, angle: T) -> Point3D<T> {
         let cos_angle = angle.cos();
         let sin_angle = angle.sin();
@@ -113,7 +114,7 @@ impl<T: Scalar> Arc3D<T> {
         self.point_at_angle(self.end_angle().to_radians())
     }
 
-    /// パラメータ範囲を取得
+    /// Arc trim-local parameter の有効範囲 `[0, 1]` を返す
     pub fn parameter_range(&self) -> (T, T) {
         (T::ZERO, T::ONE)
     }

--- a/model/geo_primitives/src/arc_3d_tests.rs
+++ b/model/geo_primitives/src/arc_3d_tests.rs
@@ -179,6 +179,25 @@ mod tests {
     }
 
     #[test]
+    fn test_parameter_and_angle_apis_are_distinct_but_consistent() {
+        let center = Point3D::origin();
+        let arc = Arc3D::xy_arc(
+            center,
+            3.0_f64,
+            angle(0.0),
+            angle(std::f64::consts::PI / 2.0),
+        )
+        .unwrap();
+
+        let from_parameter = arc.point_at_parameter(0.5);
+        let from_angle = arc.point_at_angle(std::f64::consts::PI / 4.0);
+
+        assert!((from_parameter.x() - from_angle.x()).abs() < 1e-10);
+        assert!((from_parameter.y() - from_angle.y()).abs() < 1e-10);
+        assert!((from_parameter.z() - from_angle.z()).abs() < 1e-10);
+    }
+
+    #[test]
     fn test_angle_containment() {
         let center = Point3D::origin();
         let arc = Arc3D::xy_arc(center, 2.0_f64, angle(0.0), angle(std::f64::consts::PI)).unwrap();

--- a/model/geo_primitives/src/circle_2d.rs
+++ b/model/geo_primitives/src/circle_2d.rs
@@ -97,12 +97,13 @@ impl<T: Scalar> Circle2D<T> {
         distance_squared < self.radius * self.radius
     }
 
-    /// パラメータでの点を取得
+    /// Primitive 局所座標系の local angle parameter `t` (`0 <= t <= 2π`) で円周上の点を取得
+    ///
+    /// `point_at_angle` と同じ local angle domain を使う core evaluation 入口として扱う。
     pub fn point_at_parameter(&self, t: T) -> Point2D<T> {
-        let angle = T::TAU * t;
         Point2D::new(
-            self.center.x() + self.radius * angle.cos(),
-            self.center.y() + self.radius * angle.sin(),
+            self.center.x() + self.radius * t.cos(),
+            self.center.y() + self.radius * t.sin(),
         )
     }
 
@@ -138,7 +139,7 @@ impl<T: Scalar> Circle2D<T> {
         }
     }
 
-    /// 点における円のパラメータを取得
+    /// 円周上の点を Circle core の local angle parameter (`0 <= t < 2π`) へ写像する
     pub fn parameter_at_point(&self, point: Point2D<T>) -> Option<T> {
         if !self.point_on_circumference(point) {
             return None;
@@ -148,12 +149,12 @@ impl<T: Scalar> Circle2D<T> {
         let dy = point.y() - self.center.y();
         let angle = dy.atan2(dx);
 
-        // 0-1の範囲に正規化
+        // 0-2π の local angle parameter に正規化
         let parameter = if angle < T::ZERO {
             angle + T::TAU
         } else {
             angle
-        } / T::TAU;
+        };
 
         Some(parameter)
     }

--- a/model/geo_primitives/src/circle_2d_extensions.rs
+++ b/model/geo_primitives/src/circle_2d_extensions.rs
@@ -46,7 +46,9 @@ impl<T: Scalar> Circle2D<T> {
         Self::new(Point2D::new(T::ZERO, T::ZERO), T::ONE).unwrap()
     }
 
-    /// 指定角度での点を取得（ラジアン）
+    /// 指定角度での点を取得する convenience API（ラジアン）
+    ///
+    /// `point_at_parameter` と同じ local angle domain を直接渡したい場合に使う。
     pub fn point_at_angle(&self, angle: T) -> Point2D<T> {
         let cos_a = angle.cos();
         let sin_a = angle.sin();

--- a/model/geo_primitives/src/circle_2d_tests.rs
+++ b/model/geo_primitives/src/circle_2d_tests.rs
@@ -110,23 +110,24 @@ fn test_point_at_angle() {
 fn test_point_at_parameter() {
     let circle = Circle2D::new(Point2D::new(0.0f64, 0.0f64), 1.0f64).unwrap();
 
+    // Circle core parameter は local angle domain (0..=2π)
     // t=0（開始点）
     let p0 = circle.point_at_parameter(0.0);
     assert!((p0.x() - 1.0f64).abs() < 1e-10);
     assert!((p0.y() - 0.0f64).abs() < 1e-10);
 
-    // t=0.25（90度）
-    let p25 = circle.point_at_parameter(0.25);
+    // t=π/2（90度）
+    let p25 = circle.point_at_parameter(PI / 2.0);
     assert!((p25.x() - 0.0f64).abs() < 1e-10);
     assert!((p25.y() - 1.0f64).abs() < 1e-10);
 
-    // t=0.5（180度）
-    let p50 = circle.point_at_parameter(0.5);
+    // t=π（180度）
+    let p50 = circle.point_at_parameter(PI);
     assert!((p50.x() - (-1.0f64)).abs() < 1e-10);
     assert!((p50.y() - 0.0f64).abs() < 1e-10);
 
-    // t=1.0（360度、開始点と同じ）
-    let p100 = circle.point_at_parameter(1.0);
+    // t=2π（360度、開始点と同じ）
+    let p100 = circle.point_at_parameter(TAU);
     assert!((p100.x() - 1.0f64).abs() < 1e-10);
     assert!((p100.y() - 0.0f64).abs() < 1e-10);
 }
@@ -141,8 +142,8 @@ fn test_tangent_at_parameter() {
     assert!((t0.x() - 0.0f64).abs() < 1e-10);
     assert!((t0.y() - 1.0f64).abs() < 1e-10);
 
-    // t=0.25での接線（左方向）
-    let t25 = circle.tangent_at_parameter(0.25);
+    // t=π/2での接線（左方向）
+    let t25 = circle.tangent_at_parameter(PI / 2.0);
     assert!((t25.x() - (-1.0f64)).abs() < 1e-10);
     assert!((t25.y() - 0.0f64).abs() < 1e-10);
 
@@ -279,17 +280,17 @@ fn test_geometry_foundation() {
 fn test_basic_metrics() {
     let circle = Circle2D::new(Point2D::new(0.0, 0.0), 2.0).unwrap();
 
-    // 長さ（円周）
-    let length = circle.circumference();
-    assert!((length - TAU * 2.0).abs() < 1e-10);
+    // 閉曲線の主語彙は circumference
+    let circumference = circle.circumference();
+    assert!((circumference - TAU * 2.0).abs() < 1e-10);
 
     // 面積
     let area = circle.area();
     assert!((area - PI * 4.0).abs() < 1e-10);
 
-    // 周長（円周と同じ）
-    let perimeter = circle.circumference();
-    assert!((perimeter - TAU * 2.0).abs() < 1e-10);
+    // perimeter は導入せず、closed curve は circumference で読む
+    let circumference_again = circle.circumference();
+    assert!((circumference_again - TAU * 2.0).abs() < 1e-10);
 }
 
 /// Foundation trait - BasicContainmentテスト
@@ -322,15 +323,15 @@ fn test_basic_containment() {
 fn test_basic_parametric() {
     let circle = Circle2D::new(Point2D::new(0.0f64, 0.0f64), 1.0f64).unwrap();
 
-    // パラメータ範囲 (旧仕様: 0-1正規化)
+    // この層でも Circle core の local angle parameter (0..=2π) を使う
     let (start, end) = circle.parameter_range();
     assert_eq!(start, 0.0);
-    assert_eq!(end, 1.0);
+    assert_eq!(end, TAU);
 
-    // パラメータでの点取得 (0-1正規化、内部でTAU倍)
-    let p0 = circle.point_at_parameter(0.0); // 0 * TAU = 0°
-    let p25 = circle.point_at_parameter(0.25); // 0.25 * TAU = 90°
-    let p50 = circle.point_at_parameter(0.5); // 0.5 * TAU = 180°
+    // local angle parameter での点取得
+    let p0 = circle.point_at_parameter(0.0);
+    let p25 = circle.point_at_parameter(PI / 2.0);
+    let p50 = circle.point_at_parameter(PI);
 
     assert!((p0.x() - 1.0f64).abs() < 1e-10);
     assert!((p25.y() - 1.0f64).abs() < 1e-10);
@@ -338,7 +339,7 @@ fn test_basic_parametric() {
 
     // 接線ベクトル取得
     let t0 = circle.tangent_at_parameter(0.0);
-    let t25 = circle.tangent_at_parameter(0.25);
+    let t25 = circle.tangent_at_parameter(PI / 2.0);
 
     assert!((t0.length() - 1.0f64).abs() < 1e-10);
     assert!((t25.length() - 1.0f64).abs() < 1e-10);
@@ -451,12 +452,12 @@ mod hierarchy_foundation_tests {
 
         // BasicMeasurement trait経由での計量
         let area = BasicMeasurement::area(&circle).expect("Circle area should be Some");
-        let perimeter =
+        let legacy_perimeter =
             BasicMeasurement::perimeter(&circle).expect("Circle perimeter should be Some");
 
         // 数学的正確性確認
         assert!((area - (PI * 9.0)).abs() < 1e-10); // π * r²
-        assert!((perimeter - (TAU * 3.0)).abs() < 1e-10); // 2π * r
+        assert!((legacy_perimeter - (TAU * 3.0)).abs() < 1e-10); // 互換 helper 上の perimeter
 
         // length は円では定義されない
         assert!(circle.length().is_none());
@@ -486,7 +487,7 @@ mod hierarchy_foundation_tests {
     fn test_basic_parametric_level() {
         let circle = Circle2D::new(Point2D::new(1.0, 2.0), 3.0).unwrap();
 
-        // NewBasicParametric trait経由でのパラメトリック操作
+        // 互換 helper の NewBasicParametric は local angle domain (0..TAU) を使う
         let point_0 = NewBasicParametric::point_at_parameter(&circle, 0.0);
         let point_pi_2 = NewBasicParametric::point_at_parameter(&circle, PI / 2.0);
         let point_pi = NewBasicParametric::point_at_parameter(&circle, PI);
@@ -506,7 +507,7 @@ mod hierarchy_foundation_tests {
         assert!((tangent_0.x() - 0.0).abs() < 1e-10); // -3*sin(0) = 0
         assert!((tangent_0.y() - 3.0).abs() < 1e-10); // 3*cos(0) = 3
 
-        // パラメータ範囲
+        // helper 側の parameter_range も local angle domain を返す
         let (min_t, max_t) = NewBasicParametric::parameter_range(&circle);
         assert_eq!(min_t, 0.0);
         assert_eq!(max_t, TAU);

--- a/model/geo_primitives/src/circle_3d.rs
+++ b/model/geo_primitives/src/circle_3d.rs
@@ -481,10 +481,14 @@ impl<T: Scalar> Circle3DProjection<T> for Circle3D<T> {
 }
 
 impl<T: Scalar> Circle3DEvaluation<T> for Circle3D<T> {
+    /// Primitive 局所座標系の local angle parameter `t` (`0 <= t <= 2π`) で円周上の点を計算する
+    ///
+    /// `point_at_angle` と同じ local angle domain を使う core evaluation 入口として扱う。
+    ///
+    /// `t = 2π` は周期端として `t = 0` と同じ幾何点へ戻る。
     fn point_at_parameter(&self, t: T) -> (T, T, T) {
-        let angle = t * T::TAU;
-        let cos_angle = angle.cos();
-        let sin_angle = angle.sin();
+        let cos_angle = t.cos();
+        let sin_angle = t.sin();
 
         // 円周上の点を計算
         let v_axis = self.axis.as_vector();

--- a/model/geo_primitives/src/circle_3d_extensions.rs
+++ b/model/geo_primitives/src/circle_3d_extensions.rs
@@ -4,7 +4,7 @@
 
 use crate::{Circle3D, Direction3D, Point3D, Vector3D};
 use geo_contracts::default_distance_tolerance;
-use geo_contracts::Scalar;
+use geo_contracts::{Circle3DEvaluation, Scalar};
 
 impl<T: Scalar> Circle3D<T> {
     /// 円平面のU軸（基準軸）を取得
@@ -25,33 +25,18 @@ impl<T: Scalar> Circle3D<T> {
         Direction3D::from_vector(v).unwrap()
     }
 
-    /// 円上の点を角度から取得
+    /// 円上の点を角度から取得する convenience API
     ///
     /// # 引数
     /// * `angle` - 角度（ラジアン）
     ///
     /// # 戻り値
     /// 円上の点（円の平面内での極座標から3D座標に変換）
+    ///
+    /// `point_at_parameter` と同じ local angle domain を直接渡したい場合に使う。
     pub fn point_at_angle(&self, angle: T) -> Point3D<T> {
-        // 円の平面内での基準ベクトルを計算
-        // 法線ベクトルに垂直な2つのベクトルを求める
-        let (u, v) = self.get_plane_basis();
-
-        let x = angle.cos();
-        let y = angle.sin();
-
-        // 円上の点 = 中心 + radius * (x * u + y * v)
-        let offset = Vector3D::new(
-            self.radius_internal() * (x * u.x() + y * v.x()),
-            self.radius_internal() * (x * u.y() + y * v.y()),
-            self.radius_internal() * (x * u.z() + y * v.z()),
-        );
-
-        Point3D::new(
-            self.center_internal().x() + offset.x(),
-            self.center_internal().y() + offset.y(),
-            self.center_internal().z() + offset.z(),
-        )
+        let (x, y, z) = <Circle3D<T> as Circle3DEvaluation<T>>::point_at_parameter(self, angle);
+        Point3D::new(x, y, z)
     }
 
     /// 円の平面における基準ベクトル（u, v）を取得
@@ -194,24 +179,36 @@ impl<T: Scalar> Circle3D<T> {
         (normal, d)
     }
 
-    /// 指定角度での接線ベクトルを取得
+    /// 指定 local angle parameter での接線ベクトルを取得する core API
     ///
     /// # 引数
     /// * `angle` - 角度（ラジアン）
     ///
     /// # 戻り値
     /// 指定角度での接線方向ベクトル（正規化済み）
-    pub fn tangent_at_angle(&self, angle: T) -> Direction3D<T> {
-        let (u, v) = self.get_plane_basis();
+    ///
+    /// `point_at_parameter` / `point_at_angle` と同じ local angle domain を前提とする。
+    pub fn tangent_at_parameter(&self, t: T) -> Direction3D<T> {
+        let v_axis = self.axis_internal().as_vector();
+        let v_ref = self.ref_direction_internal().as_vector();
+        let v_perp = v_axis.cross(&v_ref);
 
-        // 接線ベクトル = -sin(θ) * u + cos(θ) * v
-        let tangent = Vector3D::new(
-            -angle.sin() * u.x() + angle.cos() * v.x(),
-            -angle.sin() * u.y() + angle.cos() * v.y(),
-            -angle.sin() * u.z() + angle.cos() * v.z(),
-        );
+        let tangent = v_ref * (-t.sin()) + v_perp * t.cos();
 
         Direction3D::from_vector(tangent).unwrap()
+    }
+
+    /// 指定角度での接線ベクトルを取得する convenience API
+    ///
+    /// # 引数
+    /// * `angle` - 角度（ラジアン）
+    ///
+    /// # 戻り値
+    /// 指定角度での接線方向ベクトル（正規化済み）
+    ///
+    /// `tangent_at_parameter` と同じ local angle domain を直接渡したい場合に使う。
+    pub fn tangent_at_angle(&self, angle: T) -> Direction3D<T> {
+        self.tangent_at_parameter(angle)
     }
 
     /// 点から円への最近点を取得

--- a/model/geo_primitives/src/circle_3d_tests.rs
+++ b/model/geo_primitives/src/circle_3d_tests.rs
@@ -6,6 +6,7 @@
 mod tests {
     use crate::{Circle3D, Direction3D, Point3D, Vector3D};
     use geo_contracts::default_distance_tolerance;
+    use geo_contracts::Circle3DEvaluation;
 
     // テスト用のf64型別名
     type TestScalar = f64;
@@ -80,8 +81,10 @@ mod tests {
     fn test_point_at_angle() {
         let center = Point3D::new(0.0, 0.0, 0.0);
         let normal = Direction3D::from_vector(Vector3D::unit_z()).unwrap();
+        let ref_direction = Direction3D::from_vector(Vector3D::unit_x()).unwrap();
         let radius = 2.0;
-        let circle = Circle3D::new(center, normal, radius).unwrap();
+        let circle =
+            Circle3D::new_with_ref_direction(center, normal, ref_direction, radius).unwrap();
 
         // 角度0での点（X軸正方向）
         let point_0 = circle.point_at_angle(0.0);
@@ -94,6 +97,71 @@ mod tests {
         assert_approx_eq(point_90.x(), 0.0, 1e-10);
         assert_approx_eq(point_90.y(), 2.0, 1e-10);
         assert_approx_eq(point_90.z(), 0.0, 1e-10);
+
+        let point_90_from_parameter =
+            <Circle3D<f64> as Circle3DEvaluation<f64>>::point_at_parameter(
+                &circle,
+                std::f64::consts::PI / 2.0,
+            );
+        assert_approx_eq(point_90.x(), point_90_from_parameter.0, 1e-10);
+        assert_approx_eq(point_90.y(), point_90_from_parameter.1, 1e-10);
+        assert_approx_eq(point_90.z(), point_90_from_parameter.2, 1e-10);
+    }
+
+    #[test]
+    fn test_point_at_parameter_uses_local_angle_parameter() {
+        let center = Point3D::new(0.0, 0.0, 0.0);
+        let normal = Direction3D::from_vector(Vector3D::unit_z()).unwrap();
+        let ref_direction = Direction3D::from_vector(Vector3D::unit_x()).unwrap();
+        let radius = 2.0;
+        let circle =
+            Circle3D::new_with_ref_direction(center, normal, ref_direction, radius).unwrap();
+
+        let point_0 = <Circle3D<f64> as Circle3DEvaluation<f64>>::point_at_parameter(&circle, 0.0);
+        assert_approx_eq(point_0.0, 2.0, 1e-10);
+        assert_approx_eq(point_0.1, 0.0, 1e-10);
+        assert_approx_eq(point_0.2, 0.0, 1e-10);
+
+        let point_pi_2 = <Circle3D<f64> as Circle3DEvaluation<f64>>::point_at_parameter(
+            &circle,
+            std::f64::consts::PI / 2.0,
+        );
+        assert_approx_eq(point_pi_2.0, 0.0, 1e-10);
+        assert_approx_eq(point_pi_2.1, 2.0, 1e-10);
+        assert_approx_eq(point_pi_2.2, 0.0, 1e-10);
+
+        let point_tau = <Circle3D<f64> as Circle3DEvaluation<f64>>::point_at_parameter(
+            &circle,
+            std::f64::consts::TAU,
+        );
+        assert_approx_eq(point_tau.0, 2.0, 1e-10);
+        assert_approx_eq(point_tau.1, 0.0, 1e-10);
+        assert_approx_eq(point_tau.2, 0.0, 1e-10);
+    }
+
+    #[test]
+    fn test_tangent_at_angle_matches_parameter_semantics() {
+        let center = Point3D::new(0.0, 0.0, 0.0);
+        let normal = Direction3D::from_vector(Vector3D::unit_z()).unwrap();
+        let ref_direction = Direction3D::from_vector(Vector3D::unit_x()).unwrap();
+        let radius = 2.0;
+        let circle =
+            Circle3D::new_with_ref_direction(center, normal, ref_direction, radius).unwrap();
+
+        let tangent_0 = circle.tangent_at_parameter(0.0);
+        assert_approx_eq(tangent_0.x(), 0.0, 1e-10);
+        assert_approx_eq(tangent_0.y(), 1.0, 1e-10);
+        assert_approx_eq(tangent_0.z(), 0.0, 1e-10);
+
+        let tangent_pi_2 = circle.tangent_at_parameter(std::f64::consts::PI / 2.0);
+        assert_approx_eq(tangent_pi_2.x(), -1.0, 1e-10);
+        assert_approx_eq(tangent_pi_2.y(), 0.0, 1e-10);
+        assert_approx_eq(tangent_pi_2.z(), 0.0, 1e-10);
+
+        let tangent_angle = circle.tangent_at_angle(std::f64::consts::PI / 2.0);
+        assert_approx_eq(tangent_angle.x(), tangent_pi_2.x(), 1e-10);
+        assert_approx_eq(tangent_angle.y(), tangent_pi_2.y(), 1e-10);
+        assert_approx_eq(tangent_angle.z(), tangent_pi_2.z(), 1e-10);
     }
 
     #[test]

--- a/model/geo_primitives/src/ellipse_2d.rs
+++ b/model/geo_primitives/src/ellipse_2d.rs
@@ -198,7 +198,7 @@ impl<T: Scalar> Ellipse2D<T> {
         best_point
     }
 
-    /// パラメータ t での点を取得（0 <= t < 2π）
+    /// Primitive 局所座標系の angle parameter `t` (`0 <= t < 2π`) で楕円上の点を取得
     pub fn point_at_parameter(&self, t: T) -> Point2D<T> {
         let cos_t = t.cos();
         let sin_t = t.sin();
@@ -218,7 +218,7 @@ impl<T: Scalar> Ellipse2D<T> {
         Point2D::new(self.center.x() + x_rotated, self.center.y() + y_rotated)
     }
 
-    /// パラメータ t での接線ベクトルを取得
+    /// `point_at_parameter` と同じ local angle domain における接線ベクトルを取得
     pub fn tangent_at_parameter(&self, t: T) -> Vector2D<T> {
         let cos_t = t.cos();
         let sin_t = t.sin();
@@ -279,7 +279,7 @@ impl<T: Scalar> Ellipse2D<T> {
         distance <= tolerance
     }
 
-    /// パラメータ範囲を取得
+    /// local angle parameter の有効範囲 `[0, 2π]` を返す
     pub fn parameter_range(&self) -> (T, T) {
         (T::ZERO, T::TAU) // 0 から 2π
     }

--- a/model/geo_primitives/src/ellipse_2d_additional_tests.rs
+++ b/model/geo_primitives/src/ellipse_2d_additional_tests.rs
@@ -31,6 +31,7 @@ mod ellipse_2d_additional_tests {
         let center = Point2D::new(0.0, 0.0);
         let ellipse = Ellipse2D::new(center, 4.0, 2.0, 0.0).expect("楕円の作成に失敗");
 
+        // Ellipse core parameter は local angle domain (0..2π)
         // t=0での点（長軸の正の端）
         let point_0 = ellipse.point_at_parameter(0.0);
         assert!((point_0.x() - 4.0_f64).abs() < 1e-10);

--- a/model/geo_primitives/src/ellipse_2d_tests.rs
+++ b/model/geo_primitives/src/ellipse_2d_tests.rs
@@ -117,6 +117,7 @@ mod tests {
     fn test_point_at_parameter() {
         let ellipse = Ellipse2D::axis_aligned(Point2D::origin(), 4.0, 2.0).unwrap();
 
+        // Ellipse core parameter は local angle domain (0..2π)
         // 主軸上の点
         let point_0 = ellipse.point_at_parameter(0.0);
         assert!((point_0.x() - 4.0).abs() < 1e-10);
@@ -305,10 +306,10 @@ mod tests {
     fn test_basic_metrics() {
         let ellipse = Ellipse2D::axis_aligned(Point2D::origin(), 4.0, 3.0).unwrap();
 
-        // BasicMetrics
-        let length = ellipse.length().unwrap();
-        assert!(length > 0.0);
-        assert_eq!(length, ellipse.circumference());
+        // 互換 helper の length は closed curve の正本語彙 circumference へ委譲する
+        let legacy_length = ellipse.length().unwrap();
+        assert!(legacy_length > 0.0);
+        assert_eq!(legacy_length, ellipse.circumference());
     }
 
     #[test]
@@ -332,7 +333,7 @@ mod tests {
     fn test_basic_parametric() {
         let ellipse = Ellipse2D::axis_aligned(Point2D::origin(), 4.0, 2.0).unwrap();
 
-        // BasicParametric
+        // Ellipse の parameter_range / point_at_parameter は local angle domain を使う
         let (start, end) = ellipse.parameter_range();
         assert_eq!(start, 0.0);
         assert!((end - 2.0 * std::f64::consts::PI).abs() < 1e-10);

--- a/model/geo_primitives/src/ellipse_3d.rs
+++ b/model/geo_primitives/src/ellipse_3d.rs
@@ -182,8 +182,7 @@ impl<T: Scalar> Ellipse3D<T> {
             None
         }
     }
-    /// パラメータ t での楕円上の点を計算
-    /// t ∈ [0, 2π]
+    /// Primitive 局所座標系の angle parameter `t` (`0 <= t <= 2π`) で楕円上の点を計算
     pub fn point_at_parameter(&self, t: T) -> Point3D<T> {
         let cos_t = t.cos();
         let sin_t = t.sin();
@@ -199,8 +198,7 @@ impl<T: Scalar> Ellipse3D<T> {
         )
     }
 
-    /// パラメータ t での楕円の接線ベクトルを計算
-    /// t ∈ [0, 2π]
+    /// `point_at_parameter` と同じ local angle domain における接線ベクトルを計算
     pub fn tangent_at_parameter(&self, t: T) -> Vector3D<T> {
         let cos_t = t.cos();
         let sin_t = t.sin();
@@ -217,7 +215,7 @@ impl<T: Scalar> Ellipse3D<T> {
         self.point_at_parameter(angle.to_radians())
     }
 
-    /// パラメータ範囲を取得
+    /// local angle parameter の有効範囲 `[0, 2π]` を返す
     pub fn parameter_range(&self) -> (T, T) {
         (T::ZERO, T::TAU)
     }

--- a/model/geo_primitives/src/ellipse_arc_2d.rs
+++ b/model/geo_primitives/src/ellipse_arc_2d.rs
@@ -92,17 +92,31 @@ impl<T: Scalar> EllipseArc2D<T> {
         self.ellipse.point_at_parameter(self.end_angle.to_radians())
     }
 
-    /// パラメータ t での点を取得（0 <= t <= 1）
+    /// Arc trim-local parameter `t` (`0 <= t <= 1`) で楕円弧上の点を取得
+    ///
+    /// 基底楕円の local angle parameter へ線形写像して評価する。
     pub fn point_at_parameter(&self, t: T) -> Point2D<T> {
         let angle = self.start_angle.to_radians()
             + (self.end_angle.to_radians() - self.start_angle.to_radians()) * t;
         self.ellipse.point_at_parameter(angle)
     }
 
-    /// パラメータ t での接線ベクトルを取得
+    /// Primitive 局所角度系の角度で楕円弧上の点を取得する convenience API
+    pub fn point_at_angle(&self, angle: T) -> Point2D<T> {
+        self.ellipse.point_at_parameter(angle)
+    }
+
+    /// Arc trim-local parameter `t` (`0 <= t <= 1`) に対応する接線ベクトルを取得
+    ///
+    /// 基底楕円の local angle parameter へ線形写像して接線を評価する。
     pub fn tangent_at_parameter(&self, t: T) -> Vector2D<T> {
         let angle = self.start_angle.to_radians()
             + (self.end_angle.to_radians() - self.start_angle.to_radians()) * t;
+        self.ellipse.tangent_at_parameter(angle)
+    }
+
+    /// Primitive 局所角度系の角度で接線ベクトルを取得する convenience API
+    pub fn tangent_at_angle(&self, angle: T) -> Vector2D<T> {
         self.ellipse.tangent_at_parameter(angle)
     }
 
@@ -199,7 +213,7 @@ impl<T: Scalar> EllipseArc2D<T> {
         self.angle_in_range(angle.to_radians())
     }
 
-    /// パラメータ範囲を取得
+    /// EllipseArc trim-local parameter の有効範囲 `[0, 1]` を返す
     pub fn parameter_range(&self) -> (T, T) {
         (T::ZERO, T::ONE)
     }
@@ -497,5 +511,43 @@ impl<T: Scalar> EllipseArc2DContainment<T> for EllipseArc2D<T> {
 impl<T: Scalar> EllipseArc2DTrimRange<T> for EllipseArc2D<T> {
     fn contains_angle(&self, angle: T) -> bool {
         self.angle_in_range(angle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_ellipse_arc() -> EllipseArc2D<f64> {
+        let center = Point2D::new(2.0, 3.0);
+        let ellipse = Ellipse2D::new(center, 4.0, 2.0, 0.0).unwrap();
+
+        EllipseArc2D::new(ellipse, Angle::from_degrees(0.0), Angle::from_degrees(90.0))
+    }
+
+    #[test]
+    fn test_parameter_and_angle_apis_are_distinct_but_consistent() {
+        let ellipse_arc = create_test_ellipse_arc();
+
+        let point_from_parameter = ellipse_arc.point_at_parameter(0.5);
+        let point_from_angle = ellipse_arc.point_at_angle(std::f64::consts::PI / 4.0);
+
+        assert!((point_from_parameter.x() - point_from_angle.x()).abs() < 1e-10);
+        assert!((point_from_parameter.y() - point_from_angle.y()).abs() < 1e-10);
+
+        let tangent_from_parameter = ellipse_arc.tangent_at_parameter(0.5);
+        let tangent_from_angle = ellipse_arc.tangent_at_angle(std::f64::consts::PI / 4.0);
+
+        assert!((tangent_from_parameter.x() - tangent_from_angle.x()).abs() < 1e-10);
+        assert!((tangent_from_parameter.y() - tangent_from_angle.y()).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_parameter_range_is_trim_local_unit_interval() {
+        let ellipse_arc = create_test_ellipse_arc();
+        let range = ellipse_arc.parameter_range();
+
+        assert_eq!(range.0, 0.0);
+        assert_eq!(range.1, 1.0);
     }
 }

--- a/model/geo_primitives/src/ellipse_arc_3d.rs
+++ b/model/geo_primitives/src/ellipse_arc_3d.rs
@@ -102,12 +102,19 @@ impl<T: Scalar> EllipseArc3D<T> {
         self.ellipse.point_at_angle(self.end_angle)
     }
 
-    /// パラメータ値tにおける点を取得
+    /// Arc trim-local parameter `t` (`0 <= t <= 1`) で楕円弧上の点を取得
+    ///
+    /// 基底楕円の local angle parameter へ線形写像して評価する。
     pub fn point_at_parameter(&self, t: T) -> Point3D<T> {
         let angle_diff = self.end_angle.to_radians() - self.start_angle.to_radians();
         let current_angle = self.start_angle.to_radians() + t * angle_diff;
         self.ellipse
             .point_at_angle(Angle::from_radians(current_angle))
+    }
+
+    /// Primitive 局所角度系の角度で楕円弧上の点を取得する convenience API
+    pub fn point_at_angle(&self, angle: Angle<T>) -> Point3D<T> {
+        self.ellipse.point_at_angle(angle)
     }
 
     /// 弧の角度スパンを取得

--- a/model/geo_primitives/src/ellipse_arc_3d_extensions.rs
+++ b/model/geo_primitives/src/ellipse_arc_3d_extensions.rs
@@ -6,6 +6,20 @@ use crate::{Arc3D, Circle3D, Ellipse3D, EllipseArc3D, Point3D, Vector3D};
 use geo_contracts::{default_angle_tolerance, Angle, Scalar};
 
 impl<T: Scalar> EllipseArc3D<T> {
+    /// Arc trim-local parameter `t` (`0 <= t <= 1`) に対応する接線ベクトルを取得
+    ///
+    /// 基底楕円の local angle parameter へ線形写像して接線を評価する。
+    pub fn tangent_at_parameter(&self, t: T) -> Vector3D<T> {
+        let angle = self.start_angle().to_radians()
+            + (self.end_angle().to_radians() - self.start_angle().to_radians()) * t;
+        self.ellipse().tangent_at_parameter(angle)
+    }
+
+    /// Primitive 局所角度系の角度で接線ベクトルを取得する convenience API
+    pub fn tangent_at_angle(&self, angle: Angle<T>) -> Vector3D<T> {
+        self.ellipse().tangent_at_parameter(angle.to_radians())
+    }
+
     /// 楕円の一部分として3D楕円弧を作成（高度構築）
     pub fn from_ellipse_sector(
         center: Point3D<T>,
@@ -108,10 +122,7 @@ impl<T: Scalar> EllipseArc3D<T> {
 
     /// 楕円弧上の点での接線ベクトル（平面内）
     pub fn normal_at_parameter(&self, t: T) -> Vector3D<T> {
-        // 基底楕円から接線ベクトルを取得
-        let angle = self.start_angle().to_radians()
-            + (self.end_angle().to_radians() - self.start_angle().to_radians()) * t;
-        let tangent = self.ellipse().tangent_at_parameter(angle);
+        let tangent = self.tangent_at_parameter(t);
         let plane_normal = self.normal();
 
         // 平面内の法線：接線と平面法線の外積
@@ -120,9 +131,7 @@ impl<T: Scalar> EllipseArc3D<T> {
 
     /// 楕円弧上の点での双法線ベクトル
     pub fn binormal_at_parameter(&self, t: T) -> Vector3D<T> {
-        let angle = self.start_angle().to_radians()
-            + (self.end_angle().to_radians() - self.start_angle().to_radians()) * t;
-        let tangent = self.ellipse().tangent_at_parameter(angle);
+        let tangent = self.tangent_at_parameter(t);
         let normal = self.normal_at_parameter(t);
 
         // 双法線：接線と法線の外積
@@ -244,9 +253,7 @@ impl<T: Scalar> EllipseArc3D<T> {
             } else {
                 T::from_f64(i as f64) / T::from_f64((num_points - 1) as f64)
             };
-            let angle = self.start_angle().to_radians()
-                + (self.end_angle().to_radians() - self.start_angle().to_radians()) * t;
-            tangents.push(self.ellipse().tangent_at_parameter(angle));
+            tangents.push(self.tangent_at_parameter(t));
         }
 
         tangents

--- a/model/geo_primitives/src/ellipse_arc_3d_tests.rs
+++ b/model/geo_primitives/src/ellipse_arc_3d_tests.rs
@@ -88,6 +88,26 @@ mod tests {
     }
 
     #[test]
+    fn test_parameter_and_angle_apis_are_distinct_but_consistent() {
+        let ellipse_arc = create_test_ellipse_arc();
+
+        let mid_from_parameter = ellipse_arc.point_at_parameter(0.5);
+        let mid_angle = Angle::from_degrees(90.0);
+        let mid_from_angle = ellipse_arc.point_at_angle(mid_angle);
+
+        let tolerance = 1e-10_f64;
+        assert!((mid_from_parameter.x() - mid_from_angle.x()).abs() < tolerance);
+        assert!((mid_from_parameter.y() - mid_from_angle.y()).abs() < tolerance);
+        assert!((mid_from_parameter.z() - mid_from_angle.z()).abs() < tolerance);
+
+        let tangent_from_parameter = ellipse_arc.tangent_at_parameter(0.5);
+        let tangent_from_angle = ellipse_arc.tangent_at_angle(mid_angle);
+        assert!((tangent_from_parameter.x() - tangent_from_angle.x()).abs() < tolerance);
+        assert!((tangent_from_parameter.y() - tangent_from_angle.y()).abs() < tolerance);
+        assert!((tangent_from_parameter.z() - tangent_from_angle.z()).abs() < tolerance);
+    }
+
+    #[test]
     fn test_basic_transforms() {
         let ellipse_arc = create_test_ellipse_arc();
 

--- a/model/geo_topology/src/topology_core.rs
+++ b/model/geo_topology/src/topology_core.rs
@@ -101,6 +101,11 @@ impl<T: Scalar> CurveRef<T> {
         }
     }
 
+    /// 母曲線の native parameter semantics をそのまま使って評価点を返す
+    ///
+    /// topology 側では family 横断で parameter を再正規化しない。
+    /// 現在の variant では Line / Arc / EllipseArc のいずれも bounded curve として
+    /// ideal start/end と整合する parameter domain を使う。
     pub fn point_at_parameter(&self, t: T) -> Point3D<T> {
         match self {
             Self::Line(line) => line.line().point_at_parameter(t),
@@ -174,6 +179,7 @@ impl<T: Scalar> Edge<T> {
         &self.curve
     }
 
+    /// 母曲線 native parameter 空間における拘束区間 `[t0, t1]` を返す
     pub fn parameter_range(&self) -> (T, T) {
         self.parameter_range
     }
@@ -229,7 +235,9 @@ impl<T: Scalar> Edge<T> {
         self.oriented_curve_points(evaluated_start, evaluated_end)
     }
 
-    /// 曲線評価（0..1 のローカルパラメータ）
+    /// Edge 局所 parameter `local_t` (`0..=1`) を母曲線 parameter_range へ写像して評価する
+    ///
+    /// `same_sense=false` の場合は拘束向きに合わせて逆向きに写像する。
     pub fn point_at(&self, local_t: T) -> Option<Point3D<T>> {
         if local_t < T::ZERO || local_t > T::ONE {
             return None;


### PR DESCRIPTION
## Summary
- unify `point_at_parameter` semantics across closed curves and trimmed curves under the #558 family rules
- align Circle and Ellipse on local angle parameter semantics, and clarify Arc / EllipseArc as trim-local parameter plus mother-curve native angle convenience APIs
- sync related comments, topology semantics, contract trait docs, and regression tests around the same vocabulary

## Details
- Circle2D / Circle3D `point_at_parameter` now use local angle parameter semantics directly
- Circle3D convenience evaluation and tangent APIs delegate to the canonical parameter-based implementation
- Arc / EllipseArc expose the trim-local vs native-angle split explicitly in docs and helper APIs
- architecture docs now include a single source-of-truth section for #558 parameter semantics
- remaining wording was normalized to `local angle parameter`, `local angle domain`, and `trim-local parameter`

## Validation
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test -p geo_primitives`
- `cargo test`

Closes #558