### PR TITLE
[Phase 3] refactor: preview/display と entity commit/import の topology 境界を整理

### DIFF
--- a/dev/architecture/APPLICATION_ORCHESTRATION_LAYER_DESIGN.md
+++ b/dev/architecture/APPLICATION_ORCHESTRATION_LAYER_DESIGN.md
@@ -39,6 +39,17 @@
 - `workflow` は順序制御には適するが、port/adapter の選択や境界DTOの集約まで含めるにはやや狭い
 - `orchestration` は「どこに委譲するか」「どういう順序で進めるか」「どの境界で返すか」をまとめて表現しやすい
 
+### 2.4 geometry 系命名の使い分け
+
+- `feature` は CAD 文脈で意味が揺れやすい語である。履歴再生付きの形状処理コマンドを指す場合もあれば、設計意図を持つ形状要素を指す場合もあり、CAD 製品ごとに思想差が大きい
+- そのため RedRing では、文脈ローカルな定義なしに `feature` を総称のマジックワードとして使わない
+- `feature` は「ユーザーが意味を持つ CAD 編集単位」を表す語として使い、単なる描画補助やプレビューまで含めない
+- `geometry` は座標や寸法から形状を組み立てる処理を指し、EntityID 付与や topology 保存を含意しない
+- `preview` は画面表示補助、途中経過表示、コマンド中の矢印・座標軸・一時形状など、永続化や entity 化を前提としない経路に使う
+- `entity commit` / `import` は geometry を CAD データとして管理対象へ載せる経路を指し、必要に応じて topology と EntityID を伴う
+- したがって `feature_orchestration` を preview 系の総称として使わない。preview 系は geometry / preview / display 系の語彙で分離する
+- `feature` を使う場合は、「履歴コマンドとしての feature」か「設計意図を持つ形状単位としての feature」かを文書内で明記してから使う
+
 ---
 
 ## 3. 役割定義
@@ -146,6 +157,22 @@ Domain / Algorithm / Runtime / Adapter
 - `job_runtime` の内部型は直接露出せず、ViewModel 側が扱う job DTO は `job_domain::job_view_bridge` の `CamJobRecord` / `CamJobEvent` を経由して返す
 - timeout や retry の詳細設定は初期実装では Application 内部既定値に寄せ、境界 DTO は `job_type` / `input_ref` / `parent_job_id` の最小集合から始める
 - これにより `job` が geometry / topology / entity 更新と別系統の execution mode であることを module と trait 境界で追跡できる
+
+### 6.3 geometry / topology / entity 経路の整理
+
+- Application には少なくとも `preview/display` 系と `entity commit/import` 系の 2 経路が存在する
+- `preview/display` 系は、座標軸、コマンド矢印、一時プレビュー、デバッグ表示などを対象とし、EntityID を前提にしない
+- `entity commit/import` 系は、geometry を CAD データとして保存・参照可能な形に正規化する経路であり、EntityID と必要時の topology を伴う
+- `job_orchestration` と `cam_orchestration` はこの分類とは独立した execution mode / simulation 系の経路であり、geometry 後段責務の議論には含めない
+- この分離を明示せずに `feature` へ寄せると、preview と entity commit の責務が混線し、topology が必須か optional かの議論も不安定になる
+
+### 6.4 preview 系で topology が必要になりうるケース
+
+- preview 系は原則として EntityID 非前提であり、topology も optional とする
+- ただし sheet surface のモーフィング、trim 境界付き surface の局所プレビュー、面同士の連続性を保った変形補助などでは、preview であっても topology 情報が必要になる可能性がある
+- この場合も preview を直ちに `feature` や `entity commit` と同一視しない。必要なのは「topology を参照する preview」であって、「entity 化済み feature」ではない
+- したがって設計上は `topology optional` ではなく「preview では topology 非前提だが、要求に応じて topology を参照可能」と整理する
+- つまり topology の有無だけで preview 系と entity commit 系を分けず、EntityID 付与・保存責務・CAD データ化の有無で経路を分ける
 
 ---
 

