### PR TITLE
fix: pin trivy db repositories in CI

### DIFF
--- a/.github/workflows/develop_ci.yml
+++ b/.github/workflows/develop_ci.yml
@@ -156,6 +156,10 @@ jobs:
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             aquasec/trivy:0.57.1 image \
+            --db-repository ghcr.io/aquasecurity/trivy-db:2 \
+            --db-repository public.ecr.aws/aquasecurity/trivy-db:2 \
+            --java-db-repository ghcr.io/aquasecurity/trivy-java-db:1 \
+            --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db:1 \
             --severity HIGH,CRITICAL \
             --ignore-unfixed \
             --exit-code 1 \


### PR DESCRIPTION
## 概要
Trivy の vulnerability DB 取得が `mirror.gcr.io` 側の blob 不整合で失敗するケースに対応し、CI の Docker Security Scan を安定化します。

## 変更内容
- `develop_ci.yml` の Trivy 実行引数に `--db-repository` を追加
- vulnerability DB の取得先を `ghcr.io` と `public.ecr.aws` に明示
- Java DB の取得先も `ghcr.io` と `public.ecr.aws` に明示

## 背景
既定設定では `mirror.gcr.io/aquasec` を先に参照しますが、今回の失敗は以下でした。

- `failed to download vulnerability DB`
- `failed to download artifact from mirror.gcr.io/aquasec/trivy-db:2`
- `BLOB_UNKNOWN`

そのため、mirror 依存を避けて公式系レジストリを優先する構成に変更しています。

## 影響範囲
- GitHub Actions の Docker Security Scan ジョブのみ
- アプリケーションコードへの変更なし

## 検証
- ローカルで YAML 差分を確認
- `git diff --check -- .github/workflows/develop_ci.yml` 通過
- GitHub Actions の再実行は未実施