### PR TITLE
refactor: re-export newton_solve_2d from analysis

### DIFF
--- a/foundation/analysis/src/lib.rs
+++ b/foundation/analysis/src/lib.rs
@@ -28,7 +28,7 @@ pub use consts::{
 
 // 数値計算関数の再エクスポート（numericsモジュールから）
 pub use crate::linalg::solver::newton::{
-    newton_inverse, newton_inverse_generic, newton_solve, newton_solve_bounded,
+    newton_inverse, newton_inverse_generic, newton_solve, newton_solve_2d, newton_solve_bounded,
     newton_solve_bounded_generic, newton_solve_generic,
     newton_solve_with_numeric_derivative_bounded,
     newton_solve_with_numeric_derivative_bounded_generic,


### PR DESCRIPTION
## 概要

- `analysis` crate root から `newton_solve_2d` を再エクスポートして、公開面の一貫性を揃える
- `linalg::solver::mod` では公開済みだったため、`lib.rs` 側の欠落のみを補う最小変更

## 検証

- cargo fmt
- cargo clippy -- -D warnings
- cargo test -p analysis

## 注記

- コード変更は `foundation/analysis/src/lib.rs` の再エクスポート 1 箇所のみ
- `newton_solve_2d` 自体の挙動変更は含まない