### PR TITLE
feat: add dynamic matrix foundation

### DIFF
--- a/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
+++ b/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
@@ -603,6 +603,14 @@ fn solve_linear_2x2<T: Scalar>(
 - 最小 API として `new`、`rows`、`cols`、`get`、`set`、行列式ではなく一般アクセスと shape 検証を優先する
 - `Vector<T>` との整合を取り、residual / step と Jacobian を同じ abstraction family へ乗せる
 
+#### Phase A 実装スコープ（2026年4月8日着手）
+
+- 初手の実装は `DynamicMatrix<T>` 単体に限定し、既存 `LinearSolver<T>` trait と `GaussianSolver<T>` / `LUSolver<T>` / `CramerSolver<T>` の受け取り型は変更しない
+- 内部表現は row-major の `Vec<T>` とし、shape は `rows` と `cols` を明示保持する
+- 初回に入れる API は `new`、`zeros`、`from_rows`、`rows`、`cols`、`shape`、`get`、`set`、`as_slice`、`to_vec2d`、`transpose`、`mul_vector` を基本とする
+- `Vec<Vec<T>>` からの完全移行は Phase C で扱い、Phase A では変換補助と `Vector<T>` 連携までに留める
+- したがって、この段階の目的は「多変数 Newton 用 Jacobian の基盤型を先に正規化すること」であり、「既存線形 solver の全面置換」ではない
+
 #### Phase B: multivariate Newton solver API の設計
 
 - residual を `Vector<T>`、Jacobian を `DynamicMatrix<T>` で受ける公開 API を定義する

--- a/foundation/analysis/src/linalg/matrix/dynamic_matrix.rs
+++ b/foundation/analysis/src/linalg/matrix/dynamic_matrix.rs
@@ -1,0 +1,144 @@
+//! 動的サイズ行列
+//!
+//! 行数・列数を実行時に持つ汎用行列。
+//! 内部は row-major の 1 次元配列で保持する。
+use crate::abstract_types::Scalar;
+use crate::linalg::vector::Vector;
+
+/// 動的サイズ行列（row-major 格納）
+#[derive(Debug, Clone, PartialEq)]
+pub struct DynamicMatrix<T: Scalar> {
+    rows: usize,
+    cols: usize,
+    data: Vec<T>,
+}
+
+impl<T: Scalar> DynamicMatrix<T> {
+    /// 行列を作成
+    pub fn new(rows: usize, cols: usize, data: Vec<T>) -> Result<Self, String> {
+        if rows == 0 || cols == 0 {
+            return Err("Matrix dimensions must be greater than zero".to_string());
+        }
+
+        if data.len() != rows * cols {
+            return Err("Matrix data length does not match dimensions".to_string());
+        }
+
+        Ok(Self { rows, cols, data })
+    }
+
+    /// ゼロ行列を作成
+    pub fn zeros(rows: usize, cols: usize) -> Result<Self, String> {
+        Self::new(rows, cols, vec![T::ZERO; rows * cols])
+    }
+
+    /// 行ごとのデータから構築
+    pub fn from_rows(rows_data: Vec<Vec<T>>) -> Result<Self, String> {
+        if rows_data.is_empty() {
+            return Err("Matrix must have at least one row".to_string());
+        }
+
+        let rows = rows_data.len();
+        let cols = rows_data[0].len();
+
+        if cols == 0 {
+            return Err("Matrix must have at least one column".to_string());
+        }
+
+        if rows_data.iter().any(|row| row.len() != cols) {
+            return Err("All matrix rows must have the same length".to_string());
+        }
+
+        let data = rows_data.into_iter().flatten().collect();
+        Self::new(rows, cols, data)
+    }
+
+    /// 行数
+    #[inline]
+    pub fn rows(&self) -> usize {
+        self.rows
+    }
+
+    /// 列数
+    #[inline]
+    pub fn cols(&self) -> usize {
+        self.cols
+    }
+
+    /// 形状
+    #[inline]
+    pub fn shape(&self) -> (usize, usize) {
+        (self.rows, self.cols)
+    }
+
+    /// 内部 row-major 配列への参照
+    #[inline]
+    pub fn as_slice(&self) -> &[T] {
+        &self.data
+    }
+
+    /// 要素を取得
+    #[inline]
+    pub fn get(&self, row: usize, col: usize) -> T {
+        self.data[self.index_of(row, col)]
+    }
+
+    /// 要素を設定
+    #[inline]
+    pub fn set(&mut self, row: usize, col: usize, value: T) {
+        let index = self.index_of(row, col);
+        self.data[index] = value;
+    }
+
+    /// `Vec<Vec<T>>` に変換
+    pub fn to_vec2d(&self) -> Vec<Vec<T>> {
+        self.data
+            .chunks(self.cols)
+            .map(|row| row.to_vec())
+            .collect()
+    }
+
+    /// 転置行列を返す
+    pub fn transpose(&self) -> Self {
+        let mut data = vec![T::ZERO; self.data.len()];
+
+        for row in 0..self.rows {
+            for col in 0..self.cols {
+                data[col * self.rows + row] = self.get(row, col);
+            }
+        }
+
+        Self {
+            rows: self.cols,
+            cols: self.rows,
+            data,
+        }
+    }
+
+    /// 行列ベクトル積
+    pub fn mul_vector(&self, vector: &Vector<T>) -> Result<Vector<T>, String> {
+        if self.cols != vector.len() {
+            return Err("Matrix and vector dimensions mismatch".to_string());
+        }
+
+        let mut result = vec![T::ZERO; self.rows];
+        for (row_index, result_cell) in result.iter_mut().enumerate() {
+            let row_start = row_index * self.cols;
+            let row_end = row_start + self.cols;
+            *result_cell = self.data[row_start..row_end]
+                .iter()
+                .zip(vector.data().iter())
+                .map(|(matrix_value, vector_value)| *matrix_value * *vector_value)
+                .fold(T::ZERO, |acc, value| acc + value);
+        }
+
+        Ok(Vector::new(result))
+    }
+
+    #[inline]
+    fn index_of(&self, row: usize, col: usize) -> usize {
+        assert!(row < self.rows, "row index out of bounds");
+        assert!(col < self.cols, "column index out of bounds");
+        row * self.cols + col
+    }
+}

--- a/foundation/analysis/src/linalg/matrix/dynamic_matrix_tests.rs
+++ b/foundation/analysis/src/linalg/matrix/dynamic_matrix_tests.rs
@@ -1,0 +1,63 @@
+use crate::linalg::matrix::DynamicMatrix;
+use crate::linalg::vector::Vector;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dynamic_matrix_new_and_shape() {
+        let matrix = DynamicMatrix::<f64>::new(2, 3, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+
+        assert_eq!(matrix.rows(), 2);
+        assert_eq!(matrix.cols(), 3);
+        assert_eq!(matrix.shape(), (2, 3));
+        assert_eq!(matrix.get(1, 2), 6.0);
+    }
+
+    #[test]
+    fn test_dynamic_matrix_new_rejects_invalid_shape() {
+        let error = DynamicMatrix::<f64>::new(2, 3, vec![1.0, 2.0]).unwrap_err();
+
+        assert_eq!(error, "Matrix data length does not match dimensions");
+    }
+
+    #[test]
+    fn test_dynamic_matrix_from_rows_round_trip() {
+        let matrix = DynamicMatrix::<f32>::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0]]).unwrap();
+
+        assert_eq!(matrix.as_slice(), &[1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(matrix.to_vec2d(), vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
+    }
+
+    #[test]
+    fn test_dynamic_matrix_transpose() {
+        let matrix =
+            DynamicMatrix::<f64>::from_rows(vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]])
+                .unwrap();
+        let transposed = matrix.transpose();
+
+        assert_eq!(transposed.shape(), (3, 2));
+        assert_eq!(
+            transposed.to_vec2d(),
+            vec![vec![1.0, 4.0], vec![2.0, 5.0], vec![3.0, 6.0]]
+        );
+    }
+
+    #[test]
+    fn test_dynamic_matrix_mul_vector() {
+        let matrix = DynamicMatrix::<f64>::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0]]).unwrap();
+        let vector = Vector::new(vec![5.0, 6.0]);
+        let result = matrix.mul_vector(&vector).unwrap();
+
+        assert_eq!(result.data(), &[17.0, 39.0]);
+    }
+
+    #[test]
+    fn test_dynamic_matrix_set_updates_value() {
+        let mut matrix = DynamicMatrix::<f64>::zeros(2, 2).unwrap();
+        matrix.set(1, 0, 7.0);
+
+        assert_eq!(matrix.get(1, 0), 7.0);
+    }
+}

