### PR TITLE
refactor(#371): Phase6 Point境界をspherical/surface familyへ拡張

### DIFF
--- a/model/geo_algorithms/src/collision/primitive_3d.rs
+++ b/model/geo_algorithms/src/collision/primitive_3d.rs
@@ -35,7 +35,7 @@ pub fn spherical_solid3d_point3d_collides<T: Scalar>(
     point: &Point3D<T>,
     tolerance: T,
 ) -> bool {
-    sphere.distance_to_surface(*point) <= tolerance
+    crate::distance::spherical_solid3d_point3d_distance(sphere, point) <= tolerance
 }
 
 pub fn spherical_solid3d_circle3d_collides<T: Scalar>(
@@ -44,7 +44,9 @@ pub fn spherical_solid3d_circle3d_collides<T: Scalar>(
     tolerance: T,
 ) -> bool {
     let (cx, cy, cz) = circle.center();
-    sphere.distance_to_surface(Point3D::new(cx, cy, cz)) <= circle.radius() + tolerance
+    let center = Point3D::new(cx, cy, cz);
+    crate::distance::spherical_solid3d_point3d_distance(sphere, &center)
+        <= circle.radius() + tolerance
 }
 
 pub fn spherical_solid3d_line_segment3d_collides<T: Scalar>(
@@ -80,9 +82,9 @@ pub fn spherical_solid3d_triangle3d_collides<T: Scalar>(
     triangle: &Triangle3D<T>,
     tolerance: T,
 ) -> bool {
-    triangle3d_vertex_points(triangle)
-        .into_iter()
-        .any(|point| sphere.distance_to_surface(point) <= tolerance)
+    triangle3d_vertex_points(triangle).into_iter().any(|point| {
+        crate::distance::spherical_solid3d_point3d_distance(sphere, &point) <= tolerance
+    })
 }
 
 pub fn spherical_solid3d_plane3d_collides<T: Scalar>(
@@ -490,7 +492,7 @@ pub fn ellipsoidal_surface3d_point3d_collides<T: Scalar>(
     point: &Point3D<T>,
     tolerance: T,
 ) -> bool {
-    ellipsoid.contains_point(point, tolerance)
+    crate::distance::ellipsoidal_surface3d_point3d_distance(ellipsoid, point) <= tolerance
 }
 
 // ── TorusSolid3D ──────────────────────────────────────────────────────────────

--- a/model/geo_algorithms/src/distance/primitive_3d.rs
+++ b/model/geo_algorithms/src/distance/primitive_3d.rs
@@ -7,12 +7,13 @@
 
 use crate::{
     Arc3D, Circle3D, CylindricalSolid3D, CylindricalSurface3D, Ellipse3D, EllipsoidalSolid3D,
-    InfiniteLine3D, LineSegment3D, Plane3D, Point3D, Ray3D, TorusSolid3D, TorusSurface3D,
-    Triangle3D, TriangleMesh3D,
+    EllipsoidalSurface3D, InfiniteLine3D, LineSegment3D, Plane3D, Point3D, Ray3D, SphericalSolid3D,
+    TorusSolid3D, TorusSurface3D, Triangle3D, TriangleMesh3D,
 };
 use geo_contracts::{
     Arc3DDistance, CylindricalSolid3DDistance, CylindricalSurface3DDistance, Ellipse3DDistance,
-    EllipsoidalSolid3DContainment, EllipsoidalSolid3DDistance, Scalar, TorusSolid3DContainment,
+    EllipsoidalSolid3DContainment, EllipsoidalSolid3DDistance, EllipsoidalSurface3DDistance,
+    Scalar, SphericalSolid3DContainment, SphericalSolid3DDistance, TorusSolid3DContainment,
     TorusSolid3DDistance, TorusSurface3DDistance,
 };
 
@@ -64,6 +65,32 @@ pub fn plane3d_point3d_distance<T: Scalar>(plane: &Plane3D<T>, point: &Point3D<T
 /// 逆向きラッパー: point-plane
 pub fn point3d_plane3d_distance<T: Scalar>(point: &Point3D<T>, plane: &Plane3D<T>) -> T {
     plane.distance_to_point(*point)
+}
+
+/// SphericalSolid3D-点 間の最短距離（内部点は 0）
+pub fn spherical_solid3d_point3d_distance<T: Scalar>(
+    sphere: &SphericalSolid3D<T>,
+    point: &Point3D<T>,
+) -> T {
+    if <SphericalSolid3D<T> as SphericalSolid3DContainment<T>>::contains_point(
+        sphere,
+        (point.x(), point.y(), point.z()),
+    ) {
+        T::ZERO
+    } else {
+        <SphericalSolid3D<T> as SphericalSolid3DDistance<T>>::distance_to_point(
+            sphere,
+            (point.x(), point.y(), point.z()),
+        )
+    }
+}
+
+/// 逆向きラッパー: point-spherical_solid
+pub fn point3d_spherical_solid3d_distance<T: Scalar>(
+    point: &Point3D<T>,
+    sphere: &SphericalSolid3D<T>,
+) -> T {
+    spherical_solid3d_point3d_distance(sphere, point)
 }
 
 /// Ray3D-点 間の最短距離（Ray の有効範囲を考慮）
@@ -196,6 +223,25 @@ pub fn point3d_ellipsoidal_solid3d_distance<T: Scalar>(
     ellipsoid: &EllipsoidalSolid3D<T>,
 ) -> T {
     ellipsoidal_solid3d_point3d_distance(ellipsoid, point)
+}
+
+/// EllipsoidalSurface3D-点 間の最短距離
+pub fn ellipsoidal_surface3d_point3d_distance<T: Scalar>(
+    ellipsoid: &EllipsoidalSurface3D<T>,
+    point: &Point3D<T>,
+) -> T {
+    <EllipsoidalSurface3D<T> as EllipsoidalSurface3DDistance<T>>::distance_to_point(
+        ellipsoid,
+        (point.x(), point.y(), point.z()),
+    )
+}
+
+/// 逆向きラッパー: point-ellipsoidal_surface
+pub fn point3d_ellipsoidal_surface3d_distance<T: Scalar>(
+    point: &Point3D<T>,
+    ellipsoid: &EllipsoidalSurface3D<T>,
+) -> T {
+    ellipsoidal_surface3d_point3d_distance(ellipsoid, point)
 }
 
 /// TorusSolid3D-点 間の最短距離（内部点は 0）
@@ -617,6 +663,107 @@ mod tests {
             !intersection_ellipsoidal_solid_point_section
                 .contains(ELLIPSOIDAL_SOLID_DIRECT_CONTAINS),
             "intersection/primitive_3d.rs must not call ellipsoid.contains_point directly"
+        );
+    }
+
+    #[test]
+    fn ellipsoidal_surface_point_boundary_guard_keeps_collision_and_intersection_on_distance_entrypoint(
+    ) {
+        const ELLIPSOIDAL_SURFACE_DIRECT_CONTAINS: &str = "ellipsoid.contains_point";
+        const ELLIPSOIDAL_SURFACE_POINT_ENTRYPOINT: &str =
+            "crate::distance::ellipsoidal_surface3d_point3d_distance";
+
+        fn section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+            let start_index = source
+                .find(start)
+                .unwrap_or_else(|| panic!("missing start marker: {start}"));
+            let tail = &source[start_index..];
+            let end_index = tail
+                .find(end)
+                .unwrap_or_else(|| panic!("missing end marker: {end}"));
+            &tail[..end_index]
+        }
+
+        let collision_source = include_str!("../collision/primitive_3d.rs");
+        let intersection_source = include_str!("../intersection/primitive_3d.rs");
+        let collision_ellipsoidal_surface_point_section = section(
+            collision_source,
+            "pub fn ellipsoidal_surface3d_point3d_collides",
+            "pub fn torus_solid3d_point3d_collides",
+        );
+        let intersection_ellipsoidal_surface_point_section = section(
+            intersection_source,
+            "fn ellipsoidal_surface3d_point3d_intersection_raw",
+            "fn conical_solid3d_point3d_intersection_raw",
+        );
+
+        assert!(
+            collision_ellipsoidal_surface_point_section.contains(ELLIPSOIDAL_SURFACE_POINT_ENTRYPOINT),
+            "collision/primitive_3d.rs should route ellipsoidal surface point checks through the distance entrypoint"
+        );
+        assert!(
+            intersection_ellipsoidal_surface_point_section.contains(ELLIPSOIDAL_SURFACE_POINT_ENTRYPOINT),
+            "intersection/primitive_3d.rs should route ellipsoidal surface point checks through the distance entrypoint"
+        );
+        assert!(
+            !collision_ellipsoidal_surface_point_section
+                .contains(ELLIPSOIDAL_SURFACE_DIRECT_CONTAINS),
+            "collision/primitive_3d.rs must not call ellipsoid.contains_point directly"
+        );
+        assert!(
+            !intersection_ellipsoidal_surface_point_section
+                .contains(ELLIPSOIDAL_SURFACE_DIRECT_CONTAINS),
+            "intersection/primitive_3d.rs must not call ellipsoid.contains_point directly"
+        );
+    }
+
+    #[test]
+    fn spherical_solid_point_boundary_guard_keeps_collision_and_intersection_on_distance_entrypoint(
+    ) {
+        const SPHERICAL_SOLID_DIRECT_DISTANCE: &str = "sphere.distance_to_surface";
+        const SPHERICAL_SOLID_DIRECT_CONTAINS: &str = "sphere.contains_point";
+        const SPHERICAL_SOLID_POINT_ENTRYPOINT: &str =
+            "crate::distance::spherical_solid3d_point3d_distance";
+
+        fn section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+            let start_index = source
+                .find(start)
+                .unwrap_or_else(|| panic!("missing start marker: {start}"));
+            let tail = &source[start_index..];
+            let end_index = tail
+                .find(end)
+                .unwrap_or_else(|| panic!("missing end marker: {end}"));
+            &tail[..end_index]
+        }
+
+        let collision_source = include_str!("../collision/primitive_3d.rs");
+        let intersection_source = include_str!("../intersection/primitive_3d.rs");
+        let collision_spherical_solid_point_section = section(
+            collision_source,
+            "pub fn spherical_solid3d_point3d_collides",
+            "pub fn cylindrical_solid3d_point3d_collides",
+        );
+        let intersection_spherical_solid_point_section = section(
+            intersection_source,
+            "fn spherical_solid3d_point3d_intersection_raw",
+            "fn spherical_solid3d_line3d_intersection_raw",
+        );
+
+        assert!(
+            collision_spherical_solid_point_section.contains(SPHERICAL_SOLID_POINT_ENTRYPOINT),
+            "collision/primitive_3d.rs should route spherical solid point checks through the distance entrypoint"
+        );
+        assert!(
+            intersection_spherical_solid_point_section.contains(SPHERICAL_SOLID_POINT_ENTRYPOINT),
+            "intersection/primitive_3d.rs should route spherical solid point checks through the distance entrypoint"
+        );
+        assert!(
+            !collision_spherical_solid_point_section.contains(SPHERICAL_SOLID_DIRECT_DISTANCE),
+            "collision/primitive_3d.rs must not call sphere.distance_to_surface directly"
+        );
+        assert!(
+            !intersection_spherical_solid_point_section.contains(SPHERICAL_SOLID_DIRECT_CONTAINS),
+            "intersection/primitive_3d.rs must not call sphere.contains_point directly"
         );
     }
 

--- a/model/geo_algorithms/src/intersection/primitive_3d.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d.rs
@@ -793,7 +793,10 @@ fn ellipsoidal_surface3d_point3d_intersection_raw<T: Scalar>(
     point: &Point3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    point_intersection_if(point, ellipsoid.contains_point(point, tolerance))
+    point_intersection_if(
+        point,
+        crate::distance::ellipsoidal_surface3d_point3d_distance(ellipsoid, point) <= tolerance,
+    )
 }
 
 pub fn ellipsoidal_surface3d_point3d_intersection<T: Scalar>(
@@ -1125,9 +1128,12 @@ pub fn conical_surface3d_line_segment3d_intersections<T: Scalar>(
 fn spherical_solid3d_point3d_intersection_raw<T: Scalar>(
     sphere: &SphericalSolid3D<T>,
     point: &Point3D<T>,
-    _tolerance: T,
+    tolerance: T,
 ) -> Option<Point3D<T>> {
-    point_intersection_if(point, sphere.contains_point(*point))
+    point_intersection_if(
+        point,
+        crate::distance::spherical_solid3d_point3d_distance(sphere, point) <= tolerance,
+    )
 }
 
 pub fn spherical_solid3d_point3d_intersection<T: Scalar>(


### PR DESCRIPTION
## 概要
- SphericalSolid family の代表 point-boundary 経路を `crate::distance::spherical_solid3d_point3d_distance` 経由へ統一
- EllipsoidalSurface の point-boundary 経路を `crate::distance::ellipsoidal_surface3d_point3d_distance` 経由へ統一
- static guard を追加して、shape 側の `contains_point` / `distance_to_surface` への直接依存へ戻らないようにした

## 変更詳細
- distance
  - `spherical_solid3d_point3d_distance`
  - `point3d_spherical_solid3d_distance`
  - `ellipsoidal_surface3d_point3d_distance`
  - `point3d_ellipsoidal_surface3d_distance`
- collision
  - `spherical_solid3d_point3d_collides`
  - `spherical_solid3d_circle3d_collides`
  - `spherical_solid3d_triangle3d_collides`
  - `ellipsoidal_surface3d_point3d_collides`
- intersection
  - `spherical_solid3d_point3d_intersection_raw`
  - `ellipsoidal_surface3d_point3d_intersection_raw`
- static guard
  - spherical solid 向け guard を追加
  - ellipsoidal surface 向け guard を追加

## 検証
- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo test --workspace`

## 残件メモ
- #371 観点では ConicalSurface point family が次の最小残件
- #654 の `primitive_3d.rs` 分割やコメント整理は本PRでは扱わない

Refs #371