### PR TITLE
refactor(analysis): remove legacy newton wrapper APIs

### DIFF
--- a/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
+++ b/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
@@ -228,14 +228,12 @@
 - したがって現時点の `f64` ラッパーは「downstream 即時互換維持」のために残すが、workspace 内の正本利用経路ではない
 - 次段では deprecated 化そのものより、外部利用者向けの移行告知と `newton_solve_2d` の follow-up 分離判断を優先する
 
-### 互換ラッパー運用方針（2026年4月8日時点）
+### legacy Newton API 削除方針（2026年4月8日時点, #640）
 
-- `newton_solve` / `newton_solve_bounded` / `newton_solve_with_numeric_derivative_bounded` / `newton_inverse` は、generic API 導入後も downstream 互換維持のため公開を継続する
-- ただし、workspace 内ではこれらを正本 API と見なさず、新規の production 呼び出しを増やさない
-- `foundation/analysis` 内では互換性を検証する最小限の wrapper テストだけを維持する
-- doctest、モジュール使用例、設計文書、今後の実装は generic API を基準に記述する
-- deprecated 化は即時には行わず、外部利用状況、保守コスト、移行告知手段が揃った段階で別判断とする
-- したがって当面の整理方針は「公開は維持」「内部の新規利用は抑止」「説明責務は generic API 側へ寄せる」の3点で固定する
+- `newton_solve` / `newton_solve_bounded` / `newton_solve_with_numeric_derivative_bounded` / `newton_inverse` / `newton_solve_2d` は legacy 入口として扱い、generic / multivariate 系 API を正本とする
+- プレ版かつ downstream 利用者不在を前提に、deprecated 段階は挟まず削除まで進める
+- ただし作業順は固定し、先に workspace 内の test / doctest / module doc / 設計文書を正本 API へ寄せてから公開面を削除する
+- `newton_solve_2d` も convenience wrapper として温存せず、Newton solver API の二重入口を解消する
 
 ### `newton_solve_2d` の扱い判断（2026年4月8日）
 

--- a/foundation/analysis/src/lib.rs
+++ b/foundation/analysis/src/lib.rs
@@ -27,12 +27,11 @@ pub use consts::{
 };
 
 // 数値計算関数の再エクスポート（numericsモジュールから）
-// Newton solver は generic API を正本とし、f64 ラッパーは downstream 互換用に公開を維持する。
+// Newton solver は generic / multivariate API を正本として公開する。
 pub use crate::linalg::solver::newton::{
-    newton_inverse, newton_inverse_generic, newton_solve, newton_solve_2d, newton_solve_bounded,
-    newton_solve_bounded_generic, newton_solve_generic, newton_solve_multivariate,
-    newton_solve_multivariate_bounded, newton_solve_multivariate_bounded_with_solver,
-    newton_solve_multivariate_with_solver, newton_solve_with_numeric_derivative_bounded,
+    newton_inverse_generic, newton_solve_bounded_generic, newton_solve_generic,
+    newton_solve_multivariate, newton_solve_multivariate_bounded,
+    newton_solve_multivariate_bounded_with_solver, newton_solve_multivariate_with_solver,
     newton_solve_with_numeric_derivative_bounded_generic, MultivariateNewtonBounds,
     MultivariateNewtonOptions,
 };

--- a/foundation/analysis/src/linalg/solver/mod.rs
+++ b/foundation/analysis/src/linalg/solver/mod.rs
@@ -20,13 +20,11 @@ pub mod lu; // LU分解法
 pub mod newton; // ニュートン・ラフソン法
 
 // Newton法ソルバーの再エクスポート