--- a/foundation/analysis/src/linalg/matrix/mod.rs
+++ b/foundation/analysis/src/linalg/matrix/mod.rs
@@ -4,10 +4,13 @@
 //! - 2x2, 3x3, 4x4行列（固定サイズ、高速演算）
 //! - 動的サイズ行列（汎用性）
 //! - 将来的に疎行列、特殊行列も対応予定
+pub mod dynamic_matrix; // 動的サイズ行列
 pub mod matrix2; // 2x2行列
 pub mod matrix3; // 3x3行列
 pub mod matrix4; // 4x4行列
 
+#[cfg(test)]
+pub mod dynamic_matrix_tests;
 #[cfg(test)]
 pub mod matrix2_tests;
 #[cfg(test)]
@@ -15,6 +18,7 @@ pub mod matrix3_tests;
 #[cfg(test)]
 pub mod matrix4_tests;
 
+pub use dynamic_matrix::DynamicMatrix;
 pub use matrix2::{Matrix2x2, Matrix2x2d, Matrix2x2f};
 pub use matrix3::{Matrix3x3, Matrix3x3d, Matrix3x3f};
 pub use matrix4::{Matrix4x4, Matrix4x4d, Matrix4x4f};

--- a/foundation/analysis/src/linalg/mod.rs
+++ b/foundation/analysis/src/linalg/mod.rs
@@ -25,7 +25,7 @@ pub mod point3_tests;
 pub mod quaternion_tests;
 
 // 主要型の再エクスポート
