### PR TITLE
feat: add multivariate newton solver

### DIFF
--- a/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
+++ b/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
@@ -618,6 +618,15 @@ fn solve_linear_2x2<T: Scalar>(
 - 特異判定と失敗時の返り値方針を定義する
 - `newton_solve_2d` との差分を明示し、2変数専用 convenience wrapper へ寄せる余地を残す
 
+#### Phase B 実装スコープ（2026年4月8日着手）
+
+- 新規入口として `newton_solve_multivariate` と `newton_solve_multivariate_with_solver` を追加する
+- `system` は `&Vector<T>` を受け取り、`(Vector<T>, DynamicMatrix<T>)` を返す形に統一する
+- 既定の更新ステップは `GaussianSolver<T>` + `DynamicMatrixLinearSolver<T>` adapter を使って解く
+- solver 差し替えが必要な利用者向けに `..._with_solver` を併設し、`LUSolver<T>` などを注入可能にする
+- 返り値は既存 Newton 系との整合を優先して `Option<Vector<T>>` とし、shape 不整合・特異 Jacobian・非収束は `None` で表す
+- 収束判定は residual norm と step norm の両方を使い、既存 2変数 solver より明示的な多変数収束条件を採る
+
 #### Phase C: 線形 solver 接続方針の設計
 
 - 動的 Jacobian を既存の `GaussianSolver<T>` / `LUSolver<T>` へどう接続するかを整理する

--- a/foundation/analysis/src/lib.rs
+++ b/foundation/analysis/src/lib.rs
@@ -30,8 +30,8 @@ pub use consts::{
 // Newton solver は generic API を正本とし、f64 ラッパーは downstream 互換用に公開を維持する。
 pub use crate::linalg::solver::newton::{
     newton_inverse, newton_inverse_generic, newton_solve, newton_solve_2d, newton_solve_bounded,
-    newton_solve_bounded_generic, newton_solve_generic,
-    newton_solve_with_numeric_derivative_bounded,
+    newton_solve_bounded_generic, newton_solve_generic, newton_solve_multivariate,
+    newton_solve_multivariate_with_solver, newton_solve_with_numeric_derivative_bounded,
     newton_solve_with_numeric_derivative_bounded_generic,
 };
 pub use crate::numerics::{

--- a/foundation/analysis/src/linalg/solver/mod.rs
+++ b/foundation/analysis/src/linalg/solver/mod.rs
@@ -24,8 +24,8 @@ pub mod newton; // ニュートン・ラフソン法
 // workspace 内の新規実装では generic API を優先し、f64 ラッパーの利用は増やさない。
 pub use newton::{
     newton_inverse, newton_inverse_generic, newton_solve, newton_solve_2d, newton_solve_bounded,
-    newton_solve_bounded_generic, newton_solve_generic,
-    newton_solve_with_numeric_derivative_bounded,
+    newton_solve_bounded_generic, newton_solve_generic, newton_solve_multivariate,
+    newton_solve_multivariate_with_solver, newton_solve_with_numeric_derivative_bounded,
     newton_solve_with_numeric_derivative_bounded_generic,
 };
 

--- a/foundation/analysis/src/linalg/solver/newton.rs
+++ b/foundation/analysis/src/linalg/solver/newton.rs
@@ -3,12 +3,24 @@
 //! 非線形方程式 f(x) = 0 の求解や逆関数計算を提供する。
 //! 汎用的なニュートン法実装により、様々な数値計算問題に対応。
 
-use crate::linalg::{Matrix2x2, Vector2};
+use crate::linalg::{
+    DynamicMatrix, DynamicMatrixLinearSolver, GaussianSolver, Matrix2x2, Vector, Vector2,
+};
 use crate::{Scalar, DERIVATIVE_ZERO_THRESHOLD};
 
 #[inline]
 fn derivative_zero_threshold<T: Scalar>() -> T {
     T::from_f64(DERIVATIVE_ZERO_THRESHOLD)
+}
+
+#[inline]
+fn solver_tolerance<T: Scalar>(tol: T) -> T {
+    let threshold = derivative_zero_threshold::<T>();
+    if tol < threshold {
+        threshold
+    } else {
+        tol
+    }
 }
 
 #[inline]
@@ -23,6 +35,24 @@ fn solve_linear_2x2<T: Scalar>(jacobian: Matrix2x2<T>, residual: Vector2<T>) -> 
         inv_det * (jacobian.get(1, 1) * residual.x() - jacobian.get(0, 1) * residual.y()),
         inv_det * (-jacobian.get(1, 0) * residual.x() + jacobian.get(0, 0) * residual.y()),
     ))
+}
+
+#[inline]
+fn solve_linear_dynamic<T, S>(
+    jacobian: &DynamicMatrix<T>,
+    residual: &Vector<T>,
+    solver: &S,
+) -> Option<Vector<T>>
+where
+    T: Scalar,
+    S: DynamicMatrixLinearSolver<T>,
+{
+    let solution = solver.solve_dynamic(jacobian, residual).ok()?;
+    if solution.solution.len() != residual.len() {
+        return None;
+    }
+
+    Some(Vector::new(solution.solution))
 }
 
 /// generic Newton 法による方程式求解
