### PR TITLE
feat: complete #501 non-ECS viewmodel-model route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,10 @@ dependencies = [
  "cam_core",
  "cam_sim",
  "geo_algorithms",
+ "geo_contracts",
+ "geo_entity",
+ "geo_primitives",
+ "geo_topology",
  "job_domain",
  "job_runtime",
 ]
@@ -1083,6 +1087,7 @@ version = "0.1.0"
 dependencies = [
  "analysis",
  "geo_commons",
+ "serde",
 ]
 
 [[package]]

--- a/dev/architecture/APPLICATION_ORCHESTRATION_LAYER_DESIGN.md
+++ b/dev/architecture/APPLICATION_ORCHESTRATION_LAYER_DESIGN.md
@@ -138,7 +138,173 @@ Domain / Algorithm / Runtime / Adapter
 - `job_domain`: ドメインポリシー、投入制約、WorkflowSnapshot などの domain 寄り責務
 - `job_runtime`: 実行基盤
 - `cam_sim`: CAM 特化の実行ファサードと接続アダプタが混在
+
+---
+
+## 7. group relation 系 use case の扱い
+
+group は display trait ではなく entity relation の一種として扱う。
+そのため Application Layer では、geometry 更新系 use case と分離した relation-oriented use case として入口を定義する。
+relation モデル全体としては、group / layer を親子階層ではなく並列軸で保持する。
+
+### 7.1 group orchestration の責務
+
+1. group 作成
+2. entity の group 所属追加/解除
+3. group 可視状態の更新
+4. group 一覧、entity ごとの所属 group 一覧、group 配下 entity 一覧の query
+5. group 可視状態変更時の影響 entity 集合の集約
+
+### 7.2 推奨 port 境界
+
+初期段階では以下の 2 port に分ける。
+
+1. `GroupMutationPort`
+   - group 作成
+   - group 可視状態更新
+2. `EntityGroupRelationPort`
+   - entity の group 所属追加/解除
+   - entity→group / group→entity 参照
+
+この分離により、group 自体の state と membership relation を別実装へ逃がせる。
+
+### 7.3 request / result DTO 例
+
+```rust
+pub struct GroupDto {
+   pub group_id: GroupId,
+   pub name: String,
+   pub visible: bool,
+   pub member_count: usize,
+}
+
+pub struct CreateGroupRequest {
+   pub name: String,
+   pub visible: bool,
+}
+
+pub struct CreateGroupResult {
+   pub group: GroupDto,
+}
+
+pub struct AddEntityToGroupRequest {
+   pub entity_id: EntityId,
+   pub group_id: GroupId,
+}
+
+pub struct AddEntityToGroupResult {
+   pub entity_id: EntityId,
+   pub group_id: GroupId,
+   pub memberships: Vec<GroupMembershipDto>,
+}
+
+pub struct SetGroupVisibilityRequest {
+   pub group_id: GroupId,
+   pub visible: bool,
+}
+
+pub struct SetGroupVisibilityResult {
+   pub group: GroupDto,
+   pub affected_entity_ids: Vec<EntityId>,
+}
+
+pub struct ListGroupsForEntityQuery {
+   pub entity_id: EntityId,
+}
+
+pub struct ListGroupsForEntityResult {
+   pub entity_id: EntityId,
+   pub groups: Vec<GroupDto>,
+}
+```
+
+### 7.4 設計上の注意
+
+- group の `visible` は「強い ON/OFF」を成立させるため、Application query で取得可能な state とする
+- entity が複数 group に属する前提のため、`AddEntityToGroupResult` は単一 membership 成否だけでなく更新後 membership 集合を返してよい
+- `SetGroupVisibilityResult.affected_entity_ids` を返すことで、View 側は全件再構築ではなく影響範囲ベースの再評価へ拡張しやすくなる
+- group は render batch key ではないため、Application DTO も shader/material 単位の情報は持たない
 - `viewmodel/converter`: DTO 変換に加えて debug 実行導線が一部残存
+
+## 8. layer relation 系 use case の扱い
+
+layer も group と同様に entity relation の一種として扱うが、役割は図面・表示管理の基準単位とする。
+そのため Application Layer では、group と並ぶ relation-oriented use case として layer の入口も定義する。
+
+### 8.1 layer orchestration の責務
+
+1. layer 作成
+2. entity の layer 所属追加/解除
+3. layer 可視状態の更新
+4. layer 一覧、entity ごとの所属 layer、layer 配下 entity 一覧の query
+5. layer 可視状態変更時の影響 entity 集合の集約
+
+### 8.2 推奨 port 境界
+
+初期段階では以下の 2 port に分ける。
+
+1. `LayerMutationPort`
+   - layer 作成
+   - layer 可視状態更新
+2. `EntityLayerRelationPort`
+   - entity の layer 所属追加/解除
+   - entity→layer / layer→entity 参照
+
+これにより、layer 自体の state と membership を分離できる。
+
+### 8.3 request / result DTO 例
+
+```rust
+pub struct LayerDto {
+   pub layer_id: LayerId,
+   pub name: String,
+   pub visible: bool,
+   pub member_count: usize,
+}
+
+pub struct CreateLayerRequest {
+   pub name: String,
+   pub visible: bool,
+}
+
+pub struct CreateLayerResult {
+   pub layer: LayerDto,
+}
+
+pub struct AddEntityToLayerRequest {
+   pub entity_id: EntityId,
+   pub layer_id: LayerId,
+}
+
+pub struct AddEntityToLayerResult {
+   pub entity_id: EntityId,
+   pub layer_id: LayerId,
+   pub memberships: Vec<LayerMembershipDto>,
+}
+
+pub struct SetLayerVisibilityRequest {
+   pub layer_id: LayerId,
+   pub visible: bool,
+}
+
+pub struct SetLayerVisibilityResult {
+   pub layer: LayerDto,
+   pub affected_entity_ids: Vec<EntityId>,
+}
+```
+
+### 8.4 設計上の注意
+
+- layer の `visible` は group と同様、Application query で取得可能な state とする
+- layer 所属追加では既存 layer 所属がある場合を Application 境界で正規化エラーへ変換する
+- layer は group より表示管理寄りだが、初期 DTO では既定色・既定線種の継承責務まで持ち込まない
+- group / layer の両方が非表示フィルタとして働くため、影響 entity 集合は両 relation から計算できる形を保つ
+
+### 8.5 UI ハイブリッド運用との関係
+
+- Application の request / result DTO は、UI が layer 中心ツリーを構成できるだけの情報を返してよい
+- ただし DTO 契約でも `Layer > Group` の親子制約は持ち込まない
+- UI 側の階層表示は query 結果の再構成として実現し、正本 relation は並列軸のまま維持する
 
 ### 6.2 移行方針
 

--- a/dev/architecture/ARCHITECTURE.md
+++ b/dev/architecture/ARCHITECTURE.md
@@ -78,6 +78,8 @@ foundation/analysis（将来改名候補）
 - **`geo_foundation`廃止（完了）**: 形状trait定義は`geo_contracts`へ統一済み
 - **`geo_primitives` / `geo_nurbs` の役割**: 自 crate 型に対する impl entry point を担い、重い自由関数アルゴリズムは `geo_algorithms`、形状非依存の数値カーネルは `geo_commons` へ分離する
 - **依存と import の区別**: `geo_algorithms -> geo_primitives/geo_nurbs` 依存は許可だが、`geo_algorithms` 実装ファイルでの `use geo_primitives::...` 直接 import は禁止（`use crate::...` 再エクスポート経由を使用）
+- **`geo_topology` の曲線依存**: `geo_topology -> geo_primitives` は既存許可とし、curve edge の段階導入に限って `geo_topology -> geo_nurbs` 依存も許可する
+- **NURBS topology 依存の制約**: 許可するのは `geo_topology -> geo_nurbs` の片方向のみとし、`geo_nurbs -> geo_topology` の逆依存は禁止する
 - **上位責務分離**: tessellation/simulation/job managerは`geo_algorithms`より上位のapplication層へ集約
 - **Application Layer の役割**: 非同期実装詳細そのものは持たず、同期/非同期/job投入の実行方式境界だけを管理する
 - **CAM責務分離**: `cam_core` は中立データ、`cam_algorithms` は計算ロジック、`cam_sim` はCAM特化ユースケース実行として分離する

--- a/dev/architecture/ENTITY_VIEW_INTEGRATION_DESIGN.md
+++ b/dev/architecture/ENTITY_VIEW_INTEGRATION_DESIGN.md
@@ -33,6 +33,8 @@
    - `view/app` → `viewmodel/converter` → `model/*`
 4. **段階導入**
    - まずは debug系導線に統合し、既存の `load_debug_*` と共存
+5. **relation モデル方針**
+   - group / layer の正本モデルは並列軸とし、View のツリー表示だけを必要に応じて階層化する
 
 ---
 
