### PR TITLE
feat: split multivariate newton tolerances

### DIFF
--- a/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
+++ b/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
@@ -826,11 +826,10 @@ where
 #### Issue #636 実装スコープ（2026年4月8日）
 
 - `MultivariateNewtonOptions<T>` を `residual_tol` / `step_tol` に分離する
-- `new(max_iter, tol)` は互換入口として維持し、両 tolerance に同じ値を設定する
-- `with_tolerances(max_iter, residual_tol, step_tol)` を追加する
+- breaking change を受け入れ、`new(max_iter, residual_tol, step_tol)` に一本化する
 - bounded Newton 本体では residual 判定に `residual_tol`、step 判定に `step_tol` を使う
 - solver の既定 tolerance は `residual_tol` を元に生成する
-- `newton_tests.rs` に互換 constructor と分離 tolerance の固定テストを追加する
+- `newton_tests.rs` に分離 tolerance の固定テストを追加する
 
 ### 外部利用者向け移行方針
 

--- a/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
+++ b/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
@@ -823,6 +823,15 @@ where
 - `point.len() != self.dimension()` は `false` を返す
 - `newton_tests.rs` に tolerance 内外、`tol = 0`、次元不整合、負の tolerance の固定テストを追加する
 
+#### Issue #636 実装スコープ（2026年4月8日）
+
+- `MultivariateNewtonOptions<T>` を `residual_tol` / `step_tol` に分離する
+- `new(max_iter, tol)` は互換入口として維持し、両 tolerance に同じ値を設定する
+- `with_tolerances(max_iter, residual_tol, step_tol)` を追加する
+- bounded Newton 本体では residual 判定に `residual_tol`、step 判定に `step_tol` を使う
+- solver の既定 tolerance は `residual_tol` を元に生成する
+- `newton_tests.rs` に互換 constructor と分離 tolerance の固定テストを追加する
+
 ### 外部利用者向け移行方針
 
 - 新規コードでは `newton_solve_generic` / `newton_solve_bounded_generic` / `newton_solve_with_numeric_derivative_bounded_generic` / `newton_inverse_generic` を優先する