@@ -266,6 +296,93 @@ where
     G: Fn(f64) -> f64,
 {
     newton_inverse_generic(f, df, target, initial, max_iter, tol)
+}
+
+/// generic 多変数連立非線形方程式をニュートン法で解く
+///
+/// `system` は現在の推定値 `x` を受け取り、残差ベクトルと Jacobian 行列を返す。
+/// 更新ステップの線形系は既定で `GaussianSolver<T>` を用いて解く。
+///
+/// # Example
+/// ```rust
+/// use analysis::linalg::solver::newton::newton_solve_multivariate;
+/// use analysis::linalg::{DynamicMatrix, Vector};
+///
+/// let system = |point: &Vector<f64>| {
+///     let x = point[0];
+///     let y = point[1];
+///     let residual = Vector::new(vec![x * x + y * y - 1.0, x - y]);
+///     let jacobian = DynamicMatrix::from_rows(vec![vec![2.0 * x, 2.0 * y], vec![1.0, -1.0]])
+///         .unwrap();
+///     (residual, jacobian)
+/// };
+///
+/// let initial = Vector::new(vec![1.0, 0.5]);
+/// let result = newton_solve_multivariate(system, initial, 100, 1e-10);
+/// assert!(result.is_some());
+/// ```
+pub fn newton_solve_multivariate<T, F>(
+    system: F,
+    initial: Vector<T>,
+    max_iter: usize,
+    tol: T,
+) -> Option<Vector<T>>
+where
+    T: Scalar,
+    F: Fn(&Vector<T>) -> (Vector<T>, DynamicMatrix<T>),
+{
+    let solver = GaussianSolver::new(solver_tolerance(tol));
+    newton_solve_multivariate_with_solver(system, initial, &solver, max_iter, tol)
+}
+
+/// generic 多変数連立非線形方程式を、任意の線形 solver を使ってニュートン法で解く
+pub fn newton_solve_multivariate_with_solver<T, F, S>(
+    system: F,
+    initial: Vector<T>,
+    solver: &S,
+    max_iter: usize,
+    tol: T,
+) -> Option<Vector<T>>
+where
+    T: Scalar,
+    F: Fn(&Vector<T>) -> (Vector<T>, DynamicMatrix<T>),
+    S: DynamicMatrixLinearSolver<T>,
+{
+    let mut current = initial;
+
+    for _ in 0..max_iter {
+        let (residual, jacobian) = system(&current);
+        let dimension = current.len();
+
+        if residual.len() != dimension {
+            return None;
+        }
+
+        if jacobian.shape() != (dimension, dimension) {
+            return None;
+        }
+
+        if residual.norm() < tol {
+            return Some(current);
+        }
+
+        let step = solve_linear_dynamic(&jacobian, &residual, solver)?;
+        let step_norm = step.norm();
+        let next = (current.clone() - step).ok()?;
+
+        let (next_residual, _) = system(&next);
+        if next_residual.len() != dimension {
+            return None;
+        }
+
+        if next_residual.norm() < tol && step_norm < tol {
+            return Some(next);
+        }
+
+        current = next;
+    }
+
+    None
 }
 
 /// generic 2変数連立非線形方程式をニュートン法で解く

--- a/foundation/analysis/src/linalg/solver/newton_tests.rs
+++ b/foundation/analysis/src/linalg/solver/newton_tests.rs
@@ -1,8 +1,10 @@
 use super::newton::{
     newton_inverse, newton_inverse_generic, newton_solve, newton_solve_2d, newton_solve_generic,
+    newton_solve_multivariate, newton_solve_multivariate_with_solver,
     newton_solve_with_numeric_derivative_bounded_generic,
 };
 use crate::consts::test_constants::{INTEGRATION_TOLERANCE_STRICT, TOLERANCE_F64};
