### PR TITLE
feat: align #649 layer relation and visibility policy

### DIFF
--- a/dev/architecture/APPLICATION_ORCHESTRATION_LAYER_DESIGN.md
+++ b/dev/architecture/APPLICATION_ORCHESTRATION_LAYER_DESIGN.md
@@ -224,6 +224,17 @@ pub struct ListGroupsForEntityResult {
 - entity が複数 group に属する前提のため、`AddEntityToGroupResult` は単一 membership 成否だけでなく更新後 membership 集合を返してよい
 - `SetGroupVisibilityResult.affected_entity_ids` を返すことで、View 側は全件再構築ではなく影響範囲ベースの再評価へ拡張しやすくなる
 - group は render batch key ではないため、Application DTO も shader/material 単位の情報は持たない
+- Application は group / layer / entity の `visible` state と deny 優先の `visible_policy` を正本として返し、最終的な `effective_visible` 解決は ViewModel 側で行う
+- 初期段階では `entity_visible` / `groups_all_visible` / `layer_visible_or_true` のような bool 群で十分だが、それらが並列軸か上位/下位段かは `visible_policy` で説明できるようにする
+- `visible_policy` の正本は固定 `order` 値ではなく、parallel / sequential の構造 node を基本とし、leaf が `visible`、`source`、必要に応じて `source_id` を持つ形を優先する
+- `source` は entity / group / layer / instance_placement / instance_root / instance_cluster などの判定由来を表し、`source_id` は型付き enum として、単一 ID だけでなく `group_id + entity_id`、`group_ids + entity_ids`、`instance_id + placement_element_key` のような複合文脈も保持できるようにする
+- 要素種類については、点・線・面などごとに空間を分けることだけを合意事項とし、`Element` を独立 source にするかは下位データ設計と実装選択に委ねる
+- instance 配置は「実体は 1 つでも placement は複数持てる」前提とし、visible state は entity 共有ではなく placement ごとに持てるようにしておく
+- entity が複数 group に属する場合、Application は group 単位の visible 判定だけでなく「どの entity に効いた group 判定か」を source_id payload から辿れるようにしておく
+- なお Group source の payload 形は未確定であり、単一 `group_id + entity_id` で十分か、`group_ids + entity_ids` をまとめた GroupContext が必要かは実装直前に再確認する
+- placement 系の識別子体系は visibility 専用に再定義せず、外部の配置機構が管理する語彙を受け取って参照する
+- 点・線・面などの要素種類で表示制御したくなった場合も、visibility 側ではまず要素種類ごとの空間を切り替える前提で扱い、実装が ECS かどうかは後付けのシステム用語として分離する
+- ViewModel へ平坦な評価順が必要な場合は、構造 node から都度導出した evaluation order を渡してよいが、その順序数値を契約として固定しない
 - `viewmodel/converter`: DTO 変換に加えて debug 実行導線が一部残存
 
 ## 8. layer relation 系 use case の扱い
@@ -279,7 +290,7 @@ pub struct AddEntityToLayerRequest {
 pub struct AddEntityToLayerResult {
    pub entity_id: EntityId,
    pub layer_id: LayerId,
-   pub memberships: Vec<LayerMembershipDto>,
+   pub membership: LayerMembershipDto,
 }
 
 pub struct SetLayerVisibilityRequest {
@@ -297,8 +308,16 @@ pub struct SetLayerVisibilityResult {
 
 - layer の `visible` は group と同様、Application query で取得可能な state とする
 - layer 所属追加では既存 layer 所属がある場合を Application 境界で正規化エラーへ変換する
+- layer は単一所属前提のため、更新後所属集合ではなく単一 `membership` または `Option<LayerDto>` を返す契約を優先する
 - layer は group より表示管理寄りだが、初期 DTO では既定色・既定線種の継承責務まで持ち込まない
 - group / layer の両方が非表示フィルタとして働くため、影響 entity 集合は両 relation から計算できる形を保つ
+- 最終表示可否そのものは ViewModel が `visible_policy` に従って `effective_visible` を解決し、Application はそのための正本 state を返す役割に留める
+- `visible_policy` の実装形は初手では軽量でよく、`VisibilityPolicyNode::Sequential` / `Parallel` と leaf の `visible` / `source` / `source_id` を組み合わせた加工しやすい構造を優先する
+- これにより multi-group 所属時でも、どの group が非表示理由になったかを ViewModel と差分更新処理で共通に扱える
+- 将来 object instance の配置を許容する場合は、instance placement / instance root / instance cluster の visible state と `cluster -> instance`、`instance -> entity` index を既存 policy tree の上位 node として追加できることを前提にする
+- この上位 node が false のときは配下 instance 群の group / layer 判定を省略でき、同一 entity を参照する別 placement は独立に表示継続できるため、表示判定の効率化と個別制御を両立できる
+- さらに instance 内で entity 単位の表示制御操作が行われた場合は、その操作を `instance_id + placement_element_key` に正規化し、同一 instance 内の同一要素へは同じ表示挙動を適用する一方、別 instance には波及させない
+- ここで `placement_element_key` は外部の配置機構が供給する「instance 内で同一要素を指す識別子」を仮置きした語であり、visibility 側が独自に生成規則を持つべきではない
 
 ### 8.5 UI ハイブリッド運用との関係
 

--- a/dev/architecture/ENTITY_ATTRIBUTE_HIERARCHICAL_ID_PROPOSAL.md
+++ b/dev/architecture/ENTITY_ATTRIBUTE_HIERARCHICAL_ID_PROPOSAL.md
@@ -216,24 +216,14 @@ pub enum AttributeValue {
 - 実装は属性ではなく `EntityId ↔ GroupId` の関係で保持する
 - 基本は多対多（1寸法が複数グループ所属可能）
 
-### 2) レイヤー所属（単一/複数の区別）
+### 2) レイヤー所属（単一所属）
 
-エンティティ種別ごとに所属制約を持たせる。
+2026-04-09 時点の方針では、layer は図面・表示管理の基準単位として単一所属を前提とする。
 
-- `SingleLayer`: 最大1レイヤー
-- `MultiLayer`: 複数レイヤー可
-
-```rust
-pub enum LayerMembershipPolicy {
-    SingleLayer,
-    MultiLayer,
-}
-```
-
-追加時バリデーションでポリシーを強制する。
-
-- `SingleLayer` で既存所属あり → エラーまたは置換（運用設定）
-- `MultiLayer` は重複登録のみ禁止
+- 1 entity は最大 1 layer にのみ属する
+- 既存所属ありで別 layer を追加しようとした場合はエラーとする
+- 同じ layer の再設定は冪等な再投入として扱う
+- 複数所属が必要な横断分類は group 側で扱い、layer では扱わない
 
 ### 3) 最小データ構造（提案）
 
@@ -288,7 +278,7 @@ entity rel layer add --entity <EntityId> --layer <LayerId>
 - `code < 0` かつ未定義systemコードは拒否
 - `code > 0` は user範囲として許可（必要ならプロジェクト予約レンジを設定）
 - 値型不一致（例: Float項目へString投入）を拒否
-- `LayerMembershipPolicy` 違反を拒否
+- layer 単一所属制約違反を拒否
 
 ### 4) 監査・保守
 
@@ -305,7 +295,7 @@ entity rel layer add --entity <EntityId> --layer <LayerId>
 4. **同一コード再定義禁止**（CIテストで検出）
 5. **定義テーブル未登録のsystemコード禁止**
 6. ドメイン/カテゴリ番号は予約表で重複管理
-7. レイヤー所属は `LayerMembershipPolicy` に従って検証
+7. レイヤー所属は単一所属制約に従って検証
 8. グループ/レイヤーは属性ではなく関係テーブルで管理
 9. コマンド経由変更は監査ログを記録
 
@@ -319,7 +309,7 @@ entity rel layer add --entity <EntityId> --layer <LayerId>
 - `const + 定義テーブル` で system 属性を先行定義
 - CAM/寸法/スケッチの最小コードセット作成
 - Group/Layer 関係モデルを導入（所属データ分離）
-- `LayerMembershipPolicy` による単一/複数レイヤー制約を導入
+- layer 単一所属の relation 制約を導入
 - ユーザーコマンドの最小機能（set/get/remove）を導入
 
 ### Phase 4.1-4.3（#205）
@@ -374,7 +364,7 @@ entity rel layer add --entity <EntityId> --layer <LayerId>
 - `AttributeValue`（型付き + `Binary(Vec<u8>)`）
 - `Attributes`（型検証付き set/get/remove）
 - Group/Layer 関係モデル
-- `LayerMembershipPolicy`（SingleLayer / MultiLayer）
+- layer 単一所属制約
 - 単体テスト（正負ID、0拒否、型検証、レイヤー制約、決定的ID）
 
 本着手では、ViewModel/App統合およびB-Repトポロジー統合は対象外とする。
@@ -393,8 +383,8 @@ entity rel layer add --entity <EntityId> --layer <LayerId>
 - [ ] 任意データ（`Binary(Vec<u8>)`）を保持できる
 - [ ] `EntityId(UUID)` と独立して運用できる
 - [ ] 寸法エンティティのグループ所属（多対多）を管理できる
-- [ ] 単一レイヤー対象で複数所属を拒否できる
-- [ ] 複数レイヤー対象で複数所属を許可できる
+- [ ] layer 単一所属で複数所属を拒否できる
+- [ ] 同じ layer の再設定を冪等に扱える
 - [ ] コマンドで user属性コード（正ID）を付与・取得・削除できる
 - [ ] system属性コード（負ID）に未定義コードを拒否できる
 - [ ] 値型バリデーションが機能する

--- a/dev/architecture/ENTITY_VIEW_INTEGRATION_DESIGN.md
+++ b/dev/architecture/ENTITY_VIEW_INTEGRATION_DESIGN.md
@@ -245,7 +245,9 @@ effective_visible = entity.visible
 2. 既存 `load_debug_line` / `load_debug_toolpath` に「Entity経由パス」を追加
 3. `rebuild_stage_from_entities()` を新設
    - EntityManagerの可視エンティティを収集
-   - entity 自身の visible と group / layer 可視状態を合成して有効表示を判定
+   - Application/Model 正本の `visible_policy` と entity / group / layer state を ViewModel へ渡し、`effective_visible` を解決する
+   - 初期は bool 群で描画可否材料を渡してよいが、並列条件と上位/下位条件の違いは `visible_policy` の構造 node と leaf の `source` / `source_id` で補足できる前提にする
+   - 将来 object instance を導入する場合は、instance placement / instance root / instance cluster を最上位 node として先に評価し、非表示 cluster 配下の placement は下位条件を再走査しない
    - ViewModel変換
    - `MeshStage` / `ToolPathStage` へ反映
 4. キー操作（最小）
@@ -262,6 +264,15 @@ effective_visible = entity.visible
 - `geometric_entity_to_vertices` が表示色を反映する
 - 非対応形状で明示エラーを返す
 - `cam_entity_to_vertices` が `CAMEntity` 入力でも既存変換結果と一致する
+- `visible_policy` と View 条件から `effective_visible` を一貫して解決できる
+- bool 群だけの初期 DTO でも、`visible_policy` の構造 node と leaf の `source + source_id` 規約に従って同じ `effective_visible` を再現できる
+- `effective_visible = false` になった場合、少なくとも 1 件の `source` と必要に応じた `source_id` を辿って原因軸を説明できる
+- source 候補として少なくとも Entity / Group を持てるようにしておき、特に Group は `group_ids + entity_ids` を束ねる候補も含めて評価できるようにする
+- `Element` は source に固定せず、点・線・面など要素種類ごとに空間を分ける前提で ViewModel が受け取れるようにしておく
+- 同一 entity を参照する複数 instance placement がある場合でも、placement ごとの visible state に従って個別に `effective_visible` を解決できる
+- instance 内 entity 単位の表示操作が入った場合は、同一 instance 内の同一 `placement_element_key` を共有する要素が同じ表示挙動になり、別 instance の対応要素とは独立に扱われる
+- `placement_element_key` は visibility 専用 ID ではなく、外部の配置機構が供給する前提とする
+- instance cluster が最上位で false の場合、配下 placement の group / layer 条件を評価せずとも同じ `effective_visible = false` を再現できる
 
 ## 8.2 `view/app` 側
 
@@ -274,6 +285,10 @@ effective_visible = entity.visible
 - 既に layer 所属を持つ entity へ別 layer を追加しようとすると失敗する
 - 所属 layer が非表示の場合に有効表示が false になる
 - dirty時のみ `rebuild_stage_from_entities()` 実行
+- View は ViewModel が解決した `effective_visible` を消費し、独自の優先順位ロジックを持たない
+- instance cluster の表示変更時は、その cluster 配下の `affected_instance_ids` のみが一次再評価対象になり、必要に応じて表示中 entity へ反映する
+- instance 内 entity 操作時は、`affected_instance_ids` だけでなく `affected_instance_element_keys` のような粒度も扱えるようにして、同一 instance 内の同一要素だけを差分再評価できる余地を残す
+- ただしこの element key の定義は visibility ではなく外部の配置機構側で持ち、ViewModel はそれを受け取って差分再評価へ使うだけに留める
 - 2D 線種はビュー始点が定義平面に直交しない場合、非表示または実線フォールバックとなる
 
 ---

--- a/dev/architecture/VIEWMODEL_MODEL_ROUTE_REDEFINITION_DESIGN.md
+++ b/dev/architecture/VIEWMODEL_MODEL_ROUTE_REDEFINITION_DESIGN.md
@@ -209,6 +209,55 @@ layers_all_visible = 所属 layer が空なら true、所属 layer があれば�
 - 表示の意味論としては layer の方が図面管理寄り、group の方が横断的な論理束ね寄りである
 - ただし初期描画実装では、どちらも cache key ではなく可視フィルタとして合成する
 
+### 3.12 visible_policy の表現方針
+
+- 初期段階の DTO / query 応答では、`entity_visible`、`groups_all_visible`、`layer_visible_or_true` のような bool 群で十分とする
+- ただし bool 群だけでは「どの条件が並列軸で、どの条件が上位/下位の優先関係か」が将来拡張しにくいため、Application/Model 側には `visible_policy` を別語彙として保持する
+- 将来的に object instance の配置と instance 構造の塊単位での表示制御を導入する前提では、instance placement / instance root / instance cluster を `visible_policy` の最上位段として扱える形にしておく
+- ここで instance placement は「実体 entity は 1 つでも、その参照配置 instance は複数持てる」ものとし、表示切替は placement ごとに独立して制御できる前提とする
+- `visible_policy` は固定数値の `order` を仕様値として持つ前提にせず、parallel / sequential の構造と node の親子関係から評価順を表現できればよい
+  1. 同順位の並列フィルタであること
+  2. 上位/下位の評価段であること
+  3. deny 優先で合成すること
+-  4. どの軸の判定結果かを追跡できること
+- 例えば `VisibilityPolicyNode::Sequential(vec![ ... ])` の配下に `VisibilityPolicyNode::Parallel(vec![ ... ])` を持つような構造で、上位/下位段と並列条件を同時に表現できる
+- source 候補は少なくとも `Entity`、`Group`、`Layer`、`InstancePlacement`、`InstanceRoot`、`InstanceCluster`、`ViewCondition` を持てるようにしておき、要素種類の扱いは「要素種類ごとに空間を分ける」を合意事項として固定する
+- instance root / instance cluster を group / layer より上位の node に置ければ、該当塊全体が非表示な時点でその配下 placement / entity の下位判定を短絡できる
+- `source` は判定由来を表し、`source_id` は単一の汎用 ID ではなく型付き enum を優先し、group_id / layer_id / instance_id / cluster_id に加えて複合文脈を保持できるようにする
+- 検討案としては `VisibilitySourceId::Entity { entity_id }`、`VisibilitySourceId::GroupContext { group_ids, entity_ids }` のような形がありうる
+- `Element` については、点・線・面などの要素種類ごとに空間を分けることだけをこの段階の合意事項とする
+- その内部表現を Entity + Geometry / Topology の type 判別で持つか、将来別の実装機構へ載せ替えるかは後続の実装選択に委ねる
+- このため現段階では `Element` を独立 source に固定せず、要素種類ごとの空間分離を前提に Entity 側または下位実装側で吸収する
+- 特に Group は単一 group_id だけでなく group_id 群と entity_id 群を束ねて持てるようにしておくと、複数 group 所属時の説明と差分再評価を崩しにくい
+- instance 内 entity 単位の表示操作は `VisibilitySourceId::InstanceElement { instance_id, element_key }` のような識別子で表し、「同一 instance 内の同一要素」には同じ表示挙動を適用し、別 instance の同名要素とは分離して扱う
+- これにより「表示ON/OFF」と「評価優先順位」を同じデータ構造から取り出せるため、enum に数値を埋め込んでビットフラグ風に扱うより加工しやすい
+- さらに `effective_visible = false` になった理由を ViewModel 側で説明可能になり、`affected_instance_ids` / `affected_entity_ids` の計算時にもどの source を起点に差分再評価すべきかを揃えやすい
+- 将来の上位層追加時も、既存 node の上に新しい親 node を挿入して整合性を保てばよく、固定 `order = 100` のような予約値運用を避けられる
+- ただし初期実装では、外部 DTO に複雑な policy 配列を露出するより、bool 群 + `visible_policy` 正本語彙の併用を優先する
+- ViewModel / DTO 境界で平坦化が必要な場合に限り、構造から導出した evaluation order を一時的に使ってよいが、その数値は永続的な契約値にしない
+
+例:
+
+```rust
+pub enum VisibilitySourceId {
+  Entity { entity_id: EntityId },
+  Group { group_id: GroupId, entity_id: EntityId },
+  GroupContext { group_ids: Vec<GroupId>, entity_ids: Vec<EntityId> },
+  Layer { layer_id: LayerId, entity_id: EntityId },
+  InstancePlacement { instance_id: InstanceId },
+  InstanceRoot { root_id: InstanceRootId },
+  InstanceCluster { cluster_id: InstanceClusterId },
+  InstanceElement { instance_id: InstanceId, element_key: PlacementElementKey },
+  ViewCondition { view_id: ViewId, condition_key: ViewConditionKey },
+}
+```
+
+- 単純な単一 ID より variant ごとの payload を持てるため、group 複数所属や instance 内 element 操作のような複合ケースを `source_id` の時点で正規化できる
+- ただし上記 enum 形はまだ Fix しておらず、現時点では「Group に group_id 群 / entity_id 群を持たせる案」を中心に検討し、`Element` は要素種類ごとの空間分離を前提に下位実装へ委ねる
+- `PlacementElementKey` は現時点の仮名であり、最終的に `entity_local_key` へ固定することはまだ決めない
+- `PlacementElementKey` は visibility 側が定義する ID ではなく、将来必要な配置系・参照系から外部供給される「instance 内で同一要素を指すキー」として扱う
+- visibility policy はその外部供給キーを参照して表示判定に使うが、配置識別子の体系そのものをここで定義しない
+
 ---
 
 ## 4. 責務境界
@@ -220,7 +269,8 @@ layers_all_visible = 所属 layer が空なら true、所属 layer があれば�
 - 2D / 3D 描画カテゴリの分類を行う
 - 2D 線種の表示可否判定に必要な View 条件を受け取り、表示条件を満たさない 2D 線種を描画要求へ昇格させない
 - `EntityDisplayProperties` / `StrokeDisplayProperties` / `PlanarStroke2DProperties<T>` のどこまでを使うかで DTO の描画カテゴリを決める
-- entity 自身の表示属性と group / layer 可視状態を合成し、有効表示フラグを描画要求へ反映する
+- Application/Model が保持する `visible_policy` と View から渡る表示条件を用いて `effective_visible` を解決し、描画要求へ反映する
+- bool 群だけで解決できる初期ケースでも、`visible_policy` が示す parallel / upper / lower の規約に加え、`source` / `source_id` による原因軸の識別を保ったまま評価順を固定する
 - 非責務:
   - geometry 生成順序の決定
   - topology 構築判断
@@ -235,6 +285,11 @@ layers_all_visible = 所属 layer が空なら true、所属 layer があれば�
 - 下位エラーを上位エラーへ正規化する
 - group 作成、entity の group 所属追加/解除、group 可視状態更新、group 単位 query の入口を持つ
 - layer 作成、entity の layer 所属追加/解除、layer 可視状態更新、layer 単位 query の入口を持つ
+- entity / group / layer の `visible` state と deny 優先の `visible_policy` を正本語彙として保持し、ViewModel が `effective_visible` を計算できる材料を返す
+- 将来の instance 配置導入を見据え、Application は instance placement / instance root / instance cluster の `visible` state と relation index も同じ正本系列へ拡張できるようにしておく
+- 初期 DTO では bool 群を返してよいが、それがどの policy 軸に対応するかは `visible_policy` 側で一意に説明できるようにする
+- `visible_policy` の各 leaf node は少なくとも `source` を持ち、必要に応じて型付き enum の `source_id` で group 文脈・layer 文脈・instance 文脈を識別できるようにする
+- 可視状態更新では `affected_instance_ids` と必要に応じて `affected_entity_ids` を返せる構造を優先し、最上位 instance cluster が非表示になった場合はその配下 placement だけを再評価対象へ絞り込めるようにする
 - 非責務:
   - 幾何計算アルゴリズム本体
   - topology データ構造の詳細実装
@@ -258,6 +313,7 @@ layers_all_visible = 所属 layer が空なら true、所属 layer があれば�
 - geometry / topology を参照可能な識別単位を提供する
 - 表示属性、メタデータ、関係管理を担う
 - `feature_id + output_index + local_key` からの決定的 ID 生成は entity 側の語彙として扱う
+- ただし placement 系で必要になる複合識別子は別の語彙として扱い、entity 単体 ID と混同しない
 - View ローカルの選択状態管理とは分離する
 - group / layer などの所属関係は entity relation として保持し、display trait へ混在させない
 
@@ -464,7 +520,7 @@ pub struct AddEntityToLayerRequest {
 pub struct AddEntityToLayerResult {
   pub entity_id: EntityId,
   pub layer_id: LayerId,
-  pub memberships: Vec<LayerMembershipDto>,
+  pub membership: LayerMembershipDto,
 }
 
 pub struct RemoveEntityFromLayerRequest {
@@ -475,7 +531,7 @@ pub struct RemoveEntityFromLayerRequest {
 pub struct RemoveEntityFromLayerResult {
   pub entity_id: EntityId,
   pub layer_id: LayerId,
-  pub memberships: Vec<LayerMembershipDto>,
+  pub removed: bool,
 }
 
 pub struct SetLayerVisibilityRequest {
@@ -494,13 +550,13 @@ pub struct ListLayersResult {
   pub layers: Vec<LayerDto>,
 }
 
-pub struct ListLayersForEntityQuery {
+pub struct GetLayerForEntityQuery {
   pub entity_id: EntityId,
 }
 
-pub struct ListLayersForEntityResult {
+pub struct GetLayerForEntityResult {
   pub entity_id: EntityId,
-  pub layers: Vec<LayerDto>,
+  pub layer: Option<LayerDto>,
 }
 
 pub struct ListEntitiesForLayerQuery {
@@ -527,6 +583,7 @@ pub struct LayerMembershipDto {
 
 - `LayerDto.visible` は layer 単位 ON/OFF の正本 state を表す
 - `AddEntityToLayerRequest` は既存 layer 所属がある場合に Application 境界で正規化エラーを返す
+- layer は単一所属前提のため、entity ごとの query も `GetLayerForEntity*` のように単数契約を優先する
 - layer は将来、既定色・既定線種の継承元になりうるが、初期 DTO にはその責務を混ぜない
 
 ### 5.9 強い group / layer ON/OFF を支える state の位置づけ

--- a/model/geo_entity/src/lib.rs
+++ b/model/geo_entity/src/lib.rs
@@ -3,7 +3,7 @@
 //! - EntityId: エンティティ同一性ID（決定的生成対応）
 //! - AttributeCode: 属性種別コード（負=system, 正=user, 0禁止）
 //! - Attributes: 型検証付き属性コンテナ
-//! - Group/Layer 関係モデル: 所属管理（Single/Multi Layer制約）
+//! - Group/Layer 関係モデル: group 複数所属 / layer 単一所属の relation 管理
 
 pub mod attribute_code;
 pub mod attribute_value;
@@ -27,7 +27,7 @@ pub use geometric_entity::GeometricEntity;
 pub use metadata::Metadata;
 pub use relations::{
     EntityGroupMembership, EntityLayerMembership, GroupEntity, GroupId, LayerEntity, LayerId,
-    LayerMembershipPolicy, RelationStore,
+    RelationStore,
 };
 pub use system_attributes::{
     CAM_PATH_DRILL_CYCLE, CAM_PATH_DRILL_DWELL, CAM_PATH_DRILL_FEED_RATE, CAM_PATH_DRILL_PECK_STEP,

--- a/model/geo_entity/src/relations.rs
+++ b/model/geo_entity/src/relations.rs
@@ -33,12 +33,6 @@ impl Default for LayerId {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum LayerMembershipPolicy {
-    SingleLayer,
-    MultiLayer,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GroupEntity {
     pub id: GroupId,
@@ -86,24 +80,12 @@ pub struct EntityLayerMembership {
 #[derive(Debug, Default)]
 pub struct RelationStore {
     group_memberships: HashSet<EntityGroupMembership>,
-    layer_memberships: HashSet<EntityLayerMembership>,
-    layer_policies: HashMap<EntityId, LayerMembershipPolicy>,
+    layer_memberships: HashMap<EntityId, LayerId>,
 }
 
 impl RelationStore {
     pub fn new() -> Self {
         Self::default()
-    }
-
-    pub fn set_layer_policy(&mut self, entity_id: EntityId, policy: LayerMembershipPolicy) {
-        self.layer_policies.insert(entity_id, policy);
-    }
-
-    pub fn layer_policy_for(&self, entity_id: EntityId) -> LayerMembershipPolicy {
-        self.layer_policies
-            .get(&entity_id)
-            .copied()
-            .unwrap_or(LayerMembershipPolicy::MultiLayer)
     }
 
     pub fn add_to_group(&mut self, entity_id: EntityId, group_id: GroupId) {
@@ -129,38 +111,26 @@ impl RelationStore {
     }
 
     pub fn add_to_layer(&mut self, entity_id: EntityId, layer_id: LayerId) -> EntityResult<()> {
-        let policy = self.layer_policy_for(entity_id);
-        let existing_layers = self.layers_for_entity(entity_id);
-
-        if policy == LayerMembershipPolicy::SingleLayer
-            && !existing_layers.is_empty()
-            && !existing_layers.contains(&layer_id)
+        if let Some(current_layer_id) = self.layer_for_entity(entity_id)
+            && current_layer_id != layer_id
         {
             return Err(EntityError::SingleLayerPolicyViolation {
                 entity_id: entity_id.to_string(),
-                current_layers: existing_layers.len(),
+                current_layers: 1,
             });
         }
 
-        self.layer_memberships.insert(EntityLayerMembership {
-            entity_id,
-            layer_id,
-        });
+        self.layer_memberships.insert(entity_id, layer_id);
         Ok(())
     }
 
     pub fn remove_from_layer(&mut self, entity_id: EntityId, layer_id: LayerId) {
-        self.layer_memberships.remove(&EntityLayerMembership {
-            entity_id,
-            layer_id,
-        });
+        if self.layer_for_entity(entity_id) == Some(layer_id) {
+            self.layer_memberships.remove(&entity_id);
+        }
     }
 
-    pub fn layers_for_entity(&self, entity_id: EntityId) -> Vec<LayerId> {
-        self.layer_memberships
-            .iter()
-            .filter(|membership| membership.entity_id == entity_id)
-            .map(|membership| membership.layer_id)
-            .collect()
+    pub fn layer_for_entity(&self, entity_id: EntityId) -> Option<LayerId> {
+        self.layer_memberships.get(&entity_id).copied()
     }
 }

--- a/model/geo_entity/tests/relation_tests.rs
+++ b/model/geo_entity/tests/relation_tests.rs
@@ -1,13 +1,12 @@
-use geo_entity::{EntityId, LayerId, LayerMembershipPolicy, RelationStore};
+use geo_entity::{EntityId, LayerId, RelationStore};
 
 #[test]
-fn single_layer_policy_rejects_second_layer() {
+fn layer_membership_rejects_second_distinct_layer() {
     let mut store = RelationStore::new();
     let entity = EntityId::from_seed("entity-a");
     let layer1 = LayerId::new();
     let layer2 = LayerId::new();
 
-    store.set_layer_policy(entity, LayerMembershipPolicy::SingleLayer);
     store
         .add_to_layer(entity, layer1)
         .expect("first layer should be accepted");
@@ -17,20 +16,44 @@ fn single_layer_policy_rejects_second_layer() {
 }
 
 #[test]
-fn multi_layer_policy_accepts_multiple_layers() {
+fn layer_membership_returns_single_assigned_layer() {
     let mut store = RelationStore::new();
     let entity = EntityId::from_seed("entity-b");
     let layer1 = LayerId::new();
-    let layer2 = LayerId::new();
 
-    store.set_layer_policy(entity, LayerMembershipPolicy::MultiLayer);
     store
         .add_to_layer(entity, layer1)
-        .expect("first layer should be accepted");
-    store
-        .add_to_layer(entity, layer2)
-        .expect("second layer should be accepted");
+        .expect("layer should be accepted");
 
-    let layers = store.layers_for_entity(entity);
-    assert_eq!(layers.len(), 2);
+    assert_eq!(store.layer_for_entity(entity), Some(layer1));
+}
+
+#[test]
+fn layer_membership_allows_idempotent_reassignment_to_same_layer() {
+    let mut store = RelationStore::new();
+    let entity = EntityId::from_seed("entity-c");
+    let layer = LayerId::new();
+
+    store
+        .add_to_layer(entity, layer)
+        .expect("first assignment should be accepted");
+    store
+        .add_to_layer(entity, layer)
+        .expect("same layer assignment should be idempotent");
+
+    assert_eq!(store.layer_for_entity(entity), Some(layer));
+}
+
+#[test]
+fn remove_from_layer_clears_assigned_layer() {
+    let mut store = RelationStore::new();
+    let entity = EntityId::from_seed("entity-d");
+    let layer = LayerId::new();
+
+    store
+        .add_to_layer(entity, layer)
+        .expect("layer should be accepted");
+    store.remove_from_layer(entity, layer);
+
+    assert_eq!(store.layer_for_entity(entity), None);
 }


### PR DESCRIPTION
## Summary
- align `geo_entity` layer relation semantics to single-layer membership and remove the old multi-layer policy branch
- update #649 design docs for group/layer visibility responsibility, `visible_policy` structure, source/source_id direction, and instance-aware visibility evaluation
- narrow the unresolved `Element` discussion to one agreed point: separate spaces by element kind, while leaving lower-level data representation as a later concern

## Details
- `RelationStore` now stores a single layer per entity, rejects assigning a second distinct layer, allows idempotent reassignment to the same layer, and exposes `layer_for_entity()`
- relation tests were updated to reflect single-layer semantics
- design docs now record:
  - Application/Model owns `visible_policy` and source-of-truth visibility state
  - ViewModel resolves `effective_visible`
  - `visible_policy` should be structure-based (`Sequential` / `Parallel`) rather than rely on fixed order constants
  - `source_id` should remain a typed enum candidate
  - element handling is fixed only at the level of "separate spaces by element kind"

## Validation
- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo test`

Closes #649