### PR TITLE
refactor(#371): Phase3 Point境界をtriangle familyへ拡張

### DIFF
--- a/model/geo_algorithms/src/collision/primitive_3d.rs
+++ b/model/geo_algorithms/src/collision/primitive_3d.rs
@@ -17,6 +17,17 @@ use geo_contracts::{
     SphericalSolid3DProperties, SphericalSurface3DProperties, Triangle3DBoundaryAccess,
 };
 
+fn triangle3d_vertex_points<T: Scalar>(triangle: &Triangle3D<T>) -> [Point3D<T>; 3] {
+    let (ax, ay, az) = Triangle3DBoundaryAccess::vertex_a(triangle);
+    let (bx, by, bz) = Triangle3DBoundaryAccess::vertex_b(triangle);
+    let (cx, cy, cz) = Triangle3DBoundaryAccess::vertex_c(triangle);
+    [
+        Point3D::new(ax, ay, az),
+        Point3D::new(bx, by, bz),
+        Point3D::new(cx, cy, cz),
+    ]
+}
+
 // ── SphericalSolid3D ──────────────────────────────────────────────────────────
 
 pub fn spherical_solid3d_point3d_collides<T: Scalar>(
@@ -69,12 +80,9 @@ pub fn spherical_solid3d_triangle3d_collides<T: Scalar>(
     triangle: &Triangle3D<T>,
     tolerance: T,
 ) -> bool {
-    let (ax, ay, az) = Triangle3DBoundaryAccess::vertex_a(triangle);
-    let (bx, by, bz) = Triangle3DBoundaryAccess::vertex_b(triangle);
-    let (cx, cy, cz) = Triangle3DBoundaryAccess::vertex_c(triangle);
-    sphere.distance_to_surface(Point3D::new(ax, ay, az)) <= tolerance
-        || sphere.distance_to_surface(Point3D::new(bx, by, bz)) <= tolerance
-        || sphere.distance_to_surface(Point3D::new(cx, cy, cz)) <= tolerance
+    triangle3d_vertex_points(triangle)
+        .into_iter()
+        .any(|point| sphere.distance_to_surface(point) <= tolerance)
 }
 
 pub fn spherical_solid3d_plane3d_collides<T: Scalar>(
@@ -158,15 +166,9 @@ pub fn cylindrical_solid3d_triangle3d_collides<T: Scalar>(
     triangle: &Triangle3D<T>,
     tolerance: T,
 ) -> bool {
-    let (ax, ay, az) = triangle.vertex_a();
-    let (bx, by, bz) = triangle.vertex_b();
-    let (cx, cy, cz) = triangle.vertex_c();
-    let point_a = Point3D::new(ax, ay, az);
-    let point_b = Point3D::new(bx, by, bz);
-    let point_c = Point3D::new(cx, cy, cz);
-    crate::distance::cylindrical_solid3d_point3d_distance(cyl, &point_a) <= tolerance
-        || crate::distance::cylindrical_solid3d_point3d_distance(cyl, &point_b) <= tolerance
-        || crate::distance::cylindrical_solid3d_point3d_distance(cyl, &point_c) <= tolerance
+    triangle3d_vertex_points(triangle).into_iter().any(|point| {
+        crate::distance::cylindrical_solid3d_point3d_distance(cyl, &point) <= tolerance
+    })
 }
 
 pub fn cylindrical_solid3d_plane3d_collides<T: Scalar>(
@@ -254,15 +256,9 @@ pub fn cylindrical_surface3d_triangle3d_collides<T: Scalar>(
     triangle: &Triangle3D<T>,
     tolerance: T,
 ) -> bool {
-    let (ax, ay, az) = triangle.vertex_a();
-    let (bx, by, bz) = triangle.vertex_b();
-    let (cx, cy, cz) = triangle.vertex_c();
-    let point_a = Point3D::new(ax, ay, az);
-    let point_b = Point3D::new(bx, by, bz);
-    let point_c = Point3D::new(cx, cy, cz);
-    crate::distance::cylindrical_surface3d_point3d_distance(cyl, &point_a) <= tolerance
-        || crate::distance::cylindrical_surface3d_point3d_distance(cyl, &point_b) <= tolerance
-        || crate::distance::cylindrical_surface3d_point3d_distance(cyl, &point_c) <= tolerance
+    triangle3d_vertex_points(triangle).into_iter().any(|point| {
+        crate::distance::cylindrical_surface3d_point3d_distance(cyl, &point) <= tolerance
+    })
 }
 
 pub fn cylindrical_surface3d_plane3d_collides<T: Scalar>(
@@ -377,20 +373,15 @@ pub fn ellipse3d_triangle3d_collides<T: Scalar + From<f64>>(
     triangle: &Triangle3D<T>,
     tolerance: T,
 ) -> bool {
-    let (ax, ay, az) = triangle.vertex_a();
-    let (bx, by, bz) = triangle.vertex_b();
-    let (cx, cy, cz) = triangle.vertex_c();
-    let point_a = Point3D::new(ax, ay, az);
-    let point_b = Point3D::new(bx, by, bz);
-    let point_c = Point3D::new(cx, cy, cz);
+    let [point_a, point_b, point_c] = triangle3d_vertex_points(triangle);
     let dist_a = crate::distance::ellipse3d_point3d_distance(ellipse, &point_a);
     let dist_b = crate::distance::ellipse3d_point3d_distance(ellipse, &point_b);
     let dist_c = crate::distance::ellipse3d_point3d_distance(ellipse, &point_c);
     let three = T::from_f64(3.0);
     let centroid = Point3D::new(
-        (ax + bx + cx) / three,
-        (ay + by + cy) / three,
-        (az + bz + cz) / three,
+        (point_a.x() + point_b.x() + point_c.x()) / three,
+        (point_a.y() + point_b.y() + point_c.y()) / three,
+        (point_a.z() + point_b.z() + point_c.z()) / three,
     );
     let dist_centroid = crate::distance::ellipse3d_point3d_distance(ellipse, &centroid);
     dist_a <= tolerance || dist_b <= tolerance || dist_c <= tolerance || dist_centroid <= tolerance

--- a/model/geo_algorithms/src/collision/primitive_3d.rs
+++ b/model/geo_algorithms/src/collision/primitive_3d.rs
@@ -545,7 +545,7 @@ pub fn triangle3d_point3d_collides<T: Scalar>(
     point: &Point3D<T>,
     tolerance: T,
 ) -> bool {
-    triangle.distance_to_point(point) <= tolerance
+    crate::distance::triangle3d_point3d_distance(triangle, point) <= tolerance
 }
 
 pub fn triangle3d_line_segment3d_collides<T: Scalar>(
@@ -553,8 +553,8 @@ pub fn triangle3d_line_segment3d_collides<T: Scalar>(
     segment: &LineSegment3D<T>,
     tolerance: T,
 ) -> bool {
-    triangle.distance_to_point(&segment.start()) <= tolerance
-        || triangle.distance_to_point(&segment.end()) <= tolerance
+    crate::distance::triangle3d_point3d_distance(triangle, &segment.start()) <= tolerance
+        || crate::distance::triangle3d_point3d_distance(triangle, &segment.end()) <= tolerance
 }
 
 pub fn line_segment3d_triangle3d_collides<T: Scalar>(
@@ -570,7 +570,7 @@ pub fn triangle3d_ray3d_collides<T: Scalar>(
     ray: &Ray3D<T>,
     tolerance: T,
 ) -> bool {
-    triangle.distance_to_point(&ray.origin()) <= tolerance
+    crate::distance::triangle3d_point3d_distance(triangle, &ray.origin()) <= tolerance
 }
 
 pub fn ray3d_triangle3d_collides<T: Scalar>(
@@ -592,12 +592,17 @@ pub fn triangle3d_triangle3d_collides<T: Scalar>(
     let (ax2, ay2, az2) = Triangle3DBoundaryAccess::vertex_a(triangle_b);
     let (bx2, by2, bz2) = Triangle3DBoundaryAccess::vertex_b(triangle_b);
     let (cx2, cy2, cz2) = Triangle3DBoundaryAccess::vertex_c(triangle_b);
-    triangle_b.distance_to_point(&Point3D::new(ax, ay, az)) <= tolerance
-        || triangle_b.distance_to_point(&Point3D::new(bx, by, bz)) <= tolerance
-        || triangle_b.distance_to_point(&Point3D::new(cx, cy, cz)) <= tolerance
-        || triangle_a.distance_to_point(&Point3D::new(ax2, ay2, az2)) <= tolerance
-        || triangle_a.distance_to_point(&Point3D::new(bx2, by2, bz2)) <= tolerance
-        || triangle_a.distance_to_point(&Point3D::new(cx2, cy2, cz2)) <= tolerance
+    crate::distance::triangle3d_point3d_distance(triangle_b, &Point3D::new(ax, ay, az)) <= tolerance
+        || crate::distance::triangle3d_point3d_distance(triangle_b, &Point3D::new(bx, by, bz))
+            <= tolerance
+        || crate::distance::triangle3d_point3d_distance(triangle_b, &Point3D::new(cx, cy, cz))
+            <= tolerance
+        || crate::distance::triangle3d_point3d_distance(triangle_a, &Point3D::new(ax2, ay2, az2))
+            <= tolerance
+        || crate::distance::triangle3d_point3d_distance(triangle_a, &Point3D::new(bx2, by2, bz2))
+            <= tolerance
+        || crate::distance::triangle3d_point3d_distance(triangle_a, &Point3D::new(cx2, cy2, cz2))
+            <= tolerance
 }
 
 // ── TriangleMesh3D ────────────────────────────────────────────────────────────
@@ -607,11 +612,7 @@ pub fn triangle_mesh3d_point3d_collides<T: Scalar>(
     point: &Point3D<T>,
     tolerance: T,
 ) -> bool {
-    (0..mesh.triangle_count()).any(|i| {
-        mesh.triangle(i)
-            .map(|tri| tri.distance_to_point(point) <= tolerance)
-            .unwrap_or(false)
-    })
+    crate::distance::triangle_mesh3d_point3d_distance(mesh, point) <= tolerance
 }
 
 // ── Arc3D ─────────────────────────────────────────────────────────────────────

--- a/model/geo_algorithms/src/distance/primitive_3d.rs
+++ b/model/geo_algorithms/src/distance/primitive_3d.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     Arc3D, Circle3D, CylindricalSolid3D, CylindricalSurface3D, Ellipse3D, InfiniteLine3D,
-    LineSegment3D, Plane3D, Point3D, Ray3D, TorusSurface3D,
+    LineSegment3D, Plane3D, Point3D, Ray3D, TorusSurface3D, Triangle3D, TriangleMesh3D,
 };
 use geo_contracts::{
     Arc3DDistance, CylindricalSolid3DDistance, CylindricalSurface3DDistance, Ellipse3DDistance,
@@ -168,6 +168,38 @@ pub fn point3d_cylindrical_surface3d_distance<T: Scalar>(
     cyl: &CylindricalSurface3D<T>,
 ) -> T {
     cylindrical_surface3d_point3d_distance(cyl, point)
+}
+
+/// Triangle3D-点 間の最短距離
+pub fn triangle3d_point3d_distance<T: Scalar>(triangle: &Triangle3D<T>, point: &Point3D<T>) -> T {
+    triangle.distance_to_point(point)
+}
+
+/// 逆向きラッパー: point-triangle
+pub fn point3d_triangle3d_distance<T: Scalar>(point: &Point3D<T>, triangle: &Triangle3D<T>) -> T {
+    triangle3d_point3d_distance(triangle, point)
+}
+
+/// TriangleMesh3D-点 間の最短距離
+pub fn triangle_mesh3d_point3d_distance<T: Scalar>(
+    mesh: &TriangleMesh3D<T>,
+    point: &Point3D<T>,
+) -> T {
+    (0..mesh.triangle_count())
+        .filter_map(|index| {
+            mesh.triangle(index)
+                .map(|triangle| triangle.distance_to_point(point))
+        })
+        .reduce(|best, distance| best.min(distance))
+        .unwrap_or(T::INFINITY)
+}
+
+/// 逆向きラッパー: point-triangle_mesh
+pub fn point3d_triangle_mesh3d_distance<T: Scalar>(
+    point: &Point3D<T>,
+    mesh: &TriangleMesh3D<T>,
+) -> T {
+    triangle_mesh3d_point3d_distance(mesh, point)
 }
 
 #[cfg(test)]
@@ -445,6 +477,84 @@ mod tests {
         assert!(
             !intersection_torus_surface_point_section.contains(TORUS_SURFACE_DIRECT_UFCS),
             "intersection/primitive_3d.rs must not call TorusSurface3DDistance::distance_to_point directly"
+        );
+    }
+
+    #[test]
+    fn triangle_point_boundary_guard_keeps_collision_and_intersection_on_distance_entrypoint() {
+        const TRIANGLE_POINT_ENTRYPOINT: &str = "crate::distance::triangle3d_point3d_distance";
+
+        fn section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+            let start_index = source
+                .find(start)
+                .unwrap_or_else(|| panic!("missing start marker: {start}"));
+            let tail = &source[start_index..];
+            let end_index = tail
+                .find(end)
+                .unwrap_or_else(|| panic!("missing end marker: {end}"));
+            &tail[..end_index]
+        }
+
+        let collision_source = include_str!("../collision/primitive_3d.rs");
+        let intersection_source = include_str!("../intersection/primitive_3d.rs");
+        let collision_triangle_point_section = section(
+            collision_source,
+            "pub fn triangle3d_point3d_collides",
+            "pub fn triangle_mesh3d_point3d_collides",
+        );
+        let intersection_triangle_point_section = section(
+            intersection_source,
+            "fn triangle3d_point3d_intersection_raw",
+            "fn triangle_mesh3d_point3d_intersection_raw",
+        );
+
+        assert!(
+            collision_triangle_point_section.contains(TRIANGLE_POINT_ENTRYPOINT),
+            "collision/primitive_3d.rs should route triangle point checks through the distance entrypoint"
+        );
+        assert!(
+            intersection_triangle_point_section.contains(TRIANGLE_POINT_ENTRYPOINT),
+            "intersection/primitive_3d.rs should route triangle point checks through the distance entrypoint"
+        );
+    }
+
+    #[test]
+    fn triangle_mesh_point_boundary_guard_keeps_collision_and_intersection_on_distance_entrypoint()
+    {
+        const TRIANGLE_MESH_POINT_ENTRYPOINT: &str =
+            "crate::distance::triangle_mesh3d_point3d_distance";
+
+        fn section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+            let start_index = source
+                .find(start)
+                .unwrap_or_else(|| panic!("missing start marker: {start}"));
+            let tail = &source[start_index..];
+            let end_index = tail
+                .find(end)
+                .unwrap_or_else(|| panic!("missing end marker: {end}"));
+            &tail[..end_index]
+        }
+
+        let collision_source = include_str!("../collision/primitive_3d.rs");
+        let intersection_source = include_str!("../intersection/primitive_3d.rs");
+        let collision_triangle_mesh_point_section = section(
+            collision_source,
+            "pub fn triangle_mesh3d_point3d_collides",
+            "pub fn arc3d_point3d_collides",
+        );
+        let intersection_triangle_mesh_point_section = section(
+            intersection_source,
+            "fn triangle_mesh3d_point3d_intersection_raw",
+            "fn plane3d_point3d_intersection_raw",
+        );
+
+        assert!(
+            collision_triangle_mesh_point_section.contains(TRIANGLE_MESH_POINT_ENTRYPOINT),
+            "collision/primitive_3d.rs should route triangle mesh point checks through the distance entrypoint"
+        );
+        assert!(
+            intersection_triangle_mesh_point_section.contains(TRIANGLE_MESH_POINT_ENTRYPOINT),
+            "intersection/primitive_3d.rs should route triangle mesh point checks through the distance entrypoint"
         );
     }
 }

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -49,6 +49,17 @@ fn conical_solid3d_contains_point_with_tolerance<T: Scalar>(
     )
 }
 
+fn triangle3d_vertex_points<T: Scalar>(triangle: &Triangle3D<T>) -> [Point3D<T>; 3] {
+    let (ax, ay, az) = Triangle3DBoundaryAccess::vertex_a(triangle);
+    let (bx, by, bz) = Triangle3DBoundaryAccess::vertex_b(triangle);
+    let (cx, cy, cz) = Triangle3DBoundaryAccess::vertex_c(triangle);
+    [
+        Point3D::new(ax, ay, az),
+        Point3D::new(bx, by, bz),
+        Point3D::new(cx, cy, cz),
+    ]
+}
+
 fn spherical_surface_intersection_parameters<T: Scalar>(
     start: &Point3D<T>,
     direction: &crate::Vector3D<T>,
@@ -432,21 +443,11 @@ fn cylindrical_surface3d_triangle3d_intersection_raw<T: Scalar>(
     triangle: &Triangle3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    let (ax, ay, az) = Triangle3DBoundaryAccess::vertex_a(triangle);
-    let (bx, by, bz) = Triangle3DBoundaryAccess::vertex_b(triangle);
-    let (cx, cy, cz) = Triangle3DBoundaryAccess::vertex_c(triangle);
-    let point_a = Point3D::new(ax, ay, az);
-    let point_b = Point3D::new(bx, by, bz);
-    let point_c = Point3D::new(cx, cy, cz);
-    if crate::distance::cylindrical_surface3d_point3d_distance(cyl, &point_a) <= tolerance {
-        Some(point_a)
-    } else if crate::distance::cylindrical_surface3d_point3d_distance(cyl, &point_b) <= tolerance {
-        Some(point_b)
-    } else if crate::distance::cylindrical_surface3d_point3d_distance(cyl, &point_c) <= tolerance {
-        Some(point_c)
-    } else {
-        None
-    }
+    triangle3d_vertex_points(triangle)
+        .into_iter()
+        .find(|point| {
+            crate::distance::cylindrical_surface3d_point3d_distance(cyl, point) <= tolerance
+        })
 }
 
 pub fn cylindrical_surface3d_triangle3d_intersection<T: Scalar>(
@@ -686,21 +687,11 @@ pub fn ellipse3d_triangle3d_intersections<T: Scalar + From<f64>>(
     triangle: &Triangle3D<T>,
     tolerance: T,
 ) -> IntersectionResult<T> {
-    let (ax, ay, az) = Triangle3DBoundaryAccess::vertex_a(triangle);
-    let (bx, by, bz) = Triangle3DBoundaryAccess::vertex_b(triangle);
-    let (cx, cy, cz) = Triangle3DBoundaryAccess::vertex_c(triangle);
     let mut intersections = Vec::new();
-    let point_a = Point3D::new(ax, ay, az);
-    let point_b = Point3D::new(bx, by, bz);
-    let point_c = Point3D::new(cx, cy, cz);
-    if crate::distance::ellipse3d_point3d_distance(ellipse, &point_a) <= tolerance {
-        intersections.push(point_a);
-    }
-    if crate::distance::ellipse3d_point3d_distance(ellipse, &point_b) <= tolerance {
-        intersections.push(point_b);
-    }
-    if crate::distance::ellipse3d_point3d_distance(ellipse, &point_c) <= tolerance {
-        intersections.push(point_c);
+    for point in triangle3d_vertex_points(triangle) {
+        if crate::distance::ellipse3d_point3d_distance(ellipse, &point) <= tolerance {
+            intersections.push(point);
+        }
     }
     IntersectionResult::from_option_points(intersections, false, tolerance)
 }

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -1327,7 +1327,10 @@ fn triangle3d_point3d_intersection_raw<T: Scalar>(
     point: &Point3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    point_intersection_if(point, triangle.distance_to_point(point) <= tolerance)
+    point_intersection_if(
+        point,
+        crate::distance::triangle3d_point3d_distance(triangle, point) <= tolerance,
+    )
 }
 
 pub fn triangle3d_point3d_intersection<T: Scalar>(
@@ -1465,11 +1468,7 @@ fn triangle_mesh3d_point3d_intersection_raw<T: Scalar>(
 ) -> Option<Point3D<T>> {
     point_intersection_if(
         point,
-        (0..mesh.triangle_count()).any(|i| {
-            mesh.triangle(i)
-                .map(|tri| tri.distance_to_point(point) <= tolerance)
-                .unwrap_or(false)
-        }),
+        crate::distance::triangle_mesh3d_point3d_distance(mesh, point) <= tolerance,
     )
 }
 


### PR DESCRIPTION
## 概要

#371 の Phase 3 として、`geo_algorithms` の Point/Tuple 境界整理を triangle / triangle mesh family へ段階適用します。

対象:
- triangle / triangle mesh の representative な point 系 collision/intersection 経路
- triangle を参照する周辺 shape-pair 実装での頂点 Point 化重複

## 変更内容

- `model/geo_algorithms/src/distance/primitive_3d.rs`
  - `triangle3d_point3d_distance` / `point3d_triangle3d_distance` を追加
  - `triangle_mesh3d_point3d_distance` / `point3d_triangle_mesh3d_distance` を追加
  - triangle / triangle mesh の representative section 向け static guard を追加
- `model/geo_algorithms/src/collision/primitive_3d.rs`
  - triangle の point/segment/ray/triangle 経路を point distance entrypoint 経由に統一
  - triangle mesh の point 経路を point distance entrypoint 経由に統一
  - `triangle3d_vertex_points` helper を追加し、spherical solid / cylindrical solid / cylindrical surface / ellipse の triangle 経路で頂点 Point 化重複を集約
- `model/geo_algorithms/src/intersection/primitive_3d.rs`
  - triangle / triangle mesh の point 系 intersection を point distance entrypoint 経由に統一
  - `triangle3d_vertex_points` helper を追加し、cylindrical surface / ellipse の triangle intersection 経路で頂点 Point 化重複を集約

## 検証

- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo test --workspace`

## スコープ補足

- #371 を同一 Issue の複数 PR で段階的に進める方針の Phase 3 です
- file 分割と区切りコメント整理は #654 のスコープであり、この PR には含めていません

## 関連

- refs #371
- refs #654