+use crate::linalg::{DynamicMatrix, LUSolver, Vector};
 
 #[cfg(test)]
 mod tests {
@@ -143,6 +145,84 @@ mod tests {
         };
 
         let result = newton_solve_2d(system, (1.0_f32, 1.0_f32), 100, 1e-6_f32);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_newton_solve_multivariate_circle_line_f64() {
+        let system = |point: &Vector<f64>| {
+            let x = point[0];
+            let y = point[1];
+            let residual = Vector::new(vec![x * x + y * y - 1.0, x - y]);
+            let jacobian =
+                DynamicMatrix::from_rows(vec![vec![2.0 * x, 2.0 * y], vec![1.0, -1.0]]).unwrap();
+            (residual, jacobian)
+        };
+
+        let result =
+            newton_solve_multivariate(system, Vector::new(vec![1.0, 0.5]), 100, TOLERANCE_F64);
+        assert!(result.is_some());
+
+        let solution = result.unwrap();
+        let expected = 1.0 / 2_f64.sqrt();
+        assert!((solution[0] - expected).abs() < INTEGRATION_TOLERANCE_STRICT);
+        assert!((solution[1] - expected).abs() < INTEGRATION_TOLERANCE_STRICT);
+    }
+
+    #[test]
+    fn test_newton_solve_multivariate_with_lu_solver_f32() {
+        let system = |point: &Vector<f32>| {
+            let x = point[0];
+            let y = point[1];
+            let residual = Vector::new(vec![x * x + y * y - 1.0_f32, x - y]);
+            let jacobian = DynamicMatrix::from_rows(vec![
+                vec![2.0_f32 * x, 2.0_f32 * y],
+                vec![1.0_f32, -1.0_f32],
+            ])
+            .unwrap();
+            (residual, jacobian)
+        };
+
+        let solver = LUSolver::new(1e-6_f32);
+        let result = newton_solve_multivariate_with_solver(
+            system,
+            Vector::new(vec![1.0_f32, 0.5_f32]),
+            &solver,
+            100,
+            1e-6_f32,
+        );
+        assert!(result.is_some());
+
+        let solution = result.unwrap();
+        let expected = 1.0_f32 / 2.0_f32.sqrt();
+        assert!((solution[0] - expected).abs() < 1e-4_f32);
+        assert!((solution[1] - expected).abs() < 1e-4_f32);
+    }
+
+    #[test]
+    fn test_newton_solve_multivariate_rejects_shape_mismatch() {
+        let system = |point: &Vector<f64>| {
+            let residual = Vector::new(vec![point[0], point[1]]);
+            let jacobian =
+                DynamicMatrix::from_rows(vec![vec![1.0, 0.0, 0.0], vec![0.0, 1.0, 0.0]]).unwrap();
+            (residual, jacobian)
+        };
+
+        let result =
+            newton_solve_multivariate(system, Vector::new(vec![1.0, 1.0]), 10, TOLERANCE_F64);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_newton_solve_multivariate_singular_jacobian() {
+        let system = |point: &Vector<f64>| {
+            let residual = Vector::new(vec![point[0] + point[1], point[0] + point[1]]);
+            let jacobian = DynamicMatrix::from_rows(vec![vec![1.0, 1.0], vec![1.0, 1.0]]).unwrap();
+            (residual, jacobian)
+        };
+
+        let result =
+            newton_solve_multivariate(system, Vector::new(vec![1.0, 1.0]), 10, TOLERANCE_F64);
         assert!(result.is_none());
     }
 }


### PR DESCRIPTION
## 概要

- #624 の Phase B として多変数 Newton solver を実装
- `Vector<T>` と `DynamicMatrix<T>` を正本にした新規入口 API を追加
- 既存の DynamicMatrix adapter を使って、既存線形 solver 群と共存しながら更新ステップを解く構成にした

## 変更内容

- [foundation/analysis/src/linalg/solver/newton.rs](foundation/analysis/src/linalg/solver/newton.rs) に `newton_solve_multivariate` を追加
- [foundation/analysis/src/linalg/solver/newton.rs](foundation/analysis/src/linalg/solver/newton.rs) に `newton_solve_multivariate_with_solver` を追加
- `system` の入力を `&Vector<T>`、出力を `(Vector<T>, DynamicMatrix<T>)` に統一
- 既定 solver として `GaussianSolver<T>` を使用し、差し替え用に `..._with_solver` を併設
- [foundation/analysis/src/linalg/solver/mod.rs](foundation/analysis/src/linalg/solver/mod.rs) と [foundation/analysis/src/lib.rs](foundation/analysis/src/lib.rs) から再公開
- [foundation/analysis/src/linalg/solver/newton_tests.rs](foundation/analysis/src/linalg/solver/newton_tests.rs) に多変数 Newton の回帰テストを追加
- [dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md](dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md) に Phase B 実装スコープを追記

## 設計上の扱い

- 返り値は既存 Newton 系との整合を優先して `Option<Vector<T>>` とした
- shape 不整合、特異 Jacobian、非収束は現段階では `None` に畳んでいる
- 更新ステップは既存 `LinearSolver<T>` を直接変更せず、`DynamicMatrixLinearSolver<T>` adapter 経由で解く
- したがって、既存 solver 群の公開シグネチャは維持されている

## テスト

- `cargo fmt` 実行済み
- `cargo clippy -- -D warnings` 通過
- `cargo test -p analysis` 通過
  - 162 tests passed
  - 14 doctests passed

## 追加した確認項目

- 円と直線の交点を解く多変数 Newton の `f64` テスト
- `LUSolver<T>` を注入する差し替え経路の `f32` テスト
- Jacobian shape 不整合時に `None` を返すテスト
- 特異 Jacobian で `None` を返すテスト

## 今後の論点

- `Option` のままで十分か、失敗理由を型で分けるか
- 境界付き多変数 Newton や数値微分版を追加するか
- 将来の新規 solver を `DynamicMatrix<T>` ベースでどの粒度まで増やすか