### PR TITLE
refactor(#371): Phase1 Point/Tuple境界をcylindrical/ellipse系へ段階適用

### DIFF
--- a/dev/architecture/GEO_ALGORITHMS_MODULE_STRUCTURE_RULES.md
+++ b/dev/architecture/GEO_ALGORITHMS_MODULE_STRUCTURE_RULES.md
@@ -18,8 +18,18 @@
   - 正規方向だけ計算本体を持ち、逆方向はラッパー
 - 原則4: **公開面は mod.rs で一元再エクスポート**
 - 原則5: **新規ペア追加時は coverage matrix を同時更新**
+- 原則6: **Point/Tuple 境界は Point 型を正本にする**
+  - `geo_algorithms` の公開 free-function では `Point2D<T>` / `Point3D<T>` を優先する
+  - 下位 trait定義や既存 shape method が tuple を要求する場合でも、tuple は内部 bridge に限定する
+  - 呼び出し側が tuple を都度組み立てる経路を増やさず、Point 型の入口へ寄せる
 
-### 2.1 分割軸の定義（違和感対策）
+### 2.1 Point/Tuple 境界の段階移行
+
+- 第1段では `shape-point` 系の距離 entrypoint を Point 型正本として整える
+- collision / intersection は、その Point 型 distance entrypoint を代表箇所から優先的に利用する
+- `ToPoint2D<T>` / `ToPoint3D<T>` のような一般化 helper は、複数 shape family で同型の変換需要が確認できた段階で導入する
+
+### 2.2 分割軸の定義（違和感対策）
 
 本ルールは、次の2軸で分類する。
 
@@ -43,7 +53,7 @@
 - curve/surface でアルゴリズム責務（反復・収束特性・サンプリング戦略）が異なる
 - `primitive_3d.rs` に混在させると責務過密になる
 
-### 2.2 正規命名（目標）
+### 2.3 正規命名（目標）
 
 分割軸に一致した正規命名を以下とする。
 

--- a/model/geo_algorithms/src/collision/primitive_3d.rs
+++ b/model/geo_algorithms/src/collision/primitive_3d.rs
@@ -13,10 +13,9 @@ use crate::{
 };
 use geo_contracts::{
     Arc3DDistance, Arc3DEndpoint, Arc3DProperties, Circle3DProperties, CylindricalSolid3DDistance,
-    CylindricalSolid3DProperties, CylindricalSurface3DDistance, CylindricalSurface3DProperties,
-    Ellipse3DDistance, EllipsoidalSolid3DProperties, InfiniteLine3DProperties, Scalar,
-    SphericalSolid3DProperties, SphericalSurface3DProperties, TorusSurface3DDistance,
-    Triangle3DBoundaryAccess,
+    CylindricalSolid3DProperties, CylindricalSurface3DProperties, Ellipse3DDistance,
+    EllipsoidalSolid3DProperties, InfiniteLine3DProperties, Scalar, SphericalSolid3DProperties,
+    SphericalSurface3DProperties, TorusSurface3DDistance, Triangle3DBoundaryAccess,
 };
 
 // ── SphericalSolid3D ──────────────────────────────────────────────────────────
@@ -224,10 +223,7 @@ pub fn cylindrical_surface3d_point3d_collides<T: Scalar>(
     point: &Point3D<T>,
     tolerance: T,
 ) -> bool {
-    <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-        cyl,
-        (point.x(), point.y(), point.z()),
-    ) <= tolerance
+    crate::distance::cylindrical_surface3d_point3d_distance(cyl, point) <= tolerance
 }
 
 pub fn cylindrical_surface3d_circle3d_collides<T: Scalar>(
@@ -236,10 +232,8 @@ pub fn cylindrical_surface3d_circle3d_collides<T: Scalar>(
     tolerance: T,
 ) -> bool {
     let (cx, cy, cz) = circle.center();
-    <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-        cyl,
-        (cx, cy, cz),
-    ) <= tolerance
+    let center = Point3D::new(cx, cy, cz);
+    crate::distance::cylindrical_surface3d_point3d_distance(cyl, &center) <= tolerance
 }
 
 pub fn cylindrical_surface3d_line_segment3d_collides<T: Scalar>(
@@ -249,14 +243,8 @@ pub fn cylindrical_surface3d_line_segment3d_collides<T: Scalar>(
 ) -> bool {
     let s = segment.start();
     let e = segment.end();
-    <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-        cyl,
-        (s.x(), s.y(), s.z()),
-    ) <= tolerance
-        || <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-            cyl,
-            (e.x(), e.y(), e.z()),
-        ) <= tolerance
+    crate::distance::cylindrical_surface3d_point3d_distance(cyl, &s) <= tolerance
+        || crate::distance::cylindrical_surface3d_point3d_distance(cyl, &e) <= tolerance
 }
 
 pub fn cylindrical_surface3d_ray3d_collides<T: Scalar>(
@@ -265,10 +253,7 @@ pub fn cylindrical_surface3d_ray3d_collides<T: Scalar>(
     tolerance: T,
 ) -> bool {
     let o = ray.origin();
-    <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-        cyl,
-        (o.x(), o.y(), o.z()),
-    ) <= tolerance
+    crate::distance::cylindrical_surface3d_point3d_distance(cyl, &o) <= tolerance
 }
 
 pub fn cylindrical_surface3d_infinite_line3d_collides<T: Scalar>(
@@ -277,10 +262,8 @@ pub fn cylindrical_surface3d_infinite_line3d_collides<T: Scalar>(
     tolerance: T,
 ) -> bool {
     let (px, py, pz) = line.point();
-    <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-        cyl,
-        (px, py, pz),
-    ) <= tolerance
+    let point = Point3D::new(px, py, pz);
+    crate::distance::cylindrical_surface3d_point3d_distance(cyl, &point) <= tolerance
 }
 
 pub fn cylindrical_surface3d_triangle3d_collides<T: Scalar>(
@@ -291,18 +274,12 @@ pub fn cylindrical_surface3d_triangle3d_collides<T: Scalar>(
     let (ax, ay, az) = triangle.vertex_a();
     let (bx, by, bz) = triangle.vertex_b();
     let (cx, cy, cz) = triangle.vertex_c();
-    <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-        cyl,
-        (ax, ay, az),
-    ) <= tolerance
-        || <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-            cyl,
-            (bx, by, bz),
-        ) <= tolerance
-        || <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-            cyl,
-            (cx, cy, cz),
-        ) <= tolerance
+    let point_a = Point3D::new(ax, ay, az);
+    let point_b = Point3D::new(bx, by, bz);
+    let point_c = Point3D::new(cx, cy, cz);
+    crate::distance::cylindrical_surface3d_point3d_distance(cyl, &point_a) <= tolerance
+        || crate::distance::cylindrical_surface3d_point3d_distance(cyl, &point_b) <= tolerance
+        || crate::distance::cylindrical_surface3d_point3d_distance(cyl, &point_c) <= tolerance
 }
 
 pub fn cylindrical_surface3d_plane3d_collides<T: Scalar>(

--- a/model/geo_algorithms/src/collision/primitive_3d.rs
+++ b/model/geo_algorithms/src/collision/primitive_3d.rs
@@ -12,10 +12,10 @@ use crate::{
     SphericalSurface3D, TorusSolid3D, TorusSurface3D, Triangle3D, TriangleMesh3D,
 };
 use geo_contracts::{
-    Arc3DDistance, Arc3DEndpoint, Arc3DProperties, Circle3DProperties, CylindricalSolid3DDistance,
-    CylindricalSolid3DProperties, CylindricalSurface3DProperties, Ellipse3DDistance,
-    EllipsoidalSolid3DProperties, InfiniteLine3DProperties, Scalar, SphericalSolid3DProperties,
-    SphericalSurface3DProperties, TorusSurface3DDistance, Triangle3DBoundaryAccess,
+    Arc3DDistance, Arc3DEndpoint, Arc3DProperties, Circle3DProperties,
+    CylindricalSolid3DProperties, CylindricalSurface3DProperties, EllipsoidalSolid3DProperties,
+    InfiniteLine3DProperties, Scalar, SphericalSolid3DProperties, SphericalSurface3DProperties,
+    TorusSurface3DDistance, Triangle3DBoundaryAccess,
 };
 
 // ── SphericalSolid3D ──────────────────────────────────────────────────────────
@@ -111,10 +111,7 @@ pub fn cylindrical_solid3d_point3d_collides<T: Scalar>(
     point: &Point3D<T>,
     tolerance: T,
 ) -> bool {
-    <CylindricalSolid3D<T> as CylindricalSolid3DDistance<T>>::distance_to_point(
-        cyl,
-        (point.x(), point.y(), point.z()),
-    ) <= tolerance
+    crate::distance::cylindrical_solid3d_point3d_distance(cyl, point) <= tolerance
 }
 
 pub fn cylindrical_solid3d_circle3d_collides<T: Scalar>(
@@ -123,8 +120,8 @@ pub fn cylindrical_solid3d_circle3d_collides<T: Scalar>(
     tolerance: T,
 ) -> bool {
     let (cx, cy, cz) = circle.center();
-    <CylindricalSolid3D<T> as CylindricalSolid3DDistance<T>>::distance_to_point(cyl, (cx, cy, cz))
-        <= tolerance
+    let center = Point3D::new(cx, cy, cz);
+    crate::distance::cylindrical_solid3d_point3d_distance(cyl, &center) <= tolerance
 }
 
 pub fn cylindrical_solid3d_line_segment3d_collides<T: Scalar>(
@@ -134,14 +131,8 @@ pub fn cylindrical_solid3d_line_segment3d_collides<T: Scalar>(
 ) -> bool {
     let s = segment.start();
     let e = segment.end();
-    <CylindricalSolid3D<T> as CylindricalSolid3DDistance<T>>::distance_to_point(
-        cyl,
-        (s.x(), s.y(), s.z()),
-    ) <= tolerance
-        || <CylindricalSolid3D<T> as CylindricalSolid3DDistance<T>>::distance_to_point(
-            cyl,
-            (e.x(), e.y(), e.z()),
-        ) <= tolerance
+    crate::distance::cylindrical_solid3d_point3d_distance(cyl, &s) <= tolerance
+        || crate::distance::cylindrical_solid3d_point3d_distance(cyl, &e) <= tolerance
 }
 
 pub fn cylindrical_solid3d_infinite_line3d_collides<T: Scalar>(
@@ -150,8 +141,8 @@ pub fn cylindrical_solid3d_infinite_line3d_collides<T: Scalar>(
     tolerance: T,
 ) -> bool {
     let (px, py, pz) = line.point();
-    <CylindricalSolid3D<T> as CylindricalSolid3DDistance<T>>::distance_to_point(cyl, (px, py, pz))
-        <= tolerance
+    let point = Point3D::new(px, py, pz);
+    crate::distance::cylindrical_solid3d_point3d_distance(cyl, &point) <= tolerance
 }
 
 pub fn cylindrical_solid3d_ray3d_collides<T: Scalar>(
@@ -160,10 +151,7 @@ pub fn cylindrical_solid3d_ray3d_collides<T: Scalar>(
     tolerance: T,
 ) -> bool {
     let o = ray.origin();
-    <CylindricalSolid3D<T> as CylindricalSolid3DDistance<T>>::distance_to_point(
-        cyl,
-        (o.x(), o.y(), o.z()),
-    ) <= tolerance
+    crate::distance::cylindrical_solid3d_point3d_distance(cyl, &o) <= tolerance
 }
 
 pub fn cylindrical_solid3d_triangle3d_collides<T: Scalar>(
@@ -174,16 +162,12 @@ pub fn cylindrical_solid3d_triangle3d_collides<T: Scalar>(
     let (ax, ay, az) = triangle.vertex_a();
     let (bx, by, bz) = triangle.vertex_b();
     let (cx, cy, cz) = triangle.vertex_c();
-    <CylindricalSolid3D<T> as CylindricalSolid3DDistance<T>>::distance_to_point(cyl, (ax, ay, az))
-        <= tolerance
-        || <CylindricalSolid3D<T> as CylindricalSolid3DDistance<T>>::distance_to_point(
-            cyl,
-            (bx, by, bz),
-        ) <= tolerance
-        || <CylindricalSolid3D<T> as CylindricalSolid3DDistance<T>>::distance_to_point(
-            cyl,
-            (cx, cy, cz),
-        ) <= tolerance
+    let point_a = Point3D::new(ax, ay, az);
+    let point_b = Point3D::new(bx, by, bz);
+    let point_c = Point3D::new(cx, cy, cz);
+    crate::distance::cylindrical_solid3d_point3d_distance(cyl, &point_a) <= tolerance
+        || crate::distance::cylindrical_solid3d_point3d_distance(cyl, &point_b) <= tolerance
+        || crate::distance::cylindrical_solid3d_point3d_distance(cyl, &point_c) <= tolerance
 }
 
 pub fn cylindrical_solid3d_plane3d_collides<T: Scalar>(
@@ -318,10 +302,7 @@ pub fn ellipse3d_point3d_collides<T: Scalar + From<f64>>(
     point: &Point3D<T>,
     tolerance: T,
 ) -> bool {
-    <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(
-        ellipse,
-        (point.x(), point.y(), point.z()),
-    ) <= tolerance
+    crate::distance::ellipse3d_point3d_distance(ellipse, point) <= tolerance
 }
 
 pub fn ellipse3d_circle3d_collides<T: Scalar + From<f64>>(
@@ -330,8 +311,8 @@ pub fn ellipse3d_circle3d_collides<T: Scalar + From<f64>>(
     tolerance: T,
 ) -> bool {
     let (cx, cy, cz) = circle.center();
-    <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (cx, cy, cz))
-        <= circle.radius() + tolerance
+    let center = Point3D::new(cx, cy, cz);
+    crate::distance::ellipse3d_point3d_distance(ellipse, &center) <= circle.radius() + tolerance
 }
 
 pub fn ellipse3d_arc3d_collides<T: Scalar + From<f64>>(
@@ -341,8 +322,8 @@ pub fn ellipse3d_arc3d_collides<T: Scalar + From<f64>>(
 ) -> bool {
     let (cx, cy, cz) = Arc3DProperties::center(arc);
     let arc_radius = Arc3DProperties::radius(arc);
-    <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (cx, cy, cz))
-        <= arc_radius + tolerance
+    let center = Point3D::new(cx, cy, cz);
+    crate::distance::ellipse3d_point3d_distance(ellipse, &center) <= arc_radius + tolerance
 }
 
 pub fn ellipse3d_line_segment3d_collides<T: Scalar + From<f64>>(
@@ -352,16 +333,15 @@ pub fn ellipse3d_line_segment3d_collides<T: Scalar + From<f64>>(
 ) -> bool {
     let s = segment.start();
     let e = segment.end();
-    let dist_start =
-        <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (s.x(), s.y(), s.z()));
-    let dist_end =
-        <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (e.x(), e.y(), e.z()));
+    let dist_start = crate::distance::ellipse3d_point3d_distance(ellipse, &s);
+    let dist_end = crate::distance::ellipse3d_point3d_distance(ellipse, &e);
     let two = T::from_f64(2.0);
-    let mid_x = (s.x() + e.x()) / two;
-    let mid_y = (s.y() + e.y()) / two;
-    let mid_z = (s.z() + e.z()) / two;
-    let dist_mid =
-        <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (mid_x, mid_y, mid_z));
+    let mid = Point3D::new(
+        (s.x() + e.x()) / two,
+        (s.y() + e.y()) / two,
+        (s.z() + e.z()) / two,
+    );
+    let dist_mid = crate::distance::ellipse3d_point3d_distance(ellipse, &mid);
     dist_start <= tolerance || dist_end <= tolerance || dist_mid <= tolerance
 }
 
@@ -371,7 +351,8 @@ pub fn ellipse3d_infinite_line3d_collides<T: Scalar + From<f64>>(
     tolerance: T,
 ) -> bool {
     let (px, py, pz) = line.point();
-    <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (px, py, pz)) <= tolerance
+    let point = Point3D::new(px, py, pz);
+    crate::distance::ellipse3d_point3d_distance(ellipse, &point) <= tolerance
 }
 
 pub fn ellipse3d_ray3d_collides<T: Scalar + From<f64>>(
@@ -380,8 +361,7 @@ pub fn ellipse3d_ray3d_collides<T: Scalar + From<f64>>(
     tolerance: T,
 ) -> bool {
     let o = ray.origin();
-    <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (o.x(), o.y(), o.z()))
-        <= tolerance
+    crate::distance::ellipse3d_point3d_distance(ellipse, &o) <= tolerance
 }
 
 pub fn ellipse3d_plane3d_collides<T: Scalar>(
@@ -401,17 +381,19 @@ pub fn ellipse3d_triangle3d_collides<T: Scalar + From<f64>>(
     let (ax, ay, az) = triangle.vertex_a();
     let (bx, by, bz) = triangle.vertex_b();
     let (cx, cy, cz) = triangle.vertex_c();
-    let dist_a = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (ax, ay, az));
-    let dist_b = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (bx, by, bz));
-    let dist_c = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (cx, cy, cz));
+    let point_a = Point3D::new(ax, ay, az);
+    let point_b = Point3D::new(bx, by, bz);
+    let point_c = Point3D::new(cx, cy, cz);
+    let dist_a = crate::distance::ellipse3d_point3d_distance(ellipse, &point_a);
+    let dist_b = crate::distance::ellipse3d_point3d_distance(ellipse, &point_b);
+    let dist_c = crate::distance::ellipse3d_point3d_distance(ellipse, &point_c);
     let three = T::from_f64(3.0);
-    let centroid_x = (ax + bx + cx) / three;
-    let centroid_y = (ay + by + cy) / three;
-    let centroid_z = (az + bz + cz) / three;
-    let dist_centroid = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(
-        ellipse,
-        (centroid_x, centroid_y, centroid_z),
+    let centroid = Point3D::new(
+        (ax + bx + cx) / three,
+        (ay + by + cy) / three,
+        (az + bz + cz) / three,
     );
+    let dist_centroid = crate::distance::ellipse3d_point3d_distance(ellipse, &centroid);
     dist_a <= tolerance || dist_b <= tolerance || dist_c <= tolerance || dist_centroid <= tolerance
 }
 

--- a/model/geo_algorithms/src/distance/primitive_3d.rs
+++ b/model/geo_algorithms/src/distance/primitive_3d.rs
@@ -6,9 +6,12 @@
 //! 命名規則: `{shape_a}_{shape_b}_distance`
 
 use crate::{
-    Circle3D, CylindricalSurface3D, InfiniteLine3D, LineSegment3D, Plane3D, Point3D, Ray3D,
+    Circle3D, CylindricalSolid3D, CylindricalSurface3D, Ellipse3D, InfiniteLine3D, LineSegment3D,
+    Plane3D, Point3D, Ray3D,
 };
-use geo_contracts::{CylindricalSurface3DDistance, Scalar};
+use geo_contracts::{
+    CylindricalSolid3DDistance, CylindricalSurface3DDistance, Ellipse3DDistance, Scalar,
+};
 
 /// LineSegment3D-点 間の最短距離（端点クランプあり）
 pub fn line_segment3d_point3d_distance<T: Scalar>(
@@ -78,6 +81,44 @@ pub fn circle3d_point3d_distance<T: Scalar>(circle: &Circle3D<T>, point: &Point3
 /// 逆向きラッパー: point-circle
 pub fn point3d_circle3d_distance<T: Scalar>(point: &Point3D<T>, circle: &Circle3D<T>) -> T {
     circle.distance_to_point_3d(*point)
+}
+
+/// Ellipse3D-点 間の最短距離
+pub fn ellipse3d_point3d_distance<T: Scalar + From<f64>>(
+    ellipse: &Ellipse3D<T>,
+    point: &Point3D<T>,
+) -> T {
+    <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(
+        ellipse,
+        (point.x(), point.y(), point.z()),
+    )
+}
+
+/// 逆向きラッパー: point-ellipse
+pub fn point3d_ellipse3d_distance<T: Scalar + From<f64>>(
+    point: &Point3D<T>,
+    ellipse: &Ellipse3D<T>,
+) -> T {
+    ellipse3d_point3d_distance(ellipse, point)
+}
+
+/// CylindricalSolid3D-点 間の最短距離
+pub fn cylindrical_solid3d_point3d_distance<T: Scalar>(
+    cyl: &CylindricalSolid3D<T>,
+    point: &Point3D<T>,
+) -> T {
+    <CylindricalSolid3D<T> as CylindricalSolid3DDistance<T>>::distance_to_point(
+        cyl,
+        (point.x(), point.y(), point.z()),
+    )
+}
+
+/// 逆向きラッパー: point-cylindrical_solid
+pub fn point3d_cylindrical_solid3d_distance<T: Scalar>(
+    point: &Point3D<T>,
+    cyl: &CylindricalSolid3D<T>,
+) -> T {
+    cylindrical_solid3d_point3d_distance(cyl, point)
 }
 
 /// CylindricalSurface3D-点 間の最短距離
@@ -194,6 +235,89 @@ mod tests {
             !intersection_cylindrical_surface_point_section
                 .contains(CYLINDRICAL_SURFACE_DIRECT_UFCS),
             "intersection/primitive_3d.rs must not call CylindricalSurface3DDistance::distance_to_point directly"
+        );
+    }
+
+    #[test]
+    fn cylindrical_solid_point_boundary_guard_keeps_collision_on_distance_entrypoint() {
+        const CYLINDRICAL_SOLID_DIRECT_UFCS: &str =
+            "<CylindricalSolid3D<T> as CylindricalSolid3DDistance<T>>::distance_to_point";
+        const CYLINDRICAL_SOLID_POINT_ENTRYPOINT: &str =
+            "crate::distance::cylindrical_solid3d_point3d_distance";
+
+        fn section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+            let start_index = source
+                .find(start)
+                .unwrap_or_else(|| panic!("missing start marker: {start}"));
+            let tail = &source[start_index..];
+            let end_index = tail
+                .find(end)
+                .unwrap_or_else(|| panic!("missing end marker: {end}"));
+            &tail[..end_index]
+        }
+
+        let collision_source = include_str!("../collision/primitive_3d.rs");
+        let collision_cylindrical_solid_point_section = section(
+            collision_source,
+            "pub fn cylindrical_solid3d_point3d_collides",
+            "pub fn cylindrical_solid3d_plane3d_collides",
+        );
+
+        assert!(
+            collision_cylindrical_solid_point_section.contains(CYLINDRICAL_SOLID_POINT_ENTRYPOINT),
+            "collision/primitive_3d.rs should route cylindrical solid point checks through the distance entrypoint"
+        );
+        assert!(
+            !collision_cylindrical_solid_point_section.contains(CYLINDRICAL_SOLID_DIRECT_UFCS),
+            "collision/primitive_3d.rs must not call CylindricalSolid3DDistance::distance_to_point directly"
+        );
+    }
+
+    #[test]
+    fn ellipse_point_boundary_guard_keeps_collision_and_intersection_on_distance_entrypoint() {
+        const ELLIPSE_DIRECT_UFCS: &str =
+            "<Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point";
+        const ELLIPSE_POINT_ENTRYPOINT: &str = "crate::distance::ellipse3d_point3d_distance";
+
+        fn section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+            let start_index = source
+                .find(start)
+                .unwrap_or_else(|| panic!("missing start marker: {start}"));
+            let tail = &source[start_index..];
+            let end_index = tail
+                .find(end)
+                .unwrap_or_else(|| panic!("missing end marker: {end}"));
+            &tail[..end_index]
+        }
+
+        let collision_source = include_str!("../collision/primitive_3d.rs");
+        let intersection_source = include_str!("../intersection/primitive_3d.rs");
+        let collision_ellipse_point_section = section(
+            collision_source,
+            "pub fn ellipse3d_point3d_collides",
+            "pub fn ellipse3d_plane3d_collides",
+        );
+        let intersection_ellipse_point_section = section(
+            intersection_source,
+            "fn ellipse3d_point3d_intersection_raw",
+            "fn ellipse3d_plane3d_intersection_raw",
+        );
+
+        assert!(
+            collision_ellipse_point_section.contains(ELLIPSE_POINT_ENTRYPOINT),
+            "collision/primitive_3d.rs should route ellipse point checks through the distance entrypoint"
+        );
+        assert!(
+            intersection_ellipse_point_section.contains(ELLIPSE_POINT_ENTRYPOINT),
+            "intersection/primitive_3d.rs should route ellipse point checks through the distance entrypoint"
+        );
+        assert!(
+            !collision_ellipse_point_section.contains(ELLIPSE_DIRECT_UFCS),
+            "collision/primitive_3d.rs must not call Ellipse3DDistance::distance_to_point directly"
+        );
+        assert!(
+            !intersection_ellipse_point_section.contains(ELLIPSE_DIRECT_UFCS),
+            "intersection/primitive_3d.rs must not call Ellipse3DDistance::distance_to_point directly"
         );
     }
 }

--- a/model/geo_algorithms/src/distance/primitive_3d.rs
+++ b/model/geo_algorithms/src/distance/primitive_3d.rs
@@ -5,8 +5,10 @@
 //!
 //! 命名規則: `{shape_a}_{shape_b}_distance`
 
-use crate::{Circle3D, InfiniteLine3D, LineSegment3D, Plane3D, Point3D, Ray3D};
-use geo_contracts::Scalar;
+use crate::{
+    Circle3D, CylindricalSurface3D, InfiniteLine3D, LineSegment3D, Plane3D, Point3D, Ray3D,
+};
+use geo_contracts::{CylindricalSurface3DDistance, Scalar};
 
 /// LineSegment3D-点 間の最短距離（端点クランプあり）
 pub fn line_segment3d_point3d_distance<T: Scalar>(
@@ -78,6 +80,25 @@ pub fn point3d_circle3d_distance<T: Scalar>(point: &Point3D<T>, circle: &Circle3
     circle.distance_to_point_3d(*point)
 }
 
+/// CylindricalSurface3D-点 間の最短距離
+pub fn cylindrical_surface3d_point3d_distance<T: Scalar>(
+    cyl: &CylindricalSurface3D<T>,
+    point: &Point3D<T>,
+) -> T {
+    <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
+        cyl,
+        (point.x(), point.y(), point.z()),
+    )
+}
+
+/// 逆向きラッパー: point-cylindrical_surface
+pub fn point3d_cylindrical_surface3d_distance<T: Scalar>(
+    point: &Point3D<T>,
+    cyl: &CylindricalSurface3D<T>,
+) -> T {
+    cylindrical_surface3d_point3d_distance(cyl, point)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,5 +142,58 @@ mod tests {
 
         let d = infinite_line3d_infinite_line3d_distance(&line_a, &line_b);
         assert!(d.abs() < tol);
+    }
+
+    #[test]
+    fn cylindrical_surface_point_boundary_guard_keeps_collision_and_intersection_on_distance_entrypoint(
+    ) {
+        const CYLINDRICAL_SURFACE_DIRECT_UFCS: &str =
+            "<CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point";
+        const CYLINDRICAL_SURFACE_POINT_ENTRYPOINT: &str =
+            "crate::distance::cylindrical_surface3d_point3d_distance";
+
+        fn section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+            let start_index = source
+                .find(start)
+                .unwrap_or_else(|| panic!("missing start marker: {start}"));
+            let tail = &source[start_index..];
+            let end_index = tail
+                .find(end)
+                .unwrap_or_else(|| panic!("missing end marker: {end}"));
+            &tail[..end_index]
+        }
+
+        let collision_source = include_str!("../collision/primitive_3d.rs");
+        let intersection_source = include_str!("../intersection/primitive_3d.rs");
+        let collision_cylindrical_surface_point_section = section(
+            collision_source,
+            "pub fn cylindrical_surface3d_point3d_collides",
+            "pub fn cylindrical_surface3d_plane3d_collides",
+        );
+        let intersection_cylindrical_surface_point_section = section(
+            intersection_source,
+            "fn cylindrical_surface3d_point3d_intersection_raw",
+            "fn cylindrical_surface3d_plane3d_intersection_raw",
+        );
+
+        assert!(
+            collision_cylindrical_surface_point_section
+                .contains(CYLINDRICAL_SURFACE_POINT_ENTRYPOINT),
+            "collision/primitive_3d.rs should route cylindrical surface point checks through the distance entrypoint"
+        );
+        assert!(
+            intersection_cylindrical_surface_point_section
+                .contains(CYLINDRICAL_SURFACE_POINT_ENTRYPOINT),
+            "intersection/primitive_3d.rs should route cylindrical surface point checks through the distance entrypoint"
+        );
+        assert!(
+            !collision_cylindrical_surface_point_section.contains(CYLINDRICAL_SURFACE_DIRECT_UFCS),
+            "collision/primitive_3d.rs must not call CylindricalSurface3DDistance::distance_to_point directly"
+        );
+        assert!(
+            !intersection_cylindrical_surface_point_section
+                .contains(CYLINDRICAL_SURFACE_DIRECT_UFCS),
+            "intersection/primitive_3d.rs must not call CylindricalSurface3DDistance::distance_to_point directly"
+        );
     }
 }

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -16,9 +16,9 @@ use crate::{
 use geo_contracts::{
     Arc3DDistance, Arc3DEndpoint, Arc3DProperties, Circle3DProperties, ConicalSolid3DContainment,
     ConicalSolid3DProperties, ConicalSurface3DProperties, CylindricalSurface3DDistance,
-    CylindricalSurface3DProperties, Ellipse3DDistance, EllipsoidalSolid3DProperties,
-    InfiniteLine3DProperties, Scalar, SphericalSolid3DProperties, SphericalSurface3DProperties,
-    TorusSurface3DDistance, Triangle3DBoundaryAccess,
+    CylindricalSurface3DProperties, EllipsoidalSolid3DProperties, InfiniteLine3DProperties, Scalar,
+    SphericalSolid3DProperties, SphericalSurface3DProperties, TorusSurface3DDistance,
+    Triangle3DBoundaryAccess,
 };
 
 fn point_intersection_if<T: Scalar>(point: &Point3D<T>, condition: bool) -> Option<Point3D<T>> {
@@ -563,10 +563,7 @@ fn ellipse3d_point3d_intersection_raw<T: Scalar + From<f64>>(
 ) -> Option<Point3D<T>> {
     point_intersection_if(
         point,
-        <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(
-            ellipse,
-            (point.x(), point.y(), point.z()),
-        ) <= tolerance,
+        crate::distance::ellipse3d_point3d_distance(ellipse, point) <= tolerance,
     )
 }
 
@@ -588,9 +585,10 @@ pub fn ellipse3d_circle3d_intersections<T: Scalar + From<f64>>(
     tolerance: T,
 ) -> IntersectionResult<T> {
     let (cx, cy, cz) = Circle3DProperties::center(circle);
-    let dist = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (cx, cy, cz));
+    let center = Point3D::new(cx, cy, cz);
+    let dist = crate::distance::ellipse3d_point3d_distance(ellipse, &center);
     let points = if dist <= Circle3DProperties::radius(circle) + tolerance {
-        vec![Point3D::new(cx, cy, cz)]
+        vec![center]
     } else {
         Vec::new()
     };
@@ -603,9 +601,10 @@ pub fn ellipse3d_arc3d_intersections<T: Scalar + From<f64>>(
     tolerance: T,
 ) -> IntersectionResult<T> {
     let (cx, cy, cz) = Arc3DProperties::center(arc);
-    let dist = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (cx, cy, cz));
+    let center = Point3D::new(cx, cy, cz);
+    let dist = crate::distance::ellipse3d_point3d_distance(ellipse, &center);
     let points = if dist <= Arc3DProperties::radius(arc) + tolerance {
-        vec![Point3D::new(cx, cy, cz)]
+        vec![center]
     } else {
         Vec::new()
     };
@@ -620,18 +619,10 @@ pub fn ellipse3d_line_segment3d_intersections<T: Scalar + From<f64>>(
     let start = segment.start();
     let end = segment.end();
     let mut intersections = Vec::new();
-    if <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(
-        ellipse,
-        (start.x(), start.y(), start.z()),
-    ) <= tolerance
-    {
+    if crate::distance::ellipse3d_point3d_distance(ellipse, &start) <= tolerance {
         intersections.push(start);
     }
-    if <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(
-        ellipse,
-        (end.x(), end.y(), end.z()),
-    ) <= tolerance
-    {
+    if crate::distance::ellipse3d_point3d_distance(ellipse, &end) <= tolerance {
         intersections.push(end);
     }
     IntersectionResult::from_option_points(intersections, false, tolerance)
@@ -643,9 +634,10 @@ pub fn ellipse3d_infinite_line3d_intersections<T: Scalar + From<f64>>(
     tolerance: T,
 ) -> IntersectionResult<T> {
     let (px, py, pz) = InfiniteLine3DProperties::point(line);
-    let dist = <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (px, py, pz));
+    let point = Point3D::new(px, py, pz);
+    let dist = crate::distance::ellipse3d_point3d_distance(ellipse, &point);
     let points = if dist <= tolerance {
-        vec![Point3D::new(px, py, pz)]
+        vec![point]
     } else {
         Vec::new()
     };
@@ -658,8 +650,7 @@ pub fn ellipse3d_ray3d_intersections<T: Scalar + From<f64>>(
     tolerance: T,
 ) -> IntersectionResult<T> {
     let o = ray.origin();
-    let dist =
-        <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (o.x(), o.y(), o.z()));
+    let dist = crate::distance::ellipse3d_point3d_distance(ellipse, &o);
     let points = if dist <= tolerance {
         vec![o]
     } else {
@@ -702,17 +693,17 @@ pub fn ellipse3d_triangle3d_intersections<T: Scalar + From<f64>>(
     let (bx, by, bz) = Triangle3DBoundaryAccess::vertex_b(triangle);
     let (cx, cy, cz) = Triangle3DBoundaryAccess::vertex_c(triangle);
     let mut intersections = Vec::new();
-    if <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (ax, ay, az)) <= tolerance
-    {
-        intersections.push(Point3D::new(ax, ay, az));
+    let point_a = Point3D::new(ax, ay, az);
+    let point_b = Point3D::new(bx, by, bz);
+    let point_c = Point3D::new(cx, cy, cz);
+    if crate::distance::ellipse3d_point3d_distance(ellipse, &point_a) <= tolerance {
+        intersections.push(point_a);
     }
-    if <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (bx, by, bz)) <= tolerance
-    {
-        intersections.push(Point3D::new(bx, by, bz));
+    if crate::distance::ellipse3d_point3d_distance(ellipse, &point_b) <= tolerance {
+        intersections.push(point_b);
     }
-    if <Ellipse3D<T> as Ellipse3DDistance<T>>::distance_to_point(ellipse, (cx, cy, cz)) <= tolerance
-    {
-        intersections.push(Point3D::new(cx, cy, cz));
+    if crate::distance::ellipse3d_point3d_distance(ellipse, &point_c) <= tolerance {
+        intersections.push(point_c);
     }
     IntersectionResult::from_option_points(intersections, false, tolerance)
 }

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -359,10 +359,7 @@ fn cylindrical_surface3d_point3d_intersection_raw<T: Scalar>(
 ) -> Option<Point3D<T>> {
     point_intersection_if(
         point,
-        <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-            cyl,
-            (point.x(), point.y(), point.z()),
-        ) <= tolerance,
+        crate::distance::cylindrical_surface3d_point3d_distance(cyl, point) <= tolerance,
     )
 }
 
@@ -384,12 +381,10 @@ fn cylindrical_surface3d_circle3d_intersection_raw<T: Scalar>(
     tolerance: T,
 ) -> Option<Point3D<T>> {
     let (cx, cy, cz) = Circle3DProperties::center(circle);
-    let dist = <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-        cyl,
-        (cx, cy, cz),
-    );
+    let center = Point3D::new(cx, cy, cz);
+    let dist = crate::distance::cylindrical_surface3d_point3d_distance(cyl, &center);
     if dist <= Circle3DProperties::radius(circle) + tolerance {
-        Some(Point3D::new(cx, cy, cz))
+        Some(center)
     } else {
         None
     }
@@ -414,17 +409,9 @@ fn cylindrical_surface3d_line_segment3d_intersection_raw<T: Scalar>(
 ) -> Option<Point3D<T>> {
     let s = segment.start();
     let e = segment.end();
-    if <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-        cyl,
-        (s.x(), s.y(), s.z()),
-    ) <= tolerance
-    {
+    if crate::distance::cylindrical_surface3d_point3d_distance(cyl, &s) <= tolerance {
         Some(s)
-    } else if <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-        cyl,
-        (e.x(), e.y(), e.z()),
-    ) <= tolerance
-    {
+    } else if crate::distance::cylindrical_surface3d_point3d_distance(cyl, &e) <= tolerance {
         Some(e)
     } else {
         None
@@ -451,24 +438,15 @@ fn cylindrical_surface3d_triangle3d_intersection_raw<T: Scalar>(
     let (ax, ay, az) = Triangle3DBoundaryAccess::vertex_a(triangle);
     let (bx, by, bz) = Triangle3DBoundaryAccess::vertex_b(triangle);
     let (cx, cy, cz) = Triangle3DBoundaryAccess::vertex_c(triangle);
-    if <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-        cyl,
-        (ax, ay, az),
-    ) <= tolerance
-    {
-        Some(Point3D::new(ax, ay, az))
-    } else if <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-        cyl,
-        (bx, by, bz),
-    ) <= tolerance
-    {
-        Some(Point3D::new(bx, by, bz))
-    } else if <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-        cyl,
-        (cx, cy, cz),
-    ) <= tolerance
-    {
-        Some(Point3D::new(cx, cy, cz))
+    let point_a = Point3D::new(ax, ay, az);
+    let point_b = Point3D::new(bx, by, bz);
+    let point_c = Point3D::new(cx, cy, cz);
+    if crate::distance::cylindrical_surface3d_point3d_distance(cyl, &point_a) <= tolerance {
+        Some(point_a)
+    } else if crate::distance::cylindrical_surface3d_point3d_distance(cyl, &point_b) <= tolerance {
+        Some(point_b)
+    } else if crate::distance::cylindrical_surface3d_point3d_distance(cyl, &point_c) <= tolerance {
+        Some(point_c)
     } else {
         None
     }


### PR DESCRIPTION
## 概要

#371 の Phase1 として、`geo_algorithms` の Point/Tuple 境界整理を最小スライスで段階適用します。

今回の PR では、`primitive_3d` 全体を一気に再編せず、Point 型を正本とする距離 entrypoint を追加し、代表的な collision / intersection 経路をそこへ寄せるところまでに限定しています。

## 変更内容

- `dev/architecture/GEO_ALGORITHMS_MODULE_STRUCTURE_RULES.md` に Point/Tuple 境界の段階移行方針を追記
- `distance/primitive_3d.rs` に Point ベース distance entrypoint を追加
  - `cylindrical_surface3d_point3d_distance`
  - `cylindrical_solid3d_point3d_distance`
  - `ellipse3d_point3d_distance`
- `collision/primitive_3d.rs` の代表 section を Point ベース entrypoint 経由へ寄せる
- `intersection/primitive_3d.rs` の representative な ellipse / cylindrical surface section を Point ベース entrypoint 経由へ寄せる
- source ベースの static guard test を追加し、対象 section が UFCS + tuple 直渡しへ戻らないことを監視

## スコープ外

- `primitive_3d.rs` の shape family 分割
- 区切り線コメント整理
- shape family 横断 helper の一般化
- #371 全体の一括完了

上記は follow-up として別 Issue #654 で扱います。

## 検証

- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo test --workspace`
- `./scripts/check_architecture_dependencies_simple.ps1`

## 進め方

#371 は同一 Issue に対して複数 PR で段階実装する前提とし、本 PR はその Phase1 です。