@@ -101,7 +103,16 @@ pub fn cam_entity_to_vertices(
 
 - `geometric_entity_to_vertices` は内部で既存 `shape_converter` を呼ぶ
 - `DisplayAttributes` の色を最終頂点へ適用（ViewModel責務）
+- 共通表示属性と stroke 表示属性を分離し、線種と線幅は `StrokeDisplayProperties` 経由で受ける
+- 2D 線種の表示判定に必要な定義平面情報は `PlanarStroke2DProperties<T>` 経由で受ける
 - 失敗は `EntityConvertError` で返す（未対応形状・空データ等）
+
+### 5.3 contract 拡張方針
+
+- `EntityDisplayProperties` には `visible` と `color` だけを残す
+- 線種と線幅は `StrokeDisplayProperties` へ分離する
+- 2D 線種表示の条件判定に必要な平面情報は `PlanarStroke2DProperties<T>` へ分離する
+- これにより、3D mesh entity や solid entity が 2D 線種用の責務を持たずに済む
 
 ---
 
@@ -111,8 +122,18 @@ pub fn cam_entity_to_vertices(
 
 - `GeometricEntity`（複数形状型を扱うため enum/trait object のどちらかを採用）
 - `CAMEntity`
+- group 定義と entity-group 所属関係
+- layer 定義と entity-layer 所属関係
 - 選択状態（`EntityId`）
 - dirtyフラグ（再変換が必要か）
+
+現行PoCの `view/app` 側 `EntityManager` は、shape 種別そのものではなく View ローカルな描画キャッシュを保持する。
+このため、LineSegment3D / Circle3D / Arc3D のような異なる shape でも、`MeshStage::set_line_data` に渡す `LineList` 頂点列へ落ちた時点では同一の管理対象とみなす。
+命名も shape 名ベースの `line_*` ではなく、描画トポロジを表す `line_list_*` を優先する。
+さらに将来は 2D / 3D の描画カテゴリを分離し、2D 線種は定義平面に対する直交ビュー時のみ表示する前提で cache を分ける。
+group はこの描画 cache 分類とは別軸で持ち、複数所属を許可しつつ、group 単位の表示 ON/OFF を強い制御として扱う。
+layer も同様に描画 cache 分類とは別軸で持つが、こちらは図面管理の基準単位として扱い、単一所属を前提とする。
+View は layer 中心のツリーや group 一覧を構成してよいが、それは表示用の投影であり、内部 relation を `Layer > Group` 階層へ固定することは意味しない。
 
 ## 6.2 最小API
 
@@ -126,6 +147,20 @@ impl EntityManager {
     pub fn add_cam(&mut self, entity: cam_entity::CAMEntity) -> geo_entity::EntityId;
     pub fn remove(&mut self, id: geo_entity::EntityId) -> bool;
 
+   pub fn create_group(&mut self, name: String) -> geo_entity::GroupId;
+   pub fn add_entity_to_group(&mut self, entity_id: geo_entity::EntityId, group_id: geo_entity::GroupId) -> bool;
+   pub fn remove_entity_from_group(&mut self, entity_id: geo_entity::EntityId, group_id: geo_entity::GroupId) -> bool;
+   pub fn set_group_visible(&mut self, group_id: geo_entity::GroupId, visible: bool) -> bool;
+   pub fn groups_for_entity(&self, entity_id: geo_entity::EntityId) -> Vec<geo_entity::GroupId>;
+   pub fn entities_for_group(&self, group_id: geo_entity::GroupId) -> Vec<geo_entity::EntityId>;
+
+   pub fn create_layer(&mut self, name: String) -> geo_entity::LayerId;
+   pub fn add_entity_to_layer(&mut self, entity_id: geo_entity::EntityId, layer_id: geo_entity::LayerId) -> bool;
+   pub fn remove_entity_from_layer(&mut self, entity_id: geo_entity::EntityId, layer_id: geo_entity::LayerId) -> bool;
+   pub fn set_layer_visible(&mut self, layer_id: geo_entity::LayerId, visible: bool) -> bool;
+   pub fn layer_for_entity(&self, entity_id: geo_entity::EntityId) -> Option<geo_entity::LayerId>;
+   pub fn entities_for_layer(&self, layer_id: geo_entity::LayerId) -> Vec<geo_entity::EntityId>;
+
     pub fn select(&mut self, id: geo_entity::EntityId) -> bool;
     pub fn clear_selection(&mut self);
     pub fn selected(&self) -> Option<geo_entity::EntityId>;
@@ -133,10 +168,74 @@ impl EntityManager {
     pub fn set_visible(&mut self, id: geo_entity::EntityId, visible: bool) -> bool;
     pub fn set_color(&mut self, id: geo_entity::EntityId, color: [f32; 4]) -> bool;
 
+      // 現行PoCでは wireframe 系 shape を LineList 頂点として保持する
+      pub fn add_line_list_entity(&mut self, vertices: Vec<MeshVertex>) -> geo_entity::EntityId;
+      pub fn line_list_vertices(&self) -> Vec<MeshVertex>;
+
+   // 将来拡張では 2D / 3D の描画カテゴリ別 cache を導入する
+   pub fn add_2d_line_pattern_entity(&mut self, entity: Pattern2DDisplayItem) -> geo_entity::EntityId;
+   pub fn add_3d_wireframe_entity(&mut self, entity: Wireframe3DDisplayItem) -> geo_entity::EntityId;
+   pub fn add_3d_mesh_entity(&mut self, entity: Mesh3DDisplayItem) -> geo_entity::EntityId;
+
     pub fn is_dirty(&self) -> bool;
     pub fn clear_dirty(&mut self);
 }
 ```
+
+## 6.3 group 可視制御の扱い
+
+- group 可視状態は entity 自身の `visible` に上乗せされる上位フィルタとする
+- entity が複数 group に属する場合、1つでも `visible = false` の group があれば非表示とする
+- group 未所属 entity は group 側要因では非表示化されない
+- 有効表示判定は以下とする
+
+```text
+effective_visible = entity.visible AND all_visible(groups_for_entity(entity))
+```
+
+- `all_visible(empty)` は `true` とみなす
+- この規則により、group 所属が複数に跨っても group ON/OFF が強い制御になる
+- View 側は group ごとに別バッファを維持するのではなく、可視 entity の再収集時にこの条件を評価する
+
+## 6.4 layer 可視制御と所属制約の扱い
+
+- layer 可視状態も entity 自身の `visible` に上乗せされる上位フィルタとする
+- entity は最大 1 layer にのみ属する
+- 所属 layer が `visible = false` の場合、その entity は非表示とする
+- layer 未所属 entity は layer 側要因では非表示化されない
+- 有効表示判定は以下とする
+
+```text
+effective_visible = entity.visible
+                 AND all_visible(groups_for_entity(entity))
+                 AND layer_visible_or_true(layer_for_entity(entity))
+```
+
+- `layer_visible_or_true(None)` は `true` とみなす
+- layer 所属追加時は既存 layer 所属の有無を検証し、重複所属を View ローカルでも防げるようにする
+- layer は group より図面管理寄りの単位であるため、将来の既定色・既定線種・ロック制御の付与先として拡張しやすい形を保つ
+
+## 6.5 EntityManager の内部責務整理
+
+- `EntityManager` は Model 正本の group relation store そのものにはならない
+- ただし View ローカルで必要な最小の group / layer 可視状態と membership 参照結果は保持してよい
+- 初期段階では以下の分離を推奨する
+   1. entity display cache
+   2. group visibility state
+   3. layer visibility state
+   4. entity-group membership index
+   5. entity-layer index
+- group / layer 名やツリー構造など UI 表示用データは query DTO から再投入してよく、描画 cache と同一構造へ混在させない
+
+## 6.6 UI ハイブリッド運用の扱い
+
+- View は layer 主体のツリー表示を提供してよい
+- ただし group は layer の子ノードとして固定せず、必要に応じて以下の複数ビューを併存させてよい
+   1. layer 中心ビュー
+   2. group 中心ビュー
+   3. entity 詳細ビュー
+- layer 中心ビューで group を補助表示する場合も、それは relation の集計結果であり parent-child 正本構造ではない
+- この方針により、操作感としては階層的に見せつつ、複数所属 group の柔軟性を維持する
 
 ---
 
@@ -146,6 +245,7 @@ impl EntityManager {
 2. 既存 `load_debug_line` / `load_debug_toolpath` に「Entity経由パス」を追加
 3. `rebuild_stage_from_entities()` を新設
    - EntityManagerの可視エンティティを収集
+   - entity 自身の visible と group / layer 可視状態を合成して有効表示を判定
    - ViewModel変換
    - `MeshStage` / `ToolPathStage` へ反映
 4. キー操作（最小）
@@ -167,7 +267,14 @@ impl EntityManager {
 
 - Entity追加/削除/選択の基本操作
 - `set_color` / `set_visible` で dirty が立つ
+- group 作成、group 所属追加/解除、group 可視切替の基本操作
+- 複数 group 所属時に 1つでも非表示 group があれば有効表示が false になる
+- group 未所属 entity は entity.visible のみで判定される
+- layer 作成、layer 所属追加/解除、layer 可視切替の基本操作
+- 既に layer 所属を持つ entity へ別 layer を追加しようとすると失敗する
+- 所属 layer が非表示の場合に有効表示が false になる
 - dirty時のみ `rebuild_stage_from_entities()` 実行
+- 2D 線種はビュー始点が定義平面に直交しない場合、非表示または実線フォールバックとなる
 
 ---
 

--- a/dev/architecture/VIEWMODEL_MODEL_ROUTE_REDEFINITION_DESIGN.md
+++ b/dev/architecture/VIEWMODEL_MODEL_ROUTE_REDEFINITION_DESIGN.md
@@ -40,10 +40,34 @@
 - Topology は語彙と検証機能を持つが、Application の use case から呼ばれる位置が未定
 - Job は実行方式として独立語彙を持つが、geometry / topology / entity の更新とどう関係づけるかが未整理
 - `view/app` の `EntityManager` は View ローカル状態であり、Model 正本ではない
+- そのため `EntityManager` の命名は shape 名ではなく、現在保持している描画表現を示す語彙を優先する
+  - 現行PoCでは `LineList` 頂点列を保持するため `line_list_*` を基本とする
 
 ---
 
 ## 3. 基本判断
+
+### 3.0 relation モデル方針
+
+- group / layer は、正本モデルでは親子階層ではなく並列の relation 軸として扱う
+- 一方で UI 表示では、layer 主体の階層ビューや group を折りたたんだ擬似階層ビューを提供してよい
+- つまり採用方針は「正本モデルは並列軸、UI はハイブリッド運用」とする
+- 理由は以下の通り
+  1. group の複数所属を維持したい
+  2. layer の強さに group を従属させると、横断的な作業単位としての group が弱くなる
+  3. View / ViewModel では階層 UI を後から構成できるが、正本モデルを階層固定すると横断 relation へ戻しにくい
+- このため `Layer > Group` の親子制約は初期設計へ入れない
+
+#### 補記: 並列軸を採用する理由
+
+- 過去の CAD では `Layer > Group` 型の階層で group 機能が layer に強く従属し、横断的な束ねや再利用が制限されやすかった
+- 本設計では、その制約を正本モデルへ持ち込まないことを優先する
+- 特に以下を守るため、group を layer の子にしない
+  1. 複数所属 group の維持
+  2. 作業単位・レビュー単位・機能単位など、layer をまたぐ横断 grouping
+  3. UI 表示方式と正本 relation 構造の分離
+- 一方で layer 中心 UI 自体は有用なため、操作感は階層的に見せつつ、内部 model は並列 relation のまま保つ
+- つまり本判断は「階層 UI を否定する」のではなく、「階層 UI を正本構造へ昇格させない」ためのものである
 
 ### 3.1 Application は「Model の一部」ではなく「Model 直上のユースケース層」とする
 
@@ -93,6 +117,98 @@ job はこの直列の内部段階ではなく、
 
 本書で「初期導線」と呼ぶ直列は command 系に対する基本順序であり、query 系は read-only な参照導線として別に扱う。
 
+### 3.5 描画導線は 2D / 3D を分離して扱う
+
+- ViewModel から View へ返す描画用 DTO / キャッシュは、shape 名ではなく描画カテゴリで分離する
+- 少なくとも以下の 2 系統を先に固定する
+  1. 2D 定義平面ベースの線・曲線表示
+  2. 3D 空間ベースの wireframe / mesh 表示
+- 目的は shape 種別の増加ではなく、描画条件・キャッシュ条件・更新条件の分離にある
+- したがって `Circle2D` と `LineSegment2D` は同じ 2D 表示カテゴリに入る可能性があり、`LineSegment3D` と `Arc3D` は同じ 3D wireframe 表示カテゴリに入る可能性がある
+
+### 3.6 2D 線種表示は視点条件付きで扱う
+
+- 2D 線種（点線、破線、一点鎖線、二点鎖線など）は、定義平面上の線長と位相を保って見える場合にのみ正しく表示できる
+- そのため初期方針として、2D 線種は「ビュー始点が対象の定義平面に対して直交」と判定できる場合にのみ表示対象とする
+- 直交条件を満たさない場合は以下のいずれかに正規化する
+  1. 非表示
+  2. 実線へフォールバック
+- どちらを採用するかは use case ごとに決められるが、少なくとも ViewModel / View の契約として「2D 線種は常時表示される」とはみなさない
+- この制御は表示最適化でもあり、2D 線種専用のパターン生成や GPU 転送を不要な視点で抑制する目的を持つ
+
+### 3.7 表示属性 contract は common / stroke / planar-2d に分割する
+
+- `geo_contracts` の entity trait は、全 entity に共通な属性と、線表現にのみ必要な属性を分ける
+- 現在の `EntityDisplayProperties` は `visible` と `color` のみを持つが、ここへ線種や定義平面を直接追加しない
+- 理由は、mesh や solid 表示まで同じ trait に引きずられ、不要な責務が common trait に混ざるためである
+- 方針は以下とする
+  1. `EntityDisplayProperties`
+    - 共通属性のみ
+    - `visible`, `color`
+  2. `StrokeDisplayProperties`
+    - 線表現に必要な属性
+    - `line_style`, `line_width`
+  3. `PlanarStroke2DProperties<T>`
+    - 2D 線種表示条件に必要な属性
+    - `definition_plane_origin`, `definition_plane_normal`, `definition_plane_u_axis`
+- 2D の点線・破線・一点鎖線・二点鎖線は `PlanarStroke2DProperties<T>` を満たす entity / DTO にのみ要求する
+- 3D wireframe は `StrokeDisplayProperties` までは要求してよいが、`PlanarStroke2DProperties<T>` は要求しない
+
+### 3.8 group は表示属性ではなく関係語彙として扱う
+
+- group は shape 種別や表示属性と同列に持つのではなく、entity の所属関係として扱う
+- group 所属は多対多を前提とし、1 entity が複数 group に属することを許可する
+- したがって group は `EntityDisplayProperties` / `StrokeDisplayProperties` / `PlanarStroke2DProperties<T>` には入れない
+- group は render batch key の主軸にしない
+- group の主目的は以下とする
+  1. UI ツリーや一覧での論理分類
+  2. group 単位の表示 ON/OFF
+  3. group 単位の一括選択・一括属性変更
+  4. query 系ユースケースでのまとまり取得
+
+### 3.9 group 単位表示 ON/OFF は deny 優先で解釈する
+
+- group 表示制御は entity 単体の `visible` より上位のフィルタとして扱う
+- entity が複数 group に属する場合、1つでも非表示 group に所属していればその entity は非表示とする
+- つまり有効表示判定は以下の論理積で定義する
+
+```text
+effective_visible = entity.visible AND groups_all_visible
+groups_all_visible = 所属 group が空なら true、1つ以上あるなら全 group.visible が true
+```
+
+- この規則により、複数所属を許しつつ group 単位 ON/OFF を強い制御として扱える
+- 一方で描画最適化の観点では、group ごとに GPU バッファを持つことは初期方針としない
+- group 変更は render batch の再分類ではなく、表示対象フィルタの再評価として扱う
+
+### 3.10 layer も同時に relation 語彙として固定する
+
+- layer も group と同様に display trait へ混在させず、entity relation として扱う
+- ただし layer は group と役割が異なる
+  1. group: 複数所属を前提にした論理的束ね単位
+  2. layer: 図面・表示管理の基準単位
+- layer は将来のロック、印刷対象、編集対象制限、既定色・既定線種の継承元になりやすいため、group より表示管理寄りの語彙として扱う
+- 一方で初期段階では layer も render batch key の主軸にはしない
+- layer は単一所属を前提とし、1 entity は最大 1 layer にのみ属する
+- したがって現設計では layer を group のような複数所属 relation としては扱わない
+- layer は group の親ではなく、別軸の表示管理単位として扱う
+
+### 3.11 layer 可視制御も deny 優先で扱う
+
+- layer も group と同様に entity 単体の `visible` より上位のフィルタとする
+- entity は最大 1 layer 所属とし、その layer が非表示なら entity は非表示とする
+- 有効表示判定は以下の論理積に拡張する
+
+```text
+effective_visible = entity.visible AND groups_all_visible AND layers_all_visible
+groups_all_visible = 所属 group が空なら true、1つ以上あるなら全 group.visible が true
+layers_all_visible = 所属 layer が空なら true、所属 layer があればその layer.visible
+```
+
+- この規則により、group と layer のどちらも強い ON/OFF 制御として扱える
+- 表示の意味論としては layer の方が図面管理寄り、group の方が横断的な論理束ね寄りである
+- ただし初期描画実装では、どちらも cache key ではなく可視フィルタとして合成する
+
 ---
 
 ## 4. 責務境界
@@ -101,6 +217,10 @@ job はこの直列の内部段階ではなく、
 
 - UI 入力を request DTO に正規化する
 - result / error を表示向け DTO に変換する
+- 2D / 3D 描画カテゴリの分類を行う
+- 2D 線種の表示可否判定に必要な View 条件を受け取り、表示条件を満たさない 2D 線種を描画要求へ昇格させない
+- `EntityDisplayProperties` / `StrokeDisplayProperties` / `PlanarStroke2DProperties<T>` のどこまでを使うかで DTO の描画カテゴリを決める
+- entity 自身の表示属性と group / layer 可視状態を合成し、有効表示フラグを描画要求へ反映する
 - 非責務:
   - geometry 生成順序の決定
   - topology 構築判断
@@ -113,6 +233,8 @@ job はこの直列の内部段階ではなく、
 - geometry / topology / entity / job の利用順序を決める
 - sync / async / job 投入の切り替え点を持つ
 - 下位エラーを上位エラーへ正規化する
+- group 作成、entity の group 所属追加/解除、group 可視状態更新、group 単位 query の入口を持つ
+- layer 作成、entity の layer 所属追加/解除、layer 可視状態更新、layer 単位 query の入口を持つ
 - 非責務:
   - 幾何計算アルゴリズム本体
   - topology データ構造の詳細実装
@@ -137,6 +259,7 @@ job はこの直列の内部段階ではなく、
 - 表示属性、メタデータ、関係管理を担う
 - `feature_id + output_index + local_key` からの決定的 ID 生成は entity 側の語彙として扱う
 - View ローカルの選択状態管理とは分離する
+- group / layer などの所属関係は entity relation として保持し、display trait へ混在させない
 
 ### 4.6 job
 
@@ -184,6 +307,240 @@ geometry / topology / entity と同一階層の並列レーンとして定義し
 - Topology は独立した UI command 群から直接更新を始めるのではなく、geometry 更新の後段で導出・検証される位置を基本とする
 - ただし将来、明示的なトポロジー編集機能を追加する場合は、専用 use case を `Application` に追加してよい
 
+### 5.4 表示カテゴリ別の View ローカル導線
+
+```text
+Application Result DTO
+  -> ViewModel display classification
+  -> 2D display cache or 3D display cache
+  -> View stage rebuild
+```
+
+- 2D cache は「定義平面」「ビュー条件」「線種パターン」をキーに持つ
+- 3D cache は「wireframe / mesh」「表示属性」「dirty 状態」をキーに持つ
+- これにより、shape 名を増やしても cache 単位を増やしすぎない
+- group / layer は cache key には入れず、可視フィルタと UI 操作の単位として別管理する
+
+### 5.5 UI はハイブリッド表示を許可する
+
+- 正本モデルが並列軸であっても、UI では layer 主体のツリー表示を構成してよい
+- 例えば以下の表示は許可する
+  1. layer 一覧の下に、その layer に関連する group を補助表示する
+  2. group 一覧の下に、その group に属する entity を表示する
+  3. entity 詳細で所属 layer / 所属 group を別セクションで見せる
+- ただしこれは UI 表示モデルであり、Model の relation 構造そのものを `Layer > Group` 階層へ固定することは意味しない
+- これにより、CAD 的な layer 中心 UI を維持しつつ、group の横断的利用も阻害しない
+
+### 5.6 group command / query 導線
+
+```text
+ViewModel Event
+  -> Application Group Request DTO
+  -> entity relation update or group query
+  -> group/result DTO
+  -> ViewModel
+```
+
+- command 例:
+  1. group 作成
+  2. entity を group へ追加
+  3. entity を group から除外
+  4. group 可視状態を更新
+- query 例:
+  1. group 一覧取得
+  2. entity の所属 group 一覧取得
+  3. group 配下 entity 一覧取得
+- これらは geometry 更新とは別の entity relation 系 use case として扱う
+
+### 5.7 group request / result DTO の最小契約
+
+group 機能は entity relation 系 use case として `feature_orchestration` 直下、または同等の group-oriented orchestration で受ける。
+初期段階では以下の request / result DTO を最小契約とする。
+
+```rust
+pub struct CreateGroupRequest {
+  pub name: String,
+  pub visible: bool,
+}
+
+pub struct CreateGroupResult {
+  pub group: GroupDto,
+}
+
+pub struct AddEntityToGroupRequest {
+  pub entity_id: EntityId,
+  pub group_id: GroupId,
+}
+
+pub struct AddEntityToGroupResult {
+  pub entity_id: EntityId,
+  pub group_id: GroupId,
+  pub memberships: Vec<GroupMembershipDto>,
+}
+
+pub struct RemoveEntityFromGroupRequest {
+  pub entity_id: EntityId,
+  pub group_id: GroupId,
+}
+
+pub struct RemoveEntityFromGroupResult {
+  pub entity_id: EntityId,
+  pub group_id: GroupId,
+  pub memberships: Vec<GroupMembershipDto>,
+}
+
+pub struct SetGroupVisibilityRequest {
+  pub group_id: GroupId,
+  pub visible: bool,
+}
+
+pub struct SetGroupVisibilityResult {
+  pub group: GroupDto,
+  pub affected_entity_ids: Vec<EntityId>,
+}
+
+pub struct ListGroupsQuery;
+
+pub struct ListGroupsResult {
+  pub groups: Vec<GroupDto>,
+}
+
+pub struct ListGroupsForEntityQuery {
+  pub entity_id: EntityId,
+}
+
+pub struct ListGroupsForEntityResult {
+  pub entity_id: EntityId,
+  pub groups: Vec<GroupDto>,
+}
+
+pub struct ListEntitiesForGroupQuery {
+  pub group_id: GroupId,
+}
+
+pub struct ListEntitiesForGroupResult {
+  pub group_id: GroupId,
+  pub entity_ids: Vec<EntityId>,
+}
+
+pub struct GroupDto {
+  pub group_id: GroupId,
+  pub name: String,
+  pub visible: bool,
+  pub member_count: usize,
+}
+
+pub struct GroupMembershipDto {
+  pub entity_id: EntityId,
+  pub group_id: GroupId,
+}
+```
+
+- `CreateGroupRequest.visible` は初期表示状態であり、group ON/OFF を View ローカル専用状態へ閉じ込めないために必要とする
+- `SetGroupVisibilityResult.affected_entity_ids` は View 側が差分再評価を行うための最小情報として返す
+- `ListEntitiesForGroupResult` は初期段階では `EntityId` のみ返せばよく、表示用 summary は別 query として分けてよい
+- `GroupDto.member_count` は UI ツリーや group 一覧に必要な集約値であり、Application で整形して返す
+
+### 5.8 layer request / result DTO の最小契約
+
+layer 機能も entity relation 系 use case として group と同時に定義する。
+初期段階では以下の request / result DTO を最小契約とする。
+
+```rust
+pub struct CreateLayerRequest {
+  pub name: String,
+  pub visible: bool,
+}
+
+pub struct CreateLayerResult {
+  pub layer: LayerDto,
+}
+
+pub struct AddEntityToLayerRequest {
+  pub entity_id: EntityId,
+  pub layer_id: LayerId,
+}
+
+pub struct AddEntityToLayerResult {
+  pub entity_id: EntityId,
+  pub layer_id: LayerId,
+  pub memberships: Vec<LayerMembershipDto>,
+}
+
+pub struct RemoveEntityFromLayerRequest {
+  pub entity_id: EntityId,
+  pub layer_id: LayerId,
+}
+
+pub struct RemoveEntityFromLayerResult {
+  pub entity_id: EntityId,
+  pub layer_id: LayerId,
+  pub memberships: Vec<LayerMembershipDto>,
+}
+
+pub struct SetLayerVisibilityRequest {
+  pub layer_id: LayerId,
+  pub visible: bool,
+}
+
+pub struct SetLayerVisibilityResult {
+  pub layer: LayerDto,
+  pub affected_entity_ids: Vec<EntityId>,
+}
+
+pub struct ListLayersQuery;
+
+pub struct ListLayersResult {
+  pub layers: Vec<LayerDto>,
+}
+
+pub struct ListLayersForEntityQuery {
+  pub entity_id: EntityId,
+}
+
+pub struct ListLayersForEntityResult {
+  pub entity_id: EntityId,
+  pub layers: Vec<LayerDto>,
+}
+
+pub struct ListEntitiesForLayerQuery {
+  pub layer_id: LayerId,
+}
+
+pub struct ListEntitiesForLayerResult {
+  pub layer_id: LayerId,
+  pub entity_ids: Vec<EntityId>,
+}
+
+pub struct LayerDto {
+  pub layer_id: LayerId,
+  pub name: String,
+  pub visible: bool,
+  pub member_count: usize,
+}
+
+pub struct LayerMembershipDto {
+  pub entity_id: EntityId,
+  pub layer_id: LayerId,
+}
+```
+
+- `LayerDto.visible` は layer 単位 ON/OFF の正本 state を表す
+- `AddEntityToLayerRequest` は既存 layer 所属がある場合に Application 境界で正規化エラーを返す
+- layer は将来、既定色・既定線種の継承元になりうるが、初期 DTO にはその責務を混ぜない
+
+### 5.9 強い group / layer ON/OFF を支える state の位置づけ
+
+- 現在の `geo_entity::GroupEntity` は `id` と `name` のみを持つ
+- しかし「group 単位 ON/OFF を強い制御とする」要件を満たすには、`visible` を group state の正本側で保持する必要がある
+- したがって将来実装では以下のどちらかを採用する
+  1. `GroupEntity` 自体へ `visible: bool` を追加する
+  2. `GroupDisplayState { group_id, visible }` を relation と並列の語彙として持つ
+- 初期設計では DTO 契約を `visible` ありで固定し、Model 実装方式は後段で選択してよい
+- ただし View ローカル状態だけで group 可視性を持つ方式は、Application query と整合しないため採用しない
+- layer については現状の `LayerEntity` が `visible` を持つため、その方針を維持してよい
+- ただし group と layer の実装方式が異なっても、Application DTO 契約ではどちらも `visible` を持つ形に揃える
+
 ---
 
 ## 6. Application module の再解釈
@@ -205,11 +562,12 @@ geometry / topology / entity と同一階層の並列レーンとして定義し
 - geometry / topology / entity を直接保持しない
 - 既存 `job_runtime` / `cam_sim::CamJobExecutorAdapter` との接続窓口として育てる
 
-### 6.4 entity / topology 専用 orchestration は初手では追加しない
+### 6.4 entity / topology orchestration の初期配置
 
-- 初期段階では `entity_orchestration` や `topology_orchestration` を独立 module として増やさない
-- 理由は、use case 入口が増えるだけで責務が明確にならず、かえって導線が分散するため
-- entity / topology は feature orchestration 配下の port として扱う方が自然である
+- `entity_orchestration` と `topology_orchestration` は無条件に増やすのではなく、責務境界が追跡できる最小単位で導入する
+- 2026-04-09 時点では、topology は geometry からの導出 / 検証責務が独立しているため `topology_orchestration` を独立 module として配置している
+- 一方で entity は専用 module をまだ追加せず、`feature_orchestration` 配下の store port として保持している
+- したがって初期段階の判断基準は module 数の抑制そのものではなく、ViewModel→Application→Model 導線の責務分割をコード上で追跡できることに置く
 
 ---
 
@@ -229,6 +587,42 @@ geometry / topology / entity と同一階層の並列レーンとして定義し
    - submit / status / cancel / retry
 
 このうち `JobDispatchPort` は optional とし、#501 の最小同期導線では必須にしない。
+
+### 7.1 表示属性 contract 境界
+
+`geo_contracts` に露出する表示属性 contract は、次のように整理する。
+
+```rust
+pub trait EntityDisplayProperties {
+  fn entity_visible(&self) -> bool;
+  fn entity_color(&self) -> [f32; 4];
+}
+
+pub enum StrokePattern {
+  Solid,
+  Dashed,
+  Dotted,
+  DashDot,
+  DashDotDot,
+  Hidden,
+}
+
+pub trait StrokeDisplayProperties {
+  fn entity_stroke_pattern(&self) -> StrokePattern;
+  fn entity_stroke_width(&self) -> f32;
+}
+
+pub trait PlanarStroke2DProperties<T: Scalar> {
+  fn definition_plane_origin(&self) -> (T, T, T);
+  fn definition_plane_normal(&self) -> (T, T, T);
+  fn definition_plane_u_axis(&self) -> (T, T, T);
+}
+```
+
+- `StrokePattern` は `geo_entity` ではなく `geo_contracts` 側へ寄せる
+- 理由は、ViewModel contract が `geo_entity` の具体型へ依存しないようにするためである
+- `geo_entity::DisplayAttributes` の `LineStyle` は将来的に `StrokePattern` へ統合または alias 化する
+- 「二点鎖線」はここで stable 語彙として先に追加する
 
 ---
 
@@ -253,11 +647,46 @@ geometry / topology / entity と同一階層の並列レーンとして定義し
 - Topology を必須にする use case を追加し、導出 / 検証 port を実装する
 - ECS 差し替え時は `GeometryMutationPort` / `EntityStorePort` / `JobDispatchPort` の背後を置換する
 
+### 2026-04-09 時点の #501 実装反映
+
+- ViewModel 起点の最小 command 導線は `viewmodel/converter/src/feature_command_converter.rs` から `application` へ接続している
+- 現在の非ECS入口は `FeatureCommandOrchestration` であり、`FeatureOrchestrator` が line / circle / arc の geometry → topology → entity を直列実行する
+- triangle は face を導入せず、`GeometryOrchestrator` と `TopologyOrchestrator` を経由して closed wire として topology 責務だけを固定している
+- 通常の平面トポロジーとして triangle を Wire / Loop で扱う場合は、各辺を `LineSegment` 相当の直線 edge として表現する方針を採る
+- #256 で扱う三角形限定 topology は、工具逆オフセット法計算の前段で局所的な凸部縫合と探索効率向上を目的とする別系統の用途であり、ここでの通常 topology 表現とは分離して扱う
+- geometry の差し替え点は `LineGeometryMutationPort` と `DebugShapeGeometryMutationPort` である
+- topology の差し替え点は `LineTopologyMutationPort` と `DebugShapeTopologyMutationPort` である
+- entity / topology 保存の差し替え点は `LineEntityStorePort` / `CircleEntityStorePort` / `ArcEntityStorePort` / `CurveTopologyStorePort` である
+- 現在は in-memory 実装だが、ECS 置換時はこれら port の背後実装を ECS adapter へ差し替え、ViewModel 側の command 入口は維持する
+
+### NURBS topology の段階導入方針
+
+- NURBS topology は 1 段で trimmed face まで入れず、まず curve edge のみを対象にする
+- 初手では `NurbsCurve3D` を Edge の母曲線候補として扱い、native parameter domain を `parameter_range` にそのまま写す
+- `geo_topology` は既に `geo_primitives` に依存しているため、同列 shape family である `geo_nurbs` への依存も curve edge 対応の範囲で許可する
+- ただし依存は `geo_topology -> geo_nurbs` の片方向に限定し、`geo_nurbs -> geo_topology` の逆依存は許可しない
+- この段階では trim curve / Face / Loop / CoEdge / surface 上の 2D parameter curve は導入しない
+- trimmed NURBS face は別 Issue として扱い、face 語彙・loop 語彙・surface trim 境界の設計を先に固定してから実装する
+- したがって、NURBS 対応の初期スコープは `CurveRef` / `CurveSegment3D` / topology derive port の NURBS curve 対応までとする
+- `geo_nurbs` 側の split / evaluation は edge 段階でも利用可能だが、trimmed face の責務とは混同しない
+
+### #501 受け入れ条件との対応
+
+- `ViewModel起点の1ユースケースがModel更新まで通る`
+  - line / circle / arc は `feature_command_converter` → `FeatureOrchestrator` → in-memory entity/topology store まで到達している
+- `Entity/Topology責務境界がコード上で追跡可能`
+  - geometry は `geometry_orchestration.rs`、topology は `topology_orchestration.rs`、entity 保存は `feature_orchestration.rs` に分離されている
+- `ECS置換時に差し替えるポイントがドキュメント化済み`
+  - 本節の port 一覧を現行コード名ベースの差し替え点として扱う
+
 ---
 
 ## 9. 判断メモ
 
 - `view/app` の `EntityManager` は View ローカル状態であり、Model 側 entity 正本の代替にしない
+- ただし View ローカル状態は 2D / 3D の描画カテゴリと表示条件を反映した cache 単位を持つ
+- 2D 線種は「定義平面に対する直交ビュー」でのみ表示保証し、それ以外では非表示または実線フォールバックを許容する
+- 表示属性は common trait に詰め込まず、common / stroke / planar-2d に分割して露出する
 - `cam_orchestration` の `ToolEntityManagementOrchestrator` は現状では deterministic ID 組み立て PoC と位置づけ、Model ストレージ更新の完成形と見なさない
 - `job_runtime` はすでに execution 語彙を持っているため、#500 では job 独自モデルを再発明せず接続点だけ定義する
 - `geo_topology` は shape 意味論の代替ではなく、接続・整合性語彙として geometry 後段に置く

--- a/model/application/Cargo.toml
+++ b/model/application/Cargo.toml
@@ -11,7 +11,11 @@ description = "Application-layer orchestration entrypoints and boundary DTO cont
 
 [dependencies]
 analysis = { path = "../../foundation/analysis" }
+geo_contracts = { path = "../geo_contracts" }
 geo_algorithms = { path = "../geo_algorithms" }
+geo_entity = { path = "../geo_entity" }
+geo_primitives = { path = "../geo_primitives" }
+geo_topology = { path = "../geo_topology" }
 cam_core = { path = "../cam_core" }
 cam_sim = { path = "../cam_sim" }
 job_runtime = { path = "../job_runtime" }

--- a/model/application/src/feature_orchestration.rs
+++ b/model/application/src/feature_orchestration.rs
@@ -5,6 +5,7 @@ use crate::geometry_orchestration::{
     DebugShapeGeometryMutationPort, GeometryOrchestrationError, GeometryOrchestrator,
     LineGeometryMutationPort,
 };
+use crate::primitives::{Arc3D, Circle3D, LineSegment3D};
 use crate::topology_orchestration::{
     CreateArcTopologyRequest, CreateCircleTopologyRequest, CreateLineTopologyRequest,
     DebugShapeTopologyMutationPort, LineTopologyMutationPort, TopologyOrchestrationError,
@@ -16,7 +17,6 @@ use geo_contracts::{
     StrokePattern,
 };
 use geo_entity::{EntityId, GeometricEntity};
-use geo_primitives::{Arc3D, Circle3D, LineSegment3D};
 use geo_topology::{Edge as TopologyEdge, TopoId};
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};

--- a/model/application/src/feature_orchestration.rs
+++ b/model/application/src/feature_orchestration.rs
@@ -1,7 +1,758 @@
 //! Feature向け orchestration 境界。
 
+use crate::geometry_orchestration::{
+    CreateArcGeometryRequest, CreateCircleGeometryRequest, CreateLineGeometryRequest,
+    DebugShapeGeometryMutationPort, GeometryOrchestrationError, GeometryOrchestrator,
+    LineGeometryMutationPort,
+};
+use crate::topology_orchestration::{
+    CreateArcTopologyRequest, CreateCircleTopologyRequest, CreateLineTopologyRequest,
+    DebugShapeTopologyMutationPort, LineTopologyMutationPort, TopologyOrchestrationError,
+    TopologyOrchestrator,
+};
+use geo_contracts::{
+    Arc3DProperties, ArcEntity3DProperties, Circle3DProperties, CircleEntity3DProperties,
+    EntityDisplayProperties, EntityIdentity, LineEntity3DProperties, StrokeDisplayProperties,
+    StrokePattern,
+};
+use geo_entity::{EntityId, GeometricEntity};
+use geo_primitives::{Arc3D, Circle3D, LineSegment3D};
+use geo_topology::{Edge as TopologyEdge, TopoId};
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+type StoredLineEntity = GeometricEntity<f64, LineSegment3D<f64>>;
+type StoredLineEntityMap = HashMap<EntityId, StoredLineEntity>;
+type SharedLineEntityStore = Mutex<StoredLineEntityMap>;
+type StoredCurveTopology = TopologyEdge<f64>;
+type StoredCurveTopologyMap = HashMap<TopoId, StoredCurveTopology>;
+type SharedCurveTopologyStore = Mutex<StoredCurveTopologyMap>;
+type StoredCircleEntity = GeometricEntity<f64, Circle3D<f64>>;
+type StoredCircleEntityMap = HashMap<EntityId, StoredCircleEntity>;
+type SharedCircleEntityStore = Mutex<StoredCircleEntityMap>;
+type StoredArcEntity = GeometricEntity<f64, Arc3D<f64>>;
+type StoredArcEntityMap = HashMap<EntityId, StoredArcEntity>;
+type SharedArcEntityStore = Mutex<StoredArcEntityMap>;
+
+static LINE_ENTITY_STORE: OnceLock<SharedLineEntityStore> = OnceLock::new();
+static CURVE_TOPOLOGY_STORE: OnceLock<SharedCurveTopologyStore> = OnceLock::new();
+static CIRCLE_ENTITY_STORE: OnceLock<SharedCircleEntityStore> = OnceLock::new();
+static ARC_ENTITY_STORE: OnceLock<SharedArcEntityStore> = OnceLock::new();
+
+fn line_entity_store() -> &'static SharedLineEntityStore {
+    LINE_ENTITY_STORE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn curve_topology_store() -> &'static SharedCurveTopologyStore {
+    CURVE_TOPOLOGY_STORE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn circle_entity_store() -> &'static SharedCircleEntityStore {
+    CIRCLE_ENTITY_STORE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn arc_entity_store() -> &'static SharedArcEntityStore {
+    ARC_ENTITY_STORE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
 /// 将来の feature orchestration ユースケース向けマーカー入力境界。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FeatureOrchestrationRequest {
     pub feature_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateLineFeatureRequest {
+    pub feature_id: String,
+    pub feature_name: String,
+    pub output_index: u32,
+    pub local_key: String,
+    pub start: [f64; 3],
+    pub end: [f64; 3],
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateCircleFeatureRequest {
+    pub feature_id: String,
+    pub feature_name: String,
+    pub output_index: u32,
+    pub local_key: String,
+    pub center: [f64; 3],
+    pub radius: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateArcFeatureRequest {
+    pub feature_id: String,
+    pub feature_name: String,
+    pub output_index: u32,
+    pub local_key: String,
+    pub center: [f64; 3],
+    pub radius: f64,
+    pub start_angle_radians: f64,
+    pub end_angle_radians: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StoredLineEntityDto {
+    pub entity_id: EntityId,
+    pub feature_name: String,
+    pub start: [f64; 3],
+    pub end: [f64; 3],
+    pub color: [f32; 4],
+    pub line_style: StrokePattern,
+    pub line_width: f32,
+    pub visible: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StoredCurveTopologyDto {
+    pub edge_id: TopoId,
+    pub start_vertex_id: TopoId,
+    pub end_vertex_id: TopoId,
+    pub valid: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StoredCircleEntityDto {
+    pub entity_id: EntityId,
+    pub feature_name: String,
+    pub center: [f64; 3],
+    pub radius: f64,
+    pub axis: [f64; 3],
+    pub color: [f32; 4],
+    pub line_style: StrokePattern,
+    pub line_width: f32,
+    pub visible: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StoredArcEntityDto {
+    pub entity_id: EntityId,
+    pub feature_name: String,
+    pub center: [f64; 3],
+    pub radius: f64,
+    pub start_angle_radians: f64,
+    pub end_angle_radians: f64,
+    pub normal: [f64; 3],
+    pub start_direction: [f64; 3],
+    pub color: [f32; 4],
+    pub line_style: StrokePattern,
+    pub line_width: f32,
+    pub visible: bool,
+}
+
+impl EntityIdentity for StoredLineEntityDto {
+    type Id = EntityId;
+
+    fn entity_id(&self) -> Self::Id {
+        self.entity_id
+    }
+}
+
+impl EntityDisplayProperties for StoredLineEntityDto {
+    fn entity_visible(&self) -> bool {
+        self.visible
+    }
+
+    fn entity_color(&self) -> [f32; 4] {
+        self.color
+    }
+}
+
+impl LineEntity3DProperties<f64> for StoredLineEntityDto {
+    fn line_start(&self) -> (f64, f64, f64) {
+        (self.start[0], self.start[1], self.start[2])
+    }
+
+    fn line_end(&self) -> (f64, f64, f64) {
+        (self.end[0], self.end[1], self.end[2])
+    }
+}
+
+impl StrokeDisplayProperties for StoredLineEntityDto {
+    fn entity_stroke_pattern(&self) -> StrokePattern {
+        self.line_style
+    }
+
+    fn entity_stroke_width(&self) -> f32 {
+        self.line_width
+    }
+}
+
+impl EntityIdentity for StoredCircleEntityDto {
+    type Id = EntityId;
+
+    fn entity_id(&self) -> Self::Id {
+        self.entity_id
+    }
+}
+
+impl EntityDisplayProperties for StoredCircleEntityDto {
+    fn entity_visible(&self) -> bool {
+        self.visible
+    }
+
+    fn entity_color(&self) -> [f32; 4] {
+        self.color
+    }
+}
+
+impl CircleEntity3DProperties<f64> for StoredCircleEntityDto {
+    fn circle_center(&self) -> (f64, f64, f64) {
+        (self.center[0], self.center[1], self.center[2])
+    }
+
+    fn circle_radius(&self) -> f64 {
+        self.radius
+    }
+
+    fn circle_axis(&self) -> (f64, f64, f64) {
+        (self.axis[0], self.axis[1], self.axis[2])
+    }
+}
+
+impl StrokeDisplayProperties for StoredCircleEntityDto {
+    fn entity_stroke_pattern(&self) -> StrokePattern {
+        self.line_style
+    }
+
+    fn entity_stroke_width(&self) -> f32 {
+        self.line_width
+    }
+}
+
+impl EntityIdentity for StoredArcEntityDto {
+    type Id = EntityId;
+
+    fn entity_id(&self) -> Self::Id {
+        self.entity_id
+    }
+}
+
+impl EntityDisplayProperties for StoredArcEntityDto {
+    fn entity_visible(&self) -> bool {
+        self.visible
+    }
+
+    fn entity_color(&self) -> [f32; 4] {
+        self.color
+    }
+}
+
+impl ArcEntity3DProperties<f64> for StoredArcEntityDto {
+    fn arc_center(&self) -> (f64, f64, f64) {
+        (self.center[0], self.center[1], self.center[2])
+    }
+
+    fn arc_radius(&self) -> f64 {
+        self.radius
+    }
+
+    fn arc_start_angle(&self) -> f64 {
+        self.start_angle_radians
+    }
+
+    fn arc_end_angle(&self) -> f64 {
+        self.end_angle_radians
+    }
+
+    fn arc_normal(&self) -> (f64, f64, f64) {
+        (self.normal[0], self.normal[1], self.normal[2])
+    }
+
+    fn arc_start_direction(&self) -> (f64, f64, f64) {
+        (
+            self.start_direction[0],
+            self.start_direction[1],
+            self.start_direction[2],
+        )
+    }
+}
+
+impl StrokeDisplayProperties for StoredArcEntityDto {
+    fn entity_stroke_pattern(&self) -> StrokePattern {
+        self.line_style
+    }
+
+    fn entity_stroke_width(&self) -> f32 {
+        self.line_width
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateLineFeatureResult {
+    pub entity: StoredLineEntityDto,
+    pub topology: StoredCurveTopologyDto,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateCircleFeatureResult {
+    pub entity: StoredCircleEntityDto,
+    pub topology: StoredCurveTopologyDto,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateArcFeatureResult {
+    pub entity: StoredArcEntityDto,
+    pub topology: StoredCurveTopologyDto,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FeatureOrchestrationError {
+    InvalidLineGeometry,
+    InvalidLineTopology,
+    InvalidCircleGeometry,
+    InvalidCircleTopology,
+    InvalidArcGeometry,
+    InvalidArcTopology,
+    InvalidTriangleGeometry,
+    InvalidTriangleTopology,
+    EntityStorePoisoned,
+}
+
+impl std::fmt::Display for FeatureOrchestrationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidLineGeometry => write!(f, "invalid line geometry"),
+            Self::InvalidLineTopology => write!(f, "invalid line topology"),
+            Self::InvalidCircleGeometry => write!(f, "invalid circle geometry"),
+            Self::InvalidCircleTopology => write!(f, "invalid circle topology"),
+            Self::InvalidArcGeometry => write!(f, "invalid arc geometry"),
+            Self::InvalidArcTopology => write!(f, "invalid arc topology"),
+            Self::InvalidTriangleGeometry => write!(f, "invalid triangle geometry"),
+            Self::InvalidTriangleTopology => write!(f, "invalid triangle topology"),
+            Self::EntityStorePoisoned => write!(f, "entity store poisoned"),
+        }
+    }
+}
+
+impl std::error::Error for FeatureOrchestrationError {}
+
+impl From<GeometryOrchestrationError> for FeatureOrchestrationError {
+    fn from(value: GeometryOrchestrationError) -> Self {
+        match value {
+            GeometryOrchestrationError::InvalidLineEndpoints => Self::InvalidLineGeometry,
+            GeometryOrchestrationError::InvalidCircleParameters => Self::InvalidCircleGeometry,
+            GeometryOrchestrationError::InvalidArcParameters => Self::InvalidArcGeometry,
+            GeometryOrchestrationError::InvalidTriangleVertices => Self::InvalidTriangleGeometry,
+        }
+    }
+}
+
+impl From<TopologyOrchestrationError> for FeatureOrchestrationError {
+    fn from(value: TopologyOrchestrationError) -> Self {
+        match value {
+            TopologyOrchestrationError::InvalidLineTopology => Self::InvalidLineTopology,
+            TopologyOrchestrationError::InvalidArcTopology => Self::InvalidArcTopology,
+            TopologyOrchestrationError::InvalidCircleTopology => Self::InvalidCircleTopology,
+            TopologyOrchestrationError::InvalidTriangleTopology => Self::InvalidTriangleTopology,
+        }
+    }
+}
+
+pub trait FeatureCommandOrchestration {
+    fn create_line_feature(
+        &self,
+        request: CreateLineFeatureRequest,
+    ) -> Result<CreateLineFeatureResult, FeatureOrchestrationError>;
+
+    fn create_circle_feature(
+        &self,
+        request: CreateCircleFeatureRequest,
+    ) -> Result<CreateCircleFeatureResult, FeatureOrchestrationError>;
+
+    fn create_arc_feature(
+        &self,
+        request: CreateArcFeatureRequest,
+    ) -> Result<CreateArcFeatureResult, FeatureOrchestrationError>;
+}
+
+pub trait LineEntityStorePort {
+    fn insert_line_entity(
+        &self,
+        entity: StoredLineEntity,
+        feature_name: String,
+    ) -> Result<StoredLineEntityDto, FeatureOrchestrationError>;
+    fn contains(&self, entity_id: EntityId) -> Result<bool, FeatureOrchestrationError>;
+}
+
+pub trait CurveTopologyStorePort {
+    fn insert_curve_topology(
+        &self,
+        edge: StoredCurveTopology,
+        valid: bool,
+    ) -> Result<StoredCurveTopologyDto, FeatureOrchestrationError>;
+    fn contains_topology(&self, edge_id: TopoId) -> Result<bool, FeatureOrchestrationError>;
+}
+
+pub trait CircleEntityStorePort {
+    fn insert_circle_entity(
+        &self,
+        entity: StoredCircleEntity,
+        feature_name: String,
+    ) -> Result<StoredCircleEntityDto, FeatureOrchestrationError>;
+    fn contains_circle(&self, entity_id: EntityId) -> Result<bool, FeatureOrchestrationError>;
+}
+
+pub trait ArcEntityStorePort {
+    fn insert_arc_entity(
+        &self,
+        entity: StoredArcEntity,
+        feature_name: String,
+    ) -> Result<StoredArcEntityDto, FeatureOrchestrationError>;
+    fn contains_arc(&self, entity_id: EntityId) -> Result<bool, FeatureOrchestrationError>;
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct InMemoryLineEntityStore;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct InMemoryCurveTopologyStore;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct InMemoryCircleEntityStore;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct InMemoryArcEntityStore;
+
+impl LineEntityStorePort for InMemoryLineEntityStore {
+    fn insert_line_entity(
+        &self,
+        entity: StoredLineEntity,
+        feature_name: String,
+    ) -> Result<StoredLineEntityDto, FeatureOrchestrationError> {
+        let dto = StoredLineEntityDto {
+            entity_id: entity.id(),
+            feature_name,
+            start: [
+                entity.geometry().start().x(),
+                entity.geometry().start().y(),
+                entity.geometry().start().z(),
+            ],
+            end: [
+                entity.geometry().end().x(),
+                entity.geometry().end().y(),
+                entity.geometry().end().z(),
+            ],
+            color: entity.display().color,
+            line_style: entity.display().line_style,
+            line_width: entity.display().line_width,
+            visible: entity.display().visible,
+        };
+
+        let mut store = line_entity_store()
+            .lock()
+            .map_err(|_| FeatureOrchestrationError::EntityStorePoisoned)?;
+        store.insert(entity.id(), entity);
+        Ok(dto)
+    }
+
+    fn contains(&self, entity_id: EntityId) -> Result<bool, FeatureOrchestrationError> {
+        let store = line_entity_store()
+            .lock()
+            .map_err(|_| FeatureOrchestrationError::EntityStorePoisoned)?;
+        Ok(store.contains_key(&entity_id))
+    }
+}
+
+impl CurveTopologyStorePort for InMemoryCurveTopologyStore {
+    fn insert_curve_topology(
+        &self,
+        edge: StoredCurveTopology,
+        valid: bool,
+    ) -> Result<StoredCurveTopologyDto, FeatureOrchestrationError> {
+        let dto = StoredCurveTopologyDto {
+            edge_id: edge.id(),
+            start_vertex_id: edge.start_vertex().id(),
+            end_vertex_id: edge.end_vertex().id(),
+            valid,
+        };
+
+        let mut store = curve_topology_store()
+            .lock()
+            .map_err(|_| FeatureOrchestrationError::EntityStorePoisoned)?;
+        store.insert(edge.id(), edge);
+        Ok(dto)
+    }
+
+    fn contains_topology(&self, edge_id: TopoId) -> Result<bool, FeatureOrchestrationError> {
+        let store = curve_topology_store()
+            .lock()
+            .map_err(|_| FeatureOrchestrationError::EntityStorePoisoned)?;
+        Ok(store.contains_key(&edge_id))
+    }
+}
+
+impl CircleEntityStorePort for InMemoryCircleEntityStore {
+    fn insert_circle_entity(
+        &self,
+        entity: StoredCircleEntity,
+        feature_name: String,
+    ) -> Result<StoredCircleEntityDto, FeatureOrchestrationError> {
+        let center = Circle3DProperties::center(entity.geometry());
+        let axis = Circle3DProperties::axis(entity.geometry());
+        let dto = StoredCircleEntityDto {
+            entity_id: entity.id(),
+            feature_name,
+            center: [center.0, center.1, center.2],
+            radius: Circle3DProperties::radius(entity.geometry()),
+            axis: [axis.0, axis.1, axis.2],
+            color: entity.display().color,
+            line_style: entity.display().line_style,
+            line_width: entity.display().line_width,
+            visible: entity.display().visible,
+        };
+
+        let mut store = circle_entity_store()
+            .lock()
+            .map_err(|_| FeatureOrchestrationError::EntityStorePoisoned)?;
+        store.insert(entity.id(), entity);
+        Ok(dto)
+    }
+
+    fn contains_circle(&self, entity_id: EntityId) -> Result<bool, FeatureOrchestrationError> {
+        let store = circle_entity_store()
+            .lock()
+            .map_err(|_| FeatureOrchestrationError::EntityStorePoisoned)?;
+        Ok(store.contains_key(&entity_id))
+    }
+}
+
+impl ArcEntityStorePort for InMemoryArcEntityStore {
+    fn insert_arc_entity(
+        &self,
+        entity: StoredArcEntity,
+        feature_name: String,
+    ) -> Result<StoredArcEntityDto, FeatureOrchestrationError> {
+        let center = Arc3DProperties::center(entity.geometry());
+        let normal = entity.geometry().normal().as_vector();
+        let start_direction = entity.geometry().start_direction().as_vector();
+        let dto = StoredArcEntityDto {
+            entity_id: entity.id(),
+            feature_name,
+            center: [center.0, center.1, center.2],
+            radius: Arc3DProperties::radius(entity.geometry()),
+            start_angle_radians: entity.geometry().start_angle().to_radians(),
+            end_angle_radians: entity.geometry().end_angle().to_radians(),
+            normal: [normal.x(), normal.y(), normal.z()],
+            start_direction: [
+                start_direction.x(),
+                start_direction.y(),
+                start_direction.z(),
+            ],
+            color: entity.display().color,
+            line_style: entity.display().line_style,
+            line_width: entity.display().line_width,
+            visible: entity.display().visible,
+        };
+
+        let mut store = arc_entity_store()
+            .lock()
+            .map_err(|_| FeatureOrchestrationError::EntityStorePoisoned)?;
+        store.insert(entity.id(), entity);
+        Ok(dto)
+    }
+
+    fn contains_arc(&self, entity_id: EntityId) -> Result<bool, FeatureOrchestrationError> {
+        let store = arc_entity_store()
+            .lock()
+            .map_err(|_| FeatureOrchestrationError::EntityStorePoisoned)?;
+        Ok(store.contains_key(&entity_id))
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FeatureOrchestrator;
+
+impl FeatureCommandOrchestration for FeatureOrchestrator {
+    fn create_line_feature(
+        &self,
+        request: CreateLineFeatureRequest,
+    ) -> Result<CreateLineFeatureResult, FeatureOrchestrationError> {
+        let geometry = GeometryOrchestrator.create_line_geometry(CreateLineGeometryRequest {
+            start: request.start,
+            end: request.end,
+        })?;
+
+        let topology = TopologyOrchestrator.create_line_topology(CreateLineTopologyRequest {
+            line: geometry.line,
+        })?;
+
+        let entity = GeometricEntity::from_feature_output(
+            geometry.line,
+            &request.feature_id,
+            request.output_index,
+            &request.local_key,
+        );
+        let topology_dto = InMemoryCurveTopologyStore
+            .insert_curve_topology(topology.edge, topology.validation.is_valid())?;
+        let dto = InMemoryLineEntityStore.insert_line_entity(entity, request.feature_name)?;
+
+        Ok(CreateLineFeatureResult {
+            entity: dto,
+            topology: topology_dto,
+        })
+    }
+
+    fn create_circle_feature(
+        &self,
+        request: CreateCircleFeatureRequest,
+    ) -> Result<CreateCircleFeatureResult, FeatureOrchestrationError> {
+        let geometry =
+            GeometryOrchestrator.create_circle_geometry(CreateCircleGeometryRequest {
+                center: request.center,
+                radius: request.radius,
+            })?;
+
+        let topology =
+            TopologyOrchestrator.create_circle_topology(CreateCircleTopologyRequest {
+                circle: geometry.circle,
+            })?;
+
+        let entity = GeometricEntity::from_feature_output(
+            geometry.circle,
+            &request.feature_id,
+            request.output_index,
+            &request.local_key,
+        );
+        let topology_dto = InMemoryCurveTopologyStore
+            .insert_curve_topology(topology.edge, topology.validation.is_valid())?;
+        let dto = InMemoryCircleEntityStore.insert_circle_entity(entity, request.feature_name)?;
+
+        Ok(CreateCircleFeatureResult {
+            entity: dto,
+            topology: topology_dto,
+        })
+    }
+
+    fn create_arc_feature(
+        &self,
+        request: CreateArcFeatureRequest,
+    ) -> Result<CreateArcFeatureResult, FeatureOrchestrationError> {
+        let geometry = GeometryOrchestrator.create_arc_geometry(CreateArcGeometryRequest {
+            center: request.center,
+            radius: request.radius,
+            start_angle_radians: request.start_angle_radians,
+            end_angle_radians: request.end_angle_radians,
+        })?;
+
+        let topology = TopologyOrchestrator
+            .create_arc_topology(CreateArcTopologyRequest { arc: geometry.arc })?;
+
+        let entity = GeometricEntity::from_feature_output(
+            geometry.arc,
+            &request.feature_id,
+            request.output_index,
+            &request.local_key,
+        );
+        let topology_dto = InMemoryCurveTopologyStore
+            .insert_curve_topology(topology.edge, topology.validation.is_valid())?;
+        let dto = InMemoryArcEntityStore.insert_arc_entity(entity, request.feature_name)?;
+
+        Ok(CreateArcFeatureResult {
+            entity: dto,
+            topology: topology_dto,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ArcEntityStorePort, CircleEntityStorePort, CreateArcFeatureRequest,
+        CreateCircleFeatureRequest, CreateLineFeatureRequest, CurveTopologyStorePort,
+        FeatureCommandOrchestration, FeatureOrchestrator, InMemoryArcEntityStore,
+        InMemoryCircleEntityStore, InMemoryCurveTopologyStore, InMemoryLineEntityStore,
+        LineEntityStorePort,
+    };
+
+    #[test]
+    fn create_line_feature_stores_entity_and_returns_line_dto() {
+        let result = FeatureOrchestrator
+            .create_line_feature(CreateLineFeatureRequest {
+                feature_id: "debug_line".to_string(),
+                feature_name: "Debug Line".to_string(),
+                output_index: 0,
+                local_key: "line_a".to_string(),
+                start: [-50.0, 0.0, 0.0],
+                end: [50.0, 0.0, 0.0],
+            })
+            .expect("line feature creation should succeed");
+
+        assert_eq!(result.entity.feature_name, "Debug Line");
+        assert_eq!(result.entity.start, [-50.0, 0.0, 0.0]);
+        assert_eq!(result.entity.end, [50.0, 0.0, 0.0]);
+        assert!(result.topology.valid);
+        assert!(
+            InMemoryLineEntityStore
+                .contains(result.entity.entity_id)
+                .expect("entity store should be readable")
+        );
+        assert!(
+            InMemoryCurveTopologyStore
+                .contains_topology(result.topology.edge_id)
+                .expect("topology store should be readable")
+        );
+    }
+
+    #[test]
+    fn create_circle_feature_stores_entity_and_returns_circle_dto() {
+        let result = FeatureOrchestrator
+            .create_circle_feature(CreateCircleFeatureRequest {
+                feature_id: "debug_circle".to_string(),
+                feature_name: "Debug Circle".to_string(),
+                output_index: 0,
+                local_key: "circle_a".to_string(),
+                center: [0.0, 0.0, 0.0],
+                radius: 5.0,
+            })
+            .expect("circle feature creation should succeed");
+
+        assert_eq!(result.entity.feature_name, "Debug Circle");
+        assert_eq!(result.entity.center, [0.0, 0.0, 0.0]);
+        assert_eq!(result.entity.radius, 5.0);
+        assert!(result.topology.valid);
+        assert!(
+            InMemoryCircleEntityStore
+                .contains_circle(result.entity.entity_id)
+                .expect("circle entity store should be readable")
+        );
+        assert!(
+            InMemoryCurveTopologyStore
+                .contains_topology(result.topology.edge_id)
+                .expect("topology store should be readable")
+        );
+    }
+
+    #[test]
+    fn create_arc_feature_stores_entity_and_returns_arc_dto() {
+        let result = FeatureOrchestrator
+            .create_arc_feature(CreateArcFeatureRequest {
+                feature_id: "debug_arc".to_string(),
+                feature_name: "Debug Arc".to_string(),
+                output_index: 0,
+                local_key: "arc_a".to_string(),
+                center: [0.0, 0.0, 0.0],
+                radius: 1.5,
+                start_angle_radians: 0.0,
+                end_angle_radians: std::f64::consts::FRAC_PI_2,
+            })
+            .expect("arc feature creation should succeed");
+
+        assert_eq!(result.entity.feature_name, "Debug Arc");
+        assert_eq!(result.entity.center, [0.0, 0.0, 0.0]);
+        assert_eq!(result.entity.radius, 1.5);
+        assert!(result.topology.valid);
+        assert!(
+            InMemoryArcEntityStore
+                .contains_arc(result.entity.entity_id)
+                .expect("arc entity store should be readable")
+        );
+        assert!(
+            InMemoryCurveTopologyStore
+                .contains_topology(result.topology.edge_id)
+                .expect("topology store should be readable")
+        );
+    }
 }

--- a/model/application/src/geometry_orchestration.rs
+++ b/model/application/src/geometry_orchestration.rs
@@ -1,7 +1,249 @@
 //! Geometry向け orchestration 境界。
 
+use geo_primitives::{Angle, Arc3D, Circle3D, LineSegment3D, Point3D, Triangle3D};
+
 /// 将来の geometry orchestration ユースケース向けマーカー入力境界。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GeometryOrchestrationRequest {
     pub operation_name: String,
+}
+
+/// line geometry 生成の入力境界。
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateLineGeometryRequest {
+    pub start: [f64; 3],
+    pub end: [f64; 3],
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateLineGeometryResult {
+    pub line: LineSegment3D<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateCircleGeometryRequest {
+    pub center: [f64; 3],
+    pub radius: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateCircleGeometryResult {
+    pub circle: Circle3D<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateArcGeometryRequest {
+    pub center: [f64; 3],
+    pub radius: f64,
+    pub start_angle_radians: f64,
+    pub end_angle_radians: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateArcGeometryResult {
+    pub arc: Arc3D<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateTriangleGeometryRequest {
+    pub vertex_a: [f64; 3],
+    pub vertex_b: [f64; 3],
+    pub vertex_c: [f64; 3],
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateTriangleGeometryResult {
+    pub triangle: Triangle3D<f64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GeometryOrchestrationError {
+    InvalidLineEndpoints,
+    InvalidCircleParameters,
+    InvalidArcParameters,
+    InvalidTriangleVertices,
+}
+
+impl std::fmt::Display for GeometryOrchestrationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidLineEndpoints => write!(f, "invalid line endpoints"),
+            Self::InvalidCircleParameters => write!(f, "invalid circle parameters"),
+            Self::InvalidArcParameters => write!(f, "invalid arc parameters"),
+            Self::InvalidTriangleVertices => write!(f, "invalid triangle vertices"),
+        }
+    }
+}
+
+impl std::error::Error for GeometryOrchestrationError {}
+
+pub trait LineGeometryMutationPort {
+    fn create_line_geometry(
+        &self,
+        request: CreateLineGeometryRequest,
+    ) -> Result<CreateLineGeometryResult, GeometryOrchestrationError>;
+}
+
+pub trait DebugShapeGeometryMutationPort {
+    fn create_circle_geometry(
+        &self,
+        request: CreateCircleGeometryRequest,
+    ) -> Result<CreateCircleGeometryResult, GeometryOrchestrationError>;
+
+    fn create_arc_geometry(
+        &self,
+        request: CreateArcGeometryRequest,
+    ) -> Result<CreateArcGeometryResult, GeometryOrchestrationError>;
+
+    fn create_triangle_geometry(
+        &self,
+        request: CreateTriangleGeometryRequest,
+    ) -> Result<CreateTriangleGeometryResult, GeometryOrchestrationError>;
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct GeometryOrchestrator;
+
+impl LineGeometryMutationPort for GeometryOrchestrator {
+    fn create_line_geometry(
+        &self,
+        request: CreateLineGeometryRequest,
+    ) -> Result<CreateLineGeometryResult, GeometryOrchestrationError> {
+        let start = Point3D::new(request.start[0], request.start[1], request.start[2]);
+        let end = Point3D::new(request.end[0], request.end[1], request.end[2]);
+        let line = LineSegment3D::new(start, end)
+            .ok_or(GeometryOrchestrationError::InvalidLineEndpoints)?;
+
+        Ok(CreateLineGeometryResult { line })
+    }
+}
+
+impl DebugShapeGeometryMutationPort for GeometryOrchestrator {
+    fn create_circle_geometry(
+        &self,
+        request: CreateCircleGeometryRequest,
+    ) -> Result<CreateCircleGeometryResult, GeometryOrchestrationError> {
+        let center = Point3D::new(request.center[0], request.center[1], request.center[2]);
+        let circle = Circle3D::new_xy_plane(center, request.radius)
+            .ok_or(GeometryOrchestrationError::InvalidCircleParameters)?;
+
+        Ok(CreateCircleGeometryResult { circle })
+    }
+
+    fn create_arc_geometry(
+        &self,
+        request: CreateArcGeometryRequest,
+    ) -> Result<CreateArcGeometryResult, GeometryOrchestrationError> {
+        let center = Point3D::new(request.center[0], request.center[1], request.center[2]);
+        let arc = Arc3D::xy_arc(
+            center,
+            request.radius,
+            Angle::from_radians(request.start_angle_radians),
+            Angle::from_radians(request.end_angle_radians),
+        )
+        .ok_or(GeometryOrchestrationError::InvalidArcParameters)?;
+
+        Ok(CreateArcGeometryResult { arc })
+    }
+
+    fn create_triangle_geometry(
+        &self,
+        request: CreateTriangleGeometryRequest,
+    ) -> Result<CreateTriangleGeometryResult, GeometryOrchestrationError> {
+        let vertex_a = Point3D::new(
+            request.vertex_a[0],
+            request.vertex_a[1],
+            request.vertex_a[2],
+        );
+        let vertex_b = Point3D::new(
+            request.vertex_b[0],
+            request.vertex_b[1],
+            request.vertex_b[2],
+        );
+        let vertex_c = Point3D::new(
+            request.vertex_c[0],
+            request.vertex_c[1],
+            request.vertex_c[2],
+        );
+
+        let triangle = Triangle3D::new(vertex_a, vertex_b, vertex_c)
+            .ok_or(GeometryOrchestrationError::InvalidTriangleVertices)?;
+
+        Ok(CreateTriangleGeometryResult { triangle })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CreateArcGeometryRequest, CreateCircleGeometryRequest, CreateLineGeometryRequest,
+        CreateTriangleGeometryRequest, DebugShapeGeometryMutationPort, GeometryOrchestrationError,
+        GeometryOrchestrator, LineGeometryMutationPort,
+    };
+    use geo_contracts::{Arc3DProperties, Circle3DProperties, Triangle3DBoundaryAccess};
+
+    #[test]
+    fn create_line_geometry_returns_line_segment() {
+        let result = GeometryOrchestrator
+            .create_line_geometry(CreateLineGeometryRequest {
+                start: [0.0, 0.0, 0.0],
+                end: [10.0, 0.0, 0.0],
+            })
+            .expect("line geometry creation should succeed");
+
+        assert_eq!(result.line.start().x(), 0.0);
+        assert_eq!(result.line.end().x(), 10.0);
+    }
+
+    #[test]
+    fn create_line_geometry_rejects_identical_endpoints() {
+        let result = GeometryOrchestrator.create_line_geometry(CreateLineGeometryRequest {
+            start: [1.0, 1.0, 1.0],
+            end: [1.0, 1.0, 1.0],
+        });
+
+        assert_eq!(
+            result,
+            Err(GeometryOrchestrationError::InvalidLineEndpoints)
+        );
+    }
+
+    #[test]
+    fn create_circle_geometry_returns_circle() {
+        let result = GeometryOrchestrator
+            .create_circle_geometry(CreateCircleGeometryRequest {
+                center: [0.0, 0.0, 0.0],
+                radius: 5.0,
+            })
+            .expect("circle geometry creation should succeed");
+
+        assert_eq!(result.circle.radius(), 5.0);
+    }
+
+    #[test]
+    fn create_arc_geometry_returns_arc() {
+        let result = GeometryOrchestrator
+            .create_arc_geometry(CreateArcGeometryRequest {
+                center: [0.0, 0.0, 0.0],
+                radius: 1.5,
+                start_angle_radians: 0.0,
+                end_angle_radians: std::f64::consts::FRAC_PI_2,
+            })
+            .expect("arc geometry creation should succeed");
+
+        assert_eq!(result.arc.radius(), 1.5);
+    }
+
+    #[test]
+    fn create_triangle_geometry_returns_triangle() {
+        let result = GeometryOrchestrator
+            .create_triangle_geometry(CreateTriangleGeometryRequest {
+                vertex_a: [0.0, 0.0, 0.0],
+                vertex_b: [1.0, 0.0, 0.0],
+                vertex_c: [0.5, 1.0, 0.0],
+            })
+            .expect("triangle geometry creation should succeed");
+
+        assert_eq!(result.triangle.vertex_a(), (0.0, 0.0, 0.0));
+    }
 }

--- a/model/application/src/geometry_orchestration.rs
+++ b/model/application/src/geometry_orchestration.rs
@@ -1,6 +1,6 @@
 //! Geometry向け orchestration 境界。
 
-use geo_primitives::{Angle, Arc3D, Circle3D, LineSegment3D, Point3D, Triangle3D};
+use crate::primitives::{Angle, Arc3D, Circle3D, LineSegment3D, Point3D, Triangle3D};
 
 /// 将来の geometry orchestration ユースケース向けマーカー入力境界。
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/model/application/src/lib.rs
+++ b/model/application/src/lib.rs
@@ -3,6 +3,8 @@
 //! このクレートは、PoC段階における orchestration 責務の単一受け皿です。
 //! 初期フェーズでは単一クレート内を module 分割し、境界安定後に必要に応じて昇格します。
 
+pub extern crate geo_primitives as primitives;
+
 pub mod cam_orchestration;
 pub mod feature_orchestration;
 pub mod geometry_orchestration;

--- a/model/application/src/lib.rs
+++ b/model/application/src/lib.rs
@@ -7,3 +7,4 @@ pub mod cam_orchestration;
 pub mod feature_orchestration;
 pub mod geometry_orchestration;
 pub mod job_orchestration;
+pub mod topology_orchestration;

--- a/model/application/src/topology_orchestration.rs
+++ b/model/application/src/topology_orchestration.rs
@@ -1,0 +1,320 @@
+//! Topology向け orchestration 境界。
+
+use geo_contracts::{Arc3DConstructor, Circle3DProperties, Triangle3DBoundaryAccess};
+use geo_primitives::{Arc3D, Circle3D, LineSegment3D, Point3D, Triangle3D};
+use geo_topology::{
+    CurveRef, Edge, EdgeValidationReport, TopologyToleranceSettings, TopologyValidator, Vertex,
+    Wire, WireValidationReport,
+};
+use std::sync::Arc;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateLineTopologyRequest {
+    pub line: LineSegment3D<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateArcTopologyRequest {
+    pub arc: Arc3D<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateCircleTopologyRequest {
+    pub circle: Circle3D<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateTriangleTopologyRequest {
+    pub triangle: Triangle3D<f64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateCurveTopologyResult {
+    pub edge: Edge<f64>,
+    pub validation: EdgeValidationReport<f64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateWireTopologyResult {
+    pub wire: Wire<f64>,
+    pub validation: WireValidationReport<f64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TopologyOrchestrationError {
+    InvalidLineTopology,
+    InvalidArcTopology,
+    InvalidCircleTopology,
+    InvalidTriangleTopology,
+}
+
+impl std::fmt::Display for TopologyOrchestrationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidLineTopology => write!(f, "invalid line topology"),
+            Self::InvalidArcTopology => write!(f, "invalid arc topology"),
+            Self::InvalidCircleTopology => write!(f, "invalid circle topology"),
+            Self::InvalidTriangleTopology => write!(f, "invalid triangle topology"),
+        }
+    }
+}
+
+impl std::error::Error for TopologyOrchestrationError {}
+
+pub trait LineTopologyMutationPort {
+    fn create_line_topology(
+        &self,
+        request: CreateLineTopologyRequest,
+    ) -> Result<CreateCurveTopologyResult, TopologyOrchestrationError>;
+}
+
+pub trait DebugShapeTopologyMutationPort {
+    fn create_arc_topology(
+        &self,
+        request: CreateArcTopologyRequest,
+    ) -> Result<CreateCurveTopologyResult, TopologyOrchestrationError>;
+
+    fn create_circle_topology(
+        &self,
+        request: CreateCircleTopologyRequest,
+    ) -> Result<CreateCurveTopologyResult, TopologyOrchestrationError>;
+
+    fn create_triangle_topology(
+        &self,
+        request: CreateTriangleTopologyRequest,
+    ) -> Result<CreateWireTopologyResult, TopologyOrchestrationError>;
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TopologyOrchestrator;
+
+impl LineTopologyMutationPort for TopologyOrchestrator {
+    fn create_line_topology(
+        &self,
+        request: CreateLineTopologyRequest,
+    ) -> Result<CreateCurveTopologyResult, TopologyOrchestrationError> {
+        let start_vertex = Arc::new(Vertex::new(request.line.start()));
+        let end_vertex = Arc::new(Vertex::new(request.line.end()));
+        let edge = Edge::new(
+            start_vertex,
+            end_vertex,
+            CurveRef::Line(request.line),
+            (request.line.start_param(), request.line.end_param()),
+        )
+        .ok_or(TopologyOrchestrationError::InvalidLineTopology)?;
+
+        let validation = TopologyValidator::new(TopologyToleranceSettings::new(1.0e-9, 1.0e-9))
+            .validate_edge(&edge);
+
+        if !validation.is_valid() {
+            return Err(TopologyOrchestrationError::InvalidLineTopology);
+        }
+
+        Ok(CreateCurveTopologyResult { edge, validation })
+    }
+}
+
+impl DebugShapeTopologyMutationPort for TopologyOrchestrator {
+    fn create_arc_topology(
+        &self,
+        request: CreateArcTopologyRequest,
+    ) -> Result<CreateCurveTopologyResult, TopologyOrchestrationError> {
+        let start = request.arc.start_point();
+        let end = request.arc.end_point();
+        let start_vertex = Arc::new(Vertex::new(geo_topology::Point3D::new(
+            start.x(),
+            start.y(),
+            start.z(),
+        )));
+        let end_vertex = Arc::new(Vertex::new(geo_topology::Point3D::new(
+            end.x(),
+            end.y(),
+            end.z(),
+        )));
+        let edge = Edge::new(
+            start_vertex,
+            end_vertex,
+            CurveRef::Arc(request.arc),
+            (0.0, 1.0),
+        )
+        .ok_or(TopologyOrchestrationError::InvalidArcTopology)?;
+
+        let validation = TopologyValidator::new(TopologyToleranceSettings::new(1.0e-9, 1.0e-9))
+            .validate_edge(&edge);
+
+        if !validation.is_valid() {
+            return Err(TopologyOrchestrationError::InvalidArcTopology);
+        }
+
+        Ok(CreateCurveTopologyResult { edge, validation })
+    }
+
+    fn create_circle_topology(
+        &self,
+        request: CreateCircleTopologyRequest,
+    ) -> Result<CreateCurveTopologyResult, TopologyOrchestrationError> {
+        let center = request.circle.center();
+        let axis = request.circle.axis();
+        let full_arc = Arc3D::full_circle(center, axis, request.circle.radius())
+            .ok_or(TopologyOrchestrationError::InvalidCircleTopology)?;
+        let start = full_arc.start_point();
+        let shared_vertex = Arc::new(Vertex::new(geo_topology::Point3D::new(
+            start.x(),
+            start.y(),
+            start.z(),
+        )));
+        let edge = Edge::new(
+            shared_vertex.clone(),
+            shared_vertex,
+            CurveRef::Arc(full_arc),
+            (0.0, 1.0),
+        )
+        .ok_or(TopologyOrchestrationError::InvalidCircleTopology)?;
+
+        let validation = TopologyValidator::new(TopologyToleranceSettings::new(1.0e-9, 1.0e-9))
+            .validate_edge(&edge);
+
+        if !validation.is_valid() {
+            return Err(TopologyOrchestrationError::InvalidCircleTopology);
+        }
+
+        Ok(CreateCurveTopologyResult { edge, validation })
+    }
+
+    fn create_triangle_topology(
+        &self,
+        request: CreateTriangleTopologyRequest,
+    ) -> Result<CreateWireTopologyResult, TopologyOrchestrationError> {
+        let (ax, ay, az) = request.triangle.vertex_a();
+        let (bx, by, bz) = request.triangle.vertex_b();
+        let (cx, cy, cz) = request.triangle.vertex_c();
+
+        let point_a = Point3D::new(ax, ay, az);
+        let point_b = Point3D::new(bx, by, bz);
+        let point_c = Point3D::new(cx, cy, cz);
+        let vertex_a = Arc::new(Vertex::new(point_a));
+        let vertex_b = Arc::new(Vertex::new(point_b));
+        let vertex_c = Arc::new(Vertex::new(point_c));
+
+        let edge_ab_curve = LineSegment3D::new(point_a, point_b)
+            .ok_or(TopologyOrchestrationError::InvalidTriangleTopology)?;
+        let edge_bc_curve = LineSegment3D::new(point_b, point_c)
+            .ok_or(TopologyOrchestrationError::InvalidTriangleTopology)?;
+        let edge_ca_curve = LineSegment3D::new(point_c, point_a)
+            .ok_or(TopologyOrchestrationError::InvalidTriangleTopology)?;
+
+        let edge_ab = Edge::new(
+            vertex_a.clone(),
+            vertex_b.clone(),
+            CurveRef::Line(edge_ab_curve),
+            (edge_ab_curve.start_param(), edge_ab_curve.end_param()),
+        )
+        .ok_or(TopologyOrchestrationError::InvalidTriangleTopology)?;
+        let edge_bc = Edge::new(
+            vertex_b,
+            vertex_c.clone(),
+            CurveRef::Line(edge_bc_curve),
+            (edge_bc_curve.start_param(), edge_bc_curve.end_param()),
+        )
+        .ok_or(TopologyOrchestrationError::InvalidTriangleTopology)?;
+        let edge_ca = Edge::new(
+            vertex_c,
+            vertex_a,
+            CurveRef::Line(edge_ca_curve),
+            (edge_ca_curve.start_param(), edge_ca_curve.end_param()),
+        )
+        .ok_or(TopologyOrchestrationError::InvalidTriangleTopology)?;
+
+        let tolerances = TopologyToleranceSettings::new(1.0e-9, 1.0e-9);
+        let wire = Wire::new(vec![edge_ab, edge_bc, edge_ca], tolerances)
+            .ok_or(TopologyOrchestrationError::InvalidTriangleTopology)?;
+        let validation = TopologyValidator::new(tolerances).validate_wire(&wire);
+
+        if !validation.is_valid() || !wire.is_closed(tolerances) {
+            return Err(TopologyOrchestrationError::InvalidTriangleTopology);
+        }
+
+        Ok(CreateWireTopologyResult { wire, validation })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CreateArcTopologyRequest, CreateCircleTopologyRequest, CreateLineTopologyRequest,
+        CreateTriangleTopologyRequest, DebugShapeTopologyMutationPort, LineTopologyMutationPort,
+        TopologyOrchestrator,
+    };
+    use geo_contracts::Angle;
+    use geo_primitives::{Arc3D, Circle3D, LineSegment3D, Point3D, Triangle3D};
+    use geo_topology::TopologyToleranceSettings;
+
+    #[test]
+    fn create_line_topology_returns_valid_edge() {
+        let line = LineSegment3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(2.0, 0.0, 0.0))
+            .expect("line should be constructible");
+
+        let result = TopologyOrchestrator
+            .create_line_topology(CreateLineTopologyRequest { line })
+            .expect("topology orchestration should succeed");
+
+        assert!(result.validation.is_valid());
+        assert_eq!(result.edge.start_vertex().point().x(), 0.0);
+        assert_eq!(result.edge.end_vertex().point().x(), 2.0);
+    }
+
+    #[test]
+    fn create_arc_topology_returns_valid_edge() {
+        let arc = Arc3D::xy_arc(
+            Point3D::new(0.0, 0.0, 0.0),
+            2.0,
+            Angle::from_radians(0.0),
+            Angle::from_radians(std::f64::consts::FRAC_PI_2),
+        )
+        .expect("arc should be constructible");
+
+        let result = TopologyOrchestrator
+            .create_arc_topology(CreateArcTopologyRequest { arc })
+            .expect("arc topology orchestration should succeed");
+
+        assert!(result.validation.is_valid());
+    }
+
+    #[test]
+    fn create_circle_topology_returns_valid_closed_edge() {
+        let circle = Circle3D::new_xy_plane(Point3D::new(0.0, 0.0, 0.0), 3.0)
+            .expect("circle should be constructible");
+
+        let result = TopologyOrchestrator
+            .create_circle_topology(CreateCircleTopologyRequest { circle })
+            .expect("circle topology orchestration should succeed");
+
+        assert!(result.validation.is_valid());
+        assert_eq!(
+            result.edge.start_vertex().id().value(),
+            result.edge.end_vertex().id().value()
+        );
+    }
+
+    #[test]
+    fn create_triangle_topology_returns_valid_closed_wire() {
+        let triangle = Triangle3D::new(
+            Point3D::new(0.0, 0.0, 0.0),
+            Point3D::new(1.0, 0.0, 0.0),
+            Point3D::new(0.0, 1.0, 0.0),
+        )
+        .expect("triangle should be constructible");
+
+        let result = TopologyOrchestrator
+            .create_triangle_topology(CreateTriangleTopologyRequest { triangle })
+            .expect("triangle topology orchestration should succeed");
+
+        assert!(result.validation.is_valid());
+        assert_eq!(result.wire.edges().len(), 3);
+        assert!(
+            result
+                .wire
+                .is_closed(TopologyToleranceSettings::new(1.0e-9, 1.0e-9))
+        );
+    }
+}

--- a/model/application/src/topology_orchestration.rs
+++ b/model/application/src/topology_orchestration.rs
@@ -1,7 +1,7 @@
 //! Topology向け orchestration 境界。
 
+use crate::primitives::{Arc3D, Circle3D, LineSegment3D, Point3D, Triangle3D};
 use geo_contracts::{Arc3DConstructor, Circle3DProperties, Triangle3DBoundaryAccess};
-use geo_primitives::{Arc3D, Circle3D, LineSegment3D, Point3D, Triangle3D};
 use geo_topology::{
     CurveRef, Edge, EdgeValidationReport, TopologyToleranceSettings, TopologyValidator, Vertex,
     Wire, WireValidationReport,
@@ -245,8 +245,8 @@ mod tests {
         CreateTriangleTopologyRequest, DebugShapeTopologyMutationPort, LineTopologyMutationPort,
         TopologyOrchestrator,
     };
+    use crate::primitives::{Arc3D, Circle3D, LineSegment3D, Point3D, Triangle3D};
     use geo_contracts::Angle;
-    use geo_primitives::{Arc3D, Circle3D, LineSegment3D, Point3D, Triangle3D};
     use geo_topology::TopologyToleranceSettings;
 
     #[test]

--- a/model/geo_contracts/Cargo.toml
+++ b/model/geo_contracts/Cargo.toml
@@ -8,3 +8,4 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 analysis = { path = "../../foundation/analysis" }
 geo_commons = { path = "../geo_commons" }
+serde = { version = "1.0", features = ["derive"] }

--- a/model/geo_contracts/src/entity/entity_traits.rs
+++ b/model/geo_contracts/src/entity/entity_traits.rs
@@ -4,6 +4,17 @@
 //! 具体実装（geo_entity など）への直接依存を避ける。
 
 use crate::Scalar;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum StrokePattern {
+    Solid,
+    Dashed,
+    Dotted,
+    DashDot,
+    DashDotDot,
+    Hidden,
+}
 
 pub trait EntityIdentity {
     type Id: Copy + Eq + std::hash::Hash;
@@ -16,7 +27,33 @@ pub trait EntityDisplayProperties {
     fn entity_color(&self) -> [f32; 4];
 }
 
+pub trait StrokeDisplayProperties {
+    fn entity_stroke_pattern(&self) -> StrokePattern;
+    fn entity_stroke_width(&self) -> f32;
+}
+
+pub trait PlanarStroke2DProperties<T: Scalar> {
+    fn definition_plane_origin(&self) -> (T, T, T);
+    fn definition_plane_normal(&self) -> (T, T, T);
+    fn definition_plane_u_axis(&self) -> (T, T, T);
+}
+
 pub trait LineEntity3DProperties<T: Scalar>: EntityIdentity + EntityDisplayProperties {
     fn line_start(&self) -> (T, T, T);
     fn line_end(&self) -> (T, T, T);
+}
+
+pub trait CircleEntity3DProperties<T: Scalar>: EntityIdentity + EntityDisplayProperties {
+    fn circle_center(&self) -> (T, T, T);
+    fn circle_radius(&self) -> T;
+    fn circle_axis(&self) -> (T, T, T);
+}
+
+pub trait ArcEntity3DProperties<T: Scalar>: EntityIdentity + EntityDisplayProperties {
+    fn arc_center(&self) -> (T, T, T);
+    fn arc_radius(&self) -> T;
+    fn arc_start_angle(&self) -> T;
+    fn arc_end_angle(&self) -> T;
+    fn arc_normal(&self) -> (T, T, T);
+    fn arc_start_direction(&self) -> (T, T, T);
 }

--- a/model/geo_contracts/src/entity/mod.rs
+++ b/model/geo_contracts/src/entity/mod.rs
@@ -1,4 +1,7 @@
 //! geo_contracts entity module
 pub mod entity_traits;
 
-pub use entity_traits::{EntityDisplayProperties, EntityIdentity, LineEntity3DProperties};
+pub use entity_traits::{
+    ArcEntity3DProperties, CircleEntity3DProperties, EntityDisplayProperties, EntityIdentity,
+    LineEntity3DProperties, PlanarStroke2DProperties, StrokeDisplayProperties, StrokePattern,
+};

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -10,7 +10,10 @@ pub mod tolerance;
 
 pub use analysis::abstract_types::{Angle, Scalar, TolerantEq};
 pub use classification::{DimensionClass, GeometryPrimitive, PrimitiveKind};
-pub use entity::{EntityDisplayProperties, EntityIdentity, LineEntity3DProperties};
+pub use entity::{
+    ArcEntity3DProperties, CircleEntity3DProperties, EntityDisplayProperties, EntityIdentity,
+    LineEntity3DProperties, PlanarStroke2DProperties, StrokeDisplayProperties, StrokePattern,
+};
 pub use geometry::core::plane3d_traits::{
     Plane3DConstructor, Plane3DContainment, Plane3DCore, Plane3DDerived, Plane3DDistance,
     Plane3DEvaluation, Plane3DProjection, Plane3DProperties, Plane3DTransform,

--- a/model/geo_entity/src/display.rs
+++ b/model/geo_entity/src/display.rs
@@ -1,18 +1,12 @@
+use geo_contracts::StrokePattern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum LineStyle {
-    Solid,
-    Dashed,
-    Dotted,
-    DashDot,
-    Hidden,
-}
+pub type LineStyle = StrokePattern;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DisplayAttributes {
     pub color: [f32; 4],
-    pub line_style: LineStyle,
+    pub line_style: StrokePattern,
     pub line_width: f32,
     pub layer: String,
     pub visible: bool,
@@ -22,7 +16,7 @@ impl Default for DisplayAttributes {
     fn default() -> Self {
         Self {
             color: [1.0, 1.0, 1.0, 1.0],
-            line_style: LineStyle::Solid,
+            line_style: StrokePattern::Solid,
             line_width: 1.0,
             layer: "0".to_string(),
             visible: true,

--- a/model/geo_entity/src/geometric_entity.rs
+++ b/model/geo_entity/src/geometric_entity.rs
@@ -1,5 +1,9 @@
 use crate::{Attributes, DisplayAttributes, EntityId, Metadata};
-use geo_contracts::{EntityDisplayProperties, EntityIdentity, LineEntity3DProperties, Scalar};
+use geo_contracts::{
+    Arc3DProperties, ArcEntity3DProperties, Circle3DProperties, CircleEntity3DProperties,
+    EntityDisplayProperties, EntityIdentity, LineEntity3DProperties, Scalar,
+    StrokeDisplayProperties,
+};
 
 #[derive(Debug, Clone)]
 pub struct GeometricEntity<T: Scalar, G> {
@@ -109,6 +113,16 @@ impl<T: Scalar, G> EntityDisplayProperties for GeometricEntity<T, G> {
     }
 }
 
+impl<T: Scalar, G> StrokeDisplayProperties for GeometricEntity<T, G> {
+    fn entity_stroke_pattern(&self) -> geo_contracts::StrokePattern {
+        self.display.line_style
+    }
+
+    fn entity_stroke_width(&self) -> f32 {
+        self.display.line_width
+    }
+}
+
 impl<T: Scalar> LineEntity3DProperties<T> for GeometricEntity<T, geo_primitives::LineSegment3D<T>> {
     fn line_start(&self) -> (T, T, T) {
         let point = self.geometry.start();
@@ -118,5 +132,47 @@ impl<T: Scalar> LineEntity3DProperties<T> for GeometricEntity<T, geo_primitives:
     fn line_end(&self) -> (T, T, T) {
         let point = self.geometry.end();
         (point.x(), point.y(), point.z())
+    }
+}
+
+impl<T: Scalar> CircleEntity3DProperties<T> for GeometricEntity<T, geo_primitives::Circle3D<T>> {
+    fn circle_center(&self) -> (T, T, T) {
+        Circle3DProperties::center(self.geometry())
+    }
+
+    fn circle_radius(&self) -> T {
+        Circle3DProperties::radius(self.geometry())
+    }
+
+    fn circle_axis(&self) -> (T, T, T) {
+        Circle3DProperties::axis(self.geometry())
+    }
+}
+
+impl<T: Scalar> ArcEntity3DProperties<T> for GeometricEntity<T, geo_primitives::Arc3D<T>> {
+    fn arc_center(&self) -> (T, T, T) {
+        Arc3DProperties::center(self.geometry())
+    }
+
+    fn arc_radius(&self) -> T {
+        Arc3DProperties::radius(self.geometry())
+    }
+
+    fn arc_start_angle(&self) -> T {
+        Arc3DProperties::start_angle(self.geometry())
+    }
+
+    fn arc_end_angle(&self) -> T {
+        Arc3DProperties::end_angle(self.geometry())
+    }
+
+    fn arc_normal(&self) -> (T, T, T) {
+        let normal = self.geometry.normal().as_vector();
+        (normal.x(), normal.y(), normal.z())
+    }
+
+    fn arc_start_direction(&self) -> (T, T, T) {
+        let direction = self.geometry.start_direction().as_vector();
+        (direction.x(), direction.y(), direction.z())
     }
 }

--- a/model/geo_entity/src/lib.rs
+++ b/model/geo_entity/src/lib.rs
@@ -22,6 +22,7 @@ pub use attributes::Attributes;
 pub use display::{DisplayAttributes, LineStyle};
 pub use entity_id::EntityId;
 pub use error::{EntityError, EntityResult};
+pub use geo_contracts::StrokePattern;
 pub use geometric_entity::GeometricEntity;
 pub use metadata::Metadata;
 pub use relations::{

--- a/scripts/_arch_rules_data.ps1
+++ b/scripts/_arch_rules_data.ps1
@@ -86,9 +86,10 @@ $ARCH_ALLOWED_DEPS = @{
 }
 
 # Forbidden dependency rules
+# Last updated: 2026-04-09 (#501/#650 sync application forbidden deps with current allowed deps)
 # Pending update: add reverse dependency guards when `cam_algorithms` is created.
 $ARCH_FORBIDDEN_DEPS = @{
-    application    = @("geo_foundation", "geo_commons", "geo_core", "geo_primitives", "geo_nurbs", "geo_io", "geo_entity", "cam_entity", "converter", "graphics", "render", "stage", "app")
+    application    = @("geo_foundation", "geo_commons", "geo_core", "geo_nurbs", "geo_io", "cam_entity", "converter", "graphics", "render", "stage", "app")
     geo_foundation = @("converter", "graphics", "render", "stage", "app", "cam_core", "cam_entity", "cam_sim", "job_runtime")
     geo_contracts  = @("geo_foundation", "geo_core", "geo_primitives", "geo_nurbs", "geo_io", "geo_entity", "cam_core", "cam_entity", "cam_sim", "job_runtime", "graphics", "render", "stage", "app")
     geo_commons    = @("converter", "graphics", "render", "stage", "app", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "cam_core", "cam_entity", "cam_sim", "job_runtime")

--- a/scripts/_arch_rules_data.ps1
+++ b/scripts/_arch_rules_data.ps1
@@ -49,16 +49,16 @@ $ARCH_LAYERS = @{
 $ARCH_REQUIRED_MODEL_CRATES = @("geo_contracts", "geo_commons", "geo_core", "geo_primitives", "geo_algorithms", "geo_io", "geo_entity")
 
 # Allowed dependency rules
-# Last updated: 2026-04-02 (#533 Phase 1: allow geo_core -> geo_contracts for contracts-first Vector migration)
+# Last updated: 2026-04-09 (#650: allow geo_topology -> geo_nurbs for NURBS curve edge topology, sync application allowed deps with current crate)
 # Pending update: add CAM dependency rules when `cam_algorithms` is created.
 $ARCH_ALLOWED_DEPS = @{
     analysis       = @()
-    application    = @("analysis", "geo_algorithms", "cam_core", "cam_sim", "job_runtime", "job_domain")
+    application    = @("analysis", "geo_contracts", "geo_algorithms", "geo_entity", "geo_primitives", "geo_topology", "cam_core", "cam_sim", "job_runtime", "job_domain")
     geo_contracts  = @("analysis", "geo_commons")
     geo_commons    = @("analysis")
     geo_core       = @("analysis", "geo_contracts", "geo_entity")
     geo_primitives = @("geo_contracts", "geo_commons", "geo_core", "analysis")
-    geo_topology   = @("geo_contracts", "geo_commons", "geo_core", "geo_primitives", "analysis")
+    geo_topology   = @("geo_contracts", "geo_commons", "geo_core", "geo_primitives", "geo_nurbs", "analysis")
     geo_algorithms = @("geo_contracts", "geo_commons", "geo_core", "geo_primitives", "geo_topology", "geo_nurbs", "analysis")
     geo_nurbs      = @("geo_contracts", "geo_commons", "geo_core", "geo_primitives", "analysis")
     geo_io         = @("geo_contracts", "geo_core", "geo_primitives", "geo_algorithms", "analysis")

--- a/view/app/src/app_state/debug_scene/shapes.rs
+++ b/view/app/src/app_state/debug_scene/shapes.rs
@@ -1,9 +1,14 @@
 //! AppState のSTL/SVG形状デバッグ表示を扱うモジュール。
 
 use super::super::AppState;
+use render::vertex_3d::convert_vertex_data_to_mesh_vertices;
 use render::vertex_3d::MeshVertex;
 use stage::MeshStage;
 use std::path::Path;
+use viewmodel::feature_command_converter::{
+    create_debug_arc_vertices, create_debug_circle_vertices, create_debug_line_vertices,
+    create_debug_triangle_vertices,
+};
 
 use crate::app_asset_loader::AppAssetLoaderFacade;
 
@@ -86,14 +91,19 @@ impl AppState {
     /// デバッグ用：LineSegment3Dを表示（SVGから読み込み）
     /// EntityManager経由の管理対象として扱う。
     pub fn load_debug_line(&mut self) {
-        tracing::info!("デバッグ形状: LineSegment3D表示（EntityManager経由）");
+        tracing::info!("デバッグ形状: LineSegment3D表示（Application経由）");
 
-        let svg_path = Path::new("tests/fixtures/shapes/line.svg");
-        let Some(vertices) = self.load_svg_vertices_for_debug(svg_path) else {
+        let Ok(vertex_data) = create_debug_line_vertices() else {
+            tracing::error!(
+                error_kind = logging_foundation::ERROR_KIND_APP,
+                "debug line feature command failed"
+            );
             return;
         };
 
-        let id = self.entity_manager.add_line_entity(vertices);
+        let vertices = convert_vertex_data_to_mesh_vertices(&vertex_data);
+
+        let id = self.entity_manager.add_line_list_entity(vertices);
         let _ = self.entity_manager.select(id);
 
         self.camera.reset_to_standard_cad_view();
@@ -101,16 +111,24 @@ impl AppState {
     }
 
     /// デバッグ用：Circle3Dを表示（SVGから読み込み）
-    /// 直接MeshStage経路で扱う。
+    /// EntityManager経由の管理対象として扱う。
     pub fn load_debug_circle(&mut self) {
-        tracing::info!("デバッグ形状: Circle3D表示（SVGから）");
+        tracing::info!("デバッグ形状: Circle3D表示（Feature/Entity経由）");
 
-        let svg_path = Path::new("tests/fixtures/shapes/circle.svg");
-        let Some(vertices) = self.load_svg_vertices_for_debug(svg_path) else {
+        let Ok(vertex_data) = create_debug_circle_vertices() else {
+            tracing::error!(
+                error_kind = logging_foundation::ERROR_KIND_APP,
+                "debug circle feature command failed"
+            );
             return;
         };
 
-        self.apply_line_stage(vertices, true);
+        let vertices = convert_vertex_data_to_mesh_vertices(&vertex_data);
+        let id = self.entity_manager.add_line_list_entity(vertices);
+        let _ = self.entity_manager.select(id);
+
+        self.camera.reset_to_standard_cad_view();
+        self.rebuild_stage_from_entities();
     }
 
     /// デバッグ用：クリップ空間座標の単純な正方形（SVGから読み込み）
@@ -129,27 +147,39 @@ impl AppState {
     /// デバッグ用：Triangle3Dを表示（SVGから読み込み）
     /// 直接MeshStage経路で扱う。
     pub fn load_debug_triangle(&mut self) {
-        tracing::info!("デバッグ形状: Triangle3D表示（SVGから）");
+        tracing::info!("デバッグ形状: Triangle3D表示（Application経由）");
 
-        let svg_path = Path::new("tests/fixtures/shapes/triangle.svg");
-        let Some(vertices) = self.load_svg_vertices_for_debug(svg_path) else {
+        let Ok(vertex_data) = create_debug_triangle_vertices() else {
+            tracing::error!(
+                error_kind = logging_foundation::ERROR_KIND_APP,
+                "debug triangle geometry command failed"
+            );
             return;
         };
 
+        let vertices = convert_vertex_data_to_mesh_vertices(&vertex_data);
         let indices: Vec<u32> = vec![0, 1, 2];
         self.apply_mesh_stage(vertices, indices, true);
     }
 
     /// デバッグ用：Arc3Dを表示（SVGから読み込み）
-    /// 直接MeshStage経路で扱う。
+    /// EntityManager経由の管理対象として扱う。
     pub fn load_debug_arc(&mut self) {
-        tracing::info!("デバッグ形状: Arc3D表示（SVGから）");
+        tracing::info!("デバッグ形状: Arc3D表示（Feature/Entity経由）");
 
-        let svg_path = Path::new("tests/fixtures/shapes/arc.svg");
-        let Some(vertices) = self.load_svg_vertices_for_debug(svg_path) else {
+        let Ok(vertex_data) = create_debug_arc_vertices() else {
+            tracing::error!(
+                error_kind = logging_foundation::ERROR_KIND_APP,
+                "debug arc feature command failed"
+            );
             return;
         };
 
-        self.apply_line_stage(vertices, true);
+        let vertices = convert_vertex_data_to_mesh_vertices(&vertex_data);
+        let id = self.entity_manager.add_line_list_entity(vertices);
+        let _ = self.entity_manager.select(id);
+
+        self.camera.reset_to_standard_cad_view();
+        self.rebuild_stage_from_entities();
     }
 }

--- a/view/app/src/app_state/stage_orchestration.rs
+++ b/view/app/src/app_state/stage_orchestration.rs
@@ -15,7 +15,7 @@ impl AppState {
             return;
         }
 
-        let vertices = self.entity_manager.line_vertices();
+        let vertices = self.entity_manager.line_list_vertices();
         if vertices.is_empty() {
             self.entity_manager.clear_dirty();
             return;

--- a/view/app/src/entity_manager.rs
+++ b/view/app/src/entity_manager.rs
@@ -8,7 +8,7 @@ pub struct EntityViewId(u64);
 #[derive(Debug, Clone)]
 pub struct GeometricEntityItem {
     pub id: EntityViewId,
-    line_vertices: Vec<MeshVertex>,
+    line_list_vertices: Vec<MeshVertex>,
     visible: bool,
     color: [f32; 4],
     selected: bool,
@@ -27,12 +27,12 @@ impl EntityManager {
         Self::default()
     }
 
-    pub fn add_line_entity(&mut self, vertices: Vec<MeshVertex>) -> EntityViewId {
+    pub fn add_line_list_entity(&mut self, vertices: Vec<MeshVertex>) -> EntityViewId {
         self.next_id += 1;
         let id = EntityViewId(self.next_id);
         let entity = GeometricEntityItem {
             id,
-            line_vertices: vertices,
+            line_list_vertices: vertices,
             visible: true,
             color: [1.0, 1.0, 1.0, 1.0],
             selected: false,
@@ -105,11 +105,11 @@ impl EntityManager {
         false
     }
 
-    pub fn line_vertices(&self) -> Vec<MeshVertex> {
+    pub fn line_list_vertices(&self) -> Vec<MeshVertex> {
         let mut result = Vec::new();
         for item in self.geometric.values() {
             if item.visible {
-                result.extend(item.line_vertices.iter().copied());
+                result.extend(item.line_list_vertices.iter().copied());
             }
         }
         result
@@ -129,14 +129,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn add_select_remove_line_entity() {
+    fn add_select_remove_line_list_entity() {
         let vertices = vec![
             MeshVertex::new([0.0, 0.0, 0.0], [0.0, 0.0, 1.0]),
             MeshVertex::new([1.0, 0.0, 0.0], [0.0, 0.0, 1.0]),
         ];
 
         let mut manager = EntityManager::new();
-        let id = manager.add_line_entity(vertices);
+        let id = manager.add_line_list_entity(vertices);
 
         assert!(manager.select(id));
         assert_eq!(manager.selected(), Some(id));

--- a/viewmodel/converter/src/entity_converter.rs
+++ b/viewmodel/converter/src/entity_converter.rs
@@ -1,5 +1,6 @@
 use cam_entity::CAMEntity;
-use geo_contracts::LineEntity3DProperties;
+use geo_algorithms::Vector3D;
+use geo_contracts::{ArcEntity3DProperties, CircleEntity3DProperties, LineEntity3DProperties};
 
 use crate::mesh_converter::VertexData;
 use crate::shape_converter::TessellationQuality;
@@ -27,6 +28,104 @@ where
     ]
 }
 
+pub fn circle_entity_to_vertices<E>(entity: &E, quality: &TessellationQuality) -> Vec<VertexData>
+where
+    E: CircleEntity3DProperties<f64>,
+{
+    let segments = quality.circle_segments;
+    let center = entity.circle_center();
+    let radius = entity.circle_radius();
+    let axis = entity.circle_axis();
+    let normal_vec = Vector3D::new(axis.0, axis.1, axis.2).normalize();
+    let normal = [
+        normal_vec.x() as f32,
+        normal_vec.y() as f32,
+        normal_vec.z() as f32,
+    ];
+
+    let arbitrary = if normal_vec.x().abs() > 0.9 {
+        Vector3D::new(0.0, 1.0, 0.0)
+    } else {
+        Vector3D::new(1.0, 0.0, 0.0)
+    };
+    let u = normal_vec.cross(&arbitrary).normalize();
+    let v = normal_vec.cross(&u).normalize();
+
+    let mut vertices = Vec::with_capacity(segments * 2);
+    for index in 0..segments {
+        let angle1 = std::f64::consts::TAU * (index as f64) / (segments as f64);
+        let angle2 = std::f64::consts::TAU * ((index + 1) as f64) / (segments as f64);
+
+        let point1 = [
+            (center.0 + radius * (angle1.cos() * u.x() + angle1.sin() * v.x())) as f32,
+            (center.1 + radius * (angle1.cos() * u.y() + angle1.sin() * v.y())) as f32,
+            (center.2 + radius * (angle1.cos() * u.z() + angle1.sin() * v.z())) as f32,
+        ];
+        let point2 = [
+            (center.0 + radius * (angle2.cos() * u.x() + angle2.sin() * v.x())) as f32,
+            (center.1 + radius * (angle2.cos() * u.y() + angle2.sin() * v.y())) as f32,
+            (center.2 + radius * (angle2.cos() * u.z() + angle2.sin() * v.z())) as f32,
+        ];
+
+        vertices.push(VertexData::new(point1, normal));
+        vertices.push(VertexData::new(point2, normal));
+    }
+
+    vertices
+}
+
+pub fn arc_entity_to_vertices<E>(entity: &E, quality: &TessellationQuality) -> Vec<VertexData>
+where
+    E: ArcEntity3DProperties<f64>,
+{
+    let start_angle = entity.arc_start_angle();
+    let end_angle = entity.arc_end_angle();
+    let mut angle_range = end_angle - start_angle;
+    if angle_range < 0.0 {
+        angle_range += std::f64::consts::TAU;
+    }
+
+    let segments = ((angle_range / std::f64::consts::TAU) * (quality.circle_segments as f64))
+        .ceil()
+        .max(quality.min_segments as f64) as usize;
+    let center = entity.arc_center();
+    let radius = entity.arc_radius();
+    let normal_dir = entity.arc_normal();
+    let start_dir = entity.arc_start_direction();
+    let normal_vec = Vector3D::new(normal_dir.0, normal_dir.1, normal_dir.2).normalize();
+    let start_dir_vec = Vector3D::new(start_dir.0, start_dir.1, start_dir.2).normalize();
+    let v = normal_vec.cross(&start_dir_vec).normalize();
+    let normal = [
+        normal_vec.x() as f32,
+        normal_vec.y() as f32,
+        normal_vec.z() as f32,
+    ];
+
+    let mut vertices = Vec::with_capacity(segments * 2);
+    for index in 0..segments {
+        let t1 = (index as f64) / (segments as f64);
+        let t2 = ((index + 1) as f64) / (segments as f64);
+        let angle1 = start_angle + t1 * angle_range;
+        let angle2 = start_angle + t2 * angle_range;
+
+        let point1 = [
+            (center.0 + radius * (angle1.cos() * start_dir_vec.x() + angle1.sin() * v.x())) as f32,
+            (center.1 + radius * (angle1.cos() * start_dir_vec.y() + angle1.sin() * v.y())) as f32,
+            (center.2 + radius * (angle1.cos() * start_dir_vec.z() + angle1.sin() * v.z())) as f32,
+        ];
+        let point2 = [
+            (center.0 + radius * (angle2.cos() * start_dir_vec.x() + angle2.sin() * v.x())) as f32,
+            (center.1 + radius * (angle2.cos() * start_dir_vec.y() + angle2.sin() * v.y())) as f32,
+            (center.2 + radius * (angle2.cos() * start_dir_vec.z() + angle2.sin() * v.z())) as f32,
+        ];
+
+        vertices.push(VertexData::new(point1, normal));
+        vertices.push(VertexData::new(point2, normal));
+    }
+
+    vertices
+}
+
 pub fn geometric_entity_to_vertices<E>(
     entity: &E,
     _quality: &TessellationQuality,
@@ -48,7 +147,10 @@ pub fn cam_entity_to_vertices(
 mod tests {
     use super::*;
     use crate::shape_converter::TessellationQuality;
-    use geo_contracts::{EntityDisplayProperties, EntityIdentity, LineEntity3DProperties};
+    use geo_contracts::{
+        ArcEntity3DProperties, CircleEntity3DProperties, EntityDisplayProperties, EntityIdentity,
+        LineEntity3DProperties,
+    };
 
     #[derive(Clone, Copy)]
     struct MockLineEntity;
@@ -81,6 +183,88 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Copy)]
+    struct MockCircleEntity;
+
+    impl EntityIdentity for MockCircleEntity {
+        type Id = u64;
+
+        fn entity_id(&self) -> Self::Id {
+            2
+        }
+    }
+
+    impl EntityDisplayProperties for MockCircleEntity {
+        fn entity_visible(&self) -> bool {
+            true
+        }
+
+        fn entity_color(&self) -> [f32; 4] {
+            [1.0, 1.0, 1.0, 1.0]
+        }
+    }
+
+    impl CircleEntity3DProperties<f64> for MockCircleEntity {
+        fn circle_center(&self) -> (f64, f64, f64) {
+            (0.0, 0.0, 0.0)
+        }
+
+        fn circle_radius(&self) -> f64 {
+            1.0
+        }
+
+        fn circle_axis(&self) -> (f64, f64, f64) {
+            (0.0, 0.0, 1.0)
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    struct MockArcEntity;
+
+    impl EntityIdentity for MockArcEntity {
+        type Id = u64;
+
+        fn entity_id(&self) -> Self::Id {
+            3
+        }
+    }
+
+    impl EntityDisplayProperties for MockArcEntity {
+        fn entity_visible(&self) -> bool {
+            true
+        }
+
+        fn entity_color(&self) -> [f32; 4] {
+            [1.0, 1.0, 1.0, 1.0]
+        }
+    }
+
+    impl ArcEntity3DProperties<f64> for MockArcEntity {
+        fn arc_center(&self) -> (f64, f64, f64) {
+            (0.0, 0.0, 0.0)
+        }
+
+        fn arc_radius(&self) -> f64 {
+            1.0
+        }
+
+        fn arc_start_angle(&self) -> f64 {
+            0.0
+        }
+
+        fn arc_end_angle(&self) -> f64 {
+            std::f64::consts::FRAC_PI_2
+        }
+
+        fn arc_normal(&self) -> (f64, f64, f64) {
+            (0.0, 0.0, 1.0)
+        }
+
+        fn arc_start_direction(&self) -> (f64, f64, f64) {
+            (1.0, 0.0, 0.0)
+        }
+    }
+
     #[test]
     fn line_entity_conversion_returns_two_vertices() {
         let entity = MockLineEntity;
@@ -95,5 +279,21 @@ mod tests {
         let result = geometric_entity_to_vertices(&entity, &TessellationQuality::default());
         assert!(result.is_ok());
         assert_eq!(result.expect("conversion should succeed").len(), 2);
+    }
+
+    #[test]
+    fn circle_entity_conversion_returns_line_segments() {
+        let entity = MockCircleEntity;
+        let vertices = circle_entity_to_vertices(&entity, &TessellationQuality::default());
+        assert!(!vertices.is_empty());
+        assert_eq!(vertices.len() % 2, 0);
+    }
+
+    #[test]
+    fn arc_entity_conversion_returns_line_segments() {
+        let entity = MockArcEntity;
+        let vertices = arc_entity_to_vertices(&entity, &TessellationQuality::default());
+        assert!(!vertices.is_empty());
+        assert_eq!(vertices.len() % 2, 0);
     }
 }

--- a/viewmodel/converter/src/feature_command_converter.rs
+++ b/viewmodel/converter/src/feature_command_converter.rs
@@ -1,0 +1,144 @@
+use application::feature_orchestration::{
+    CreateArcFeatureRequest, CreateCircleFeatureRequest, CreateLineFeatureRequest,
+    FeatureCommandOrchestration, FeatureOrchestrator,
+};
+use application::geometry_orchestration::{
+    CreateTriangleGeometryRequest, DebugShapeGeometryMutationPort, GeometryOrchestrator,
+};
+use application::topology_orchestration::{
+    CreateTriangleTopologyRequest, DebugShapeTopologyMutationPort, TopologyOrchestrator,
+};
+
+use crate::entity_converter::{
+    arc_entity_to_vertices, circle_entity_to_vertices, geometric_entity_to_vertices,
+    EntityConvertError,
+};
+use crate::mesh_converter::VertexData;
+use crate::shape_converter::{triangle_to_solid_vertices, TessellationQuality};
+
+#[derive(Debug, thiserror::Error)]
+pub enum FeatureCommandConvertError {
+    #[error("feature orchestration failed: {0}")]
+    Orchestration(String),
+    #[error(transparent)]
+    EntityConvert(#[from] EntityConvertError),
+}
+
+pub fn create_debug_line_vertices() -> Result<Vec<VertexData>, FeatureCommandConvertError> {
+    let result = FeatureOrchestrator
+        .create_line_feature(CreateLineFeatureRequest {
+            feature_id: "debug_line".to_string(),
+            feature_name: "Debug Line".to_string(),
+            output_index: 0,
+            local_key: "line_a".to_string(),
+            start: [-50.0, 0.0, 0.0],
+            end: [50.0, 0.0, 0.0],
+        })
+        .map_err(|error| FeatureCommandConvertError::Orchestration(error.to_string()))?;
+
+    geometric_entity_to_vertices(&result.entity, &TessellationQuality::default())
+        .map_err(FeatureCommandConvertError::from)
+}
+
+pub fn create_debug_circle_vertices() -> Result<Vec<VertexData>, FeatureCommandConvertError> {
+    let result = FeatureOrchestrator
+        .create_circle_feature(CreateCircleFeatureRequest {
+            feature_id: "debug_circle".to_string(),
+            feature_name: "Debug Circle".to_string(),
+            output_index: 0,
+            local_key: "circle_a".to_string(),
+            center: [0.0, 0.0, 0.0],
+            radius: 5.0,
+        })
+        .map_err(|error| FeatureCommandConvertError::Orchestration(error.to_string()))?;
+
+    Ok(circle_entity_to_vertices(
+        &result.entity,
+        &TessellationQuality::default(),
+    ))
+}
+
+pub fn create_debug_arc_vertices() -> Result<Vec<VertexData>, FeatureCommandConvertError> {
+    let result = FeatureOrchestrator
+        .create_arc_feature(CreateArcFeatureRequest {
+            feature_id: "debug_arc".to_string(),
+            feature_name: "Debug Arc".to_string(),
+            output_index: 0,
+            local_key: "arc_a".to_string(),
+            center: [0.0, 0.0, 0.0],
+            radius: 1.5,
+            start_angle_radians: 0.0,
+            end_angle_radians: std::f64::consts::FRAC_PI_2,
+        })
+        .map_err(|error| FeatureCommandConvertError::Orchestration(error.to_string()))?;
+
+    Ok(arc_entity_to_vertices(
+        &result.entity,
+        &TessellationQuality::default(),
+    ))
+}
+
+pub fn create_debug_triangle_vertices() -> Result<Vec<VertexData>, FeatureCommandConvertError> {
+    let result = GeometryOrchestrator
+        .create_triangle_geometry(CreateTriangleGeometryRequest {
+            vertex_a: [0.0, 0.0, 0.0],
+            vertex_b: [1.0, 0.0, 0.0],
+            vertex_c: [0.5, 1.0, 0.0],
+        })
+        .map_err(|error| FeatureCommandConvertError::Orchestration(error.to_string()))?;
+
+    TopologyOrchestrator
+        .create_triangle_topology(CreateTriangleTopologyRequest {
+            triangle: result.triangle,
+        })
+        .map_err(|error| FeatureCommandConvertError::Orchestration(error.to_string()))?;
+
+    Ok(triangle_to_solid_vertices(&result.triangle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        create_debug_arc_vertices, create_debug_circle_vertices, create_debug_line_vertices,
+        create_debug_triangle_vertices,
+    };
+
+    #[test]
+    fn create_debug_line_vertices_returns_two_vertices() {
+        let vertices = create_debug_line_vertices()
+            .expect("debug line command should produce viewmodel vertices");
+
+        assert_eq!(vertices.len(), 2);
+        assert_eq!(vertices[0].position, [-50.0, 0.0, 0.0]);
+        assert_eq!(vertices[1].position, [50.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn create_debug_circle_vertices_returns_line_segments() {
+        let vertices = create_debug_circle_vertices()
+            .expect("debug circle command should produce viewmodel vertices");
+
+        assert!(!vertices.is_empty());
+        assert_eq!(vertices.len() % 2, 0);
+    }
+
+    #[test]
+    fn create_debug_arc_vertices_returns_line_segments() {
+        let vertices = create_debug_arc_vertices()
+            .expect("debug arc command should produce viewmodel vertices");
+
+        assert!(!vertices.is_empty());
+        assert_eq!(vertices.len() % 2, 0);
+    }
+
+    #[test]
+    fn create_debug_triangle_vertices_returns_triangle_vertices() {
+        let vertices = create_debug_triangle_vertices()
+            .expect("debug triangle command should produce viewmodel vertices");
+
+        assert_eq!(vertices.len(), 3);
+        assert_eq!(vertices[0].position, [0.0, 0.0, 0.0]);
+        assert_eq!(vertices[1].position, [1.0, 0.0, 0.0]);
+        assert_eq!(vertices[2].position, [0.5, 1.0, 0.0]);
+    }
+}

--- a/viewmodel/converter/src/lib.rs
+++ b/viewmodel/converter/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod cam_sim_visualization_converter;
 pub mod entity_converter;
+pub mod feature_command_converter;
 pub mod job_converter;
 pub mod job_message_catalog;
 pub mod job_message_mapper;


### PR DESCRIPTION
## 概要

Issue #501 の最小非ECS導線を実装し、ViewModel から application を経由して geometry / topology / entity 責務境界を追跡できる状態まで整理しました。

## 主な変更

- line / circle / arc の debug 導線を `FeatureOrchestrator` に集約し、geometry → topology → entity の経路を application 層で固定
- triangle は通常トポロジーとして closed wire を導入し、`GeometryOrchestrator` / `TopologyOrchestrator` 経由で責務境界を固定
- `topology_orchestration` を追加し、line / arc / circle / triangle の topology 導出と検証を application 層へ分離
- `geo_contracts` に `StrokePattern` / `StrokeDisplayProperties` / `PlanarStroke2DProperties` を追加し、表示属性 contract を整理
- `view/app` の debug 表示を application / viewmodel 経由へ揃え、`EntityManager` の命名を `line_list_*` へ調整
- #501 現行実装、#256 との用途分離、#650 の NURBS edge 追補方針を設計書へ反映
- アーキテクチャ依存ルールを更新し、`geo_topology -> geo_nurbs` を edge 導入準備として片方向のみ許可

## スコープ整理

- #501 は非ECSの最小導線と責務境界の固定が対象です
- #256 の三角形限定 topology は、工具逆オフセット法前段の局所凸部縫合・探索効率化という別用途として継続します
- `NurbsCurve3D` を edge として扱う最小拡張は #650 で継続します
- group / layer の単一所属整理は #649 側で扱います

## テスト・検証

- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check_pr_preflight.ps1` ✅
- preflight 内で `cargo fmt --check` ✅
- preflight 内で `cargo clippy -- -D warnings` ✅
- preflight 内で `cargo test --workspace` ✅
- `scripts/check_architecture_dependencies_simple.ps1` ✅

## 関連

- Closes #501
- Related: #256
- Related: #649
- Related: #650