### PR TITLE
test: add f32 coverage for linear solvers

### DIFF
--- a/foundation/analysis/src/linalg/solver/cramer_tests.rs
+++ b/foundation/analysis/src/linalg/solver/cramer_tests.rs
@@ -51,4 +51,17 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("only supports 2x2 and 3x3"));
     }
+
+    #[test]
+    fn test_cramer_2x2_f32() {
+        let matrix = vec![vec![2.0_f32, 1.0_f32], vec![1.0_f32, 3.0_f32]];
+        let rhs = vec![5.0_f32, 6.0_f32];
+
+        let solver = CramerSolver::<f32>::new(1e-6_f32);
+        let result = solver.solve(&matrix, &rhs).unwrap();
+
+        assert!((result.solution[0] - 1.8_f32).abs() < 1e-4_f32);
+        assert!((result.solution[1] - 1.4_f32).abs() < 1e-4_f32);
+        assert!(result.converged);
+    }
 }

--- a/foundation/analysis/src/linalg/solver/gaussian_tests.rs
+++ b/foundation/analysis/src/linalg/solver/gaussian_tests.rs
@@ -54,4 +54,17 @@ mod tests {
 
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn test_gaussian_2x2_f32() {
+        let matrix = vec![vec![2.0_f32, 1.0_f32], vec![1.0_f32, 3.0_f32]];
+        let rhs = vec![5.0_f32, 6.0_f32];
+
+        let solver = GaussianSolver::<f32>::new(1e-6_f32);
+        let result = solver.solve(&matrix, &rhs).unwrap();
+
+        assert!((result.solution[0] - 1.8_f32).abs() < 1e-4_f32);
+        assert!((result.solution[1] - 1.4_f32).abs() < 1e-4_f32);
+        assert!(result.converged);
+    }
 }

--- a/foundation/analysis/src/linalg/solver/lu_tests.rs
+++ b/foundation/analysis/src/linalg/solver/lu_tests.rs
@@ -79,4 +79,16 @@ mod tests {
         let solver = LUSolver::<f64>::new(SOLVER_TOLERANCE_F64);
         assert!(solver.decompose(&matrix).is_err());
     }
+
+    #[test]
+    fn test_lu_solver_2x2_f32() {
+        let matrix = vec![vec![2.0_f32, 1.0_f32], vec![1.0_f32, 3.0_f32]];
+        let rhs = vec![5.0_f32, 6.0_f32];
+        let solver = LUSolver::<f32>::new(1e-6_f32);
+
+        let result = solver.solve(&matrix, &rhs).unwrap();
+        assert!((result.solution[0] - 1.8_f32).abs() < 1e-4_f32);
+        assert!((result.solution[1] - 1.4_f32).abs() < 1e-4_f32);
+        assert!(result.converged);
+    }
 }


### PR DESCRIPTION
## 概要

- Gaussian / LU / Cramer solver に `f32` の 2x2 解法テストを追加
- generic 実装が `f64` だけでなく `f32` でも素直に動作することを回帰テストで補強
- 既存の `f64` テスト構成は維持し、最小追加でカバレッジを広げる

## 検証

- cargo fmt
- cargo clippy -- -D warnings
- cargo test -p analysis

## 注記

- 変更対象は test ファイル 3 本のみ
- solver 本体の実装変更は含まない