### PR TITLE
refactor(#371): Phase2 Point境界をarc/torus surface/conical solidへ拡張

### DIFF
--- a/model/geo_algorithms/src/collision/primitive_3d.rs
+++ b/model/geo_algorithms/src/collision/primitive_3d.rs
@@ -12,10 +12,10 @@ use crate::{
     SphericalSurface3D, TorusSolid3D, TorusSurface3D, Triangle3D, TriangleMesh3D,
 };
 use geo_contracts::{
-    Arc3DDistance, Arc3DEndpoint, Arc3DProperties, Circle3DProperties,
-    CylindricalSolid3DProperties, CylindricalSurface3DProperties, EllipsoidalSolid3DProperties,
-    InfiniteLine3DProperties, Scalar, SphericalSolid3DProperties, SphericalSurface3DProperties,
-    TorusSurface3DDistance, Triangle3DBoundaryAccess,
+    Arc3DEndpoint, Arc3DProperties, Circle3DProperties, CylindricalSolid3DProperties,
+    CylindricalSurface3DProperties, EllipsoidalSolid3DProperties, InfiniteLine3DProperties, Scalar,
+    SphericalSolid3DProperties, SphericalSurface3DProperties, TorusSurface3DDistance,
+    Triangle3DBoundaryAccess,
 };
 
 // ── SphericalSolid3D ──────────────────────────────────────────────────────────
@@ -621,8 +621,7 @@ pub fn triangle_mesh3d_point3d_collides<T: Scalar>(
 // ── Arc3D ─────────────────────────────────────────────────────────────────────
 
 pub fn arc3d_point3d_collides<T: Scalar>(arc: &Arc3D<T>, point: &Point3D<T>, tolerance: T) -> bool {
-    <Arc3D<T> as Arc3DDistance<T>>::distance_to_point(arc, (point.x(), point.y(), point.z()))
-        <= tolerance
+    crate::distance::arc3d_point3d_distance(arc, point) <= tolerance
         && arc.contains_point_angle(Point3D::new(point.x(), point.y(), point.z()))
 }
 
@@ -635,18 +634,8 @@ pub fn arc3d_line_segment3d_collides<T: Scalar>(
     let (ex, ey, ez) = <Arc3D<T> as Arc3DEndpoint<T>>::end_point(arc);
     let arc_start = Point3D::new(sx, sy, sz);
     let arc_end = Point3D::new(ex, ey, ez);
-    <Arc3D<T> as Arc3DDistance<T>>::distance_to_point(
-        arc,
-        (
-            segment.start().x(),
-            segment.start().y(),
-            segment.start().z(),
-        ),
-    ) <= tolerance
-        || <Arc3D<T> as Arc3DDistance<T>>::distance_to_point(
-            arc,
-            (segment.end().x(), segment.end().y(), segment.end().z()),
-        ) <= tolerance
+    crate::distance::arc3d_point3d_distance(arc, &segment.start()) <= tolerance
+        || crate::distance::arc3d_point3d_distance(arc, &segment.end()) <= tolerance
         || {
             let d1 = crate::Vector3D::from_points(&arc_start, &segment.start()).magnitude();
             let d2 = crate::Vector3D::from_points(&arc_end, &segment.start()).magnitude();
@@ -655,10 +644,7 @@ pub fn arc3d_line_segment3d_collides<T: Scalar>(
 }
 
 pub fn arc3d_ray3d_collides<T: Scalar>(arc: &Arc3D<T>, ray: &Ray3D<T>, tolerance: T) -> bool {
-    <Arc3D<T> as Arc3DDistance<T>>::distance_to_point(
-        arc,
-        (ray.origin().x(), ray.origin().y(), ray.origin().z()),
-    ) <= tolerance
+    crate::distance::arc3d_point3d_distance(arc, &ray.origin()) <= tolerance
 }
 
 pub fn arc3d_infinite_line3d_collides<T: Scalar>(
@@ -667,7 +653,7 @@ pub fn arc3d_infinite_line3d_collides<T: Scalar>(
     tolerance: T,
 ) -> bool {
     let (px, py, pz) = line.point();
-    <Arc3D<T> as Arc3DDistance<T>>::distance_to_point(arc, (px, py, pz)) <= tolerance
+    crate::distance::arc3d_point3d_distance(arc, &Point3D::new(px, py, pz)) <= tolerance
 }
 
 pub fn arc3d_arc3d_collides<T: Scalar>(arc_a: &Arc3D<T>, arc_b: &Arc3D<T>, tolerance: T) -> bool {

--- a/model/geo_algorithms/src/collision/primitive_3d.rs
+++ b/model/geo_algorithms/src/collision/primitive_3d.rs
@@ -14,8 +14,7 @@ use crate::{
 use geo_contracts::{
     Arc3DEndpoint, Arc3DProperties, Circle3DProperties, CylindricalSolid3DProperties,
     CylindricalSurface3DProperties, EllipsoidalSolid3DProperties, InfiniteLine3DProperties, Scalar,
-    SphericalSolid3DProperties, SphericalSurface3DProperties, TorusSurface3DDistance,
-    Triangle3DBoundaryAccess,
+    SphericalSolid3DProperties, SphericalSurface3DProperties, Triangle3DBoundaryAccess,
 };
 
 // ── SphericalSolid3D ──────────────────────────────────────────────────────────
@@ -536,10 +535,7 @@ pub fn torus_surface3d_point3d_collides<T: Scalar>(
     point: &Point3D<T>,
     tolerance: T,
 ) -> bool {
-    <TorusSurface3D<T> as TorusSurface3DDistance<T>>::distance_to_point(
-        torus,
-        (point.x(), point.y(), point.z()),
-    ) <= tolerance
+    crate::distance::torus_surface3d_point3d_distance(torus, point) <= tolerance
 }
 
 // ── Triangle3D ────────────────────────────────────────────────────────────────

--- a/model/geo_algorithms/src/collision/primitive_3d.rs
+++ b/model/geo_algorithms/src/collision/primitive_3d.rs
@@ -24,7 +24,7 @@ pub fn spherical_solid3d_point3d_collides<T: Scalar>(
     point: &Point3D<T>,
     tolerance: T,
 ) -> bool {
-    sphere.distance_to_surface(Point3D::new(point.x(), point.y(), point.z())) <= tolerance
+    sphere.distance_to_surface(*point) <= tolerance
 }
 
 pub fn spherical_solid3d_circle3d_collides<T: Scalar>(
@@ -674,7 +674,7 @@ pub fn circle3d_point3d_collides<T: Scalar>(
     point: &Point3D<T>,
     tolerance: T,
 ) -> bool {
-    circle.distance_to_point_3d(Point3D::new(point.x(), point.y(), point.z())) <= tolerance
+    crate::distance::circle3d_point3d_distance(circle, point) <= tolerance
 }
 
 pub fn circle3d_line_segment3d_collides<T: Scalar>(
@@ -729,7 +729,7 @@ pub fn plane3d_point3d_collides<T: Scalar>(
     point: &Point3D<T>,
     tolerance: T,
 ) -> bool {
-    plane.contains_point(Point3D::new(point.x(), point.y(), point.z()), tolerance)
+    plane.contains_point(*point, tolerance)
 }
 
 pub fn plane3d_line_segment3d_collides<T: Scalar>(

--- a/model/geo_algorithms/src/distance/primitive_3d.rs
+++ b/model/geo_algorithms/src/distance/primitive_3d.rs
@@ -7,11 +7,11 @@
 
 use crate::{
     Arc3D, Circle3D, CylindricalSolid3D, CylindricalSurface3D, Ellipse3D, InfiniteLine3D,
-    LineSegment3D, Plane3D, Point3D, Ray3D,
+    LineSegment3D, Plane3D, Point3D, Ray3D, TorusSurface3D,
 };
 use geo_contracts::{
     Arc3DDistance, CylindricalSolid3DDistance, CylindricalSurface3DDistance, Ellipse3DDistance,
-    Scalar,
+    Scalar, TorusSurface3DDistance,
 };
 
 /// LineSegment3D-点 間の最短距離（端点クランプあり）
@@ -82,6 +82,25 @@ pub fn arc3d_point3d_distance<T: Scalar>(arc: &Arc3D<T>, point: &Point3D<T>) -> 
 /// 逆向きラッパー: point-arc
 pub fn point3d_arc3d_distance<T: Scalar>(point: &Point3D<T>, arc: &Arc3D<T>) -> T {
     arc3d_point3d_distance(arc, point)
+}
+
+/// TorusSurface3D-点 間の最短距離
+pub fn torus_surface3d_point3d_distance<T: Scalar>(
+    torus: &TorusSurface3D<T>,
+    point: &Point3D<T>,
+) -> T {
+    <TorusSurface3D<T> as TorusSurface3DDistance<T>>::distance_to_point(
+        torus,
+        (point.x(), point.y(), point.z()),
+    )
+}
+
+/// 逆向きラッパー: point-torus_surface
+pub fn point3d_torus_surface3d_distance<T: Scalar>(
+    point: &Point3D<T>,
+    torus: &TorusSurface3D<T>,
+) -> T {
+    torus_surface3d_point3d_distance(torus, point)
 }
 
 /// Circle3D-点 間の最短距離（円周への3D空間での距離）
@@ -376,6 +395,56 @@ mod tests {
         assert!(
             !intersection_arc_point_section.contains(ARC_DIRECT_UFCS),
             "intersection/primitive_3d.rs must not call Arc3DDistance::distance_to_point directly"
+        );
+    }
+
+    #[test]
+    fn torus_surface_point_boundary_guard_keeps_collision_and_intersection_on_distance_entrypoint()
+    {
+        const TORUS_SURFACE_DIRECT_UFCS: &str =
+            "<TorusSurface3D<T> as TorusSurface3DDistance<T>>::distance_to_point";
+        const TORUS_SURFACE_POINT_ENTRYPOINT: &str =
+            "crate::distance::torus_surface3d_point3d_distance";
+
+        fn section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+            let start_index = source
+                .find(start)
+                .unwrap_or_else(|| panic!("missing start marker: {start}"));
+            let tail = &source[start_index..];
+            let end_index = tail
+                .find(end)
+                .unwrap_or_else(|| panic!("missing end marker: {end}"));
+            &tail[..end_index]
+        }
+
+        let collision_source = include_str!("../collision/primitive_3d.rs");
+        let intersection_source = include_str!("../intersection/primitive_3d.rs");
+        let collision_torus_surface_point_section = section(
+            collision_source,
+            "pub fn torus_surface3d_point3d_collides",
+            "pub fn triangle3d_point3d_collides",
+        );
+        let intersection_torus_surface_point_section = section(
+            intersection_source,
+            "fn torus_surface3d_point3d_intersection_raw",
+            "fn triangle3d_point3d_intersection_raw",
+        );
+
+        assert!(
+            collision_torus_surface_point_section.contains(TORUS_SURFACE_POINT_ENTRYPOINT),
+            "collision/primitive_3d.rs should route torus surface point checks through the distance entrypoint"
+        );
+        assert!(
+            intersection_torus_surface_point_section.contains(TORUS_SURFACE_POINT_ENTRYPOINT),
+            "intersection/primitive_3d.rs should route torus surface point checks through the distance entrypoint"
+        );
+        assert!(
+            !collision_torus_surface_point_section.contains(TORUS_SURFACE_DIRECT_UFCS),
+            "collision/primitive_3d.rs must not call TorusSurface3DDistance::distance_to_point directly"
+        );
+        assert!(
+            !intersection_torus_surface_point_section.contains(TORUS_SURFACE_DIRECT_UFCS),
+            "intersection/primitive_3d.rs must not call TorusSurface3DDistance::distance_to_point directly"
         );
     }
 }

--- a/model/geo_algorithms/src/distance/primitive_3d.rs
+++ b/model/geo_algorithms/src/distance/primitive_3d.rs
@@ -6,11 +6,12 @@
 //! 命名規則: `{shape_a}_{shape_b}_distance`
 
 use crate::{
-    Circle3D, CylindricalSolid3D, CylindricalSurface3D, Ellipse3D, InfiniteLine3D, LineSegment3D,
-    Plane3D, Point3D, Ray3D,
+    Arc3D, Circle3D, CylindricalSolid3D, CylindricalSurface3D, Ellipse3D, InfiniteLine3D,
+    LineSegment3D, Plane3D, Point3D, Ray3D,
 };
 use geo_contracts::{
-    CylindricalSolid3DDistance, CylindricalSurface3DDistance, Ellipse3DDistance, Scalar,
+    Arc3DDistance, CylindricalSolid3DDistance, CylindricalSurface3DDistance, Ellipse3DDistance,
+    Scalar,
 };
 
 /// LineSegment3D-点 間の最短距離（端点クランプあり）
@@ -71,6 +72,16 @@ pub fn ray3d_point3d_distance<T: Scalar>(ray: &Ray3D<T>, point: &Point3D<T>) -> 
 /// 逆向きラッパー: point-ray
 pub fn point3d_ray3d_distance<T: Scalar>(point: &Point3D<T>, ray: &Ray3D<T>) -> T {
     ray.distance_to_point(point)
+}
+
+/// Arc3D-点 間の最短距離
+pub fn arc3d_point3d_distance<T: Scalar>(arc: &Arc3D<T>, point: &Point3D<T>) -> T {
+    <Arc3D<T> as Arc3DDistance<T>>::distance_to_point(arc, (point.x(), point.y(), point.z()))
+}
+
+/// 逆向きラッパー: point-arc
+pub fn point3d_arc3d_distance<T: Scalar>(point: &Point3D<T>, arc: &Arc3D<T>) -> T {
+    arc3d_point3d_distance(arc, point)
 }
 
 /// Circle3D-点 間の最短距離（円周への3D空間での距離）
@@ -318,6 +329,53 @@ mod tests {
         assert!(
             !intersection_ellipse_point_section.contains(ELLIPSE_DIRECT_UFCS),
             "intersection/primitive_3d.rs must not call Ellipse3DDistance::distance_to_point directly"
+        );
+    }
+
+    #[test]
+    fn arc_point_boundary_guard_keeps_collision_and_intersection_on_distance_entrypoint() {
+        const ARC_DIRECT_UFCS: &str = "<Arc3D<T> as Arc3DDistance<T>>::distance_to_point";
+        const ARC_POINT_ENTRYPOINT: &str = "crate::distance::arc3d_point3d_distance";
+
+        fn section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+            let start_index = source
+                .find(start)
+                .unwrap_or_else(|| panic!("missing start marker: {start}"));
+            let tail = &source[start_index..];
+            let end_index = tail
+                .find(end)
+                .unwrap_or_else(|| panic!("missing end marker: {end}"));
+            &tail[..end_index]
+        }
+
+        let collision_source = include_str!("../collision/primitive_3d.rs");
+        let intersection_source = include_str!("../intersection/primitive_3d.rs");
+        let collision_arc_point_section = section(
+            collision_source,
+            "pub fn arc3d_point3d_collides",
+            "pub fn circle3d_point3d_collides",
+        );
+        let intersection_arc_point_section = section(
+            intersection_source,
+            "fn arc3d_point3d_intersection_raw",
+            "fn circle3d_point3d_intersection_raw",
+        );
+
+        assert!(
+            collision_arc_point_section.contains(ARC_POINT_ENTRYPOINT),
+            "collision/primitive_3d.rs should route arc point checks through the distance entrypoint"
+        );
+        assert!(
+            intersection_arc_point_section.contains(ARC_POINT_ENTRYPOINT),
+            "intersection/primitive_3d.rs should route arc point checks through the distance entrypoint"
+        );
+        assert!(
+            !collision_arc_point_section.contains(ARC_DIRECT_UFCS),
+            "collision/primitive_3d.rs must not call Arc3DDistance::distance_to_point directly"
+        );
+        assert!(
+            !intersection_arc_point_section.contains(ARC_DIRECT_UFCS),
+            "intersection/primitive_3d.rs must not call Arc3DDistance::distance_to_point directly"
         );
     }
 }

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -37,6 +37,18 @@ fn point_matches_either_segment_endpoint<T: Scalar>(
         || point.distance_to(&segment.end()) <= tolerance
 }
 
+fn conical_solid3d_contains_point_with_tolerance<T: Scalar>(
+    cone: &ConicalSolid3D<T>,
+    point: &Point3D<T>,
+    tolerance: T,
+) -> bool {
+    ConicalSolid3DContainment::contains_point_tolerance(
+        cone,
+        (point.x(), point.y(), point.z()),
+        tolerance,
+    )
+}
+
 fn spherical_surface_intersection_parameters<T: Scalar>(
     start: &Point3D<T>,
     direction: &crate::Vector3D<T>,
@@ -812,11 +824,7 @@ fn conical_solid3d_point3d_intersection_raw<T: Scalar>(
 ) -> Option<Point3D<T>> {
     point_intersection_if(
         point,
-        ConicalSolid3DContainment::contains_point_tolerance(
-            cone,
-            (point.x(), point.y(), point.z()),
-            tolerance,
-        ),
+        conical_solid3d_contains_point_with_tolerance(cone, point, tolerance),
     )
 }
 
@@ -841,7 +849,7 @@ fn conical_solid3d_line3d_intersection_raw<T: Scalar>(
     let point_on_line = Point3D::new(px, py, pz);
     point_intersection_if(
         &point_on_line,
-        ConicalSolid3DContainment::contains_point_tolerance(cone, (px, py, pz), tolerance),
+        conical_solid3d_contains_point_with_tolerance(cone, &point_on_line, tolerance),
     )
 }
 
@@ -865,11 +873,7 @@ fn conical_solid3d_ray3d_intersection_raw<T: Scalar>(
     let origin = ray.origin();
     point_intersection_if(
         &origin,
-        ConicalSolid3DContainment::contains_point_tolerance(
-            cone,
-            (origin.x(), origin.y(), origin.z()),
-            tolerance,
-        ),
+        conical_solid3d_contains_point_with_tolerance(cone, &origin, tolerance),
     )
 }
 
@@ -893,11 +897,7 @@ fn conical_solid3d_line_segment3d_intersection_raw<T: Scalar>(
     let start = segment.start();
     point_intersection_if(
         &start,
-        ConicalSolid3DContainment::contains_point_tolerance(
-            cone,
-            (start.x(), start.y(), start.z()),
-            tolerance,
-        ),
+        conical_solid3d_contains_point_with_tolerance(cone, &start, tolerance),
     )
 }
 
@@ -2665,5 +2665,39 @@ mod tests {
             panic!("Expected IntersectionGeometry::Point for crossing");
         }
         assert_eq!(disjoint.topology, IntersectionTopology::Disjoint);
+    }
+
+    #[test]
+    fn conical_solid_point_boundary_guard_keeps_intersection_on_point_helper() {
+        const CONICAL_SOLID_DIRECT_CONTAINMENT: &str =
+            "ConicalSolid3DContainment::contains_point_tolerance";
+        const CONICAL_SOLID_POINT_HELPER: &str = "conical_solid3d_contains_point_with_tolerance";
+
+        fn section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+            let start_index = source
+                .find(start)
+                .unwrap_or_else(|| panic!("missing start marker: {start}"));
+            let tail = &source[start_index..];
+            let end_index = tail
+                .find(end)
+                .unwrap_or_else(|| panic!("missing end marker: {end}"));
+            &tail[..end_index]
+        }
+
+        let source = include_str!("primitive_3d.rs");
+        let conical_solid_point_section = section(
+            source,
+            "fn conical_solid3d_point3d_intersection_raw",
+            "fn conical_surface3d_intersect_params",
+        );
+
+        assert!(
+            conical_solid_point_section.contains(CONICAL_SOLID_POINT_HELPER),
+            "intersection/primitive_3d.rs should route conical solid point-like checks through the point helper"
+        );
+        assert!(
+            !conical_solid_point_section.contains(CONICAL_SOLID_DIRECT_CONTAINMENT),
+            "intersection/primitive_3d.rs must not call ConicalSolid3DContainment::contains_point_tolerance directly in the representative conical solid section"
+        );
     }
 }

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -14,7 +14,7 @@ use crate::{
     Triangle3D, TriangleMesh3D,
 };
 use geo_contracts::{
-    Arc3DDistance, Arc3DEndpoint, Arc3DProperties, Circle3DProperties, ConicalSolid3DContainment,
+    Arc3DEndpoint, Arc3DProperties, Circle3DProperties, ConicalSolid3DContainment,
     ConicalSolid3DProperties, ConicalSurface3DProperties, CylindricalSurface3DDistance,
     CylindricalSurface3DProperties, EllipsoidalSolid3DProperties, InfiniteLine3DProperties, Scalar,
     SphericalSolid3DProperties, SphericalSurface3DProperties, TorusSurface3DDistance,
@@ -76,10 +76,9 @@ fn arc3d_point3d_intersection_raw<T: Scalar>(
     point: &Point3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    let point_tuple = (point.x(), point.y(), point.z());
     point_intersection_if(
         point,
-        <Arc3D<T> as Arc3DDistance<T>>::distance_to_point(arc, point_tuple) <= tolerance
+        crate::distance::arc3d_point3d_distance(arc, point) <= tolerance
             && arc.contains_point_angle(Point3D::new(point.x(), point.y(), point.z())),
     )
 }
@@ -105,18 +104,8 @@ fn arc3d_line_segment3d_intersection_raw<T: Scalar>(
     let (ex, ey, ez) = <Arc3D<T> as Arc3DEndpoint<T>>::end_point(arc);
     let arc_start = Point3D::new(sx, sy, sz);
     let arc_end = Point3D::new(ex, ey, ez);
-    let d_seg_s = <Arc3D<T> as Arc3DDistance<T>>::distance_to_point(
-        arc,
-        (
-            segment.start().x(),
-            segment.start().y(),
-            segment.start().z(),
-        ),
-    );
-    let d_seg_e = <Arc3D<T> as Arc3DDistance<T>>::distance_to_point(
-        arc,
-        (segment.end().x(), segment.end().y(), segment.end().z()),
-    );
+    let d_seg_s = crate::distance::arc3d_point3d_distance(arc, &segment.start());
+    let d_seg_e = crate::distance::arc3d_point3d_distance(arc, &segment.end());
     if d_seg_s <= tolerance {
         return Some(segment.start());
     }
@@ -150,10 +139,7 @@ fn arc3d_ray3d_intersection_raw<T: Scalar>(
     tolerance: T,
 ) -> Option<Point3D<T>> {
     let origin = ray.origin();
-    let d = <Arc3D<T> as Arc3DDistance<T>>::distance_to_point(
-        arc,
-        (origin.x(), origin.y(), origin.z()),
-    );
+    let d = crate::distance::arc3d_point3d_distance(arc, &origin);
     if d <= tolerance {
         Some(origin)
     } else {
@@ -180,7 +166,7 @@ fn arc3d_infinite_line3d_intersection_raw<T: Scalar>(
 ) -> Option<Point3D<T>> {
     let (px, py, pz) = InfiniteLine3DProperties::point(line);
     let pt = Point3D::new(px, py, pz);
-    let d = <Arc3D<T> as Arc3DDistance<T>>::distance_to_point(arc, (px, py, pz));
+    let d = crate::distance::arc3d_point3d_distance(arc, &pt);
     if d <= tolerance {
         Some(pt)
     } else {

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -246,7 +246,7 @@ fn circle3d_point3d_intersection_raw<T: Scalar>(
 ) -> Option<Point3D<T>> {
     point_intersection_if(
         point,
-        circle.distance_to_point_3d(Point3D::new(point.x(), point.y(), point.z())) <= tolerance,
+        crate::distance::circle3d_point3d_distance(circle, point) <= tolerance,
     )
 }
 
@@ -1492,10 +1492,7 @@ fn plane3d_point3d_intersection_raw<T: Scalar>(
     point: &Point3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    point_intersection_if(
-        point,
-        plane.contains_point(Point3D::new(point.x(), point.y(), point.z()), tolerance),
-    )
+    point_intersection_if(point, plane.contains_point(*point, tolerance))
 }
 
 pub fn plane3d_point3d_intersection<T: Scalar>(

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -17,8 +17,7 @@ use geo_contracts::{
     Arc3DEndpoint, Arc3DProperties, Circle3DProperties, ConicalSolid3DContainment,
     ConicalSolid3DProperties, ConicalSurface3DProperties, CylindricalSurface3DDistance,
     CylindricalSurface3DProperties, EllipsoidalSolid3DProperties, InfiniteLine3DProperties, Scalar,
-    SphericalSolid3DProperties, SphericalSurface3DProperties, TorusSurface3DDistance,
-    Triangle3DBoundaryAccess,
+    SphericalSolid3DProperties, SphericalSurface3DProperties, Triangle3DBoundaryAccess,
 };
 
 fn point_intersection_if<T: Scalar>(point: &Point3D<T>, condition: bool) -> Option<Point3D<T>> {
@@ -1305,10 +1304,7 @@ fn torus_surface3d_point3d_intersection_raw<T: Scalar>(
 ) -> Option<Point3D<T>> {
     point_intersection_if(
         point,
-        <TorusSurface3D<T> as TorusSurface3DDistance<T>>::distance_to_point(
-            torus,
-            (point.x(), point.y(), point.z()),
-        ) <= tolerance,
+        crate::distance::torus_surface3d_point3d_distance(torus, point) <= tolerance,
     )
 }
 


### PR DESCRIPTION
## 概要

#371 の Phase 2 として、`geo_algorithms` の Point/Tuple 境界整理を `primitive_3d` の追加 family へ段階適用します。

対象:
- Arc 系の point 系 collision/intersection 経路
- TorusSurface 系の point 系 collision/intersection 経路
- ConicalSolid 系の representative な point/line/ray/segment intersection 経路
- representative な point 判定での不要な `Point3D` 再構築の整理

## 変更内容

- `model/geo_algorithms/src/distance/primitive_3d.rs`
  - `arc3d_point3d_distance` / `point3d_arc3d_distance` を追加
  - `torus_surface3d_point3d_distance` / `point3d_torus_surface3d_distance` を追加
  - Arc / TorusSurface の representative section 向け static guard を追加
- `model/geo_algorithms/src/collision/primitive_3d.rs`
  - Arc の point/segment/ray/line 経路を point distance entrypoint 経由に統一
  - TorusSurface の point 経路を point distance entrypoint 経由に統一
  - circle / plane / spherical solid の representative な point 判定で既存 Point をそのまま使うよう整理
- `model/geo_algorithms/src/intersection/primitive_3d.rs`
  - Arc の point/segment/ray/line 経路を point distance entrypoint 経由に統一
  - TorusSurface の point 経路を point distance entrypoint 経由に統一
  - ConicalSolid 用に `conical_solid3d_contains_point_with_tolerance` helper を追加し、representative な containment 判定を helper 経由へ集約
  - ConicalSolid representative section 向け static guard を追加
  - circle / plane の representative な point 判定で既存 Point をそのまま使うよう整理

## 検証

- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo test --workspace`

## スコープ補足

- #371 を同一 Issue の複数 PR で段階的に進める方針の Phase 2 です
- file 分割と区切りコメント整理は #654 のスコープであり、この PR には含めていません

## 関連

- refs #371
- refs #654