### PR TITLE
fix: separate typed tolerances for analysis and geometry

### DIFF
--- a/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
+++ b/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
@@ -512,7 +512,7 @@ fn solve_linear_2x2<T: Scalar>(
 
 #### 特異判定と閾値方針
 
-- 1変数 generic solver と同様に `DERIVATIVE_ZERO_THRESHOLD` を `T::from_f64` で変換して利用する
+- `DERIVATIVE_ZERO_THRESHOLD_F32` / `DERIVATIVE_ZERO_THRESHOLD_F64` を型に応じて選択して利用する
 - helper 名は既存との整合を優先し、`derivative_zero_threshold::<T>()` を再利用する
 - 2変数 solver 専用の別閾値はこの段階では導入しない
 

--- a/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
+++ b/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
@@ -251,6 +251,60 @@
 - 特に 1変数 solver 群だけが generic 化され、2変数 solver だけが `f64` 固定で残る状態は、数値解析基盤としての API 一貫性を損ないやすい
 - よって #619 では `newton_solve_2d` の generic 化を単なる将来候補ではなく、計画された follow-up として扱う
 
+## 追加設計判断: Newton 収束 tolerance と線形 solver tolerance の分離（2026年4月8日, #638）
+
+### 背景
+
+- `newton_solve_multivariate` は `tol` を Newton 収束判定に使う
+- `newton_solve_multivariate_bounded` は `MultivariateNewtonOptions<T>::residual_tol` と `step_tol` を停止判定に使う
+- ただし従来の既定 `GaussianSolver<T>` 生成では、これらの収束 tolerance をそのまま線形 solver tolerance へ流用していた
+
+この結合により、Newton の停止条件を緩くしたいだけの呼び出しでも、線形 solver 側の特異判定閾値まで同時に緩んでしまっていた。
+
+### 比較案
+
+#### 案1: `MultivariateNewtonOptions<T>` に線形 solver tolerance を追加する
+
+利点:
+
+- 境界付き Newton の既定経路でも責務分離が明示される
+
+欠点:
+
+- constructor 引数が増えるか builder 導入が必要になる
+- 既に存在する `*_with_solver` 系 API と責務が一部重複する
+
+#### 案2: 既定 solver 生成だけを独立定数へ分離し、override は `*_with_solver` に委ねる
+
+利点:
+
+- 最小変更で責務分離できる
+- 公開 API を再度破壊せずに済む
+- 「既定値」と「明示 override」の責務境界が明確になる
+
+欠点:
+
+- default API だけを見ると solver tolerance がフィールドとしては見えない
+
+### 採用案
+
+本 follow-up では **案2** を採用する。
+
+方針:
+
+- Newton の収束 tolerance は停止判定専用とする
+- 既定 `GaussianSolver<T>` の tolerance は収束 tolerance から導出しない
+- 既定 solver 生成には `LINEAR_SOLVER_TOLERANCE_F64` を generic 変換した独立値を使う
+- custom な線形 solver tolerance が必要な場合は `newton_solve_multivariate_with_solver` / `newton_solve_multivariate_bounded_with_solver` を使用する
+
+### 使い分け方針
+
+- `tol` / `residual_tol`: 非線形方程式の residual が十分小さいかを判定する Newton 側の収束基準
+- `step_tol`: Newton 更新量が十分小さいかを判定する停止基準
+- `LINEAR_SOLVER_TOLERANCE_F64`: Jacobian 線形系を解く際の特異判定・ピボット判定に使う既定閾値
+
+したがって、Newton の停止精度を変更したい場合に `tol` や `residual_tol` を調整しても、既定線形 solver の特異判定閾値は連動させない。
+
 ### #619 の比較案
 
 #### 案1: 2変数専用 API を維持したまま generic 化する

--- a/dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md
+++ b/dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md
@@ -174,6 +174,7 @@ integration テストで `ToleranceSettings` を使ってよい理由は次の�
 2. 固定しきい値は `foundation/analysis/src/consts.rs` に用途別の意味付き定数として定義し、暗黙の `T::EPSILON` 直書きを避ける。
 3. `ToleranceSettings::distance_tolerance` は幾何意味判定（包含、近接、一致）に限定し、数値安定化ガードの既定値に流用しない。
 4. 無次元判定（内積・外積誤差）には無次元しきい値を使用し、単位付き距離トレランスを混在させない。
+5. `f64` 専用の極小固定値を `T::from_f64(...)` で generic に流用しない。`f32`/`f64` の両対応が必要な固定しきい値は、型別定義または `default_*` wrapper を経由して選択する。
 
 ## 廃止ロードマップ
 

--- a/foundation/analysis/src/consts.rs
+++ b/foundation/analysis/src/consts.rs
@@ -5,8 +5,17 @@
 
 /// 数値計算アルゴリズム用の閾値
 pub mod numerical {
-    /// ニュートン法で微分がゼロとみなされる閾値
+    /// ニュートン法で微分がゼロとみなされる閾値（f32）
+    pub const DERIVATIVE_ZERO_THRESHOLD_F32: f32 = 1e-6;
+
+    /// ニュートン法で微分がゼロとみなされる閾値（f64）
     pub const DERIVATIVE_ZERO_THRESHOLD: f64 = 1e-12;
+
+    /// 線形 solver の特異判定・ピボット判定に使う既定閾値（f32）
+    pub const LINEAR_SOLVER_TOLERANCE_F32: f32 = 1e-6;
+
+    /// 線形 solver の特異判定・ピボット判定に使う既定閾値
+    pub const LINEAR_SOLVER_TOLERANCE_F64: f64 = 1e-15;
 
     /// カーネル内部のゼロ判定（ゼロベクトル長・分母ゼロ近傍）用固定閾値（f64）
     pub const KERNEL_NUMERICAL_ZERO_THRESHOLD_F64: f64 = 1e-12;
@@ -195,8 +204,11 @@ pub mod test_constants {
 
     // 数値計算アルゴリズム専用の許容誤差
 
+    /// ソルバー用高精度許容誤差（f32）
+    pub const SOLVER_TOLERANCE_F32: f32 = super::numerical::LINEAR_SOLVER_TOLERANCE_F32;
+
     /// ソルバー用高精度許容誤差
-    pub const SOLVER_TOLERANCE_F64: f64 = 1e-15;
+    pub const SOLVER_TOLERANCE_F64: f64 = super::numerical::LINEAR_SOLVER_TOLERANCE_F64;
 
     /// 数値積分用許容誤差（標準精度）
     pub const INTEGRATION_TOLERANCE: f64 = 1e-4;

--- a/foundation/analysis/src/consts.rs
+++ b/foundation/analysis/src/consts.rs
@@ -9,7 +9,7 @@ pub mod numerical {
     pub const DERIVATIVE_ZERO_THRESHOLD_F32: f32 = 1e-6;
 
     /// ニュートン法で微分がゼロとみなされる閾値（f64）
-    pub const DERIVATIVE_ZERO_THRESHOLD: f64 = 1e-12;
+    pub const DERIVATIVE_ZERO_THRESHOLD_F64: f64 = 1e-12;
 
     /// 線形 solver の特異判定・ピボット判定に使う既定閾値（f32）
     pub const LINEAR_SOLVER_TOLERANCE_F32: f32 = 1e-6;
@@ -181,8 +181,9 @@ impl GeometricTolerance for f64 {
     const ORTHOGONALITY_DOT_ERROR_TOLERANCE: f64 = numerical::ORTHOGONALITY_DOT_ERROR_TOLERANCE_F64;
 }
 
-// 数値計算定数の再エクスポート（後方互換性）
-pub const DERIVATIVE_ZERO_THRESHOLD: f64 = numerical::DERIVATIVE_ZERO_THRESHOLD;
+// 数値計算定数の再エクスポート
+pub const DERIVATIVE_ZERO_THRESHOLD_F32: f32 = numerical::DERIVATIVE_ZERO_THRESHOLD_F32;
+pub const DERIVATIVE_ZERO_THRESHOLD_F64: f64 = numerical::DERIVATIVE_ZERO_THRESHOLD_F64;
 
 /// テスト用の統一トレランス定数
 pub mod test_constants {

--- a/foundation/analysis/src/consts.rs
+++ b/foundation/analysis/src/consts.rs
@@ -53,6 +53,10 @@ pub mod special {
     /// 平方根 √3
     pub const SQRT_3_F64: f64 = 1.7320508075688772;
     pub const SQRT_3_F32: f32 = 1.7320508_f32;
+
+    /// 平方根 √3 の半分
+    pub const SQRT_3_OVER_2_F64: f64 = SQRT_3_F64 / 2.0;
+    pub const SQRT_3_OVER_2_F32: f32 = SQRT_3_F32 / 2.0;
 }
 
 /// 幾何計算用の定数

--- a/foundation/analysis/src/consts_tests.rs
+++ b/foundation/analysis/src/consts_tests.rs
@@ -1,5 +1,7 @@
 use super::{special, GeometricTolerance};
-use crate::consts::test_constants::{SOLVER_TOLERANCE_F64, TOLERANCE_F32, TOLERANCE_F64};
+use crate::consts::test_constants::{
+    SOLVER_TOLERANCE_F32, SOLVER_TOLERANCE_F64, TOLERANCE_F32, TOLERANCE_F64,
+};
 
 #[test]
 fn test_special_constants() {
@@ -46,4 +48,11 @@ fn test_tolerance_constants() {
     let distance_f32 = <f32 as GeometricTolerance>::DISTANCE_TOLERANCE;
     assert_eq!(angle_f32, 1e-6);
     assert_eq!(distance_f32, 1e-6);
+
+    assert_eq!(SOLVER_TOLERANCE_F32, 1e-6_f32);
+    assert_eq!(SOLVER_TOLERANCE_F64, 1e-15_f64);
+    assert!(SOLVER_TOLERANCE_F32 > 0.0_f32);
+
+    assert_eq!(super::numerical::DERIVATIVE_ZERO_THRESHOLD_F32, 1e-6_f32);
+    assert_eq!(super::DERIVATIVE_ZERO_THRESHOLD, 1e-12_f64);
 }

--- a/foundation/analysis/src/consts_tests.rs
+++ b/foundation/analysis/src/consts_tests.rs
@@ -54,7 +54,6 @@ fn test_tolerance_constants() {
 
     assert_eq!(SOLVER_TOLERANCE_F32, 1e-6_f32);
     assert_eq!(SOLVER_TOLERANCE_F64, 1e-15_f64);
-    assert!(SOLVER_TOLERANCE_F32 > 0.0_f32);
 
     assert_eq!(super::numerical::DERIVATIVE_ZERO_THRESHOLD_F32, 1e-6_f32);
     assert_eq!(super::DERIVATIVE_ZERO_THRESHOLD, 1e-12_f64);

--- a/foundation/analysis/src/consts_tests.rs
+++ b/foundation/analysis/src/consts_tests.rs
@@ -56,5 +56,5 @@ fn test_tolerance_constants() {
     assert_eq!(SOLVER_TOLERANCE_F64, 1e-15_f64);
 
     assert_eq!(super::numerical::DERIVATIVE_ZERO_THRESHOLD_F32, 1e-6_f32);
-    assert_eq!(super::DERIVATIVE_ZERO_THRESHOLD, 1e-12_f64);
+    assert_eq!(super::numerical::DERIVATIVE_ZERO_THRESHOLD_F64, 1e-12_f64);
 }

--- a/foundation/analysis/src/consts_tests.rs
+++ b/foundation/analysis/src/consts_tests.rs
@@ -25,6 +25,9 @@ fn test_special_constants() {
     // √3のテスト
     let sqrt_3_f64 = special::SQRT_3_F64;
     assert!((sqrt_3_f64 - 3.0_f64.sqrt()).abs() < SOLVER_TOLERANCE_F64);
+
+    let sqrt_3_over_2_f64 = special::SQRT_3_OVER_2_F64;
+    assert!((sqrt_3_over_2_f64 - (3.0_f64.sqrt() / 2.0)).abs() < SOLVER_TOLERANCE_F64);
 }
 
 #[test]

--- a/foundation/analysis/src/lib.rs
+++ b/foundation/analysis/src/lib.rs
@@ -21,9 +21,9 @@ pub use linalg::vector::{Vector2, Vector3, Vector4};
 
 // 定数の再エクスポート
 pub use consts::{
-    game, precision, test_constants, GeometricTolerance, DEG_TO_RAD, DERIVATIVE_ZERO_THRESHOLD, E,
-    GEOMETRIC_ANGLE_TOLERANCE, GEOMETRIC_DISTANCE_TOLERANCE, PI, PI_2, PI_3, PI_4, PI_6,
-    RAD_TO_DEG, TAU,
+    game, precision, test_constants, GeometricTolerance, DEG_TO_RAD, DERIVATIVE_ZERO_THRESHOLD_F32,
+    DERIVATIVE_ZERO_THRESHOLD_F64, E, GEOMETRIC_ANGLE_TOLERANCE, GEOMETRIC_DISTANCE_TOLERANCE, PI,
+    PI_2, PI_3, PI_4, PI_6, RAD_TO_DEG, TAU,
 };
 
 // 数値計算関数の再エクスポート（numericsモジュールから）

--- a/foundation/analysis/src/linalg/solver/cramer_tests.rs
+++ b/foundation/analysis/src/linalg/solver/cramer_tests.rs
@@ -1,5 +1,5 @@
 use super::{CramerSolver, LinearSolver};
-use crate::consts::test_constants::{SOLVER_TOLERANCE_F64, TOLERANCE_F64};
+use crate::consts::test_constants::{SOLVER_TOLERANCE_F32, SOLVER_TOLERANCE_F64, TOLERANCE_F64};
 
 #[cfg(test)]
 mod tests {
@@ -57,7 +57,7 @@ mod tests {
         let matrix = vec![vec![2.0_f32, 1.0_f32], vec![1.0_f32, 3.0_f32]];
         let rhs = vec![5.0_f32, 6.0_f32];
 
-        let solver = CramerSolver::<f32>::new(1e-6_f32);
+        let solver = CramerSolver::<f32>::new(SOLVER_TOLERANCE_F32);
         let result = solver.solve(&matrix, &rhs).unwrap();
 
         assert!((result.solution[0] - 1.8_f32).abs() < 1e-4_f32);

--- a/foundation/analysis/src/linalg/solver/gaussian_tests.rs
+++ b/foundation/analysis/src/linalg/solver/gaussian_tests.rs
@@ -1,5 +1,5 @@
 use super::{GaussianSolver, LinearSolver};
-use crate::consts::test_constants::{SOLVER_TOLERANCE_F64, TOLERANCE_F64};
+use crate::consts::test_constants::{SOLVER_TOLERANCE_F32, SOLVER_TOLERANCE_F64, TOLERANCE_F64};
 
 #[cfg(test)]
 mod tests {
@@ -60,7 +60,7 @@ mod tests {
         let matrix = vec![vec![2.0_f32, 1.0_f32], vec![1.0_f32, 3.0_f32]];
         let rhs = vec![5.0_f32, 6.0_f32];
 
-        let solver = GaussianSolver::<f32>::new(1e-6_f32);
+        let solver = GaussianSolver::<f32>::new(SOLVER_TOLERANCE_F32);
         let result = solver.solve(&matrix, &rhs).unwrap();
 
         assert!((result.solution[0] - 1.8_f32).abs() < 1e-4_f32);

--- a/foundation/analysis/src/linalg/solver/lu_tests.rs
+++ b/foundation/analysis/src/linalg/solver/lu_tests.rs
@@ -1,5 +1,5 @@
 use super::{LUSolver, LinearSolver};
-use crate::consts::test_constants::{SOLVER_TOLERANCE_F64, TOLERANCE_F64};
+use crate::consts::test_constants::{SOLVER_TOLERANCE_F32, SOLVER_TOLERANCE_F64, TOLERANCE_F64};
 
 #[cfg(test)]
 mod tests {
@@ -84,7 +84,7 @@ mod tests {
     fn test_lu_solver_2x2_f32() {
         let matrix = vec![vec![2.0_f32, 1.0_f32], vec![1.0_f32, 3.0_f32]];
         let rhs = vec![5.0_f32, 6.0_f32];
-        let solver = LUSolver::<f32>::new(1e-6_f32);
+        let solver = LUSolver::<f32>::new(SOLVER_TOLERANCE_F32);
 
         let result = solver.solve(&matrix, &rhs).unwrap();
         assert!((result.solution[0] - 1.8_f32).abs() < 1e-4_f32);

--- a/foundation/analysis/src/linalg/solver/newton.rs
+++ b/foundation/analysis/src/linalg/solver/newton.rs
@@ -6,19 +6,20 @@
 use std::any::TypeId;
 
 use crate::consts::numerical::{
-    DERIVATIVE_ZERO_THRESHOLD_F32, LINEAR_SOLVER_TOLERANCE_F32, LINEAR_SOLVER_TOLERANCE_F64,
+    DERIVATIVE_ZERO_THRESHOLD_F32, DERIVATIVE_ZERO_THRESHOLD_F64, LINEAR_SOLVER_TOLERANCE_F32,
+    LINEAR_SOLVER_TOLERANCE_F64,
 };
 use crate::linalg::{
     DynamicMatrix, DynamicMatrixLinearSolver, GaussianSolver, Matrix2x2, Vector, Vector2,
 };
-use crate::{Scalar, DERIVATIVE_ZERO_THRESHOLD};
+use crate::Scalar;
 
 #[inline]
 fn derivative_zero_threshold<T: Scalar>() -> T {
     if TypeId::of::<T>() == TypeId::of::<f32>() {
         T::from_f32(DERIVATIVE_ZERO_THRESHOLD_F32)
     } else {
-        T::from_f64(DERIVATIVE_ZERO_THRESHOLD)
+        T::from_f64(DERIVATIVE_ZERO_THRESHOLD_F64)
     }
 }
 

--- a/foundation/analysis/src/linalg/solver/newton.rs
+++ b/foundation/analysis/src/linalg/solver/newton.rs
@@ -3,6 +3,11 @@
 //! 非線形方程式 f(x) = 0 の求解や逆関数計算を提供する。
 //! 汎用的なニュートン法実装により、様々な数値計算問題に対応。
 
+use std::any::TypeId;
+
+use crate::consts::numerical::{
+    DERIVATIVE_ZERO_THRESHOLD_F32, LINEAR_SOLVER_TOLERANCE_F32, LINEAR_SOLVER_TOLERANCE_F64,
+};
 use crate::linalg::{
     DynamicMatrix, DynamicMatrixLinearSolver, GaussianSolver, Matrix2x2, Vector, Vector2,
 };
@@ -10,7 +15,11 @@ use crate::{Scalar, DERIVATIVE_ZERO_THRESHOLD};
 
 #[inline]
 fn derivative_zero_threshold<T: Scalar>() -> T {
-    T::from_f64(DERIVATIVE_ZERO_THRESHOLD)
+    if TypeId::of::<T>() == TypeId::of::<f32>() {
+        T::from_f32(DERIVATIVE_ZERO_THRESHOLD_F32)
+    } else {
+        T::from_f64(DERIVATIVE_ZERO_THRESHOLD)
+    }
 }
 
 #[inline]
@@ -21,6 +30,17 @@ fn solver_tolerance<T: Scalar>(tol: T) -> T {
     } else {
         tol
     }
+}
+
+#[inline]
+fn default_linear_solver_tolerance<T: Scalar>() -> T {
+    let tolerance = if TypeId::of::<T>() == TypeId::of::<f32>() {
+        T::from_f32(LINEAR_SOLVER_TOLERANCE_F32)
+    } else {
+        T::from_f64(LINEAR_SOLVER_TOLERANCE_F64)
+    };
+
+    solver_tolerance(tolerance)
 }
 
 #[inline]
@@ -434,7 +454,7 @@ where
     T: Scalar,
     F: Fn(&Vector<T>) -> (Vector<T>, DynamicMatrix<T>),
 {
-    let solver = GaussianSolver::new(solver_tolerance(tol));
+    let solver = GaussianSolver::new(default_linear_solver_tolerance());
     newton_solve_multivariate_with_solver(system, initial, &solver, max_iter, tol)
 }
 
@@ -493,7 +513,7 @@ where
     T: Scalar,
     F: Fn(&Vector<T>) -> (Vector<T>, DynamicMatrix<T>),
 {
-    let solver = GaussianSolver::new(solver_tolerance(options.residual_tol));
+    let solver = GaussianSolver::new(default_linear_solver_tolerance());
     newton_solve_multivariate_bounded_with_solver(system, initial, bounds, &solver, options)
 }
 

--- a/foundation/analysis/src/linalg/solver/newton_tests.rs
+++ b/foundation/analysis/src/linalg/solver/newton_tests.rs
@@ -5,7 +5,9 @@ use super::newton::{
     newton_solve_with_numeric_derivative_bounded_generic, MultivariateNewtonBounds,
     MultivariateNewtonOptions,
 };
-use crate::consts::test_constants::{INTEGRATION_TOLERANCE_STRICT, TOLERANCE_F64};
+use crate::consts::test_constants::{
+    INTEGRATION_TOLERANCE_STRICT, SOLVER_TOLERANCE_F32, TOLERANCE_F64,
+};
 use crate::linalg::{DynamicMatrix, LUSolver, Vector};
 
 #[cfg(test)]
@@ -185,7 +187,7 @@ mod tests {
             (residual, jacobian)
         };
 
-        let solver = LUSolver::new(1e-6_f32);
+        let solver = LUSolver::new(SOLVER_TOLERANCE_F32);
         let result = newton_solve_multivariate_with_solver(
             system,
             Vector::new(vec![1.0_f32, 0.5_f32]),
@@ -226,6 +228,21 @@ mod tests {
         let result =
             newton_solve_multivariate(system, Vector::new(vec![1.0, 1.0]), 10, TOLERANCE_F64);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_newton_solve_multivariate_default_solver_tolerance_is_independent_from_convergence_tol()
+    {
+        let system = |point: &Vector<f64>| {
+            let residual = Vector::new(vec![1e-5_f64 * point[0] - 1e-3_f64]);
+            let jacobian = DynamicMatrix::from_rows(vec![vec![1e-5_f64]]).unwrap();
+            (residual, jacobian)
+        };
+
+        let result = newton_solve_multivariate(system, Vector::new(vec![0.0_f64]), 5, 1e-4_f64);
+
+        assert!(result.is_some());
+        assert!((result.unwrap()[0] - 100.0_f64).abs() < INTEGRATION_TOLERANCE_STRICT);
     }
 
     #[test]
@@ -469,5 +486,29 @@ mod tests {
         );
 
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_newton_solve_multivariate_bounded_default_solver_tolerance_is_independent_from_residual_tol(
+    ) {
+        let system = |point: &Vector<f64>| {
+            let residual = Vector::new(vec![1e-5_f64 * point[0] - 1e-3_f64]);
+            let jacobian = DynamicMatrix::from_rows(vec![vec![1e-5_f64]]).unwrap();
+            (residual, jacobian)
+        };
+        let bounds =
+            MultivariateNewtonBounds::new(Vector::new(vec![0.0_f64]), Vector::new(vec![200.0_f64]))
+                .unwrap();
+        let options = MultivariateNewtonOptions::new(5, 1e-4_f64, 1e-4_f64);
+
+        let result = newton_solve_multivariate_bounded(
+            system,
+            Vector::new(vec![0.0_f64]),
+            &bounds,
+            &options,
+        );
+
+        assert!(result.is_some());
+        assert!((result.unwrap()[0] - 100.0_f64).abs() < INTEGRATION_TOLERANCE_STRICT);
     }
 }

--- a/model/geo_contracts/src/tolerance.rs
+++ b/model/geo_contracts/src/tolerance.rs
@@ -2,7 +2,50 @@
 //!
 //! geo_contracts で共有するトレランス設定。
 
+use std::any::TypeId;
+
+use analysis::consts::numerical::{
+    KERNEL_NUMERICAL_ZERO_THRESHOLD_F32, KERNEL_NUMERICAL_ZERO_THRESHOLD_F64,
+};
+
 use crate::Scalar;
+
+#[inline]
+fn is_f32_scalar<T: Scalar>() -> bool {
+    TypeId::of::<T>() == TypeId::of::<f32>()
+}
+
+#[inline]
+fn precision_distance_tolerance<T: Scalar>() -> T {
+    if is_f32_scalar::<T>() {
+        T::DISTANCE_TOLERANCE
+    } else {
+        T::from_f64(1e-12)
+    }
+}
+
+#[inline]
+fn precision_angle_tolerance<T: Scalar>() -> T {
+    if is_f32_scalar::<T>() {
+        T::ANGLE_TOLERANCE
+    } else {
+        T::from_f64(1e-10)
+    }
+}
+
+#[inline]
+fn precision_length_tolerance<T: Scalar>() -> T {
+    if is_f32_scalar::<T>() {
+        T::DISTANCE_TOLERANCE
+    } else {
+        T::from_f64(1e-12)
+    }
+}
+
+#[inline]
+fn area_tolerance_from_length<T: Scalar>(length_tolerance: T) -> T {
+    length_tolerance * length_tolerance
+}
 
 /// アプリケーション固有の許容誤差設定
 #[derive(Debug, Clone, Copy)]
@@ -13,7 +56,7 @@ pub struct ToleranceSettings<T: Scalar> {
     /// 角度計算用の許容誤差（平行・垂直判定など）
     pub angle_tolerance: T,
 
-    /// 面積計算用の許容誤差
+    /// 面積計算用の許容誤差（長さトレランスの二乗系）
     pub area_tolerance: T,
 
     /// 長さ計算用の許容誤差
@@ -23,31 +66,40 @@ pub struct ToleranceSettings<T: Scalar> {
 impl<T: Scalar> ToleranceSettings<T> {
     /// 高精度設定（CAD/精密加工用）
     pub fn precision() -> Self {
+        let distance_tolerance = precision_distance_tolerance();
+        let angle_tolerance = precision_angle_tolerance();
+        let length_tolerance = precision_length_tolerance();
         Self {
-            distance_tolerance: T::from_f64(1e-12),
-            angle_tolerance: T::from_f64(1e-10),
-            area_tolerance: T::from_f64(1e-10),
-            length_tolerance: T::from_f64(1e-12),
+            distance_tolerance,
+            angle_tolerance,
+            area_tolerance: area_tolerance_from_length(length_tolerance),
+            length_tolerance,
         }
     }
 
     /// 標準設定（一般的な工学計算用）
     pub fn standard() -> Self {
+        let distance_tolerance = T::from_f64(1e-6);
+        let angle_tolerance = T::from_f64(1e-4);
+        let length_tolerance = T::from_f64(1e-6);
         Self {
-            distance_tolerance: T::from_f64(1e-6),
-            angle_tolerance: T::from_f64(1e-4),
-            area_tolerance: T::from_f64(1e-6),
-            length_tolerance: T::from_f64(1e-6),
+            distance_tolerance,
+            angle_tolerance,
+            area_tolerance: area_tolerance_from_length(length_tolerance),
+            length_tolerance,
         }
     }
 
     /// 緩い設定（ゲーム・リアルタイム用）
     pub fn relaxed() -> Self {
+        let distance_tolerance = T::from_f64(1e-3);
+        let angle_tolerance = T::from_f64(1e-2);
+        let length_tolerance = T::from_f64(1e-3);
         Self {
-            distance_tolerance: T::from_f64(1e-3),
-            angle_tolerance: T::from_f64(1e-2),
-            area_tolerance: T::from_f64(1e-3),
-            length_tolerance: T::from_f64(1e-3),
+            distance_tolerance,
+            angle_tolerance,
+            area_tolerance: area_tolerance_from_length(length_tolerance),
+            length_tolerance,
         }
     }
 
@@ -92,7 +144,11 @@ pub fn default_orthogonality_dot_error_tolerance<T: Scalar>() -> T {
 ///
 /// `ToleranceSettings` とは独立しており、アプリケーション設定で変更しない。
 pub fn default_kernel_numerical_zero_tolerance<T: Scalar>() -> T {
-    T::from_f64(analysis::consts::numerical::KERNEL_NUMERICAL_ZERO_THRESHOLD_F64)
+    if is_f32_scalar::<T>() {
+        T::from_f32(KERNEL_NUMERICAL_ZERO_THRESHOLD_F32)
+    } else {
+        T::from_f64(KERNEL_NUMERICAL_ZERO_THRESHOLD_F64)
+    }
 }
 
 /// 幾何計算コンテキスト
@@ -126,5 +182,46 @@ impl<T: Scalar> GeometryContext<T> {
 impl<T: Scalar> Default for GeometryContext<T> {
     fn default() -> Self {
         Self::standard()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_precision_profile_is_type_aware() {
+        let f32_profile = ToleranceSettings::<f32>::precision();
+        assert_eq!(f32_profile.distance_tolerance, 1e-6_f32);
+        assert_eq!(f32_profile.angle_tolerance, 1e-6_f32);
+        assert_eq!(f32_profile.area_tolerance, 1e-12_f32);
+        assert_eq!(f32_profile.length_tolerance, 1e-6_f32);
+
+        let f64_profile = ToleranceSettings::<f64>::precision();
+        assert_eq!(f64_profile.distance_tolerance, 1e-12_f64);
+        assert_eq!(f64_profile.angle_tolerance, 1e-10_f64);
+        assert_eq!(f64_profile.area_tolerance, 1e-24_f64);
+        assert_eq!(f64_profile.length_tolerance, 1e-12_f64);
+    }
+
+    #[test]
+    fn test_standard_and_relaxed_area_tolerance_follow_length_squared() {
+        let standard = ToleranceSettings::<f64>::standard();
+        assert_eq!(
+            standard.area_tolerance,
+            standard.length_tolerance * standard.length_tolerance
+        );
+
+        let relaxed = ToleranceSettings::<f32>::relaxed();
+        assert_eq!(
+            relaxed.area_tolerance,
+            relaxed.length_tolerance * relaxed.length_tolerance
+        );
+    }
+
+    #[test]
+    fn test_default_kernel_numerical_zero_tolerance_is_type_aware() {
+        assert_eq!(default_kernel_numerical_zero_tolerance::<f32>(), 1e-6_f32);
+        assert_eq!(default_kernel_numerical_zero_tolerance::<f64>(), 1e-12_f64);
     }
 }

--- a/model/geo_primitives/src/conical_solid_3d.rs
+++ b/model/geo_primitives/src/conical_solid_3d.rs
@@ -17,7 +17,7 @@
 
 use crate::{Direction3D, Point3D, Vector3D};
 
-use geo_contracts::Scalar;
+use geo_contracts::{default_distance_tolerance, Scalar};
 
 /// 3次元円錐ソリッド（STEP準拠のCore実装）
 ///
@@ -343,9 +343,10 @@ impl<T: Scalar> ConicalSolid3D<T> {
     pub fn is_valid(&self) -> bool {
         let axis_length = self.axis.as_vector().length();
         let ref_length = self.ref_direction.as_vector().length();
+        let unit_tol = default_distance_tolerance::<T>();
 
-        (axis_length - T::ONE).abs() < T::from_f64(1e-10)
-            && (ref_length - T::ONE).abs() < T::from_f64(1e-10)
+        (axis_length - T::ONE).abs() < unit_tol
+            && (ref_length - T::ONE).abs() < unit_tol
             && self.radius > T::ZERO
             && self.height > T::ZERO
     }

--- a/model/geo_primitives/src/triangle_2d.rs
+++ b/model/geo_primitives/src/triangle_2d.rs
@@ -2,10 +2,14 @@
 //!
 //! Foundation統一システムに基づくTriangle2Dの必須機能のみ
 
+use std::any::TypeId;
+
 use crate::{Point2D, Vector2D};
+use analysis::consts::special::{SQRT_3_OVER_2_F32, SQRT_3_OVER_2_F64};
 use geo_contracts::{
-    PrimitiveKind, PrimitiveMetadata, Scalar, Triangle2DBoundaryAccess, Triangle2DBoundaryQuantity,
-    Triangle2DConstructor, Triangle2DContainment, Triangle2DDerived, Triangle2DDistance,
+    default_kernel_numerical_zero_tolerance, PrimitiveKind, PrimitiveMetadata, Scalar,
+    Triangle2DBoundaryAccess, Triangle2DBoundaryQuantity, Triangle2DConstructor,
+    Triangle2DContainment, Triangle2DDerived, Triangle2DDistance,
 };
 
 /// 2次元三角形（Core実装）
@@ -23,6 +27,15 @@ impl<T: Scalar> PrimitiveMetadata for Triangle2D<T> {
 }
 
 impl<T: Scalar> Triangle2D<T> {
+    #[inline]
+    fn equilateral_height_factor() -> T {
+        if TypeId::of::<T>() == TypeId::of::<f32>() {
+            T::from_f32(SQRT_3_OVER_2_F32)
+        } else {
+            T::from_f64(SQRT_3_OVER_2_F64)
+        }
+    }
+
     /// 新しい2D三角形を作成
     ///
     /// 基本的な検証のみ実行（退化三角形チェック）
@@ -30,10 +43,11 @@ impl<T: Scalar> Triangle2D<T> {
         // 退化した三角形（3点が一直線上）を検証
         let ab = Vector2D::from_points(vertex_a, vertex_b);
         let ac = Vector2D::from_points(vertex_a, vertex_c);
+        let zero_tol = default_kernel_numerical_zero_tolerance::<T>();
 
         // 外積（2Dでは z成分のみ）の絶対値が非常に小さい場合、3点が一直線上
         let cross_z = ab.x() * ac.y() - ab.y() * ac.x();
-        if cross_z.abs() < T::from_f64(1e-10) {
+        if cross_z.abs() < zero_tol {
             return None;
         }
 
@@ -46,7 +60,7 @@ impl<T: Scalar> Triangle2D<T> {
 
     /// 原点と単位ベクトルから正三角形を作成
     pub fn unit_triangle() -> Self {
-        let h = T::from_f64(0.8660254037844387); // sqrt(3)/2
+        let h = Self::equilateral_height_factor();
         Self::new(
             Point2D::new(T::ZERO, T::ONE),
             Point2D::new(-h, -T::ONE / (T::ONE + T::ONE)),
@@ -57,7 +71,7 @@ impl<T: Scalar> Triangle2D<T> {
 
     /// 原点中心の正三角形を生成（辺の長さ指定）
     pub fn equilateral_at_origin(side_length: T) -> Self {
-        let h = T::from_f64(0.8660254037844387); // sqrt(3)/2
+        let h = Self::equilateral_height_factor();
         let half = side_length / (T::ONE + T::ONE);
         Self::new(
             Point2D::new(T::ZERO, side_length * h / T::from_f64(1.5)),
@@ -152,7 +166,7 @@ impl<T: Scalar> Triangle2D<T> {
 
         // 行列式計算
         let d = (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by)) * (T::ONE + T::ONE);
-        if d.abs() < T::from_f64(1e-10) {
+        if d.abs() < default_kernel_numerical_zero_tolerance::<T>() {
             return None; // 退化した三角形
         }
 
@@ -259,7 +273,7 @@ impl<T: Scalar> Triangle2D<T> {
         let to_point = Vector2D::from_points(p1, *point);
 
         let edge_length_sq = edge.dot(&edge);
-        if edge_length_sq < T::from_f64(1e-10) {
+        if edge_length_sq < default_kernel_numerical_zero_tolerance::<T>() {
             // 退化した辺の場合、点p1までの距離
             return to_point.length();
         }

--- a/model/geo_primitives/src/triangle_3d.rs
+++ b/model/geo_primitives/src/triangle_3d.rs
@@ -2,10 +2,14 @@
 //!
 //! Foundation統一システムに基づくTriangle3Dの必須機能のみ
 
+use std::any::TypeId;
+
 use crate::{Point3D, Vector3D};
+use analysis::consts::special::{SQRT_3_OVER_2_F32, SQRT_3_OVER_2_F64};
 use geo_contracts::{
-    Scalar, Triangle3DBoundaryAccess, Triangle3DBoundaryQuantity, Triangle3DConstructor,
-    Triangle3DContainment, Triangle3DDerived, Triangle3DDistance,
+    default_kernel_numerical_zero_tolerance, Scalar, Triangle3DBoundaryAccess,
+    Triangle3DBoundaryQuantity, Triangle3DConstructor, Triangle3DContainment, Triangle3DDerived,
+    Triangle3DDistance,
 };
 
 /// 3次元三角形（Core実装）
@@ -39,6 +43,15 @@ impl<T: Scalar> geo_contracts::TolerantEq<T> for Triangle3D<T> {
 }
 
 impl<T: Scalar> Triangle3D<T> {
+    #[inline]
+    fn equilateral_height_factor() -> T {
+        if TypeId::of::<T>() == TypeId::of::<f32>() {
+            T::from_f32(SQRT_3_OVER_2_F32)
+        } else {
+            T::from_f64(SQRT_3_OVER_2_F64)
+        }
+    }
+
     /// 新しい3D三角形を作成
     ///
     /// 基本的な検証のみ実行（退化三角形チェック）
@@ -46,10 +59,11 @@ impl<T: Scalar> Triangle3D<T> {
         // 退化した三角形（3点が一直線上）を検証
         let ab = Vector3D::from_points(&vertex_a, &vertex_b);
         let ac = Vector3D::from_points(&vertex_a, &vertex_c);
+        let zero_tol = default_kernel_numerical_zero_tolerance::<T>();
 
         // 外積の大きさが非常に小さい場合、3点が一直線上
         let cross = ab.cross(&ac);
-        if cross.length() < T::from_f64(1e-10) {
+        if cross.length() < zero_tol {
             return None;
         }
         Some(Self {
@@ -100,7 +114,7 @@ impl<T: Scalar> Triangle3D<T> {
         let ac = Vector3D::from_points(&self.vertex_a, &self.vertex_c);
 
         let cross = ab.cross(&ac);
-        if cross.length() < T::from_f64(1e-10) {
+        if cross.length() < default_kernel_numerical_zero_tolerance::<T>() {
             None
         } else {
             Some(cross.normalize())
@@ -137,7 +151,7 @@ impl<T: Scalar> Triangle3D<T> {
     /// 三角形が退化していないかチェック
     pub fn is_valid(&self) -> bool {
         let area: T = self.area();
-        let threshold = T::from_f64(1e-10);
+        let threshold = default_kernel_numerical_zero_tolerance::<T>();
         area > threshold
     }
 
@@ -164,7 +178,7 @@ impl<T: Scalar> Triangle3D<T> {
 
     /// xz平面上の単位正三角形を生成
     pub fn unit_triangle_xz() -> Self {
-        let h = T::from_f64(0.8660254037844387); // sqrt(3)/2
+        let h = Self::equilateral_height_factor();
         Self::new(
             Point3D::new(T::ZERO, T::ZERO, T::ONE),
             Point3D::new(-h, T::ZERO, -T::ONE / (T::ONE + T::ONE)),
@@ -175,7 +189,7 @@ impl<T: Scalar> Triangle3D<T> {
 
     /// yz平面上の単位正三角形を生成
     pub fn unit_triangle_yz() -> Self {
-        let h = T::from_f64(0.8660254037844387); // sqrt(3)/2
+        let h = Self::equilateral_height_factor();
         Self::new(
             Point3D::new(T::ZERO, T::ZERO, T::ONE),
             Point3D::new(T::ZERO, -h, -T::ONE / (T::ONE + T::ONE)),
@@ -217,7 +231,7 @@ impl<T: Scalar> Triangle3D<T> {
         let d =
             (a_2d.0 * (b_2d.1 - c_2d.1) + b_2d.0 * (c_2d.1 - a_2d.1) + c_2d.0 * (a_2d.1 - b_2d.1))
                 * (T::ONE + T::ONE);
-        if d.abs() < T::from_f64(1e-10) {
+        if d.abs() < default_kernel_numerical_zero_tolerance::<T>() {
             return None;
         }
 
@@ -294,7 +308,7 @@ impl<T: Scalar> Triangle3D<T> {
         let to_point = Vector3D::from_points(p1, point);
 
         let edge_length_sq = edge.dot(&edge);
-        if edge_length_sq < T::from_f64(1e-10) {
+        if edge_length_sq < default_kernel_numerical_zero_tolerance::<T>() {
             return to_point.length();
         }
 
@@ -333,7 +347,7 @@ impl<T: Scalar> Triangle3DConstructor<T> for Triangle3D<T> {
     }
 
     fn unit_triangle_xy() -> Self {
-        let h = T::from_f64(0.8660254037844387); // sqrt(3)/2
+        let h = Self::equilateral_height_factor();
         let pa = Point3D::new(T::ZERO, T::ONE, T::ZERO);
         let pb = Point3D::new(-h, -T::ONE / (T::ONE + T::ONE), T::ZERO);
         let pc = Point3D::new(h, -T::ONE / (T::ONE + T::ONE), T::ZERO);


### PR DESCRIPTION
## 概要

Newton solver と geometry kernel で混在していた generic `f32` / `f64` のしきい値運用を整理しました。
収束判定、線形 solver の数値安定性、幾何カーネルの数値ゼロ判定を責務ごとに分離し、`f64` 専用の極小固定値を generic に流用しない形へ揃えています。

Closes #638

## 変更内容

- `foundation/analysis`
- Newton の収束判定トレランスと既定線形 solver tolerance を分離
- `LINEAR_SOLVER_TOLERANCE_F32/F64` を導入
- `DERIVATIVE_ZERO_THRESHOLD_F32` を導入
- f32 テストの solver tolerance 直書きを共通定数へ統一

- `model/geo_contracts`
- `ToleranceSettings<T>` の precision profile を `f32` / `f64` で型別化
- `default_kernel_numerical_zero_tolerance<T>()` を型別化
- `area_tolerance` を `length_tolerance * length_tolerance` 由来へ変更

- `model/geo_primitives`
- Triangle2D / Triangle3D の数値ガードを `default_kernel_numerical_zero_tolerance::<T>()` へ置換
- ConicalSolid3D の単位長チェックを `default_distance_tolerance::<T>()` へ置換
- Triangle の `sqrt(3)/2` マジックナンバーを共通定数化

- ドキュメント
- generic 実装で `f64` 専用の極小固定値を `T::from_f64(...)` で流用しないルールを追記

## 検証

- `cargo clippy -p analysis -p geo_contracts -p geo_primitives -p geo_nurbs -p geo_algorithms -- -D warnings`
- `cargo fmt --all`
- `cargo test -p analysis -p geo_contracts -p geo_primitives -p geo_nurbs -p geo_algorithms`

## 関連コミット

- `da8815aa` fix(analysis): separate typed newton and solver tolerances
- `86353582` fix(geometry): align typed tolerance semantics