-pub use matrix::{Matrix2x2, Matrix3x3, Matrix4x4};
+pub use matrix::{DynamicMatrix, Matrix2x2, Matrix3x3, Matrix4x4};
 pub use quaternion::{Quaternion, Quaterniond, Quaternionf};
 pub use solver::{CramerSolver, GaussianSolver, LUSolver, LinearSolver};
 pub use vector::{Vector, Vector2, Vector3, Vector4};


### PR DESCRIPTION
## 概要

- #624 Phase A として `DynamicMatrix<T>` を追加
- row-major の 1 次元配列で保持する動的行列基盤を `foundation/analysis` に導入
- 既存 solver 群の受け取り型は変更せず、まず Jacobian 基盤型の正規化に限定

## 変更内容

- [foundation/analysis/src/linalg/matrix/dynamic_matrix.rs](foundation/analysis/src/linalg/matrix/dynamic_matrix.rs) を追加
- `new` / `zeros` / `from_rows` / `rows` / `cols` / `shape` / `get` / `set` / `as_slice` / `to_vec2d` / `transpose` / `mul_vector` を実装
- [foundation/analysis/src/linalg/matrix/dynamic_matrix_tests.rs](foundation/analysis/src/linalg/matrix/dynamic_matrix_tests.rs) を追加
- [foundation/analysis/src/linalg/matrix/mod.rs](foundation/analysis/src/linalg/matrix/mod.rs) と [foundation/analysis/src/linalg/mod.rs](foundation/analysis/src/linalg/mod.rs) から再公開
- [dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md](dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md) に Phase A 実装スコープを追記

## 設計上の扱い

- 今回は `DynamicMatrix<T>` 単体の導入に留め、`LinearSolver<T>` trait や `GaussianSolver<T>` / `LUSolver<T>` / `CramerSolver<T>` の `Vec<Vec<T>>` 受け取りは変更していません
- 既存 solver 接続は #624 の後続段階で扱います
- したがって、この PR の役割は「多変数 Newton 用 Jacobian の基盤型を先に正規化すること」です

## 品質確認

- `cargo clippy -- -D warnings` 通過
- `cargo fmt` 実行済み
- `cargo test -p analysis` 通過
  - 155 tests passed
  - 13 doctests passed

## 残している論点

- `LinearSolver<T>` の入力を `DynamicMatrix<T>` に拡張するかどうか
- `DynamicMatrix<T>` から既存 solver へ渡す adapter を設けるかどうか
- multivariate Newton solver の API で residual / Jacobian / step をどう束ねるか