-// generic API を正本とし、f64 API は downstream 互換入口として併存させる。
-// workspace 内の新規実装では generic API を優先し、f64 ラッパーの利用は増やさない。
+// generic / multivariate API を正本として公開する。
 pub use newton::{
-    newton_inverse, newton_inverse_generic, newton_solve, newton_solve_2d, newton_solve_bounded,
-    newton_solve_bounded_generic, newton_solve_generic, newton_solve_multivariate,
-    newton_solve_multivariate_bounded, newton_solve_multivariate_bounded_with_solver,
-    newton_solve_multivariate_with_solver, newton_solve_with_numeric_derivative_bounded,
+    newton_inverse_generic, newton_solve_bounded_generic, newton_solve_generic,
+    newton_solve_multivariate, newton_solve_multivariate_bounded,
+    newton_solve_multivariate_bounded_with_solver, newton_solve_multivariate_with_solver,
     newton_solve_with_numeric_derivative_bounded_generic, MultivariateNewtonBounds,
     MultivariateNewtonOptions,
 };

--- a/foundation/analysis/src/linalg/solver/newton.rs
+++ b/foundation/analysis/src/linalg/solver/newton.rs
@@ -9,9 +9,7 @@ use crate::consts::numerical::{
     DERIVATIVE_ZERO_THRESHOLD_F32, DERIVATIVE_ZERO_THRESHOLD_F64, LINEAR_SOLVER_TOLERANCE_F32,
     LINEAR_SOLVER_TOLERANCE_F64,
 };
-use crate::linalg::{
-    DynamicMatrix, DynamicMatrixLinearSolver, GaussianSolver, Matrix2x2, Vector, Vector2,
-};
+use crate::linalg::{DynamicMatrix, DynamicMatrixLinearSolver, GaussianSolver, Vector};
 use crate::Scalar;
 
 #[inline]
@@ -42,20 +40,6 @@ fn default_linear_solver_tolerance<T: Scalar>() -> T {
     };
 
     solver_tolerance(tolerance)
-}
-
-#[inline]
-fn solve_linear_2x2<T: Scalar>(jacobian: Matrix2x2<T>, residual: Vector2<T>) -> Option<Vector2<T>> {
-    let det = jacobian.determinant();
-    if det.abs() < derivative_zero_threshold::<T>() {
-        return None;
-    }
-
-    let inv_det = T::ONE / det;
-    Some(Vector2::new(
-        inv_det * (jacobian.get(1, 1) * residual.x() - jacobian.get(0, 1) * residual.y()),
-        inv_det * (-jacobian.get(1, 0) * residual.x() + jacobian.get(0, 0) * residual.y()),
-    ))
 }
 
 #[inline]
@@ -292,136 +276,6 @@ where
     newton_solve_generic(g, df, initial, max_iter, tol)
 }
 
