### PR TITLE
docs: clarify newton wrapper policy

### DIFF
--- a/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
+++ b/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
@@ -228,6 +228,15 @@
 - したがって現時点の `f64` ラッパーは「downstream 即時互換維持」のために残すが、workspace 内の正本利用経路ではない
 - 次段では deprecated 化そのものより、外部利用者向けの移行告知と `newton_solve_2d` の follow-up 分離判断を優先する
 
+### 互換ラッパー運用方針（2026年4月8日時点）
+
+- `newton_solve` / `newton_solve_bounded` / `newton_solve_with_numeric_derivative_bounded` / `newton_inverse` は、generic API 導入後も downstream 互換維持のため公開を継続する
+- ただし、workspace 内ではこれらを正本 API と見なさず、新規の production 呼び出しを増やさない
+- `foundation/analysis` 内では互換性を検証する最小限の wrapper テストだけを維持する
+- doctest、モジュール使用例、設計文書、今後の実装は generic API を基準に記述する
+- deprecated 化は即時には行わず、外部利用状況、保守コスト、移行告知手段が揃った段階で別判断とする
+- したがって当面の整理方針は「公開は維持」「内部の新規利用は抑止」「説明責務は generic API 側へ寄せる」の3点で固定する
+
 ### `newton_solve_2d` の扱い判断（2026年4月8日）
 
 - workspace 内監査では `newton_solve_2d` の利用は doctest と `foundation/analysis` 内テストに限定され、production 呼び出しは確認されなかった

--- a/foundation/analysis/src/lib.rs
+++ b/foundation/analysis/src/lib.rs
@@ -27,6 +27,7 @@ pub use consts::{
 };
 
 // 数値計算関数の再エクスポート（numericsモジュールから）
+// Newton solver は generic API を正本とし、f64 ラッパーは downstream 互換用に公開を維持する。
 pub use crate::linalg::solver::newton::{
     newton_inverse, newton_inverse_generic, newton_solve, newton_solve_2d, newton_solve_bounded,
     newton_solve_bounded_generic, newton_solve_generic,

--- a/foundation/analysis/src/linalg/solver/mod.rs
+++ b/foundation/analysis/src/linalg/solver/mod.rs
@@ -20,7 +20,8 @@ pub mod lu; // LU分解法
 pub mod newton; // ニュートン・ラフソン法
 
 // Newton法ソルバーの再エクスポート
-// generic API を正本とし、f64 API は互換入口として併存させる。
+// generic API を正本とし、f64 API は downstream 互換入口として併存させる。
+// workspace 内の新規実装では generic API を優先し、f64 ラッパーの利用は増やさない。
 pub use newton::{
     newton_inverse, newton_inverse_generic, newton_solve, newton_solve_2d, newton_solve_bounded,
     newton_solve_bounded_generic, newton_solve_generic,


### PR DESCRIPTION
## 概要

- Newton `f64` 互換ラッパーの運用方針を設計文書に明記
- `solver::mod` と `analysis::lib` の公開コメントを、generic API 正本 / wrapper 互換維持の方針に揃える
- workspace 内では wrapper の新規 production 利用を増やさない方針を明文化

## 検証

- cargo fmt
- cargo clippy -- -D warnings
- cargo test -p analysis

## 注記

- 今回は運用方針とコメント整理のみ
- API 追加・削除や deprecated 化は行っていない
- `f64` ラッパーは downstream 互換維持のため引き続き公開する