--- a/dev/architecture/VIEWMODEL_MODEL_ROUTE_REDEFINITION_DESIGN.md
+++ b/dev/architecture/VIEWMODEL_MODEL_ROUTE_REDEFINITION_DESIGN.md
@@ -607,11 +607,16 @@ pub struct LayerMembershipDto {
 - 各 UI command に近い use case 入口を持つ
 - 1つの feature 編集要求に対して geometry / topology / entity の順序を束ねる
 - 初期の ViewModel→Model 導線の主入口はここに置く
+- ただし `feature` は CAD 製品ごとに「履歴再生付きコマンド」と「設計意図を持つ形状要素」の両義性を持つため、RedRing では無定義の総称として使わない
+- ただしここでいう `feature` は CAD 編集単位を指し、座標軸・矢印・一時プレビューのような display 補助まで含める総称としては使わない
+- そのため preview 系経路を `feature_orchestration` に無理に寄せず、EntityID を持たない geometry / preview 系の導線は別語彙で整理する
 
 ### 6.2 geometry_orchestration
 
 - 単なる `operation_name` の marker ではなく、geometry 更新の adapter / port 群へ発展させる
 - ただし UI から直接叩く主入口ではなく、feature orchestration の下位協調点として使う
+- 一方で preview/display 系では、entity commit を伴わない geometry 組み立て入口として直接使う余地を残す
+- したがって `geometry_orchestration` は常に topology や entity 化へ進む前段とは限らず、preview 導線では geometry-only 結果で完結しうる
 
 ### 6.3 job_orchestration
 
@@ -628,6 +633,15 @@ pub struct LayerMembershipDto {
 - 2026-04-09 時点では、topology は geometry からの導出 / 検証責務が独立しているため `topology_orchestration` を独立 module として配置している
 - 一方で entity は専用 module をまだ追加せず、`feature_orchestration` 配下の store port として保持している
 - したがって初期段階の判断基準は module 数の抑制そのものではなく、ViewModel→Application→Model 導線の責務分割をコード上で追跡できることに置く
+
+### 6.5 preview 系と entity commit 系の読み替え
+
+- ViewModel 起点の geometry 系 command には、少なくとも `preview/display` 系と `entity commit/import` 系の 2 種類がある
+- `preview/display` 系は EntityID を前提にせず、描画のための geometry または必要最小限の topology 参照で完結する
+- `entity commit/import` 系は CAD データとして管理対象へ載せる経路であり、geometry → topology(必要時) → entity → result の順序を取る
+- triangle のように geometry 後に topology 検証を行っても、entity 化を伴わないなら `entity commit` ではなく `topology-aware preview` とみなす
+- このため「topology を通ったかどうか」だけで feature 系を定義しない。EntityID 付与、保存責務、CAD データへの反映有無まで含めて経路分類を行う
+- さらに `feature` という語だけで経路分類を語らず、必要に応じて `preview`、`entity commit`、`import`、`history command` などの具体語へ分解して記述する
 
 ---
 
@@ -701,6 +715,13 @@ pub trait PlanarStroke2DProperties<T: Scalar> {
 - topology は optional port として位置だけ固定し、対象 use case で必要なら導入する
 - result / error を ViewModel に返す
 
+### Phase 1 補足: preview 導線の位置づけ
+
+- preview 系は #501 / #646 の entity commit 導線とは別に扱う
+- preview では topology 非前提を基本とするが、sheet surface morphing や trim 境界を伴う面プレビューでは topology 参照が必要になる可能性がある
+- その場合も preview は EntityID を持つ CAD entity 化と同一視せず、`topology-aware preview` として別経路で整理する
+- これにより preview 要件の拡張が、feature/entity commit 導線の責務を曖昧にしないようにする
+
 ### Phase 2: 後続で拡張すること
 
 - job_orchestration と `job_runtime` の接続を `Application` 正本に寄せる
@@ -712,6 +733,7 @@ pub trait PlanarStroke2DProperties<T: Scalar> {
 - ViewModel 起点の最小 command 導線は `viewmodel/converter/src/feature_command_converter.rs` から `application` へ接続している
 - 現在の非ECS入口は `FeatureCommandOrchestration` であり、`FeatureOrchestrator` が line / circle / arc の geometry → topology → entity を直列実行する
 - triangle は face を導入せず、`GeometryOrchestrator` と `TopologyOrchestrator` を経由して closed wire として topology 責務だけを固定している
+- この triangle 導線は topology を参照するが、EntityID を生成して保存する経路ではないため、現時点では `entity commit` ではなく `topology-aware preview` 寄りの暫定導線とみなす
 - 通常の平面トポロジーとして triangle を Wire / Loop で扱う場合は、各辺を `LineSegment` 相当の直線 edge として表現する方針を採る
 - #256 で扱う三角形限定 topology は、工具逆オフセット法計算の前段で局所的な凸部縫合と探索効率向上を目的とする別系統の用途であり、ここでの通常 topology 表現とは分離して扱う
 - geometry の差し替え点は `LineGeometryMutationPort` と `DebugShapeGeometryMutationPort` である


### PR DESCRIPTION
## 概要
- preview/display 系と entity commit/import 系の topology 境界整理を設計文書へ反映
- `feature` を CAD ごとに意味が揺れるマジックワードとして扱い、無定義の総称として使わない方針を明記
- #646 の issue 本文と実装メモを、line を最小候補にした整理へ更新

## 変更点
- `dev/architecture/APPLICATION_ORCHESTRATION_LAYER_DESIGN.md`
  - `feature` / `geometry` / `preview` / `entity commit/import` の命名使い分けを追加
  - preview/display 系と entity commit/import 系の 2 経路整理を追加
  - sheet surface morphing など preview でも topology 参照が必要になりうる例外を `topology-aware preview` として明記
- `dev/architecture/VIEWMODEL_MODEL_ROUTE_REDEFINITION_DESIGN.md`
  - `feature` を無定義の総称として使わないことを明記
  - preview 系と entity commit 系の読み替え、および triangle 導線の暫定的位置づけを追記
- Issue #646
  - タイトルと本文を preview/display と entity commit/import の境界整理に合わせて更新
  - line を最小の entity commit/import 系候補とする実装整理メモをコメント追加

## 位置づけ
- 本PRは設計整理のみ
- 実装本体ではなく、#646 の後続実装で何を commit/import 系の正本候補として扱うかを固定するための前段整理

Closes #646