-/// ニュートン法による方程式求解
-///
-/// `f64` 固定の互換 API。
-/// generic 実装を使う新規コードでは `newton_solve_generic` を優先する。
-///
-/// 一般的な非線形方程式 f(x) = 0 をニュートン・ラフソン法で解く。
-/// 初期値と関数、その導関数を指定して反復計算を行う。
-///
-/// # Arguments
-/// * `f` - 解きたい方程式 f(x) = 0 の関数
-/// * `df` - f(x) の導関数
-/// * `initial` - 反復の初期値
-/// * `max_iter` - 最大反復回数
-/// * `tol` - 収束判定の許容誤差
-///
-/// # Returns
-/// * `Some(x)` - 収束した場合の解
-/// * `None` - 発散または導関数が0になった場合
-///
-/// # Example
-/// ```rust
-/// use analysis::linalg::solver::newton::newton_solve_generic;
-///
-/// // x^2 - 2 = 0 の解を求める（√2を計算）
-/// let f = |x: f64| x * x - 2.0;
-/// let df = |x: f64| 2.0 * x;
-/// let result = newton_solve_generic(f, df, 1.0, 100, 1e-10);
-/// assert!((result.unwrap() - std::f64::consts::SQRT_2).abs() < 1e-6);
-/// ```
-pub fn newton_solve<F, G>(f: F, df: G, initial: f64, max_iter: usize, tol: f64) -> Option<f64>
-where
-    F: Fn(f64) -> f64,
-    G: Fn(f64) -> f64,
-{
-    newton_solve_generic(f, df, initial, max_iter, tol)
-}
-
-/// 境界付きニュートン法による方程式求解
-///
-/// `f64` 固定の互換 API。
-/// generic 実装を使う新規コードでは `newton_solve_bounded_generic` を優先する。
-///
-/// `newton_solve` と同様に f(x)=0 を解くが、各反復更新後に値を `[min, max]` にクランプする。
-/// パラメータ領域が有限な問題（例: NURBS パラメータ最適化）で使用する。
-pub fn newton_solve_bounded<F, G>(
-    f: F,
-    df: G,
-    initial: f64,
-    min: f64,
-    max: f64,
-    max_iter: usize,
-    tol: f64,
-) -> Option<f64>
-where
-    F: Fn(f64) -> f64,
-    G: Fn(f64) -> f64,
-{
-    newton_solve_bounded_generic(f, df, initial, min, max, max_iter, tol)
-}
-
-/// 数値微分（前進差分）を用いた境界付きニュートン法
-///
-/// `f64` 固定の互換 API。
-/// generic 実装を使う新規コードでは
-/// `newton_solve_with_numeric_derivative_bounded_generic` を優先する。
-///
-/// 導関数を解析的に与えづらい場合に、`f(x+h)-f(x)` の差分で導関数を近似して解く。
-/// 反復制御と境界拘束は `newton_solve_bounded` に委譲する。
-pub fn newton_solve_with_numeric_derivative_bounded<F>(
-    f: F,
-    initial: f64,
-    min: f64,
-    max: f64,
-    max_iter: usize,
-    tol: f64,
-    diff_step: f64,
-) -> Option<f64>
-where
-    F: Fn(f64) -> f64,
-{
-    newton_solve_with_numeric_derivative_bounded_generic(
-        f, initial, min, max, max_iter, tol, diff_step,
-    )
-}
-
-/// 単調関数 f(x) = y に対する逆関数 x をニュートン法で求める
-///
-/// `f64` 固定の互換 API。
-/// generic 実装を使う新規コードでは `newton_inverse_generic` を優先する。
-///
-/// 既知の関数値 y に対して、f(x) = y を満たす x を求める。
-/// 単調関数（狭義単調増加または狭義単調減少）である必要がある。
-///
-/// # Arguments
-/// * `f` - 逆関数を求めたい単調関数
-/// * `df` - f(x) の導関数
-/// * `target` - 目標値 y
-/// * `initial` - 反復の初期値
-/// * `max_iter` - 最大反復回数
-/// * `tol` - 収束判定の許容誤差
-///
-/// # Returns
-/// * `Some(x)` - f(x) = target を満たす x
-/// * `None` - 収束しなかった場合
-///
-/// # Example
-/// ```rust
-/// use analysis::linalg::solver::newton::newton_inverse_generic;
-///
-/// // x^3 の逆関数（立方根）を計算
-/// let f = |x: f64| x * x * x;
-/// let df = |x: f64| 3.0 * x * x;
-/// let result = newton_inverse_generic(f, df, 8.0, 2.0, 100, 1e-10);
-/// assert!((result.unwrap() - 2.0).abs() < 1e-6);
-/// ```
-pub fn newton_inverse<F, G>(
-    f: F,
-    df: G,
-    target: f64,
-    initial: f64,
-    max_iter: usize,
-    tol: f64,
-) -> Option<f64>
-where
-    F: Fn(f64) -> f64,
-    G: Fn(f64) -> f64,
-{
-    newton_inverse_generic(f, df, target, initial, max_iter, tol)
-}
-
 /// generic 多変数連立非線形方程式をニュートン法で解く
 ///
 /// `system` は現在の推定値 `x` を受け取り、残差ベクトルと Jacobian 行列を返す。
