### PR TITLE
[Phase 2] feat: Application から job_runtime 接続を実装

### DIFF
--- a/dev/architecture/APPLICATION_ORCHESTRATION_LAYER_DESIGN.md
+++ b/dev/architecture/APPLICATION_ORCHESTRATION_LAYER_DESIGN.md
@@ -139,6 +139,14 @@ Domain / Algorithm / Runtime / Adapter
 - `job_runtime`: 実行基盤
 - `cam_sim`: CAM 特化の実行ファサードと接続アダプタが混在
 
+### 6.2 2026-04-10 時点の job_orchestration 最小実装方針
+
+- `model/application::job_orchestration` は `JobManager` を内部保持し、`CamJobExecutorAdapter` を使って local 実行モードを提供する
+- command は `submit_workflow` のみを持ち、query は `query_status` / `query_result` に分離する
+- `job_runtime` の内部型は直接露出せず、ViewModel 側が扱う job DTO は `job_domain::job_view_bridge` の `CamJobRecord` / `CamJobEvent` を経由して返す
+- timeout や retry の詳細設定は初期実装では Application 内部既定値に寄せ、境界 DTO は `job_type` / `input_ref` / `parent_job_id` の最小集合から始める
+- これにより `job` が geometry / topology / entity 更新と別系統の execution mode であることを module と trait 境界で追跡できる
+
 ---
 
 ## 7. group relation 系 use case の扱い

--- a/dev/architecture/VIEWMODEL_MODEL_ROUTE_REDEFINITION_DESIGN.md
+++ b/dev/architecture/VIEWMODEL_MODEL_ROUTE_REDEFINITION_DESIGN.md
@@ -618,6 +618,9 @@ pub struct LayerMembershipDto {
 - submit / status / cancel / retry の実行方式境界を担う
 - geometry / topology / entity を直接保持しない
 - 既存 `job_runtime` / `cam_sim::CamJobExecutorAdapter` との接続窓口として育てる
+- 2026-04-10 時点の最小実装では、`JobWorkflowOrchestrator` が `submit_workflow` command と `query_status` / `query_result` query を提供する
+- `job_runtime::JobEvent` は `job_domain::CamJobEvent` へ正規化し、ViewModel 側は runtime 固有 enum を直接扱わない
+- `job_runtime::JobRecord` は `job_domain::CamJobRecord` に写像して返し、Application が query 境界の正本となる
 
 ### 6.4 entity / topology orchestration の初期配置
 
@@ -746,6 +749,7 @@ pub trait PlanarStroke2DProperties<T: Scalar> {
 - 表示属性は common trait に詰め込まず、common / stroke / planar-2d に分割して露出する
 - `cam_orchestration` の `ToolEntityManagementOrchestrator` は現状では deterministic ID 組み立て PoC と位置づけ、Model ストレージ更新の完成形と見なさない
 - `job_runtime` はすでに execution 語彙を持っているため、#500 では job 独自モデルを再発明せず接続点だけ定義する
+- #647 ではこの方針に従い、job 独自の永続モデルを増やさず `job_runtime` の record/event を Application 境界 DTO に正規化して返す
 - `geo_topology` は shape 意味論の代替ではなく、接続・整合性語彙として geometry 後段に置く
 
 ---

--- a/model/application/src/job_orchestration.rs
+++ b/model/application/src/job_orchestration.rs
@@ -1,22 +1,329 @@
 //! Job向け orchestration 境界。
 
+use cam_sim::{CamJobExecutorAdapter, CamWorkflowError, CamWorkflowSubmitter};
+use job_domain::{CamJobEvent, CamJobRecord, CamJobStatus, CamJobType};
+use job_runtime::{JobError, JobId, JobManager, JobSpec, JobType, RetryPolicy};
+
+const DEFAULT_TIMEOUT_SECS: u64 = 60;
+
+/// Job orchestration で返却する統一エラー。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JobOrchestrationError {
+    InvalidRequest(String),
+    Workflow(String),
+    Runtime(String),
+}
+
+impl std::fmt::Display for JobOrchestrationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidRequest(message) | Self::Workflow(message) | Self::Runtime(message) => {
+                write!(f, "{}", message)
+            }
+        }
+    }
+}
+
+impl std::error::Error for JobOrchestrationError {}
+
+impl From<JobError> for JobOrchestrationError {
+    fn from(value: JobError) -> Self {
+        Self::Runtime(value.to_string())
+    }
+}
+
+impl From<CamWorkflowError> for JobOrchestrationError {
+    fn from(value: CamWorkflowError) -> Self {
+        Self::Workflow(value.to_string())
+    }
+}
+
 /// 汎用 workflow 送信の入力境界。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct JobWorkflowSubmitRequest {
