### PR TITLE
feat: add dynamic matrix solver adapter

### DIFF
--- a/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
+++ b/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
@@ -624,6 +624,14 @@ fn solve_linear_2x2<T: Scalar>(
 - 既存 solver を `Vec<Vec<T>>` のまま維持するか、`DynamicMatrix<T>` 受け取りへ拡張するかを比較する
 - 多変数 Newton の更新ステップ専用 helper を設けるか、既存 solver を直接使うかを決める
 
+#### Phase C 接続方針（2026年4月8日合意）
+
+- 初手では既存 `LinearSolver<T>` trait の `Vec<Vec<T>>` 受け取りを維持し、破壊的変更を避ける
+- その代わり、`DynamicMatrix<T>` と `Vector<T>` を既存 solver へ橋渡しする adapter 層を追加し、多変数 Newton 側からは `DynamicMatrix<T>` ベースで呼べる経路を先に整える
+- 将来の新規 generic solver は `DynamicMatrix<T>` ベースで追加し、既存 solver 群とは一定期間共存させる
+- その後、利用実績と API 安定性を見ながら `Vec<Vec<T>>` ベース solver から段階移行する
+- したがって現段階では「既存 solver を変える」のではなく、「DynamicMatrix ベースの新規利用経路を先に正本化する」を優先する
+
 #### Phase D: follow-up 実装計画への分割
 
 - 動的行列 abstraction

--- a/foundation/analysis/src/linalg/mod.rs
+++ b/foundation/analysis/src/linalg/mod.rs
@@ -27,7 +27,7 @@ pub mod quaternion_tests;
 // 主要型の再エクスポート
 pub use matrix::{DynamicMatrix, Matrix2x2, Matrix3x3, Matrix4x4};
 pub use quaternion::{Quaternion, Quaterniond, Quaternionf};
-pub use solver::{CramerSolver, GaussianSolver, LUSolver, LinearSolver};
+pub use solver::{CramerSolver, DynamicMatrixLinearSolver, GaussianSolver, LUSolver, LinearSolver};
 pub use vector::{Vector, Vector2, Vector3, Vector4};
 
 // 便利な型エイリアス（ベクトル）

--- a/foundation/analysis/src/linalg/solver/mod.rs
+++ b/foundation/analysis/src/linalg/solver/mod.rs
@@ -46,6 +46,7 @@ pub use gaussian::GaussianSolver;
 pub use lu::LUSolver;
 
 use crate::abstract_types::Scalar;
+use crate::linalg::{DynamicMatrix, Vector};
 
 /// 連立方程式の解法結果
 #[derive(Debug, Clone)]
@@ -81,4 +82,29 @@ impl<T: Scalar> SolutionInfo<T> {
 pub trait LinearSolver<T: Scalar> {
     /// 連立方程式 Ax = b を解く
     fn solve(&self, matrix: &[Vec<T>], rhs: &[T]) -> Result<SolutionInfo<T>, String>;
+}
+
+/// DynamicMatrix ベースの入力を既存 solver へ橋渡しする拡張 trait
+pub trait DynamicMatrixLinearSolver<T: Scalar>: LinearSolver<T> {
+    /// `DynamicMatrix<T>` と `Vector<T>` を受けて既存 solver を実行する
+    fn solve_dynamic(
+        &self,
+        matrix: &DynamicMatrix<T>,
+        rhs: &Vector<T>,
+    ) -> Result<SolutionInfo<T>, String> {
+        if matrix.rows() != matrix.cols() {
+            return Err("Matrix must be square".to_string());
+        }
+
+        if rhs.len() != matrix.rows() {
+            return Err("RHS dimension mismatch".to_string());
+        }
+
+        self.solve(&matrix.to_vec2d(), rhs.data())
+    }
+}
+
+impl<T: Scalar, TLinearSolver> DynamicMatrixLinearSolver<T> for TLinearSolver where
+    TLinearSolver: LinearSolver<T>
+{
 }

--- a/foundation/analysis/src/linalg/solver/mod_tests.rs
+++ b/foundation/analysis/src/linalg/solver/mod_tests.rs
@@ -1,5 +1,8 @@
 use crate::consts::test_constants::{SOLVER_TOLERANCE_F64, TOLERANCE_F64};
-use crate::linalg::solver::{CramerSolver, GaussianSolver, LUSolver, LinearSolver};
+use crate::linalg::solver::{
+    CramerSolver, DynamicMatrixLinearSolver, GaussianSolver, LUSolver, LinearSolver,
+};
+use crate::linalg::{DynamicMatrix, Vector};
 
 #[cfg(test)]
 mod tests {
@@ -106,5 +109,41 @@ mod tests {
         let loose_solver = GaussianSolver::new(1e-8);
         let result = loose_solver.solve(&matrix, &rhs).unwrap();
         assert!(result.converged);
+    }
+
+    #[test]
+    fn test_gaussian_solver_dynamic_matrix_adapter() {
+        let matrix = DynamicMatrix::<f64>::from_rows(vec![vec![2.0, 1.0], vec![1.0, 3.0]]).unwrap();
+        let rhs = Vector::new(vec![5.0, 6.0]);
+        let solver = GaussianSolver::new(SOLVER_TOLERANCE_F64);
+
+        let result = solver.solve_dynamic(&matrix, &rhs).unwrap();
+
+        assert!((result.solution[0] - 1.8).abs() < TOLERANCE_F64);
+        assert!((result.solution[1] - 1.4).abs() < TOLERANCE_F64);
+        assert!(result.converged);
+    }
+
+    #[test]
+    fn test_lu_solver_dynamic_matrix_adapter() {
+        let matrix = DynamicMatrix::<f64>::from_rows(vec![vec![2.0, 1.0], vec![1.0, 3.0]]).unwrap();
+        let rhs = Vector::new(vec![5.0, 6.0]);
+        let solver = LUSolver::new(SOLVER_TOLERANCE_F64);
+
+        let result = solver.solve_dynamic(&matrix, &rhs).unwrap();
+
+        assert!((result.solution[0] - 1.8).abs() < TOLERANCE_F64);
+        assert!((result.solution[1] - 1.4).abs() < TOLERANCE_F64);
+        assert!(result.converged);
+    }
+
+    #[test]
+    fn test_dynamic_matrix_adapter_rejects_rhs_mismatch() {
+        let matrix = DynamicMatrix::<f64>::from_rows(vec![vec![2.0, 1.0], vec![1.0, 3.0]]).unwrap();
+        let rhs = Vector::new(vec![5.0]);
+        let solver = GaussianSolver::new(SOLVER_TOLERANCE_F64);
+
+        let error = solver.solve_dynamic(&matrix, &rhs).unwrap_err();
+        assert_eq!(error, "RHS dimension mismatch");
     }
 }


### PR DESCRIPTION
## 概要

- #624 の接続方針として、`DynamicMatrix<T>` / `Vector<T>` から既存 `LinearSolver<T>` を呼べる adapter 層を追加
- 既存 solver 群の `Vec<Vec<T>>` 受け取りは維持しつつ、DynamicMatrix ベースの新規利用経路を先に整備
- 将来の新規 generic solver を `DynamicMatrix<T>` ベースで共存移行させる方針を設計文書へ反映

## 変更内容

- [foundation/analysis/src/linalg/solver/mod.rs](foundation/analysis/src/linalg/solver/mod.rs) に `DynamicMatrixLinearSolver` trait を追加
- `solve_dynamic(&DynamicMatrix<T>, &Vector<T>)` から既存 `solve(&[Vec<T>], &[T])` を呼ぶ bridge を実装
- [foundation/analysis/src/linalg/mod.rs](foundation/analysis/src/linalg/mod.rs) から `DynamicMatrixLinearSolver` を再公開
- [foundation/analysis/src/linalg/solver/mod_tests.rs](foundation/analysis/src/linalg/solver/mod_tests.rs) に adapter 経由の Gaussian/LU テストと RHS 次元不一致テストを追加
- [dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md](dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md) に Phase C 接続方針を追記

## 設計上の扱い

- 今回は既存 `LinearSolver<T>` trait のシグネチャを変更していません
- `DynamicMatrix<T>` は内部で `Vec<Vec<T>>` に変換され、既存 solver 群をそのまま利用します
- この段階では「既存 solver を DynamicMatrix 化する」のではなく、「DynamicMatrix ベースの呼び出し経路を先に正本化する」ことを目的としています

## 品質確認

- `cargo clippy -- -D warnings` 通過
- `cargo fmt` 実行済み
- `cargo test -p analysis` 通過
  - 158 tests passed
  - 13 doctests passed

## 残している論点

- multivariate Newton solver の公開 API 形状
- residual / Jacobian / step の収束判定と返り値方針
- 将来の新規 solver を `DynamicMatrix<T>` ベースでどの粒度で追加するか