@@ -558,69 +412,6 @@ where
         }
 
         current = next;
-    }
-
-    None
-}
-
-/// generic 2変数連立非線形方程式をニュートン法で解く
-///
-/// f1(x, y) = 0 と f2(x, y) = 0 を同時に満たす (x, y) を求める。
-/// ヤコビ行列を用いた多変数ニュートン法を実装。
-///
-/// # Arguments
-/// * `system` - (f1, f2, ヤコビ行列) を返す関数
-///   - f1, f2: 方程式の値
-///   - jacobian: [[∂f1/∂x, ∂f1/∂y], [∂f2/∂x, ∂f2/∂y]]
-/// * `initial` - 初期値 (x0, y0)
-/// * `max_iter` - 最大反復回数
-/// * `tol` - 収束判定の許容誤差
-///
-/// # Returns
-/// * `Some((x, y))` - 収束した場合の解
-/// * `None` - 発散またはヤコビ行列が特異な場合
-///
-/// # Example
-/// ```rust
-/// use analysis::linalg::solver::newton::newton_solve_2d;
-///
-/// // 連立方程式: x^2 + y^2 = 1, x - y = 0 (単位円と y=x の交点)
-/// let system = |x: f64, y: f64| {
-///     let f1 = x * x + y * y - 1.0;
-///     let f2 = x - y;
-///     let jacobian = [
-///         [2.0 * x, 2.0 * y],
-///         [1.0, -1.0]
-///     ];
-///     (f1, f2, jacobian)
-/// };
-/// let result = newton_solve_2d(system, (1.0, 0.5), 100, 1e-10);
-/// assert!(result.is_some());
-/// let (x, y) = result.unwrap();
-/// let expected = 1.0 / 2_f64.sqrt();
-/// assert!((x - expected).abs() < 1e-6);
-/// assert!((y - expected).abs() < 1e-6);
-/// ```
-pub fn newton_solve_2d<T, F>(system: F, initial: (T, T), max_iter: usize, tol: T) -> Option<(T, T)>
-where
-    T: Scalar,
-    F: Fn(T, T) -> (T, T, [[T; 2]; 2]),
-{
-    let mut x = initial.0;
-    let mut y = initial.1;
-
-    for _ in 0..max_iter {
-        let (f1, f2, jacobian_raw) = system(x, y);
-        let residual = Vector2::new(f1, f2);
-        let jacobian = Matrix2x2::from(jacobian_raw);
-        let delta = solve_linear_2x2(jacobian, residual)?;
-
-        x -= delta.x();
-        y -= delta.y();
-
-        if residual.norm() < tol && delta.norm() < tol {
-            return Some((x, y));
-        }
     }
 
     None

--- a/foundation/analysis/src/linalg/solver/newton_tests.rs
+++ b/foundation/analysis/src/linalg/solver/newton_tests.rs
@@ -1,9 +1,8 @@
 use super::newton::{
-    newton_inverse, newton_inverse_generic, newton_solve, newton_solve_2d, newton_solve_generic,
-    newton_solve_multivariate, newton_solve_multivariate_bounded,
-    newton_solve_multivariate_bounded_with_solver, newton_solve_multivariate_with_solver,
-    newton_solve_with_numeric_derivative_bounded_generic, MultivariateNewtonBounds,
-    MultivariateNewtonOptions,
+    newton_inverse_generic, newton_solve_generic, newton_solve_multivariate,
+    newton_solve_multivariate_bounded, newton_solve_multivariate_bounded_with_solver,
+    newton_solve_multivariate_with_solver, newton_solve_with_numeric_derivative_bounded_generic,
+    MultivariateNewtonBounds, MultivariateNewtonOptions,
 };
 use crate::consts::test_constants::{
     INTEGRATION_TOLERANCE_STRICT, SOLVER_TOLERANCE_F32, TOLERANCE_F64,
@@ -15,37 +14,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_newton_solve_wrapper_square_root_f64() {
-        let f = |x: f64| x * x - 2.0;
-        let df = |x: f64| 2.0 * x;
-        let result = newton_solve(f, df, 1.0, 100, TOLERANCE_F64);
-
-        assert!(result.is_some());
-        let sqrt_2 = result.unwrap();
-        assert!((sqrt_2 - std::f64::consts::SQRT_2).abs() < INTEGRATION_TOLERANCE_STRICT);
-    }
-
-    #[test]
-    fn test_newton_inverse_wrapper_cube_root_f64() {
-        let f = |x: f64| x * x * x;
-        let df = |x: f64| 3.0 * x * x;
-        let result = newton_inverse(f, df, 8.0, 2.0, 100, TOLERANCE_F64);
-
-        assert!(result.is_some());
-        let cube_root = result.unwrap();
-        assert!((cube_root - 2.0).abs() < INTEGRATION_TOLERANCE_STRICT);
-    }
-
-    #[test]
-    fn test_newton_solve_wrapper_zero_derivative() {
-        let f = |x: f64| x * x;
-        let df = |_: f64| 0.0;
-        let result = newton_solve(f, df, 1.0, 100, TOLERANCE_F64);
-
-        assert!(result.is_none());
-    }
-
-    #[test]
     fn test_newton_solve_generic_square_root_f64() {
         let f = |x: f64| x * x - 2.0;
         let df = |x: f64| 2.0 * x;
@@ -54,6 +22,26 @@ mod tests {
         assert!(result.is_some());
         let sqrt_2 = result.unwrap();
         assert!((sqrt_2 - std::f64::consts::SQRT_2).abs() < INTEGRATION_TOLERANCE_STRICT);
+    }
+
+    #[test]
+    fn test_newton_inverse_generic_cube_root_f64() {
+        let f = |x: f64| x * x * x;
+        let df = |x: f64| 3.0 * x * x;
+        let result = newton_inverse_generic(f, df, 8.0_f64, 2.0_f64, 100, TOLERANCE_F64);
+
+        assert!(result.is_some());
+        let cube_root = result.unwrap();
+        assert!((cube_root - 2.0).abs() < INTEGRATION_TOLERANCE_STRICT);
+    }
+
+    #[test]
+    fn test_newton_solve_generic_zero_derivative() {
+        let f = |x: f64| x * x;
+        let df = |_: f64| 0.0;
+        let result = newton_solve_generic(f, df, 1.0_f64, 100, TOLERANCE_F64);
+
+        assert!(result.is_none());
     }
 
     #[test]
@@ -91,68 +79,6 @@ mod tests {
     }
 
     #[test]
-    fn test_newton_solve_2d_circle_line() {
-        let system = |x: f64, y: f64| {
-            let f1 = x * x + y * y - 1.0;
-            let f2 = x - y;
-            let jacobian = [[2.0 * x, 2.0 * y], [1.0, -1.0]];
-            (f1, f2, jacobian)
-        };
-
-        let result = newton_solve_2d(system, (1.0, 0.5), 100, TOLERANCE_F64);
-        assert!(result.is_some());
-
-        let (x, y) = result.unwrap();
-        let expected = 1.0 / 2_f64.sqrt();
-        assert!((x - expected).abs() < INTEGRATION_TOLERANCE_STRICT);
-        assert!((y - expected).abs() < INTEGRATION_TOLERANCE_STRICT);
-    }
-
-    #[test]
-    fn test_newton_solve_2d_singular_jacobian() {
-        let system = |x: f64, y: f64| {
-            let f1 = x + y;
-            let f2 = x + y;
-            let jacobian = [[1.0, 1.0], [1.0, 1.0]];
-            (f1, f2, jacobian)
-        };
-
-        let result = newton_solve_2d(system, (1.0, 1.0), 100, TOLERANCE_F64);
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_newton_solve_2d_circle_line_f32() {
-        let system = |x: f32, y: f32| {
-            let f1 = x * x + y * y - 1.0_f32;
-            let f2 = x - y;
-            let jacobian = [[2.0_f32 * x, 2.0_f32 * y], [1.0_f32, -1.0_f32]];
-            (f1, f2, jacobian)
-        };
-
-        let result = newton_solve_2d(system, (1.0_f32, 0.5_f32), 100, 1e-6_f32);
-        assert!(result.is_some());
-
-        let (x, y) = result.unwrap();
-        let expected = 1.0_f32 / 2.0_f32.sqrt();
-        assert!((x - expected).abs() < 1e-4_f32);
-        assert!((y - expected).abs() < 1e-4_f32);
-    }
-
-    #[test]
-    fn test_newton_solve_2d_singular_jacobian_f32() {
-        let system = |x: f32, y: f32| {
-            let f1 = x + y;
-            let f2 = x + y;
-            let jacobian = [[1.0_f32, 1.0_f32], [1.0_f32, 1.0_f32]];
-            (f1, f2, jacobian)
-        };
-
-        let result = newton_solve_2d(system, (1.0_f32, 1.0_f32), 100, 1e-6_f32);
-        assert!(result.is_none());
-    }
-
-    #[test]
     fn test_newton_solve_multivariate_circle_line_f64() {
         let system = |point: &Vector<f64>| {
             let x = point[0];
@@ -171,6 +97,45 @@ mod tests {
         let expected = 1.0 / 2_f64.sqrt();
         assert!((solution[0] - expected).abs() < INTEGRATION_TOLERANCE_STRICT);
         assert!((solution[1] - expected).abs() < INTEGRATION_TOLERANCE_STRICT);
+    }
+
+    #[test]
+    fn test_newton_solve_multivariate_circle_line_f32() {
+        let system = |point: &Vector<f32>| {
+            let x = point[0];
+            let y = point[1];
+            let residual = Vector::new(vec![x * x + y * y - 1.0_f32, x - y]);
+            let jacobian = DynamicMatrix::from_rows(vec![
+                vec![2.0_f32 * x, 2.0_f32 * y],
+                vec![1.0_f32, -1.0_f32],
+            ])
+            .unwrap();
+            (residual, jacobian)
+        };
+
+        let result =
+            newton_solve_multivariate(system, Vector::new(vec![1.0_f32, 0.5_f32]), 100, 1e-6_f32);
+        assert!(result.is_some());
+
+        let solution = result.unwrap();
+        let expected = 1.0_f32 / 2.0_f32.sqrt();
+        assert!((solution[0] - expected).abs() < 1e-4_f32);
+        assert!((solution[1] - expected).abs() < 1e-4_f32);
+    }
+
+    #[test]
+    fn test_newton_solve_multivariate_singular_jacobian_f32() {
+        let system = |point: &Vector<f32>| {
+            let residual = Vector::new(vec![point[0] + point[1], point[0] + point[1]]);
+            let jacobian =
+                DynamicMatrix::from_rows(vec![vec![1.0_f32, 1.0_f32], vec![1.0_f32, 1.0_f32]])
+                    .unwrap();
+            (residual, jacobian)
+        };
+
+        let result =
+            newton_solve_multivariate(system, Vector::new(vec![1.0_f32, 1.0_f32]), 100, 1e-6_f32);
+        assert!(result.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- remove legacy Newton wrapper/re-export APIs from `analysis` and keep the generic/multivariate APIs as the canonical public surface
- migrate Newton tests to the canonical APIs and replace the legacy 2D wrapper coverage with multivariate solver tests
- update the Newton genericization design document to record the one-shot legacy API removal policy for pre-release cleanup

## Validation
- cargo clippy -p analysis -- -D warnings
- cargo fmt
- cargo test -p analysis

Closes #640