### PR TITLE
refactor(#371): Phase5 Point境界をsolid familyへ拡張

### DIFF
--- a/model/geo_algorithms/src/collision/primitive_3d.rs
+++ b/model/geo_algorithms/src/collision/primitive_3d.rs
@@ -404,9 +404,9 @@ pub fn ellipse3d_ellipse3d_collides<T: Scalar>(
 pub fn ellipsoidal_solid3d_point3d_collides<T: Scalar>(
     ellipsoid: &EllipsoidalSolid3D<T>,
     point: &Point3D<T>,
-    _tolerance: T,
+    tolerance: T,
 ) -> bool {
-    ellipsoid.contains_point(point)
+    crate::distance::ellipsoidal_solid3d_point3d_distance(ellipsoid, point) <= tolerance
 }
 
 pub fn ellipsoidal_solid3d_line_segment3d_collides<T: Scalar>(
@@ -416,16 +416,8 @@ pub fn ellipsoidal_solid3d_line_segment3d_collides<T: Scalar>(
 ) -> bool {
     let start = segment.start();
     let end = segment.end();
-    let d1 = if ellipsoid.contains_point(&start) {
-        T::ZERO
-    } else {
-        ellipsoid.distance_to_surface(&start)
-    };
-    let d2 = if ellipsoid.contains_point(&end) {
-        T::ZERO
-    } else {
-        ellipsoid.distance_to_surface(&end)
-    };
+    let d1 = crate::distance::ellipsoidal_solid3d_point3d_distance(ellipsoid, &start);
+    let d2 = crate::distance::ellipsoidal_solid3d_point3d_distance(ellipsoid, &end);
     d1 <= tolerance || d2 <= tolerance
 }
 
@@ -435,11 +427,7 @@ pub fn ellipsoidal_solid3d_ray3d_collides<T: Scalar>(
     tolerance: T,
 ) -> bool {
     let origin = ray.origin();
-    let d = if ellipsoid.contains_point(&origin) {
-        T::ZERO
-    } else {
-        ellipsoid.distance_to_surface(&origin)
-    };
+    let d = crate::distance::ellipsoidal_solid3d_point3d_distance(ellipsoid, &origin);
     d <= tolerance
 }
 
@@ -450,11 +438,7 @@ pub fn ellipsoidal_solid3d_infinite_line3d_collides<T: Scalar>(
 ) -> bool {
     let (px, py, pz) = line.point();
     let pt = Point3D::new(px, py, pz);
-    let d = if ellipsoid.contains_point(&pt) {
-        T::ZERO
-    } else {
-        ellipsoid.distance_to_surface(&pt)
-    };
+    let d = crate::distance::ellipsoidal_solid3d_point3d_distance(ellipsoid, &pt);
     d <= tolerance
 }
 
@@ -514,9 +498,9 @@ pub fn ellipsoidal_surface3d_point3d_collides<T: Scalar>(
 pub fn torus_solid3d_point3d_collides<T: Scalar>(
     torus: &TorusSolid3D<T>,
     point: &Point3D<T>,
-    _tolerance: T,
+    tolerance: T,
 ) -> bool {
-    torus.contains_point(point)
+    crate::distance::torus_solid3d_point3d_distance(torus, point) <= tolerance
 }
 
 // ── TorusSurface3D ────────────────────────────────────────────────────────────

--- a/model/geo_algorithms/src/distance/primitive_3d.rs
+++ b/model/geo_algorithms/src/distance/primitive_3d.rs
@@ -6,12 +6,14 @@
 //! 命名規則: `{shape_a}_{shape_b}_distance`
 
 use crate::{
-    Arc3D, Circle3D, CylindricalSolid3D, CylindricalSurface3D, Ellipse3D, InfiniteLine3D,
-    LineSegment3D, Plane3D, Point3D, Ray3D, TorusSurface3D, Triangle3D, TriangleMesh3D,
+    Arc3D, Circle3D, CylindricalSolid3D, CylindricalSurface3D, Ellipse3D, EllipsoidalSolid3D,
+    InfiniteLine3D, LineSegment3D, Plane3D, Point3D, Ray3D, TorusSolid3D, TorusSurface3D,
+    Triangle3D, TriangleMesh3D,
 };
 use geo_contracts::{
     Arc3DDistance, CylindricalSolid3DDistance, CylindricalSurface3DDistance, Ellipse3DDistance,
-    Scalar, TorusSurface3DDistance,
+    EllipsoidalSolid3DContainment, EllipsoidalSolid3DDistance, Scalar, TorusSolid3DContainment,
+    TorusSolid3DDistance, TorusSurface3DDistance,
 };
 
 /// LineSegment3D-点 間の最短距離（端点クランプあり）
@@ -168,6 +170,52 @@ pub fn point3d_cylindrical_surface3d_distance<T: Scalar>(
     cyl: &CylindricalSurface3D<T>,
 ) -> T {
     cylindrical_surface3d_point3d_distance(cyl, point)
+}
+
+/// EllipsoidalSolid3D-点 間の最短距離（内部点は 0）
+pub fn ellipsoidal_solid3d_point3d_distance<T: Scalar>(
+    ellipsoid: &EllipsoidalSolid3D<T>,
+    point: &Point3D<T>,
+) -> T {
+    if <EllipsoidalSolid3D<T> as EllipsoidalSolid3DContainment<T>>::contains_point(
+        ellipsoid,
+        (point.x(), point.y(), point.z()),
+    ) {
+        T::ZERO
+    } else {
+        <EllipsoidalSolid3D<T> as EllipsoidalSolid3DDistance<T>>::distance_to_surface(
+            ellipsoid,
+            (point.x(), point.y(), point.z()),
+        )
+    }
+}
+
+/// 逆向きラッパー: point-ellipsoidal_solid
+pub fn point3d_ellipsoidal_solid3d_distance<T: Scalar>(
+    point: &Point3D<T>,
+    ellipsoid: &EllipsoidalSolid3D<T>,
+) -> T {
+    ellipsoidal_solid3d_point3d_distance(ellipsoid, point)
+}
+
+/// TorusSolid3D-点 間の最短距離（内部点は 0）
+pub fn torus_solid3d_point3d_distance<T: Scalar>(torus: &TorusSolid3D<T>, point: &Point3D<T>) -> T {
+    if <TorusSolid3D<T> as TorusSolid3DContainment<T>>::contains_point(
+        torus,
+        (point.x(), point.y(), point.z()),
+    ) {
+        T::ZERO
+    } else {
+        <TorusSolid3D<T> as TorusSolid3DDistance<T>>::distance_to_point(
+            torus,
+            (point.x(), point.y(), point.z()),
+        )
+    }
+}
+
+/// 逆向きラッパー: point-torus_solid
+pub fn point3d_torus_solid3d_distance<T: Scalar>(point: &Point3D<T>, torus: &TorusSolid3D<T>) -> T {
+    torus_solid3d_point3d_distance(torus, point)
 }
 
 /// Triangle3D-点 間の最短距離
@@ -514,6 +562,109 @@ mod tests {
         assert!(
             !intersection_circle_point_section.contains(CIRCLE_DIRECT_CONTAINS),
             "intersection/primitive_3d.rs must not call circle.contains_point_3d directly"
+        );
+    }
+
+    #[test]
+    fn ellipsoidal_solid_point_boundary_guard_keeps_collision_and_intersection_on_distance_entrypoint(
+    ) {
+        const ELLIPSOIDAL_SOLID_DIRECT_DISTANCE: &str = "ellipsoid.distance_to_surface";
+        const ELLIPSOIDAL_SOLID_DIRECT_CONTAINS: &str = "ellipsoid.contains_point";
+        const ELLIPSOIDAL_SOLID_POINT_ENTRYPOINT: &str =
+            "crate::distance::ellipsoidal_solid3d_point3d_distance";
+
+        fn section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+            let start_index = source
+                .find(start)
+                .unwrap_or_else(|| panic!("missing start marker: {start}"));
+            let tail = &source[start_index..];
+            let end_index = tail
+                .find(end)
+                .unwrap_or_else(|| panic!("missing end marker: {end}"));
+            &tail[..end_index]
+        }
+
+        let collision_source = include_str!("../collision/primitive_3d.rs");
+        let intersection_source = include_str!("../intersection/primitive_3d.rs");
+        let collision_ellipsoidal_solid_point_section = section(
+            collision_source,
+            "pub fn ellipsoidal_solid3d_point3d_collides",
+            "pub fn ellipsoidal_surface3d_point3d_collides",
+        );
+        let intersection_ellipsoidal_solid_point_section = section(
+            intersection_source,
+            "fn ellipsoidal_solid3d_point3d_intersection_raw",
+            "fn ellipsoidal_surface3d_point3d_intersection_raw",
+        );
+
+        assert!(
+            collision_ellipsoidal_solid_point_section.contains(ELLIPSOIDAL_SOLID_POINT_ENTRYPOINT),
+            "collision/primitive_3d.rs should route ellipsoidal solid point checks through the distance entrypoint"
+        );
+        assert!(
+            intersection_ellipsoidal_solid_point_section.contains(ELLIPSOIDAL_SOLID_POINT_ENTRYPOINT),
+            "intersection/primitive_3d.rs should route ellipsoidal solid point checks through the distance entrypoint"
+        );
+        assert!(
+            !collision_ellipsoidal_solid_point_section.contains(ELLIPSOIDAL_SOLID_DIRECT_DISTANCE),
+            "collision/primitive_3d.rs must not call ellipsoid.distance_to_surface directly"
+        );
+        assert!(
+            !collision_ellipsoidal_solid_point_section.contains(ELLIPSOIDAL_SOLID_DIRECT_CONTAINS),
+            "collision/primitive_3d.rs must not call ellipsoid.contains_point directly"
+        );
+        assert!(
+            !intersection_ellipsoidal_solid_point_section
+                .contains(ELLIPSOIDAL_SOLID_DIRECT_CONTAINS),
+            "intersection/primitive_3d.rs must not call ellipsoid.contains_point directly"
+        );
+    }
+
+    #[test]
+    fn torus_solid_point_boundary_guard_keeps_collision_and_intersection_on_distance_entrypoint() {
+        const TORUS_SOLID_DIRECT_CONTAINS: &str = "torus.contains_point";
+        const TORUS_SOLID_POINT_ENTRYPOINT: &str =
+            "crate::distance::torus_solid3d_point3d_distance";
+
+        fn section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+            let start_index = source
+                .find(start)
+                .unwrap_or_else(|| panic!("missing start marker: {start}"));
+            let tail = &source[start_index..];
+            let end_index = tail
+                .find(end)
+                .unwrap_or_else(|| panic!("missing end marker: {end}"));
+            &tail[..end_index]
+        }
+
+        let collision_source = include_str!("../collision/primitive_3d.rs");
+        let intersection_source = include_str!("../intersection/primitive_3d.rs");
+        let collision_torus_solid_point_section = section(
+            collision_source,
+            "pub fn torus_solid3d_point3d_collides",
+            "pub fn torus_surface3d_point3d_collides",
+        );
+        let intersection_torus_solid_point_section = section(
+            intersection_source,
+            "fn torus_solid3d_point3d_intersection_raw",
+            "fn torus_surface3d_point3d_intersection_raw",
+        );
+
+        assert!(
+            collision_torus_solid_point_section.contains(TORUS_SOLID_POINT_ENTRYPOINT),
+            "collision/primitive_3d.rs should route torus solid point checks through the distance entrypoint"
+        );
+        assert!(
+            intersection_torus_solid_point_section.contains(TORUS_SOLID_POINT_ENTRYPOINT),
+            "intersection/primitive_3d.rs should route torus solid point checks through the distance entrypoint"
+        );
+        assert!(
+            !collision_torus_solid_point_section.contains(TORUS_SOLID_DIRECT_CONTAINS),
+            "collision/primitive_3d.rs must not call torus.contains_point directly"
+        );
+        assert!(
+            !intersection_torus_solid_point_section.contains(TORUS_SOLID_DIRECT_CONTAINS),
+            "intersection/primitive_3d.rs must not call torus.contains_point directly"
         );
     }
 

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -705,9 +705,12 @@ pub fn ellipse3d_ellipse3d_intersections<T: Scalar>(
 fn ellipsoidal_solid3d_point3d_intersection_raw<T: Scalar>(
     ellipsoid: &EllipsoidalSolid3D<T>,
     point: &Point3D<T>,
-    _tolerance: T,
+    tolerance: T,
 ) -> Option<Point3D<T>> {
-    point_intersection_if(point, ellipsoid.contains_point(point))
+    point_intersection_if(
+        point,
+        crate::distance::ellipsoidal_solid3d_point3d_distance(ellipsoid, point) <= tolerance,
+    )
 }
 
 pub fn ellipsoidal_solid3d_point3d_intersection<T: Scalar>(
@@ -758,7 +761,9 @@ pub fn ellipsoidal_solid3d_infinite_line3d_intersections<T: Scalar>(
 ) -> IntersectionResult<T> {
     let (px, py, pz) = InfiniteLine3DProperties::point(line);
     let point_on_line = Point3D::new(px, py, pz);
-    let points = if ellipsoid.contains_point(&point_on_line) {
+    let points = if crate::distance::ellipsoidal_solid3d_point3d_distance(ellipsoid, &point_on_line)
+        <= tolerance
+    {
         vec![point_on_line]
     } else {
         vec![]
@@ -772,11 +777,12 @@ pub fn ellipsoidal_solid3d_ray3d_intersections<T: Scalar>(
     tolerance: T,
 ) -> IntersectionResult<T> {
     let origin = ray.origin();
-    let points = if ellipsoid.contains_point(&origin) {
-        vec![origin]
-    } else {
-        vec![]
-    };
+    let points =
+        if crate::distance::ellipsoidal_solid3d_point3d_distance(ellipsoid, &origin) <= tolerance {
+            vec![origin]
+        } else {
+            vec![]
+        };
     IntersectionResult::from_option_points(points, false, tolerance)
 }
 
@@ -1265,9 +1271,12 @@ pub fn spherical_solid3d_plane3d_intersection<T: Scalar>(
 fn torus_solid3d_point3d_intersection_raw<T: Scalar>(
     torus: &TorusSolid3D<T>,
     point: &Point3D<T>,
-    _tolerance: T,
+    tolerance: T,
 ) -> Option<Point3D<T>> {
-    point_intersection_if(point, torus.contains_point(point))
+    point_intersection_if(
+        point,
+        crate::distance::torus_solid3d_point3d_distance(torus, point) <= tolerance,
+    )
 }
 
 pub fn torus_solid3d_point3d_intersection<T: Scalar>(


### PR DESCRIPTION
## 概要
- EllipsoidalSolid family の代表 point-boundary 経路を `crate::distance::ellipsoidal_solid3d_point3d_distance` 経由へ統一
- TorusSolid の point-boundary 経路を `crate::distance::torus_solid3d_point3d_distance` 経由へ統一
- static guard を追加して、shape 側の `contains_point` / `distance_to_surface` / `distance_to_point` への直接依存へ戻らないようにした

## 変更詳細
- distance
  - `ellipsoidal_solid3d_point3d_distance`
  - `point3d_ellipsoidal_solid3d_distance`
  - `torus_solid3d_point3d_distance`
  - `point3d_torus_solid3d_distance`
- collision
  - `ellipsoidal_solid3d_point3d_collides`
  - `ellipsoidal_solid3d_line_segment3d_collides`
  - `ellipsoidal_solid3d_ray3d_collides`
  - `ellipsoidal_solid3d_infinite_line3d_collides`
  - `torus_solid3d_point3d_collides`
- intersection
  - `ellipsoidal_solid3d_point3d_intersection_raw`
  - `ellipsoidal_solid3d_infinite_line3d_intersections`
  - `ellipsoidal_solid3d_ray3d_intersections`
  - `torus_solid3d_point3d_intersection_raw`
- static guard
  - ellipsoidal solid 向け guard を追加
  - torus solid 向け guard を追加

## 検証
- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo test --workspace`

## 残件メモ
- #371 観点では SphericalSolid / EllipsoidalSurface の point-boundary family が次候補
- #654 の `primitive_3d.rs` 分割やコメント整理は本PRでは扱わない

Refs #371