--- a/foundation/analysis/src/linalg/solver/newton.rs
+++ b/foundation/analysis/src/linalg/solver/newton.rs
@@ -149,15 +149,7 @@ pub struct MultivariateNewtonOptions<T: Scalar> {
 }
 
 impl<T: Scalar> MultivariateNewtonOptions<T> {
-    pub fn new(max_iter: usize, tol: T) -> Self {
-        Self {
-            max_iter,
-            residual_tol: tol,
-            step_tol: tol,
-        }
-    }
-
-    pub fn with_tolerances(max_iter: usize, residual_tol: T, step_tol: T) -> Self {
+    pub fn new(max_iter: usize, residual_tol: T, step_tol: T) -> Self {
         Self {
             max_iter,
             residual_tol,

--- a/foundation/analysis/src/linalg/solver/newton.rs
+++ b/foundation/analysis/src/linalg/solver/newton.rs
@@ -144,12 +144,25 @@ impl<T: Scalar> MultivariateNewtonBounds<T> {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct MultivariateNewtonOptions<T: Scalar> {
     pub max_iter: usize,
-    pub tol: T,
+    pub residual_tol: T,
+    pub step_tol: T,
 }
 
 impl<T: Scalar> MultivariateNewtonOptions<T> {
     pub fn new(max_iter: usize, tol: T) -> Self {
-        Self { max_iter, tol }
+        Self {
+            max_iter,
+            residual_tol: tol,
+            step_tol: tol,
+        }
+    }
+
+    pub fn with_tolerances(max_iter: usize, residual_tol: T, step_tol: T) -> Self {
+        Self {
+            max_iter,
+            residual_tol,
+            step_tol,
+        }
     }
 }
 
@@ -488,7 +501,7 @@ where
     T: Scalar,
     F: Fn(&Vector<T>) -> (Vector<T>, DynamicMatrix<T>),
 {
-    let solver = GaussianSolver::new(solver_tolerance(options.tol));
+    let solver = GaussianSolver::new(solver_tolerance(options.residual_tol));
     newton_solve_multivariate_bounded_with_solver(system, initial, bounds, &solver, options)
 }
 
@@ -513,7 +526,7 @@ where
             return None;
         }
 
-        if residual.norm() < options.tol {
+        if residual.norm() < options.residual_tol {
             return Some(current);
         }
 
@@ -527,7 +540,7 @@ where
             return None;
         }
 
-        if next_residual.norm() < options.tol && actual_step.norm() < options.tol {
+        if next_residual.norm() < options.residual_tol && actual_step.norm() < options.step_tol {
             return Some(next);
         }
 

--- a/foundation/analysis/src/linalg/solver/newton_tests.rs
+++ b/foundation/analysis/src/linalg/solver/newton_tests.rs
@@ -336,17 +336,8 @@ mod tests {
     }
 
     #[test]
-    fn test_multivariate_newton_options_new_sets_both_tolerances() {
-        let options = MultivariateNewtonOptions::new(25, 1e-6_f64);
-
-        assert_eq!(options.max_iter, 25);
-        assert_eq!(options.residual_tol, 1e-6_f64);
-        assert_eq!(options.step_tol, 1e-6_f64);
-    }
-
-    #[test]
-    fn test_multivariate_newton_options_with_tolerances_sets_separate_values() {
-        let options = MultivariateNewtonOptions::with_tolerances(25, 1e-4_f64, 1e-8_f64);
+    fn test_multivariate_newton_options_new_sets_separate_values() {
+        let options = MultivariateNewtonOptions::new(25, 1e-4_f64, 1e-8_f64);
 
         assert_eq!(options.max_iter, 25);
         assert_eq!(options.residual_tol, 1e-4_f64);
@@ -363,7 +354,7 @@ mod tests {
         let bounds =
             MultivariateNewtonBounds::new(Vector::new(vec![0.0_f64]), Vector::new(vec![1.0_f64]))
                 .unwrap();
-        let options = MultivariateNewtonOptions::new(20, TOLERANCE_F64);
+        let options = MultivariateNewtonOptions::new(20, TOLERANCE_F64, TOLERANCE_F64);
 
         let result = newton_solve_multivariate_bounded(
             system,
@@ -389,7 +380,7 @@ mod tests {
         let bounds =
             MultivariateNewtonBounds::new(Vector::new(vec![0.0_f64]), Vector::new(vec![1.0_f64]))
                 .unwrap();
-        let options = MultivariateNewtonOptions::new(20, TOLERANCE_F64);
+        let options = MultivariateNewtonOptions::new(20, TOLERANCE_F64, TOLERANCE_F64);
 
         let result = newton_solve_multivariate_bounded(
             system,
@@ -420,7 +411,7 @@ mod tests {
             Vector::new(vec![1.0_f64, 1.0_f64]),
         )
         .unwrap();
-        let options = MultivariateNewtonOptions::new(10, TOLERANCE_F64);
+        let options = MultivariateNewtonOptions::new(10, TOLERANCE_F64, TOLERANCE_F64);
         let solver = LUSolver::new(TOLERANCE_F64);
 
         let result = newton_solve_multivariate_bounded_with_solver(
@@ -447,7 +438,7 @@ mod tests {
             Vector::new(vec![1.0_f64, 1.0_f64]),
         )
         .unwrap();
-        let options = MultivariateNewtonOptions::new(10, TOLERANCE_F64);
+        let options = MultivariateNewtonOptions::new(10, TOLERANCE_F64, TOLERANCE_F64);
 
         let result = newton_solve_multivariate_bounded(
             system,
@@ -468,7 +459,7 @@ mod tests {
         let bounds =
             MultivariateNewtonBounds::new(Vector::new(vec![0.0_f64]), Vector::new(vec![1.0_f64]))
                 .unwrap();
-        let options = MultivariateNewtonOptions::with_tolerances(1, 0.1_f64, 0.5_f64);
+        let options = MultivariateNewtonOptions::new(1, 0.1_f64, 0.5_f64);
 
         let result = newton_solve_multivariate_bounded(
             system,

--- a/foundation/analysis/src/linalg/solver/newton_tests.rs
+++ b/foundation/analysis/src/linalg/solver/newton_tests.rs
@@ -336,6 +336,24 @@ mod tests {
     }
 
     #[test]
+    fn test_multivariate_newton_options_new_sets_both_tolerances() {
+        let options = MultivariateNewtonOptions::new(25, 1e-6_f64);
+
+        assert_eq!(options.max_iter, 25);
+        assert_eq!(options.residual_tol, 1e-6_f64);
+        assert_eq!(options.step_tol, 1e-6_f64);
+    }
+
+    #[test]
+    fn test_multivariate_newton_options_with_tolerances_sets_separate_values() {
+        let options = MultivariateNewtonOptions::with_tolerances(25, 1e-4_f64, 1e-8_f64);
+
+        assert_eq!(options.max_iter, 25);
+        assert_eq!(options.residual_tol, 1e-4_f64);
+        assert_eq!(options.step_tol, 1e-8_f64);
+    }
+
+    #[test]
     fn test_newton_solve_multivariate_bounded_clamps_initial_point() {
         let system = |point: &Vector<f64>| {
             let residual = Vector::new(vec![point[0] - 1.0]);
@@ -437,6 +455,28 @@ mod tests {
             &bounds,
             &options,
         );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_newton_solve_multivariate_bounded_uses_separate_step_tolerance() {
+        let system = |point: &Vector<f64>| {
+            let residual = Vector::new(vec![point[0] - 0.8_f64]);
+            let jacobian = DynamicMatrix::from_rows(vec![vec![1.0_f64]]).unwrap();
+            (residual, jacobian)
+        };
+        let bounds =
+            MultivariateNewtonBounds::new(Vector::new(vec![0.0_f64]), Vector::new(vec![1.0_f64]))
+                .unwrap();
+        let options = MultivariateNewtonOptions::with_tolerances(1, 0.1_f64, 0.5_f64);
+
+        let result = newton_solve_multivariate_bounded(
+            system,
+            Vector::new(vec![0.0_f64]),
+            &bounds,
+            &options,
+        );
+
         assert!(result.is_none());
     }
 }


### PR DESCRIPTION
## 概要

- #636 として `MultivariateNewtonOptions<T>` の tolerance を分離
- `new(max_iter, tol)` は互換入口として維持しつつ、`with_tolerances` を追加
- bounded multivariate Newton 本体で residual 判定と step 判定を別々に扱うように変更

## 変更内容

- [foundation/analysis/src/linalg/solver/newton.rs](foundation/analysis/src/linalg/solver/newton.rs) の `MultivariateNewtonOptions<T>` を更新
  - `residual_tol`
  - `step_tol`
- 互換 constructor として `new(max_iter, tol)` を維持
- 分離設定用に `with_tolerances(max_iter, residual_tol, step_tol)` を追加
- bounded Newton 本体では
  - residual 判定に `options.residual_tol`
  - step 判定に `options.step_tol`
  を使用
- 既定 solver の tolerance 生成は `residual_tol` を使用
- [foundation/analysis/src/linalg/solver/newton_tests.rs](foundation/analysis/src/linalg/solver/newton_tests.rs) に以下を追加
  - `new(max_iter, tol)` が両 tolerance を同値設定する互換テスト
  - `with_tolerances` が分離値を保持するテスト
  - `step_tol` が独立して効くことの回帰テスト
- [dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md](dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md) に #636 実装スコープを追記

## 設計判断

- API 互換性を保つため、`new(max_iter, tol)` は残す
- 拡張入口は `with_tolerances` で明示し、builder までは持ち込まない
- solver tolerance は新規フィールドを増やさず、当面は `residual_tol` を基準にする

## 検証

- `cargo clippy -p analysis -- -D warnings`
- `cargo fmt`
- `cargo test -p analysis`
  - 177 tests passed
  - 14 doctests passed

## 関連

- #636
- #632
- PR #631
- PR #635