-    pub job_type: String,
+    pub job_type: CamJobType,
     pub input_ref: String,
+    pub parent_job_id: Option<u64>,
 }
 
 /// workflow 送信の出力境界。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct JobWorkflowSubmitResult {
     pub job_id: u64,
+    pub status: CamJobStatus,
 }
 
-/// job 送信ユースケースの orchestration port。
+/// status query の入力境界。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JobWorkflowStatusQuery {
+    pub job_id: u64,
+}
+
+/// status query の出力境界。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JobWorkflowStatusResult {
+    pub job_id: u64,
+    pub status: CamJobStatus,
+}
+
+/// result query の入力境界。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JobWorkflowResultQuery {
+    pub job_id: u64,
+}
+
+/// result query の出力境界。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JobWorkflowResult {
+    pub job: CamJobRecord,
+    pub active_result_ref: Option<String>,
+}
+
+/// ViewModel 向けイベント batch。
+#[derive(Debug, Clone, PartialEq)]
+pub struct JobWorkflowEventBatch {
+    pub events: Vec<CamJobEvent>,
+}
+
+/// job 実行ユースケースの orchestration port。
 pub trait JobWorkflowOrchestration {
     fn submit_workflow(
-        &self,
+        &mut self,
         request: JobWorkflowSubmitRequest,
-    ) -> Result<JobWorkflowSubmitResult, String>;
+    ) -> Result<JobWorkflowSubmitResult, JobOrchestrationError>;
+
+    fn query_status(
+        &self,
+        query: JobWorkflowStatusQuery,
+    ) -> Result<JobWorkflowStatusResult, JobOrchestrationError>;
+
+    fn query_result(
+        &self,
+        query: JobWorkflowResultQuery,
+    ) -> Result<JobWorkflowResult, JobOrchestrationError>;
+
+    fn take_event_batch(&mut self) -> JobWorkflowEventBatch;
+}
+
+/// `job_runtime` と `cam_sim` adapter を Application 境界へ束ねる既定実装。
+#[derive(Debug, Default)]
+pub struct JobWorkflowOrchestrator {
+    manager: JobManager,
+    executor: CamJobExecutorAdapter,
+}
+
+impl JobWorkflowOrchestrator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_runtime(manager: JobManager, executor: CamJobExecutorAdapter) -> Self {
+        Self { manager, executor }
+    }
+}
+
+impl JobWorkflowOrchestration for JobWorkflowOrchestrator {
+    fn submit_workflow(
+        &mut self,
+        request: JobWorkflowSubmitRequest,
+    ) -> Result<JobWorkflowSubmitResult, JobOrchestrationError> {
+        let spec = build_job_spec(&request);
+        let job_id = submit_to_runtime(&mut self.manager, &request, spec)?;
+        self.manager.execute_with(job_id, &self.executor)?;
+
+        Ok(JobWorkflowSubmitResult {
+            job_id: job_id.0,
+            status: self.manager.status(job_id)?.into(),
+        })
+    }
+
+    fn query_status(
+        &self,
+        query: JobWorkflowStatusQuery,
+    ) -> Result<JobWorkflowStatusResult, JobOrchestrationError> {
+        let job_id = JobId(query.job_id);
+        Ok(JobWorkflowStatusResult {
+            job_id: query.job_id,
+            status: self.manager.status(job_id)?.into(),
+        })
+    }
+
+    fn query_result(
+        &self,
+        query: JobWorkflowResultQuery,
+    ) -> Result<JobWorkflowResult, JobOrchestrationError> {
+        let job_id = JobId(query.job_id);
+        let active_result_ref = self.manager.active_result_ref(job_id)?.map(str::to_owned);
+        let job = CamJobRecord::from(self.manager.get(job_id)?);
+
+        Ok(JobWorkflowResult {
+            job,
+            active_result_ref,
+        })
+    }
+
+    fn take_event_batch(&mut self) -> JobWorkflowEventBatch {
+        let events = self.manager.take_events();
+        JobWorkflowEventBatch {
+            events: events.iter().map(CamJobEvent::from).collect(),
+        }
+    }
+}
+
+fn build_job_spec(request: &JobWorkflowSubmitRequest) -> JobSpec {
+    JobSpec {
+        job_type: map_job_type(request.job_type.clone()),
+        input_ref: request.input_ref.clone(),
+        timeout_secs: DEFAULT_TIMEOUT_SECS,
+        retry_policy: RetryPolicy::default(),
+    }
+}
+
+fn submit_to_runtime(
+    manager: &mut JobManager,
+    request: &JobWorkflowSubmitRequest,
+    spec: JobSpec,
+) -> Result<JobId, JobOrchestrationError> {
+    match (request.job_type.clone(), request.parent_job_id) {
+        (CamJobType::CamProcess, None) => {
+            let mut submitter = CamWorkflowSubmitter::new(manager);
+            Ok(submitter.submit_cam_process(spec)?)
+        }
+        (CamJobType::CuttingSimulation, None) => Err(JobOrchestrationError::InvalidRequest(
+            "cutting simulation requires parent_job_id".to_string(),
+        )),
+        (CamJobType::CuttingSimulation, Some(parent_job_id)) => {
+            let mut submitter = CamWorkflowSubmitter::new(manager);
+            Ok(submitter.submit_cutting_simulation(JobId(parent_job_id), spec)?)
+        }
+        (CamJobType::CamProcess, Some(parent_job_id)) => {
+            let mut submitter = CamWorkflowSubmitter::new(manager);
+            Ok(submitter.submit_child_under(JobId(parent_job_id), spec)?)
+        }
+    }
+}
+
+fn map_job_type(job_type: CamJobType) -> JobType {
+    match job_type {
+        CamJobType::CamProcess => JobType::CamProcess,
+        CamJobType::CuttingSimulation => JobType::CuttingSimulation,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use job_domain::{CamJobEvent, CamJobStatus, CamJobType};
+
+    use super::{
+        JobWorkflowOrchestration, JobWorkflowOrchestrator, JobWorkflowResultQuery,
+        JobWorkflowStatusQuery, JobWorkflowSubmitRequest,
+    };
+
+    #[test]
+    fn submit_status_and_result_queries_work_for_cam_process() {
+        let mut orchestrator = JobWorkflowOrchestrator::new();
+        let submit = orchestrator
+            .submit_workflow(JobWorkflowSubmitRequest {
+                job_type: CamJobType::CamProcess,
+                input_ref: "input://cam/sample".to_string(),
+                parent_job_id: None,
+            })
+            .expect("cam process should succeed");
+
+        assert_eq!(submit.job_id, 1);
+        assert_eq!(submit.status, CamJobStatus::Succeeded);
+
+        let status = orchestrator
+            .query_status(JobWorkflowStatusQuery {
+                job_id: submit.job_id,
+            })
+            .expect("status query should succeed");
+        assert_eq!(status.status, CamJobStatus::Succeeded);
+
+        let result = orchestrator
+            .query_result(JobWorkflowResultQuery {
+                job_id: submit.job_id,
+            })
+            .expect("result query should succeed");
+        assert_eq!(result.job.status, CamJobStatus::Succeeded);
+        assert_eq!(
+            result.active_result_ref.as_deref(),
+            Some("result://cam/1/ok")
+        );
+        assert_eq!(result.job.output_history.len(), 1);
+    }
+
+    #[test]
+    fn submit_failure_is_visible_through_status_and_result_queries() {
+        let mut orchestrator = JobWorkflowOrchestrator::new();
+        let submit = orchestrator
+            .submit_workflow(JobWorkflowSubmitRequest {
+                job_type: CamJobType::CamProcess,
+                input_ref: "input://invalid".to_string(),
+                parent_job_id: None,
+            })
+            .expect("submit should still complete with failed runtime status");
+
+        assert_eq!(submit.status, CamJobStatus::Failed);
+
+        let result = orchestrator
+            .query_result(JobWorkflowResultQuery {
+                job_id: submit.job_id,
+            })
+            .expect("failed job should still be queryable");
+        assert_eq!(result.job.status, CamJobStatus::Failed);
+        assert_eq!(result.active_result_ref, None);
+        assert!(
+            result
+                .job
+                .last_error
+                .as_deref()
+                .is_some_and(|message| message.contains("invalid input_ref"))
+        );
+    }
+
+    #[test]
+    fn event_batch_is_normalized_for_viewmodel_consumption() {
+        let mut orchestrator = JobWorkflowOrchestrator::new();
+        let submit = orchestrator
+            .submit_workflow(JobWorkflowSubmitRequest {
+                job_type: CamJobType::CamProcess,
+                input_ref: "input://cam/sample".to_string(),
+                parent_job_id: None,
+            })
+            .expect("cam process should succeed");
+
+        let batch = orchestrator.take_event_batch();
+
+        assert!(batch.events.iter().any(|event| matches!(
+            event,
+            CamJobEvent::ArtifactReady { job_id, result_ref }
+                if *job_id == submit.job_id && result_ref == "result://cam/1/ok"
+        )));
+        assert!(batch.events.iter().any(|event| matches!(
+            event,
+            CamJobEvent::Completed {
+                job_id,
+                status: CamJobStatus::Succeeded,
+                ..
+            } if *job_id == submit.job_id
+        )));
+    }
+
+    #[test]
+    fn cutting_simulation_requires_parent_job_id() {
+        let mut orchestrator = JobWorkflowOrchestrator::new();
+        let error = orchestrator
+            .submit_workflow(JobWorkflowSubmitRequest {
+                job_type: CamJobType::CuttingSimulation,
+                input_ref: "input://sim/sample".to_string(),
+                parent_job_id: None,
+            })
+            .expect_err("cutting simulation without parent should be rejected");
+
+        assert_eq!(
+            error.to_string(),
+            "cutting simulation requires parent_job_id".to_string()
+        );
+    }
 }


### PR DESCRIPTION
## 概要
- Application 正本として job execution mode の最小導線を追加
- `model/application/src/job_orchestration.rs` に submit/status/result query と event batch 正規化を実装
- `dev/architecture/APPLICATION_ORCHESTRATION_LAYER_DESIGN.md` と `dev/architecture/VIEWMODEL_MODEL_ROUTE_REDEFINITION_DESIGN.md` に最小実装方針を反映

## 変更点
- `JobWorkflowOrchestrator` を追加し、`JobManager` と `CamJobExecutorAdapter` を Application 境界で統合
- command と query を分離し、`submit_workflow`、`query_status`、`query_result`、`take_event_batch` を公開
- `job_runtime::JobRecord` / `JobEvent` を `job_domain::CamJobRecord` / `CamJobEvent` に正規化
- submit 成功系、失敗系、event 正規化、親必須制約の単体テストを追加

## 検証
- `cargo clippy -- -D warnings`
- `cargo fmt`
- `cargo test --workspace`

Closes #647