### PR TITLE
feat: add bounded multivariate newton solver

### DIFF
--- a/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
+++ b/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
@@ -791,6 +791,14 @@ where
 4. clamp 動作、shape 不整合、境界端収束のテストを追加する
 5. 必要なら follow-up で `tol` を `residual_tol` / `step_tol` に分離する
 
+#### Phase D 実装スコープ（2026年4月8日）
+
+- `foundation/analysis/src/linalg/solver/newton.rs` に `MultivariateNewtonBounds<T>` と `MultivariateNewtonOptions<T>` を追加する
+- bounded 版 API と `..._with_solver` 版を追加する
+- 反復ごとに clamp を適用し、実際に採用された更新量で step 判定を行う
+- `newton_tests.rs` に bounds 検証、初期値 clamp、境界端収束、shape 不整合、特異 Jacobian の回帰テストを追加する
+- 既存 unbounded API の署名・挙動は変更しない
+
 ### 外部利用者向け移行方針
 
 - 新規コードでは `newton_solve_generic` / `newton_solve_bounded_generic` / `newton_solve_with_numeric_derivative_bounded_generic` / `newton_inverse_generic` を優先する

--- a/foundation/analysis/src/lib.rs
+++ b/foundation/analysis/src/lib.rs
@@ -31,8 +31,10 @@ pub use consts::{
 pub use crate::linalg::solver::newton::{
     newton_inverse, newton_inverse_generic, newton_solve, newton_solve_2d, newton_solve_bounded,
     newton_solve_bounded_generic, newton_solve_generic, newton_solve_multivariate,
+    newton_solve_multivariate_bounded, newton_solve_multivariate_bounded_with_solver,
     newton_solve_multivariate_with_solver, newton_solve_with_numeric_derivative_bounded,
-    newton_solve_with_numeric_derivative_bounded_generic,
+    newton_solve_with_numeric_derivative_bounded_generic, MultivariateNewtonBounds,
+    MultivariateNewtonOptions,
 };
 pub use crate::numerics::{
     find_span_in_non_decreasing_sequence, newton_arc_length, trapezoidal_rule, NormedVector,

--- a/foundation/analysis/src/linalg/mod.rs
+++ b/foundation/analysis/src/linalg/mod.rs
@@ -27,7 +27,10 @@ pub mod quaternion_tests;
 // 主要型の再エクスポート
 pub use matrix::{DynamicMatrix, Matrix2x2, Matrix3x3, Matrix4x4};
 pub use quaternion::{Quaternion, Quaterniond, Quaternionf};
-pub use solver::{CramerSolver, DynamicMatrixLinearSolver, GaussianSolver, LUSolver, LinearSolver};
+pub use solver::{
+    CramerSolver, DynamicMatrixLinearSolver, GaussianSolver, LUSolver, LinearSolver,
+    MultivariateNewtonBounds, MultivariateNewtonOptions,
+};
 pub use vector::{Vector, Vector2, Vector3, Vector4};
 
 // 便利な型エイリアス（ベクトル）

--- a/foundation/analysis/src/linalg/solver/mod.rs
+++ b/foundation/analysis/src/linalg/solver/mod.rs
@@ -25,8 +25,10 @@ pub mod newton; // ニュートン・ラフソン法
 pub use newton::{
     newton_inverse, newton_inverse_generic, newton_solve, newton_solve_2d, newton_solve_bounded,
     newton_solve_bounded_generic, newton_solve_generic, newton_solve_multivariate,
+    newton_solve_multivariate_bounded, newton_solve_multivariate_bounded_with_solver,
     newton_solve_multivariate_with_solver, newton_solve_with_numeric_derivative_bounded,
-    newton_solve_with_numeric_derivative_bounded_generic,
+    newton_solve_with_numeric_derivative_bounded_generic, MultivariateNewtonBounds,
+    MultivariateNewtonOptions,
 };
 
 // テストモジュール

--- a/foundation/analysis/src/linalg/solver/newton.rs
+++ b/foundation/analysis/src/linalg/solver/newton.rs
@@ -55,6 +55,91 @@ where
     Some(Vector::new(solution.solution))
 }
 
+#[inline]
+fn validate_multivariate_system<T: Scalar>(
+    current: &Vector<T>,
+    residual: &Vector<T>,
+    jacobian: &DynamicMatrix<T>,
+) -> bool {
+    let dimension = current.len();
+    residual.len() == dimension && jacobian.shape() == (dimension, dimension)
+}
+
+/// 境界付き多変数 Newton の境界条件
+#[derive(Debug, Clone, PartialEq)]
+pub struct MultivariateNewtonBounds<T: Scalar> {
+    lower: Vector<T>,
+    upper: Vector<T>,
+}
+
+impl<T: Scalar> MultivariateNewtonBounds<T> {
+    pub fn new(lower: Vector<T>, upper: Vector<T>) -> Result<Self, String> {
+        if lower.len() != upper.len() {
+            return Err("Bounds dimension mismatch".to_string());
+        }
+
+        for index in 0..lower.len() {
+            if lower[index] > upper[index] {
+                return Err("Lower bound must be less than or equal to upper bound".to_string());
+            }
+        }
+
+        Ok(Self { lower, upper })
+    }
+
+    pub fn dimension(&self) -> usize {
+        self.lower.len()
+    }
+
+    pub fn lower(&self) -> &Vector<T> {
+        &self.lower
+    }
+
+    pub fn upper(&self) -> &Vector<T> {
+        &self.upper
+    }
+
+    pub fn clamp(&self, point: &Vector<T>) -> Result<Vector<T>, String> {
+        if point.len() != self.dimension() {
+            return Err("Point dimension mismatch".to_string());
+        }
+
+        Ok(Vector::new(
+            point
+                .data()
+                .iter()
+                .enumerate()
+                .map(|(index, value)| value.clamp(self.lower[index], self.upper[index]))
+                .collect(),
+        ))
+    }
+
+    pub fn contains(&self, point: &Vector<T>) -> bool {
+        if point.len() != self.dimension() {
+            return false;
+        }
+
+        point
+            .data()
+            .iter()
+            .enumerate()
+            .all(|(index, value)| *value >= self.lower[index] && *value <= self.upper[index])
+    }
+}
+
+/// 境界付き多変数 Newton の反復設定
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MultivariateNewtonOptions<T: Scalar> {
+    pub max_iter: usize,
+    pub tol: T,
+}
+
+impl<T: Scalar> MultivariateNewtonOptions<T> {
+    pub fn new(max_iter: usize, tol: T) -> Self {
+        Self { max_iter, tol }
+    }
+}
+
 /// generic Newton 法による方程式求解
 pub fn newton_solve_generic<T, F, G>(f: F, df: G, initial: T, max_iter: usize, tol: T) -> Option<T>
 where
@@ -352,13 +437,7 @@ where
 
     for _ in 0..max_iter {
         let (residual, jacobian) = system(&current);
-        let dimension = current.len();
-
-        if residual.len() != dimension {
-            return None;
-        }
-
-        if jacobian.shape() != (dimension, dimension) {
+        if !validate_multivariate_system(&current, &residual, &jacobian) {
             return None;
         }
 
@@ -371,11 +450,71 @@ where
         let next = (current.clone() - step).ok()?;
 
         let (next_residual, _) = system(&next);
-        if next_residual.len() != dimension {
+        if next_residual.len() != current.len() {
             return None;
         }
 
         if next_residual.norm() < tol && step_norm < tol {
+            return Some(next);
+        }
+
+        current = next;
+    }
+
+    None
+}
+
+/// generic 境界付き多変数連立非線形方程式をニュートン法で解く
+pub fn newton_solve_multivariate_bounded<T, F>(
+    system: F,
+    initial: Vector<T>,
+    bounds: &MultivariateNewtonBounds<T>,
+    options: &MultivariateNewtonOptions<T>,
+) -> Option<Vector<T>>
+where
+    T: Scalar,
+    F: Fn(&Vector<T>) -> (Vector<T>, DynamicMatrix<T>),
+{
+    let solver = GaussianSolver::new(solver_tolerance(options.tol));
+    newton_solve_multivariate_bounded_with_solver(system, initial, bounds, &solver, options)
+}
+
+/// generic 境界付き多変数連立非線形方程式を、任意の線形 solver を使ってニュートン法で解く
+pub fn newton_solve_multivariate_bounded_with_solver<T, F, S>(
+    system: F,
+    initial: Vector<T>,
+    bounds: &MultivariateNewtonBounds<T>,
+    solver: &S,
+    options: &MultivariateNewtonOptions<T>,
+) -> Option<Vector<T>>
+where
+    T: Scalar,
+    F: Fn(&Vector<T>) -> (Vector<T>, DynamicMatrix<T>),
+    S: DynamicMatrixLinearSolver<T>,
+{
+    let mut current = bounds.clamp(&initial).ok()?;
+
+    for _ in 0..options.max_iter {
+        let (residual, jacobian) = system(&current);
+        if !validate_multivariate_system(&current, &residual, &jacobian) {
+            return None;
+        }
+
+        if residual.norm() < options.tol {
+            return Some(current);
+        }
+
+        let step = solve_linear_dynamic(&jacobian, &residual, solver)?;
+        let unclamped_next = (current.clone() - step).ok()?;
+        let next = bounds.clamp(&unclamped_next).ok()?;
+        let actual_step = (next.clone() - current.clone()).ok()?;
+
+        let (next_residual, _) = system(&next);
+        if next_residual.len() != current.len() {
+            return None;
+        }
+
+        if next_residual.norm() < options.tol && actual_step.norm() < options.tol {
             return Some(next);
         }
 

--- a/foundation/analysis/src/linalg/solver/newton_tests.rs
+++ b/foundation/analysis/src/linalg/solver/newton_tests.rs
@@ -1,7 +1,9 @@
 use super::newton::{
     newton_inverse, newton_inverse_generic, newton_solve, newton_solve_2d, newton_solve_generic,
-    newton_solve_multivariate, newton_solve_multivariate_with_solver,
-    newton_solve_with_numeric_derivative_bounded_generic,
+    newton_solve_multivariate, newton_solve_multivariate_bounded,
+    newton_solve_multivariate_bounded_with_solver, newton_solve_multivariate_with_solver,
+    newton_solve_with_numeric_derivative_bounded_generic, MultivariateNewtonBounds,
+    MultivariateNewtonOptions,
 };
 use crate::consts::test_constants::{INTEGRATION_TOLERANCE_STRICT, TOLERANCE_F64};
 use crate::linalg::{DynamicMatrix, LUSolver, Vector};
@@ -223,6 +225,147 @@ mod tests {
 
         let result =
             newton_solve_multivariate(system, Vector::new(vec![1.0, 1.0]), 10, TOLERANCE_F64);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_multivariate_newton_bounds_reject_dimension_mismatch() {
+        let result = MultivariateNewtonBounds::new(
+            Vector::new(vec![0.0_f64, 0.0_f64]),
+            Vector::new(vec![1.0_f64]),
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_multivariate_newton_bounds_reject_inverted_axis_range() {
+        let result = MultivariateNewtonBounds::new(
+            Vector::new(vec![0.0_f64, 2.0_f64]),
+            Vector::new(vec![1.0_f64, 1.0_f64]),
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_multivariate_newton_bounds_clamp_and_contains() {
+        let bounds = MultivariateNewtonBounds::new(
+            Vector::new(vec![0.0_f64, -1.0_f64]),
+            Vector::new(vec![1.0_f64, 2.0_f64]),
+        )
+        .unwrap();
+
+        let point = Vector::new(vec![1.5_f64, -2.0_f64]);
+        let clamped = bounds.clamp(&point).unwrap();
+
+        assert_eq!(clamped, Vector::new(vec![1.0_f64, -1.0_f64]));
+        assert!(bounds.contains(&clamped));
+        assert!(!bounds.contains(&point));
+    }
+
+    #[test]
+    fn test_newton_solve_multivariate_bounded_clamps_initial_point() {
+        let system = |point: &Vector<f64>| {
+            let residual = Vector::new(vec![point[0] - 1.0]);
+            let jacobian = DynamicMatrix::from_rows(vec![vec![1.0_f64]]).unwrap();
+            (residual, jacobian)
+        };
+        let bounds =
+            MultivariateNewtonBounds::new(Vector::new(vec![0.0_f64]), Vector::new(vec![1.0_f64]))
+                .unwrap();
+        let options = MultivariateNewtonOptions::new(20, TOLERANCE_F64);
+
+        let result = newton_solve_multivariate_bounded(
+            system,
+            Vector::new(vec![3.0_f64]),
+            &bounds,
+            &options,
+        );
+        assert!(result.is_some());
+
+        let solution = result.unwrap();
+        assert_eq!(solution, Vector::new(vec![1.0_f64]));
+        assert!(bounds.contains(&solution));
+    }
+
+    #[test]
+    fn test_newton_solve_multivariate_bounded_converges_on_boundary() {
+        let system = |point: &Vector<f64>| {
+            let x = point[0];
+            let residual = Vector::new(vec![x * x - 1.0]);
+            let jacobian = DynamicMatrix::from_rows(vec![vec![2.0_f64 * x]]).unwrap();
+            (residual, jacobian)
+        };
+        let bounds =
+            MultivariateNewtonBounds::new(Vector::new(vec![0.0_f64]), Vector::new(vec![1.0_f64]))
+                .unwrap();
+        let options = MultivariateNewtonOptions::new(20, TOLERANCE_F64);
+
+        let result = newton_solve_multivariate_bounded(
+            system,
+            Vector::new(vec![0.2_f64]),
+            &bounds,
+            &options,
+        );
+        assert!(result.is_some());
+
+        let solution = result.unwrap();
+        assert!((solution[0] - 1.0_f64).abs() < INTEGRATION_TOLERANCE_STRICT);
+        assert!(bounds.contains(&solution));
+    }
+
+    #[test]
+    fn test_newton_solve_multivariate_bounded_with_solver_rejects_shape_mismatch() {
+        let system = |point: &Vector<f64>| {
+            let residual = Vector::new(vec![point[0], point[1]]);
+            let jacobian = DynamicMatrix::from_rows(vec![
+                vec![1.0_f64, 0.0_f64, 0.0_f64],
+                vec![0.0_f64, 1.0_f64, 0.0_f64],
+            ])
+            .unwrap();
+            (residual, jacobian)
+        };
+        let bounds = MultivariateNewtonBounds::new(
+            Vector::new(vec![-1.0_f64, -1.0_f64]),
+            Vector::new(vec![1.0_f64, 1.0_f64]),
+        )
+        .unwrap();
+        let options = MultivariateNewtonOptions::new(10, TOLERANCE_F64);
+        let solver = LUSolver::new(TOLERANCE_F64);
+
+        let result = newton_solve_multivariate_bounded_with_solver(
+            system,
+            Vector::new(vec![0.5_f64, 0.5_f64]),
+            &bounds,
+            &solver,
+            &options,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_newton_solve_multivariate_bounded_singular_jacobian() {
+        let system = |point: &Vector<f64>| {
+            let residual = Vector::new(vec![point[0] + point[1], point[0] + point[1]]);
+            let jacobian =
+                DynamicMatrix::from_rows(vec![vec![1.0_f64, 1.0_f64], vec![1.0_f64, 1.0_f64]])
+                    .unwrap();
+            (residual, jacobian)
+        };
+        let bounds = MultivariateNewtonBounds::new(
+            Vector::new(vec![-1.0_f64, -1.0_f64]),
+            Vector::new(vec![1.0_f64, 1.0_f64]),
+        )
+        .unwrap();
+        let options = MultivariateNewtonOptions::new(10, TOLERANCE_F64);
+
+        let result = newton_solve_multivariate_bounded(
+            system,
+            Vector::new(vec![0.5_f64, 0.5_f64]),
+            &bounds,
+            &options,
+        );
         assert!(result.is_none());
     }
 }


### PR DESCRIPTION
## 概要

- #624 の bounded 多変数 Newton solver を実装
- `MultivariateNewtonBounds<T>` と `MultivariateNewtonOptions<T>` を追加
- clamp ベースの bounded Newton API と solver 差し替え版を追加

## 変更内容

- [foundation/analysis/src/linalg/solver/newton.rs](foundation/analysis/src/linalg/solver/newton.rs) に以下を追加
  - `MultivariateNewtonBounds<T>`
  - `MultivariateNewtonOptions<T>`
  - `newton_solve_multivariate_bounded`
  - `newton_solve_multivariate_bounded_with_solver`
- bounded 版でも unbounded 版と同じ `system: Fn(&Vector<T>) -> (Vector<T>, DynamicMatrix<T>)` 署名を維持
- 反復ごとに `next = current - step` を計算したあと `bounds.clamp(...)` を適用
- step 判定は clamp 後の実際に採用された更新量で評価
- [foundation/analysis/src/linalg/solver/mod.rs](foundation/analysis/src/linalg/solver/mod.rs)、[foundation/analysis/src/linalg/mod.rs](foundation/analysis/src/linalg/mod.rs)、[foundation/analysis/src/lib.rs](foundation/analysis/src/lib.rs) で新 API と型を再エクスポート
- [foundation/analysis/src/linalg/solver/newton_tests.rs](foundation/analysis/src/linalg/solver/newton_tests.rs) に以下を追加
  - bounds の次元不整合
  - 軸範囲逆転の拒否
  - clamp / contains
  - 初期値 clamp
  - 境界端収束
  - shape 不整合
  - 特異 Jacobian
- [dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md](dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md) に Phase D 実装スコープを追記

## 設計判断

- `Option<Vector<T>>` は既存 Newton 系との整合を優先して維持
- `MultivariateNewtonOptions<T>` は初手では `max_iter` と `tol` のみを保持
- `contains` は厳密比較のままとし、tolerance 付き境界判定は follow-up 論点として残す
- unbounded API の署名と挙動は変更しない

## 検証

- `cargo clippy -p analysis -- -D warnings`
- `cargo fmt`
- `cargo test -p analysis`
  - 169 tests passed
  - 14 doctests passed
