### PR TITLE
feat: add contains_with_tolerance for newton bounds

### DIFF
--- a/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
+++ b/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
@@ -814,6 +814,15 @@ where
 - `contains` の意味を後から tolerance-aware に変えると、既存利用者にとって API 意味論が変化する
 - 必要時に `contains_with_tolerance` を追加する方が、互換性と責務分離の両面で扱いやすい
 
+#### Issue #634 実装スコープ（2026年4月8日）
+
+- `MultivariateNewtonBounds<T>` に `contains_with_tolerance(&self, point: &Vector<T>, tol: T) -> bool` を追加する
+- `contains` の既存意味は変更しない
+- `tol < 0` 相当の入力は `0` に clamp して扱う
+- 判定は各軸で `lower[i] - tol <= value <= upper[i] + tol` を満たすかで決める
+- `point.len() != self.dimension()` は `false` を返す
+- `newton_tests.rs` に tolerance 内外、`tol = 0`、次元不整合、負の tolerance の固定テストを追加する
+
 ### 外部利用者向け移行方針
 
 - 新規コードでは `newton_solve_generic` / `newton_solve_bounded_generic` / `newton_solve_with_numeric_derivative_bounded_generic` / `newton_inverse_generic` を優先する

--- a/foundation/analysis/src/linalg/solver/newton.rs
+++ b/foundation/analysis/src/linalg/solver/newton.rs
@@ -125,6 +125,19 @@ impl<T: Scalar> MultivariateNewtonBounds<T> {
             .enumerate()
             .all(|(index, value)| *value >= self.lower[index] && *value <= self.upper[index])
     }
+
+    pub fn contains_with_tolerance(&self, point: &Vector<T>, tol: T) -> bool {
+        if point.len() != self.dimension() {
+            return false;
+        }
+
+        let effective_tol = tol.max(T::ZERO);
+
+        point.data().iter().enumerate().all(|(index, value)| {
+            *value >= self.lower[index] - effective_tol
+                && *value <= self.upper[index] + effective_tol
+        })
+    }
 }
 
 /// 境界付き多変数 Newton の反復設定

--- a/foundation/analysis/src/linalg/solver/newton_tests.rs
+++ b/foundation/analysis/src/linalg/solver/newton_tests.rs
@@ -265,6 +265,77 @@ mod tests {
     }
 
     #[test]
+    fn test_multivariate_newton_bounds_contains_with_tolerance_accepts_near_boundary() {
+        let bounds = MultivariateNewtonBounds::new(
+            Vector::new(vec![0.0_f64, -1.0_f64]),
+            Vector::new(vec![1.0_f64, 2.0_f64]),
+        )
+        .unwrap();
+        let point = Vector::new(vec![1.0005_f64, -1.0005_f64]);
+
+        assert!(bounds.contains_with_tolerance(&point, 1e-3_f64));
+    }
+
+    #[test]
+    fn test_multivariate_newton_bounds_contains_with_tolerance_rejects_outside_range() {
+        let bounds = MultivariateNewtonBounds::new(
+            Vector::new(vec![0.0_f64, -1.0_f64]),
+            Vector::new(vec![1.0_f64, 2.0_f64]),
+        )
+        .unwrap();
+        let point = Vector::new(vec![1.01_f64, -1.01_f64]);
+
+        assert!(!bounds.contains_with_tolerance(&point, 1e-3_f64));
+    }
+
+    #[test]
+    fn test_multivariate_newton_bounds_contains_with_tolerance_zero_matches_strict_contains() {
+        let bounds = MultivariateNewtonBounds::new(
+            Vector::new(vec![0.0_f64, -1.0_f64]),
+            Vector::new(vec![1.0_f64, 2.0_f64]),
+        )
+        .unwrap();
+        let point = Vector::new(vec![1.0_f64, -1.0_f64]);
+        let outside = Vector::new(vec![1.0001_f64, -1.0_f64]);
+
+        assert_eq!(
+            bounds.contains(&point),
+            bounds.contains_with_tolerance(&point, 0.0_f64)
+        );
+        assert_eq!(
+            bounds.contains(&outside),
+            bounds.contains_with_tolerance(&outside, 0.0_f64)
+        );
+    }
+
+    #[test]
+    fn test_multivariate_newton_bounds_contains_with_tolerance_rejects_dimension_mismatch() {
+        let bounds = MultivariateNewtonBounds::new(
+            Vector::new(vec![0.0_f64, -1.0_f64]),
+            Vector::new(vec![1.0_f64, 2.0_f64]),
+        )
+        .unwrap();
+        let point = Vector::new(vec![0.5_f64]);
+
+        assert!(!bounds.contains_with_tolerance(&point, 1e-3_f64));
+    }
+
+    #[test]
+    fn test_multivariate_newton_bounds_contains_with_tolerance_clamps_negative_tolerance_to_zero() {
+        let bounds = MultivariateNewtonBounds::new(
+            Vector::new(vec![0.0_f64, -1.0_f64]),
+            Vector::new(vec![1.0_f64, 2.0_f64]),
+        )
+        .unwrap();
+        let point = Vector::new(vec![1.0001_f64, -1.0_f64]);
+
+        assert_eq!(
+            bounds.contains_with_tolerance(&point, -1e-3_f64),
+            bounds.contains_with_tolerance(&point, 0.0_f64)
+        );
+    }
+
+    #[test]
     fn test_newton_solve_multivariate_bounded_clamps_initial_point() {
         let system = |point: &Vector<f64>| {
             let residual = Vector::new(vec![point[0] - 1.0]);


### PR DESCRIPTION
## 概要

- #634 の `contains_with_tolerance` を `MultivariateNewtonBounds<T>` に追加
- `contains` の既存意味は変更せず、tolerance-aware な補助判定を別 API として追加
- 負の tolerance は `0` に clamp して扱う挙動を固定

## 変更内容

- [foundation/analysis/src/linalg/solver/newton.rs](foundation/analysis/src/linalg/solver/newton.rs) に以下を追加
  - `MultivariateNewtonBounds<T>::contains_with_tolerance(&self, point: &Vector<T>, tol: T) -> bool`
- 判定ルールを各軸で `lower[i] - tol <= value <= upper[i] + tol` に統一
- `point.len() != self.dimension()` は `false` を返す
- `tol < 0` 相当は `0` に clamp して扱う
- [foundation/analysis/src/linalg/solver/newton_tests.rs](foundation/analysis/src/linalg/solver/newton_tests.rs) に以下の回帰テストを追加
  - 許容誤差内の近傍点を受理
  - 許容誤差外を拒否
  - `tol = 0` は strict `contains` と同値
  - 次元不整合は `false`
  - 負の tolerance は `0` に clamp
- [dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md](dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md) に #634 実装スコープを追記

## 設計判断

- `contains` は厳密比較のまま維持し、API 意味論を変えない
- tolerance-aware 判定は `contains_with_tolerance` に分離する
- 負の tolerance は panic や `false` 固定ではなく、利用側が安全に扱えるよう `0` と同値で処理する

## 検証

- `cargo clippy -p analysis -- -D warnings`
- `cargo fmt`
- `cargo test -p analysis`
  - 174 tests passed
  - 14 doctests passed

## 関連

- #634
- #632
- PR #631
- PR #633
