### PR TITLE
refactor(#371): Phase4 Point境界をcircle familyへ拡張

### DIFF
--- a/model/geo_algorithms/src/collision/primitive_3d.rs
+++ b/model/geo_algorithms/src/collision/primitive_3d.rs
@@ -674,14 +674,15 @@ pub fn circle3d_line_segment3d_collides<T: Scalar>(
     segment: &LineSegment3D<T>,
     tolerance: T,
 ) -> bool {
-    let dist_start = circle.distance_to_point_3d(segment.start());
-    let dist_end = circle.distance_to_point_3d(segment.end());
+    let dist_start = crate::distance::circle3d_point3d_distance(circle, &segment.start());
+    let dist_end = crate::distance::circle3d_point3d_distance(circle, &segment.end());
     let mid_x = (segment.start().x() + segment.end().x()) / T::from_f64(2.0);
     let mid_y = (segment.start().y() + segment.end().y()) / T::from_f64(2.0);
     let mid_z = (segment.start().z() + segment.end().z()) / T::from_f64(2.0);
+    let midpoint = Point3D::new(mid_x, mid_y, mid_z);
     dist_start <= tolerance
         || dist_end <= tolerance
-        || circle.distance_to_point_3d(Point3D::new(mid_x, mid_y, mid_z)) <= tolerance
+        || crate::distance::circle3d_point3d_distance(circle, &midpoint) <= tolerance
 }
 
 pub fn circle3d_ray3d_collides<T: Scalar>(
@@ -689,7 +690,7 @@ pub fn circle3d_ray3d_collides<T: Scalar>(
     ray: &Ray3D<T>,
     tolerance: T,
 ) -> bool {
-    circle.distance_to_point_3d(ray.origin()) <= tolerance
+    crate::distance::circle3d_point3d_distance(circle, &ray.origin()) <= tolerance
 }
 
 pub fn circle3d_infinite_line3d_collides<T: Scalar>(
@@ -698,7 +699,8 @@ pub fn circle3d_infinite_line3d_collides<T: Scalar>(
     tolerance: T,
 ) -> bool {
     let (px, py, pz) = line.point();
-    circle.distance_to_point_3d(Point3D::new(px, py, pz)) <= tolerance
+    let point_on_line = Point3D::new(px, py, pz);
+    crate::distance::circle3d_point3d_distance(circle, &point_on_line) <= tolerance
 }
 
 pub fn circle3d_circle3d_collides<T: Scalar>(

--- a/model/geo_algorithms/src/distance/primitive_3d.rs
+++ b/model/geo_algorithms/src/distance/primitive_3d.rs
@@ -431,6 +431,58 @@ mod tests {
     }
 
     #[test]
+    fn circle_point_boundary_guard_keeps_collision_and_intersection_on_distance_entrypoint() {
+        const CIRCLE_DIRECT_DISTANCE: &str = "circle.distance_to_point_3d";
+        const CIRCLE_DIRECT_CONTAINS: &str = "circle.contains_point_3d";
+        const CIRCLE_POINT_ENTRYPOINT: &str = "crate::distance::circle3d_point3d_distance";
+
+        fn section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+            let start_index = source
+                .find(start)
+                .unwrap_or_else(|| panic!("missing start marker: {start}"));
+            let tail = &source[start_index..];
+            let end_index = tail
+                .find(end)
+                .unwrap_or_else(|| panic!("missing end marker: {end}"));
+            &tail[..end_index]
+        }
+
+        let collision_source = include_str!("../collision/primitive_3d.rs");
+        let intersection_source = include_str!("../intersection/primitive_3d.rs");
+        let collision_circle_point_section = section(
+            collision_source,
+            "pub fn circle3d_point3d_collides",
+            "pub fn plane3d_point3d_collides",
+        );
+        let intersection_circle_point_section = section(
+            intersection_source,
+            "fn circle3d_point3d_intersection_raw",
+            "fn cylindrical_surface3d_point3d_intersection_raw",
+        );
+
+        assert!(
+            collision_circle_point_section.contains(CIRCLE_POINT_ENTRYPOINT),
+            "collision/primitive_3d.rs should route circle point checks through the distance entrypoint"
+        );
+        assert!(
+            intersection_circle_point_section.contains(CIRCLE_POINT_ENTRYPOINT),
+            "intersection/primitive_3d.rs should route circle point checks through the distance entrypoint"
+        );
+        assert!(
+            !collision_circle_point_section.contains(CIRCLE_DIRECT_DISTANCE),
+            "collision/primitive_3d.rs must not call circle.distance_to_point_3d directly"
+        );
+        assert!(
+            !intersection_circle_point_section.contains(CIRCLE_DIRECT_DISTANCE),
+            "intersection/primitive_3d.rs must not call circle.distance_to_point_3d directly"
+        );
+        assert!(
+            !intersection_circle_point_section.contains(CIRCLE_DIRECT_CONTAINS),
+            "intersection/primitive_3d.rs must not call circle.contains_point_3d directly"
+        );
+    }
+
+    #[test]
     fn torus_surface_point_boundary_guard_keeps_collision_and_intersection_on_distance_entrypoint()
     {
         const TORUS_SURFACE_DIRECT_UFCS: &str =

--- a/model/geo_algorithms/src/distance/primitive_3d.rs
+++ b/model/geo_algorithms/src/distance/primitive_3d.rs
@@ -301,6 +301,41 @@ mod tests {
     }
 
     #[test]
+    fn cylindrical_surface_pair_guard_keeps_intersection_on_distance_entrypoint() {
+        const CYLINDRICAL_SURFACE_DIRECT_UFCS: &str =
+            "<CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point";
+        const CYLINDRICAL_SURFACE_POINT_ENTRYPOINT: &str =
+            "crate::distance::cylindrical_surface3d_point3d_distance";
+
+        fn section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+            let start_index = source
+                .find(start)
+                .unwrap_or_else(|| panic!("missing start marker: {start}"));
+            let tail = &source[start_index..];
+            let end_index = tail
+                .find(end)
+                .unwrap_or_else(|| panic!("missing end marker: {end}"));
+            &tail[..end_index]
+        }
+
+        let intersection_source = include_str!("../intersection/primitive_3d.rs");
+        let intersection_cylindrical_surface_pair_section = section(
+            intersection_source,
+            "fn cylindrical_surface3d_cylindrical_surface3d_intersection_raw",
+            "fn ellipse3d_point3d_intersection_raw",
+        );
+
+        assert!(
+            intersection_cylindrical_surface_pair_section.contains(CYLINDRICAL_SURFACE_POINT_ENTRYPOINT),
+            "intersection/primitive_3d.rs should route cylindrical surface pair center checks through the distance entrypoint"
+        );
+        assert!(
+            !intersection_cylindrical_surface_pair_section.contains(CYLINDRICAL_SURFACE_DIRECT_UFCS),
+            "intersection/primitive_3d.rs must not call CylindricalSurface3DDistance::distance_to_point directly in the cylindrical surface pair section"
+        );
+    }
+
+    #[test]
     fn cylindrical_solid_point_boundary_guard_keeps_collision_on_distance_entrypoint() {
         const CYLINDRICAL_SOLID_DIRECT_UFCS: &str =
             "<CylindricalSolid3D<T> as CylindricalSolid3DDistance<T>>::distance_to_point";

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -276,13 +276,15 @@ pub fn circle3d_point3d_intersection<T: Scalar>(
 fn circle3d_line_segment3d_intersection_raw<T: Scalar>(
     circle: &Circle3D<T>,
     segment: &LineSegment3D<T>,
-    _tolerance: T,
+    tolerance: T,
 ) -> Option<Point3D<T>> {
-    if circle.contains_point_3d(segment.start()) {
-        return Some(segment.start());
+    let start = segment.start();
+    if crate::distance::circle3d_point3d_distance(circle, &start) <= tolerance {
+        return Some(start);
     }
-    if circle.contains_point_3d(segment.end()) {
-        return Some(segment.end());
+    let end = segment.end();
+    if crate::distance::circle3d_point3d_distance(circle, &end) <= tolerance {
+        return Some(end);
     }
     None
 }
@@ -302,10 +304,10 @@ pub fn circle3d_line_segment3d_intersection<T: Scalar>(
 fn circle3d_ray3d_intersection_raw<T: Scalar>(
     circle: &Circle3D<T>,
     ray: &Ray3D<T>,
-    _tolerance: T,
+    tolerance: T,
 ) -> Option<Point3D<T>> {
     let origin = ray.origin();
-    if circle.contains_point_3d(origin) {
+    if crate::distance::circle3d_point3d_distance(circle, &origin) <= tolerance {
         Some(origin)
     } else {
         None
@@ -327,11 +329,11 @@ pub fn circle3d_ray3d_intersection<T: Scalar>(
 fn circle3d_infinite_line3d_intersection_raw<T: Scalar>(
     circle: &Circle3D<T>,
     line: &InfiniteLine3D<T>,
-    _tolerance: T,
+    tolerance: T,
 ) -> Option<Point3D<T>> {
     let (px, py, pz) = InfiniteLine3DProperties::point(line);
     let pt = Point3D::new(px, py, pz);
-    if circle.contains_point_3d(pt) {
+    if crate::distance::circle3d_point3d_distance(circle, &pt) <= tolerance {
         Some(pt)
     } else {
         None

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -15,9 +15,9 @@ use crate::{
 };
 use geo_contracts::{
     Arc3DEndpoint, Arc3DProperties, Circle3DProperties, ConicalSolid3DContainment,
-    ConicalSolid3DProperties, ConicalSurface3DProperties, CylindricalSurface3DDistance,
-    CylindricalSurface3DProperties, EllipsoidalSolid3DProperties, InfiniteLine3DProperties, Scalar,
-    SphericalSolid3DProperties, SphericalSurface3DProperties, Triangle3DBoundaryAccess,
+    ConicalSolid3DProperties, ConicalSurface3DProperties, CylindricalSurface3DProperties,
+    EllipsoidalSolid3DProperties, InfiniteLine3DProperties, Scalar, SphericalSolid3DProperties,
+    SphericalSurface3DProperties, Triangle3DBoundaryAccess,
 };
 
 fn point_intersection_if<T: Scalar>(point: &Point3D<T>, condition: bool) -> Option<Point3D<T>> {
@@ -503,14 +503,8 @@ fn cylindrical_surface3d_cylindrical_surface3d_intersection_raw<T: Scalar>(
     let lhs_center = Point3D::new(lhs_center_tuple.0, lhs_center_tuple.1, lhs_center_tuple.2);
     let rhs_center = Point3D::new(rhs_center_tuple.0, rhs_center_tuple.1, rhs_center_tuple.2);
 
-    let lhs_dist = <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-        lhs,
-        rhs_center_tuple,
-    );
-    let rhs_dist = <CylindricalSurface3D<T> as CylindricalSurface3DDistance<T>>::distance_to_point(
-        rhs,
-        lhs_center_tuple,
-    );
+    let lhs_dist = crate::distance::cylindrical_surface3d_point3d_distance(lhs, &rhs_center);
+    let rhs_dist = crate::distance::cylindrical_surface3d_point3d_distance(rhs, &lhs_center);
 
     let lhs_axis_tuple = <CylindricalSurface3D<T> as CylindricalSurface3DProperties<T>>::axis(lhs);
     let rhs_axis_tuple = <CylindricalSurface3D<T> as CylindricalSurface3DProperties<T>>::axis(rhs);


### PR DESCRIPTION
## 概要
- Circle family の代表 point-boundary 経路を `crate::distance::circle3d_point3d_distance` 経由へ統一
- `cylindrical_surface3d_cylindrical_surface3d_intersection_raw` の中心点チェックを `crate::distance::cylindrical_surface3d_point3d_distance` 経由へ統一
- point-boundary / pair-section の static guard を追加して、shape 側 API への直接依存へ戻らないようにした

## 変更詳細
- collision
  - `circle3d_line_segment3d_collides`
  - `circle3d_ray3d_collides`
  - `circle3d_infinite_line3d_collides`
- intersection
  - `circle3d_line_segment3d_intersection_raw`
  - `circle3d_ray3d_intersection_raw`
  - `circle3d_infinite_line3d_intersection_raw`
  - `cylindrical_surface3d_cylindrical_surface3d_intersection_raw`
- static guard
  - circle family 向け guard を追加
  - cylindrical surface pair section 向け guard を追加

## 検証
- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo test --workspace`

## スコープ外
- #654 の `primitive_3d.rs` 分割やコメント整理は本PRでは扱わない

Refs #371