### PR TITLE
[Phase 4.2] #650 geo_topology NURBS curve edge最小対応

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,6 +1164,7 @@ dependencies = [
  "geo_commons",
  "geo_contracts",
  "geo_core",
+ "geo_nurbs",
  "geo_primitives",
 ]
 

--- a/model/geo_topology/Cargo.toml
+++ b/model/geo_topology/Cargo.toml
@@ -8,6 +8,7 @@ geo_contracts = { path = "../geo_contracts", version = "0.1.0" }
 geo_commons = { path = "../geo_commons", version = "0.1.0" }
 geo_core = { path = "../geo_core", version = "0.1.0" }
 geo_primitives = { path = "../geo_primitives", version = "0.1.0" }
+geo_nurbs = { path = "../geo_nurbs", version = "0.1.0" }
 analysis = { path = "../../foundation/analysis", version = "0.1.0" }
 
 [dev-dependencies]

--- a/model/geo_topology/src/composite_curve.rs
+++ b/model/geo_topology/src/composite_curve.rs
@@ -186,6 +186,22 @@ mod tests {
     use super::*;
     use geo_contracts::NurbsCurve3DConstructor;
 
+    fn assert_point_close(actual: Point3D<f64>, expected: Point3D<f64>, tolerance: f64) {
+        assert!(
+            (actual.x() - expected.x()).abs() < tolerance
+                && (actual.y() - expected.y()).abs() < tolerance
+                && (actual.z() - expected.z()).abs() < tolerance,
+            "points are not within tolerance: actual=({:?}, {:?}, {:?}), expected=({:?}, {:?}, {:?}), tol={}",
+            actual.x(),
+            actual.y(),
+            actual.z(),
+            expected.x(),
+            expected.y(),
+            expected.z(),
+            tolerance
+        );
+    }
+
     #[test]
     fn curve_segment_line_start_end() {
         let seg = TopoLineSegment3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(1.0, 0.0, 0.0))
@@ -228,6 +244,7 @@ mod tests {
 
     #[test]
     fn curve_segment_nurbs_start_end_and_constraint_endpoints() {
+        let tolerance = 1.0e-9;
         let curve = <TopoNurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(
             (0.0, 0.0, 0.0),
             (2.0, 0.0, 0.0),
@@ -236,10 +253,18 @@ mod tests {
 
         let segment = CurveSegment3D::Nurbs(curve);
 
-        assert_eq!(segment.start(), Point3D::new(0.0, 0.0, 0.0));
-        assert_eq!(segment.end(), Point3D::new(2.0, 0.0, 0.0));
-        assert_eq!(segment.constraint_start(), Point3D::new(0.0, 0.0, 0.0));
-        assert_eq!(segment.constraint_end(), Point3D::new(2.0, 0.0, 0.0));
+        assert_point_close(segment.start(), Point3D::new(0.0, 0.0, 0.0), tolerance);
+        assert_point_close(segment.end(), Point3D::new(2.0, 0.0, 0.0), tolerance);
+        assert_point_close(
+            segment.constraint_start(),
+            Point3D::new(0.0, 0.0, 0.0),
+            tolerance,
+        );
+        assert_point_close(
+            segment.constraint_end(),
+            Point3D::new(2.0, 0.0, 0.0),
+            tolerance,
+        );
     }
 
     #[test]
@@ -273,6 +298,7 @@ mod tests {
 
     #[test]
     fn composite_curve_accepts_nurbs_segment() {
+        let tolerance = 1.0e-9;
         let curve = <TopoNurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(
             (0.0, 0.0, 0.0),
             (2.0, 0.0, 0.0),
@@ -281,10 +307,26 @@ mod tests {
 
         let composite = CompositeCurve3D::new(vec![CurveSegment3D::Nurbs(curve)]).unwrap();
 
-        assert_eq!(composite.ideal_start_point(), Point3D::new(0.0, 0.0, 0.0));
-        assert_eq!(composite.ideal_end_point(), Point3D::new(2.0, 0.0, 0.0));
-        assert_eq!(composite.start_point(), Point3D::new(0.0, 0.0, 0.0));
-        assert_eq!(composite.end_point(), Point3D::new(2.0, 0.0, 0.0));
+        assert_point_close(
+            composite.ideal_start_point(),
+            Point3D::new(0.0, 0.0, 0.0),
+            tolerance,
+        );
+        assert_point_close(
+            composite.ideal_end_point(),
+            Point3D::new(2.0, 0.0, 0.0),
+            tolerance,
+        );
+        assert_point_close(
+            composite.start_point(),
+            Point3D::new(0.0, 0.0, 0.0),
+            tolerance,
+        );
+        assert_point_close(
+            composite.end_point(),
+            Point3D::new(2.0, 0.0, 0.0),
+            tolerance,
+        );
     }
 
     #[test]

--- a/model/geo_topology/src/composite_curve.rs
+++ b/model/geo_topology/src/composite_curve.rs
@@ -3,7 +3,10 @@
 //! 命名は Solidworks 系の CompositeCurve に合わせる
 //! （Rhino: PolyCurve、ISO STEP: CompositeCurve）
 
-use crate::{Point3D, TopoArc3D, TopoLineSegment3D, TopoNurbsCurve3D, Vector3D};
+use crate::{
+    Point3D, TopoArc3D, TopoLineSegment3D, TopoNurbsCurve3D, Vector3D,
+    TOPO_NURBS_LENGTH_SUBDIVISIONS,
+};
 use geo_contracts::Scalar;
 
 /// 複合曲線を構成する個別セグメント
@@ -70,7 +73,7 @@ impl<T: Scalar> CurveSegment3D<T> {
                 vec.magnitude()
             }
             Self::Arc(arc) => arc.length(),
-            Self::Nurbs(curve) => curve.approximate_length(100),
+            Self::Nurbs(curve) => curve.approximate_length(TOPO_NURBS_LENGTH_SUBDIVISIONS),
         }
     }
 }

--- a/model/geo_topology/src/composite_curve.rs
+++ b/model/geo_topology/src/composite_curve.rs
@@ -186,6 +186,10 @@ mod tests {
     use super::*;
     use geo_contracts::NurbsCurve3DConstructor;
 
+    // テスト内で個別にトレランスを定義しないため、比較トレランスは共通定数を使う。
+    const POINT_COMPARISON_TOLERANCE_F64: f64 =
+        analysis::consts::test_constants::DISTANCE_TOLERANCE_F64;
+
     fn assert_point_close(actual: Point3D<f64>, expected: Point3D<f64>, tolerance: f64) {
         assert!(
             (actual.x() - expected.x()).abs() < tolerance
@@ -244,7 +248,6 @@ mod tests {
 
     #[test]
     fn curve_segment_nurbs_start_end_and_constraint_endpoints() {
-        let tolerance = 1.0e-9;
         let curve = <TopoNurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(
             (0.0, 0.0, 0.0),
             (2.0, 0.0, 0.0),
@@ -253,17 +256,25 @@ mod tests {
 
         let segment = CurveSegment3D::Nurbs(curve);
 
-        assert_point_close(segment.start(), Point3D::new(0.0, 0.0, 0.0), tolerance);
-        assert_point_close(segment.end(), Point3D::new(2.0, 0.0, 0.0), tolerance);
+        assert_point_close(
+            segment.start(),
+            Point3D::new(0.0, 0.0, 0.0),
+            POINT_COMPARISON_TOLERANCE_F64,
+        );
+        assert_point_close(
+            segment.end(),
+            Point3D::new(2.0, 0.0, 0.0),
+            POINT_COMPARISON_TOLERANCE_F64,
+        );
         assert_point_close(
             segment.constraint_start(),
             Point3D::new(0.0, 0.0, 0.0),
-            tolerance,
+            POINT_COMPARISON_TOLERANCE_F64,
         );
         assert_point_close(
             segment.constraint_end(),
             Point3D::new(2.0, 0.0, 0.0),
-            tolerance,
+            POINT_COMPARISON_TOLERANCE_F64,
         );
     }
 
@@ -298,7 +309,6 @@ mod tests {
 
     #[test]
     fn composite_curve_accepts_nurbs_segment() {
-        let tolerance = 1.0e-9;
         let curve = <TopoNurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(
             (0.0, 0.0, 0.0),
             (2.0, 0.0, 0.0),
@@ -310,22 +320,22 @@ mod tests {
         assert_point_close(
             composite.ideal_start_point(),
             Point3D::new(0.0, 0.0, 0.0),
-            tolerance,
+            POINT_COMPARISON_TOLERANCE_F64,
         );
         assert_point_close(
             composite.ideal_end_point(),
             Point3D::new(2.0, 0.0, 0.0),
-            tolerance,
+            POINT_COMPARISON_TOLERANCE_F64,
         );
         assert_point_close(
             composite.start_point(),
             Point3D::new(0.0, 0.0, 0.0),
-            tolerance,
+            POINT_COMPARISON_TOLERANCE_F64,
         );
         assert_point_close(
             composite.end_point(),
             Point3D::new(2.0, 0.0, 0.0),
-            tolerance,
+            POINT_COMPARISON_TOLERANCE_F64,
         );
     }
 

--- a/model/geo_topology/src/composite_curve.rs
+++ b/model/geo_topology/src/composite_curve.rs
@@ -3,10 +3,7 @@
 //! 命名は Solidworks 系の CompositeCurve に合わせる
 //! （Rhino: PolyCurve、ISO STEP: CompositeCurve）
 
-use crate::{
-    Point3D, TopoArc3D, TopoLineSegment3D, TopoNurbsCurve3D, Vector3D,
-    TOPO_NURBS_LENGTH_SUBDIVISIONS,
-};
+use crate::{Point3D, TopoArc3D, TopoLineSegment3D, TopoNurbsCurve3D, Vector3D};
 use geo_contracts::Scalar;
 
 /// 複合曲線を構成する個別セグメント
@@ -73,7 +70,9 @@ impl<T: Scalar> CurveSegment3D<T> {
                 vec.magnitude()
             }
             Self::Arc(arc) => arc.length(),
-            Self::Nurbs(curve) => curve.approximate_length(TOPO_NURBS_LENGTH_SUBDIVISIONS),
+            Self::Nurbs(curve) => {
+                curve.approximate_length(geo_nurbs::constants::CURVE_LENGTH_SUBDIVISIONS)
+            }
         }
     }
 }

--- a/model/geo_topology/src/composite_curve.rs
+++ b/model/geo_topology/src/composite_curve.rs
@@ -186,9 +186,9 @@ mod tests {
     use super::*;
     use geo_contracts::NurbsCurve3DConstructor;
 
-    // テスト内で個別にトレランスを定義しないため、比較トレランスは共通定数を使う。
-    const POINT_COMPARISON_TOLERANCE_F64: f64 =
-        analysis::consts::test_constants::DISTANCE_TOLERANCE_F64;
+    fn standard_distance_tol() -> f64 {
+        analysis::consts::test_constants::DISTANCE_TOLERANCE_F64
+    }
 
     fn assert_point_close(actual: Point3D<f64>, expected: Point3D<f64>, tolerance: f64) {
         assert!(
@@ -248,6 +248,7 @@ mod tests {
 
     #[test]
     fn curve_segment_nurbs_start_end_and_constraint_endpoints() {
+        let tol = standard_distance_tol();
         let curve = <TopoNurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(
             (0.0, 0.0, 0.0),
             (2.0, 0.0, 0.0),
@@ -256,26 +257,10 @@ mod tests {
 
         let segment = CurveSegment3D::Nurbs(curve);
 
-        assert_point_close(
-            segment.start(),
-            Point3D::new(0.0, 0.0, 0.0),
-            POINT_COMPARISON_TOLERANCE_F64,
-        );
-        assert_point_close(
-            segment.end(),
-            Point3D::new(2.0, 0.0, 0.0),
-            POINT_COMPARISON_TOLERANCE_F64,
-        );
-        assert_point_close(
-            segment.constraint_start(),
-            Point3D::new(0.0, 0.0, 0.0),
-            POINT_COMPARISON_TOLERANCE_F64,
-        );
-        assert_point_close(
-            segment.constraint_end(),
-            Point3D::new(2.0, 0.0, 0.0),
-            POINT_COMPARISON_TOLERANCE_F64,
-        );
+        assert_point_close(segment.start(), Point3D::new(0.0, 0.0, 0.0), tol);
+        assert_point_close(segment.end(), Point3D::new(2.0, 0.0, 0.0), tol);
+        assert_point_close(segment.constraint_start(), Point3D::new(0.0, 0.0, 0.0), tol);
+        assert_point_close(segment.constraint_end(), Point3D::new(2.0, 0.0, 0.0), tol);
     }
 
     #[test]
@@ -309,6 +294,7 @@ mod tests {
 
     #[test]
     fn composite_curve_accepts_nurbs_segment() {
+        let tol = standard_distance_tol();
         let curve = <TopoNurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(
             (0.0, 0.0, 0.0),
             (2.0, 0.0, 0.0),
@@ -320,23 +306,15 @@ mod tests {
         assert_point_close(
             composite.ideal_start_point(),
             Point3D::new(0.0, 0.0, 0.0),
-            POINT_COMPARISON_TOLERANCE_F64,
+            tol,
         );
         assert_point_close(
             composite.ideal_end_point(),
             Point3D::new(2.0, 0.0, 0.0),
-            POINT_COMPARISON_TOLERANCE_F64,
+            tol,
         );
-        assert_point_close(
-            composite.start_point(),
-            Point3D::new(0.0, 0.0, 0.0),
-            POINT_COMPARISON_TOLERANCE_F64,
-        );
-        assert_point_close(
-            composite.end_point(),
-            Point3D::new(2.0, 0.0, 0.0),
-            POINT_COMPARISON_TOLERANCE_F64,
-        );
+        assert_point_close(composite.start_point(), Point3D::new(0.0, 0.0, 0.0), tol);
+        assert_point_close(composite.end_point(), Point3D::new(2.0, 0.0, 0.0), tol);
     }
 
     #[test]

--- a/model/geo_topology/src/composite_curve.rs
+++ b/model/geo_topology/src/composite_curve.rs
@@ -3,7 +3,7 @@
 //! 命名は Solidworks 系の CompositeCurve に合わせる
 //! （Rhino: PolyCurve、ISO STEP: CompositeCurve）
 
-use crate::{Point3D, TopoArc3D, TopoLineSegment3D, Vector3D};
+use crate::{Point3D, TopoArc3D, TopoLineSegment3D, TopoNurbsCurve3D, Vector3D};
 use geo_contracts::Scalar;
 
 /// 複合曲線を構成する個別セグメント
@@ -13,7 +13,8 @@ pub enum CurveSegment3D<T: Scalar> {
     Line(TopoLineSegment3D<T>),
     /// 3D円弧セグメント
     Arc(TopoArc3D<T>),
-    // 将来: Nurbs(NurbsCurve3D<T>)  ← geo_nurbs 依存方針確定後に追加
+    /// 3D NURBS曲線セグメント（native parameter semantics）
+    Nurbs(TopoNurbsCurve3D<T>),
 }
 
 impl<T: Scalar> CurveSegment3D<T> {
@@ -22,6 +23,11 @@ impl<T: Scalar> CurveSegment3D<T> {
         match self {
             Self::Line(seg) => seg.start(),
             Self::Arc(arc) => arc.start_point(),
+            Self::Nurbs(curve) => {
+                let (u_min, _) = curve.parameter_domain();
+                let p = curve.evaluate_at(u_min);
+                Point3D::new(p.x(), p.y(), p.z())
+            }
         }
     }
 
@@ -30,6 +36,11 @@ impl<T: Scalar> CurveSegment3D<T> {
         match self {
             Self::Line(seg) => seg.end(),
             Self::Arc(arc) => arc.end_point(),
+            Self::Nurbs(curve) => {
+                let (_, u_max) = curve.parameter_domain();
+                let p = curve.evaluate_at(u_max);
+                Point3D::new(p.x(), p.y(), p.z())
+            }
         }
     }
 
@@ -38,6 +49,7 @@ impl<T: Scalar> CurveSegment3D<T> {
         match self {
             Self::Line(seg) => seg.constraint_start_point(),
             Self::Arc(arc) => arc.start_point(),
+            Self::Nurbs(_) => self.start(),
         }
     }
 
@@ -46,6 +58,7 @@ impl<T: Scalar> CurveSegment3D<T> {
         match self {
             Self::Line(seg) => seg.constraint_end_point(),
             Self::Arc(arc) => arc.end_point(),
+            Self::Nurbs(_) => self.end(),
         }
     }
 
@@ -57,6 +70,7 @@ impl<T: Scalar> CurveSegment3D<T> {
                 vec.magnitude()
             }
             Self::Arc(arc) => arc.length(),
+            Self::Nurbs(curve) => curve.approximate_length(100),
         }
     }
 }
@@ -168,6 +182,7 @@ impl<T: Scalar> CompositeCurve3D<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use geo_contracts::NurbsCurve3DConstructor;
 
     #[test]
     fn curve_segment_line_start_end() {
@@ -210,6 +225,22 @@ mod tests {
     }
 
     #[test]
+    fn curve_segment_nurbs_start_end_and_constraint_endpoints() {
+        let curve = <TopoNurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(
+            (0.0, 0.0, 0.0),
+            (2.0, 0.0, 0.0),
+        )
+        .unwrap();
+
+        let segment = CurveSegment3D::Nurbs(curve);
+
+        assert_eq!(segment.start(), Point3D::new(0.0, 0.0, 0.0));
+        assert_eq!(segment.end(), Point3D::new(2.0, 0.0, 0.0));
+        assert_eq!(segment.constraint_start(), Point3D::new(0.0, 0.0, 0.0));
+        assert_eq!(segment.constraint_end(), Point3D::new(2.0, 0.0, 0.0));
+    }
+
+    #[test]
     fn composite_curve_single_segment() {
         let seg = TopoLineSegment3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(1.0, 0.0, 0.0))
             .unwrap();
@@ -236,6 +267,22 @@ mod tests {
         assert_eq!(composite.end_point(), Point3D::new(1.0, 1.0, 0.0));
         assert_eq!(composite.segments().len(), 2);
         assert_eq!(composite.total_length(), 2.0);
+    }
+
+    #[test]
+    fn composite_curve_accepts_nurbs_segment() {
+        let curve = <TopoNurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(
+            (0.0, 0.0, 0.0),
+            (2.0, 0.0, 0.0),
+        )
+        .unwrap();
+
+        let composite = CompositeCurve3D::new(vec![CurveSegment3D::Nurbs(curve)]).unwrap();
+
+        assert_eq!(composite.ideal_start_point(), Point3D::new(0.0, 0.0, 0.0));
+        assert_eq!(composite.ideal_end_point(), Point3D::new(2.0, 0.0, 0.0));
+        assert_eq!(composite.start_point(), Point3D::new(0.0, 0.0, 0.0));
+        assert_eq!(composite.end_point(), Point3D::new(2.0, 0.0, 0.0));
     }
 
     #[test]

--- a/model/geo_topology/src/lib.rs
+++ b/model/geo_topology/src/lib.rs
@@ -3,7 +3,7 @@
 //! 交差判定・モデリングで利用する最小のトポロジー構造を提供する。
 //! 現在の提供:
 //! - CompositeCurve3D: 拘束端点で連結された複合曲線
-//! - CurveSegment3D: 個別セグメント（Line / Arc、ideal/constraint endpoint を区別）
+//! - CurveSegment3D: 個別セグメント（Line / Arc / Nurbs、ideal/constraint endpoint を区別）
 //!
 //! 将来拡張（#205 連携）:
 //! - Vertex: 点トポロジー
@@ -28,3 +28,4 @@ pub type TopoArc3D<T> = geo_primitives::Arc3D<T>;
 pub type TopoEllipseArc3D<T> = geo_primitives::EllipseArc3D<T>;
 pub type TopoInfiniteLine3D<T> = geo_primitives::InfiniteLine3D<T>;
 pub type TopoLineSegment3D<T> = geo_primitives::LineSegment3D<T>;
+pub type TopoNurbsCurve3D<T> = geo_nurbs::NurbsCurve3D<T>;

--- a/model/geo_topology/src/lib.rs
+++ b/model/geo_topology/src/lib.rs
@@ -24,9 +24,6 @@ pub use topology_core::{CurveRef, Edge, TopoId, Vertex};
 pub use topology_validator::{EdgeValidationReport, TopologyValidator, WireValidationReport};
 pub use wire::Wire;
 
-pub(crate) const TOPO_NURBS_LENGTH_SUBDIVISIONS: usize =
-    geo_nurbs::constants::CURVE_LENGTH_SUBDIVISIONS;
-
 pub type TopoArc3D<T> = geo_primitives::Arc3D<T>;
 pub type TopoEllipseArc3D<T> = geo_primitives::EllipseArc3D<T>;
 pub type TopoInfiniteLine3D<T> = geo_primitives::InfiniteLine3D<T>;

--- a/model/geo_topology/src/lib.rs
+++ b/model/geo_topology/src/lib.rs
@@ -24,6 +24,8 @@ pub use topology_core::{CurveRef, Edge, TopoId, Vertex};
 pub use topology_validator::{EdgeValidationReport, TopologyValidator, WireValidationReport};
 pub use wire::Wire;
 
+pub(crate) const TOPO_NURBS_LENGTH_SUBDIVISIONS: usize = 100;
+
 pub type TopoArc3D<T> = geo_primitives::Arc3D<T>;
 pub type TopoEllipseArc3D<T> = geo_primitives::EllipseArc3D<T>;
 pub type TopoInfiniteLine3D<T> = geo_primitives::InfiniteLine3D<T>;

--- a/model/geo_topology/src/lib.rs
+++ b/model/geo_topology/src/lib.rs
@@ -24,7 +24,8 @@ pub use topology_core::{CurveRef, Edge, TopoId, Vertex};
 pub use topology_validator::{EdgeValidationReport, TopologyValidator, WireValidationReport};
 pub use wire::Wire;
 
-pub(crate) const TOPO_NURBS_LENGTH_SUBDIVISIONS: usize = 100;
+pub(crate) const TOPO_NURBS_LENGTH_SUBDIVISIONS: usize =
+    geo_nurbs::constants::CURVE_LENGTH_SUBDIVISIONS;
 
 pub type TopoArc3D<T> = geo_primitives::Arc3D<T>;
 pub type TopoEllipseArc3D<T> = geo_primitives::EllipseArc3D<T>;

--- a/model/geo_topology/src/topology_core.rs
+++ b/model/geo_topology/src/topology_core.rs
@@ -3,7 +3,10 @@
 //! #408 の最小導入として、Vertex/Edge/CurveRef を提供する。
 
 use crate::tolerance::ResolvedEdgeToleranceSettings;
-use crate::{Point3D, TopoArc3D, TopoEllipseArc3D, TopoLineSegment3D, TopoNurbsCurve3D};
+use crate::{
+    Point3D, TopoArc3D, TopoEllipseArc3D, TopoLineSegment3D, TopoNurbsCurve3D,
+    TOPO_NURBS_LENGTH_SUBDIVISIONS,
+};
 use geo_contracts::{
     Arc3DEndpoint, Arc3DEvaluation, EllipseArc3DDerived, EllipseArc3DEndpoint,
     EllipseArc3DEvaluation, NurbsCurve3DEvaluation, NurbsCurve3DProperties, Scalar,
@@ -132,10 +135,30 @@ impl<T: Scalar> CurveRef<T> {
                 Point3D::new(x, y, z)
             }
             Self::Nurbs(curve) => {
-                <TopoNurbsCurve3D<T> as NurbsCurve3DEvaluation<T>>::evaluate(curve, t)
+                let (u_min, u_max) =
+                    <TopoNurbsCurve3D<T> as NurbsCurve3DProperties<T>>::parameter_domain(curve);
+                let is_out_of_domain = t < u_min || t > u_max;
+                debug_assert!(
+                    !is_out_of_domain,
+                    "CurveRef::point_at_parameter received out-of-domain NURBS parameter"
+                );
+
+                let clamped_t = if t < u_min {
+                    u_min
+                } else if t > u_max {
+                    u_max
+                } else {
+                    t
+                };
+
+                <TopoNurbsCurve3D<T> as NurbsCurve3DEvaluation<T>>::evaluate(curve, clamped_t)
                     .map(|(x, y, z)| Point3D::new(x, y, z))
                     .unwrap_or_else(|| {
-                        let p = curve.evaluate_at(t);
+                        debug_assert!(
+                            false,
+                            "NURBS evaluation returned None even after parameter clamping"
+                        );
+                        let p = curve.evaluate_at(clamped_t);
                         Point3D::new(p.x(), p.y(), p.z())
                     })
             }
@@ -147,7 +170,7 @@ impl<T: Scalar> CurveRef<T> {
             Self::Line(line) => line.length(),
             Self::Arc(arc) => <TopoArc3D<T> as geo_contracts::Arc3DDerived<T>>::length(arc),
             Self::EllipseArc(arc) => <TopoEllipseArc3D<T> as EllipseArc3DDerived<T>>::length(arc),
-            Self::Nurbs(curve) => curve.approximate_length(100),
+            Self::Nurbs(curve) => curve.approximate_length(TOPO_NURBS_LENGTH_SUBDIVISIONS),
         }
     }
 }
@@ -414,9 +437,11 @@ mod tests {
 
     #[test]
     fn curve_ref_nurbs_supports_ideal_endpoints_and_native_parameter_evaluation() {
-        let curve = <TopoNurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(
-            (0.0, 0.0, 0.0),
-            (2.0, 0.0, 0.0),
+        let curve = <TopoNurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::new(
+            1,
+            vec![2.0, 2.0, 3.0, 3.0],
+            vec![(0.0, 0.0, 0.0), (2.0, 0.0, 0.0)],
+            None,
         )
         .unwrap();
 
@@ -432,7 +457,7 @@ mod tests {
         assert!((end.y() - 0.0).abs() < 1.0e-12);
         assert!((end.z() - 0.0).abs() < 1.0e-12);
 
-        let mid = curve_ref.point_at_parameter(0.5);
+        let mid = curve_ref.point_at_parameter(2.5);
         assert!((mid.x() - 1.0).abs() < 1.0e-9);
         assert!((mid.y() - 0.0).abs() < 1.0e-9);
         assert!((mid.z() - 0.0).abs() < 1.0e-9);
@@ -440,23 +465,28 @@ mod tests {
 
     #[test]
     fn edge_with_nurbs_curve_uses_native_parameter_range() {
-        let curve = <TopoNurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(
-            (0.0, 0.0, 0.0),
-            (2.0, 0.0, 0.0),
+        let curve = <TopoNurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::new(
+            1,
+            vec![2.0, 2.0, 3.0, 3.0],
+            vec![(0.0, 0.0, 0.0), (2.0, 0.0, 0.0)],
+            None,
         )
         .unwrap();
+
+        let native_range =
+            <TopoNurbsCurve3D<f64> as NurbsCurve3DProperties<f64>>::parameter_domain(&curve);
 
         let edge = Edge::new(
             Arc::new(Vertex::new(Point3D::new(0.0, 0.0, 0.0))),
             Arc::new(Vertex::new(Point3D::new(2.0, 0.0, 0.0))),
             CurveRef::Nurbs(curve),
-            (0.0, 1.0),
+            native_range,
         )
         .unwrap();
 
         let (t0, t1) = edge.parameter_range();
-        assert!((t0 - 0.0).abs() < 1.0e-12);
-        assert!((t1 - 1.0).abs() < 1.0e-12);
+        assert!((t0 - 2.0).abs() < 1.0e-12);
+        assert!((t1 - 3.0).abs() < 1.0e-12);
 
         let p = edge.point_at(0.5).unwrap();
         assert!((p.x() - 1.0).abs() < 1.0e-9);

--- a/model/geo_topology/src/topology_core.rs
+++ b/model/geo_topology/src/topology_core.rs
@@ -77,6 +77,16 @@ pub enum CurveRef<T: Scalar> {
 }
 
 impl<T: Scalar> CurveRef<T> {
+    fn nurbs_parameter_tolerance() -> T {
+        let scaled_epsilon = T::EPSILON * T::from_f64(16.0);
+        let minimum_tolerance = T::from_f64(1.0e-12);
+        if scaled_epsilon > minimum_tolerance {
+            scaled_epsilon
+        } else {
+            minimum_tolerance
+        }
+    }
+
     pub fn ideal_start_point(&self) -> Point3D<T> {
         match self {
             Self::Line(line) => line.start(),
@@ -137,14 +147,25 @@ impl<T: Scalar> CurveRef<T> {
             Self::Nurbs(curve) => {
                 let (u_min, u_max) =
                     <TopoNurbsCurve3D<T> as NurbsCurve3DProperties<T>>::parameter_domain(curve);
-                let is_out_of_domain = t < u_min || t > u_max;
+                let tolerance = Self::nurbs_parameter_tolerance();
+                let lower_bound = u_min - tolerance;
+                let upper_bound = u_max + tolerance;
+                let is_out_of_domain = t < lower_bound || t > upper_bound;
                 assert!(
                     !is_out_of_domain,
                     "CurveRef::point_at_parameter received out-of-domain NURBS parameter"
                 );
 
+                let adjusted_t = if t < u_min {
+                    u_min
+                } else if t > u_max {
+                    u_max
+                } else {
+                    t
+                };
+
                 let (x, y, z) =
-                    <TopoNurbsCurve3D<T> as NurbsCurve3DEvaluation<T>>::evaluate(curve, t)
+                    <TopoNurbsCurve3D<T> as NurbsCurve3DEvaluation<T>>::evaluate(curve, adjusted_t)
                         .expect("NURBS evaluation returned None for an in-domain parameter");
                 Point3D::new(x, y, z)
             }
@@ -173,6 +194,10 @@ pub struct Edge<T: Scalar> {
 }
 
 impl<T: Scalar> Edge<T> {
+    fn nurbs_parameter_tolerance() -> T {
+        CurveRef::<T>::nurbs_parameter_tolerance()
+    }
+
     /// Edge を生成する
     pub fn new(
         start_vertex: Arc<Vertex<T>>,
@@ -180,7 +205,27 @@ impl<T: Scalar> Edge<T> {
         curve: CurveRef<T>,
         parameter_range: (T, T),
     ) -> Option<Self> {
-        if parameter_range.0 >= parameter_range.1 {
+        let mut normalized_parameter_range = parameter_range;
+        if let CurveRef::Nurbs(nurbs_curve) = &curve {
+            let (u_min, u_max) =
+                <TopoNurbsCurve3D<T> as NurbsCurve3DProperties<T>>::parameter_domain(nurbs_curve);
+            let tolerance = Self::nurbs_parameter_tolerance();
+
+            if normalized_parameter_range.0 < u_min - tolerance
+                || normalized_parameter_range.1 > u_max + tolerance
+            {
+                return None;
+            }
+
+            if normalized_parameter_range.0 < u_min {
+                normalized_parameter_range.0 = u_min;
+            }
+            if normalized_parameter_range.1 > u_max {
+                normalized_parameter_range.1 = u_max;
+            }
+        }
+
+        if normalized_parameter_range.0 >= normalized_parameter_range.1 {
             return None;
         }
 
@@ -189,7 +234,7 @@ impl<T: Scalar> Edge<T> {
             start_vertex,
             end_vertex,
             curve,
-            parameter_range,
+            parameter_range: normalized_parameter_range,
             same_sense: true,
         })
     }
@@ -478,5 +523,25 @@ mod tests {
         assert!((p.x() - 1.0).abs() < 1.0e-9);
         assert!((p.y() - 0.0).abs() < 1.0e-9);
         assert!((p.z() - 0.0).abs() < 1.0e-9);
+    }
+
+    #[test]
+    fn edge_new_rejects_nurbs_range_outside_native_domain() {
+        let curve = <TopoNurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::new(
+            1,
+            vec![2.0, 2.0, 3.0, 3.0],
+            vec![(0.0, 0.0, 0.0), (2.0, 0.0, 0.0)],
+            None,
+        )
+        .unwrap();
+
+        let edge = Edge::new(
+            Arc::new(Vertex::new(Point3D::new(0.0, 0.0, 0.0))),
+            Arc::new(Vertex::new(Point3D::new(2.0, 0.0, 0.0))),
+            CurveRef::Nurbs(curve),
+            (1.0, 2.5),
+        );
+
+        assert!(edge.is_none());
     }
 }

--- a/model/geo_topology/src/topology_core.rs
+++ b/model/geo_topology/src/topology_core.rs
@@ -8,8 +8,8 @@ use crate::{
     TOPO_NURBS_LENGTH_SUBDIVISIONS,
 };
 use geo_contracts::{
-    Arc3DEndpoint, Arc3DEvaluation, EllipseArc3DDerived, EllipseArc3DEndpoint,
-    EllipseArc3DEvaluation, NurbsCurve3DEvaluation, NurbsCurve3DProperties, Scalar,
+    default_kernel_numerical_zero_tolerance, Arc3DEndpoint, Arc3DEvaluation, EllipseArc3DDerived,
+    EllipseArc3DEndpoint, EllipseArc3DEvaluation, NurbsCurve3DProperties, Scalar,
 };
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -79,7 +79,7 @@ pub enum CurveRef<T: Scalar> {
 impl<T: Scalar> CurveRef<T> {
     fn nurbs_parameter_tolerance() -> T {
         let scaled_epsilon = T::EPSILON * T::from_f64(16.0);
-        let minimum_tolerance = T::from_f64(1.0e-12);
+        let minimum_tolerance = default_kernel_numerical_zero_tolerance::<T>();
         if scaled_epsilon > minimum_tolerance {
             scaled_epsilon
         } else {
@@ -151,9 +151,15 @@ impl<T: Scalar> CurveRef<T> {
                 let lower_bound = u_min - tolerance;
                 let upper_bound = u_max + tolerance;
                 let is_out_of_domain = t < lower_bound || t > upper_bound;
-                assert!(
+                debug_assert!(
                     !is_out_of_domain,
-                    "CurveRef::point_at_parameter received out-of-domain NURBS parameter"
+                    "CurveRef::point_at_parameter received out-of-domain NURBS parameter: t={:?}, domain=[{:?}, {:?}], tolerance={:?}, accepted_bounds=[{:?}, {:?}]",
+                    t,
+                    u_min,
+                    u_max,
+                    tolerance,
+                    lower_bound,
+                    upper_bound
                 );
 
                 let adjusted_t = if t < u_min {
@@ -164,10 +170,8 @@ impl<T: Scalar> CurveRef<T> {
                     t
                 };
 
-                let (x, y, z) =
-                    <TopoNurbsCurve3D<T> as NurbsCurve3DEvaluation<T>>::evaluate(curve, adjusted_t)
-                        .expect("NURBS evaluation returned None for an in-domain parameter");
-                Point3D::new(x, y, z)
+                let point = curve.evaluate_at(adjusted_t);
+                Point3D::new(point.x(), point.y(), point.z())
             }
         }
     }
@@ -199,6 +203,10 @@ impl<T: Scalar> Edge<T> {
     }
 
     /// Edge を生成する
+    ///
+    /// NURBS の場合は parameter_range を native domain に対して検証する。
+    /// 許容幅を超えて domain 外なら `None` を返し、端点近傍の微小ズレは
+    /// `[u_min, u_max]` へ吸着したうえで保持する。
     pub fn new(
         start_vertex: Arc<Vertex<T>>,
         end_vertex: Arc<Vertex<T>>,

--- a/model/geo_topology/src/topology_core.rs
+++ b/model/geo_topology/src/topology_core.rs
@@ -138,29 +138,15 @@ impl<T: Scalar> CurveRef<T> {
                 let (u_min, u_max) =
                     <TopoNurbsCurve3D<T> as NurbsCurve3DProperties<T>>::parameter_domain(curve);
                 let is_out_of_domain = t < u_min || t > u_max;
-                debug_assert!(
+                assert!(
                     !is_out_of_domain,
                     "CurveRef::point_at_parameter received out-of-domain NURBS parameter"
                 );
 
-                let clamped_t = if t < u_min {
-                    u_min
-                } else if t > u_max {
-                    u_max
-                } else {
-                    t
-                };
-
-                <TopoNurbsCurve3D<T> as NurbsCurve3DEvaluation<T>>::evaluate(curve, clamped_t)
-                    .map(|(x, y, z)| Point3D::new(x, y, z))
-                    .unwrap_or_else(|| {
-                        debug_assert!(
-                            false,
-                            "NURBS evaluation returned None even after parameter clamping"
-                        );
-                        let p = curve.evaluate_at(clamped_t);
-                        Point3D::new(p.x(), p.y(), p.z())
-                    })
+                let (x, y, z) =
+                    <TopoNurbsCurve3D<T> as NurbsCurve3DEvaluation<T>>::evaluate(curve, t)
+                        .expect("NURBS evaluation returned None for an in-domain parameter");
+                Point3D::new(x, y, z)
             }
         }
     }

--- a/model/geo_topology/src/topology_core.rs
+++ b/model/geo_topology/src/topology_core.rs
@@ -3,10 +3,7 @@
 //! #408 の最小導入として、Vertex/Edge/CurveRef を提供する。
 
 use crate::tolerance::ResolvedEdgeToleranceSettings;
-use crate::{
-    Point3D, TopoArc3D, TopoEllipseArc3D, TopoLineSegment3D, TopoNurbsCurve3D,
-    TOPO_NURBS_LENGTH_SUBDIVISIONS,
-};
+use crate::{Point3D, TopoArc3D, TopoEllipseArc3D, TopoLineSegment3D, TopoNurbsCurve3D};
 use geo_contracts::{
     default_kernel_numerical_zero_tolerance, Arc3DEndpoint, Arc3DEvaluation, EllipseArc3DDerived,
     EllipseArc3DEndpoint, EllipseArc3DEvaluation, NurbsCurve3DProperties, Scalar,
@@ -181,7 +178,9 @@ impl<T: Scalar> CurveRef<T> {
             Self::Line(line) => line.length(),
             Self::Arc(arc) => <TopoArc3D<T> as geo_contracts::Arc3DDerived<T>>::length(arc),
             Self::EllipseArc(arc) => <TopoEllipseArc3D<T> as EllipseArc3DDerived<T>>::length(arc),
-            Self::Nurbs(curve) => curve.approximate_length(TOPO_NURBS_LENGTH_SUBDIVISIONS),
+            Self::Nurbs(curve) => {
+                curve.approximate_length(geo_nurbs::constants::CURVE_LENGTH_SUBDIVISIONS)
+            }
         }
     }
 }

--- a/model/geo_topology/src/topology_core.rs
+++ b/model/geo_topology/src/topology_core.rs
@@ -74,8 +74,10 @@ pub enum CurveRef<T: Scalar> {
 }
 
 impl<T: Scalar> CurveRef<T> {
-    fn nurbs_parameter_tolerance() -> T {
-        let scaled_epsilon = T::EPSILON * T::from_f64(16.0);
+    fn nurbs_parameter_tolerance_for_domain(u_min: T, u_max: T) -> T {
+        let domain_span = (u_max - u_min).abs();
+        let magnitude = u_min.abs().max(u_max.abs()).max(domain_span).max(T::ONE);
+        let scaled_epsilon = T::EPSILON * T::from_f64(16.0) * magnitude;
         let minimum_tolerance = default_kernel_numerical_zero_tolerance::<T>();
         if scaled_epsilon > minimum_tolerance {
             scaled_epsilon
@@ -144,7 +146,7 @@ impl<T: Scalar> CurveRef<T> {
             Self::Nurbs(curve) => {
                 let (u_min, u_max) =
                     <TopoNurbsCurve3D<T> as NurbsCurve3DProperties<T>>::parameter_domain(curve);
-                let tolerance = Self::nurbs_parameter_tolerance();
+                let tolerance = Self::nurbs_parameter_tolerance_for_domain(u_min, u_max);
                 let lower_bound = u_min - tolerance;
                 let upper_bound = u_max + tolerance;
                 let is_out_of_domain = t < lower_bound || t > upper_bound;
@@ -197,8 +199,8 @@ pub struct Edge<T: Scalar> {
 }
 
 impl<T: Scalar> Edge<T> {
-    fn nurbs_parameter_tolerance() -> T {
-        CurveRef::<T>::nurbs_parameter_tolerance()
+    fn nurbs_parameter_tolerance_for_domain(u_min: T, u_max: T) -> T {
+        CurveRef::<T>::nurbs_parameter_tolerance_for_domain(u_min, u_max)
     }
 
     /// Edge を生成する
@@ -216,7 +218,7 @@ impl<T: Scalar> Edge<T> {
         if let CurveRef::Nurbs(nurbs_curve) = &curve {
             let (u_min, u_max) =
                 <TopoNurbsCurve3D<T> as NurbsCurve3DProperties<T>>::parameter_domain(nurbs_curve);
-            let tolerance = Self::nurbs_parameter_tolerance();
+            let tolerance = Self::nurbs_parameter_tolerance_for_domain(u_min, u_max);
 
             if normalized_parameter_range.0 < u_min - tolerance
                 || normalized_parameter_range.1 > u_max + tolerance
@@ -550,5 +552,31 @@ mod tests {
         );
 
         assert!(edge.is_none());
+    }
+
+    #[test]
+    fn edge_new_accepts_near_boundary_nurbs_range_on_large_domain_scale() {
+        let u_min = 1_000_000.0;
+        let u_max = 1_000_001.0;
+        let curve = <TopoNurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::new(
+            1,
+            vec![u_min, u_min, u_max, u_max],
+            vec![(0.0, 0.0, 0.0), (2.0, 0.0, 0.0)],
+            None,
+        )
+        .unwrap();
+
+        let tolerance = CurveRef::<f64>::nurbs_parameter_tolerance_for_domain(u_min, u_max);
+        let edge = Edge::new(
+            Arc::new(Vertex::new(Point3D::new(0.0, 0.0, 0.0))),
+            Arc::new(Vertex::new(Point3D::new(2.0, 0.0, 0.0))),
+            CurveRef::Nurbs(curve),
+            (u_min - tolerance * 0.5, u_max + tolerance * 0.5),
+        )
+        .unwrap();
+
+        let (t0, t1) = edge.parameter_range();
+        assert!((t0 - u_min).abs() < 1.0e-12);
+        assert!((t1 - u_max).abs() < 1.0e-12);
     }
 }

--- a/model/geo_topology/src/topology_core.rs
+++ b/model/geo_topology/src/topology_core.rs
@@ -3,10 +3,10 @@
 //! #408 の最小導入として、Vertex/Edge/CurveRef を提供する。
 
 use crate::tolerance::ResolvedEdgeToleranceSettings;
-use crate::{Point3D, TopoArc3D, TopoEllipseArc3D, TopoLineSegment3D};
+use crate::{Point3D, TopoArc3D, TopoEllipseArc3D, TopoLineSegment3D, TopoNurbsCurve3D};
 use geo_contracts::{
     Arc3DEndpoint, Arc3DEvaluation, EllipseArc3DDerived, EllipseArc3DEndpoint,
-    EllipseArc3DEvaluation, Scalar,
+    EllipseArc3DEvaluation, NurbsCurve3DEvaluation, NurbsCurve3DProperties, Scalar,
 };
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -70,6 +70,7 @@ pub enum CurveRef<T: Scalar> {
     Line(TopoLineSegment3D<T>),
     Arc(TopoArc3D<T>),
     EllipseArc(TopoEllipseArc3D<T>),
+    Nurbs(TopoNurbsCurve3D<T>),
 }
 
 impl<T: Scalar> CurveRef<T> {
@@ -84,6 +85,12 @@ impl<T: Scalar> CurveRef<T> {
                 let (x, y, z) = <TopoEllipseArc3D<T> as EllipseArc3DEndpoint<T>>::start_point(arc);
                 Point3D::new(x, y, z)
             }
+            Self::Nurbs(curve) => {
+                let (u_min, _) =
+                    <TopoNurbsCurve3D<T> as NurbsCurve3DProperties<T>>::parameter_domain(curve);
+                let point = curve.evaluate_at(u_min);
+                Point3D::new(point.x(), point.y(), point.z())
+            }
         }
     }
 
@@ -97,6 +104,12 @@ impl<T: Scalar> CurveRef<T> {
             Self::EllipseArc(arc) => {
                 let (x, y, z) = <TopoEllipseArc3D<T> as EllipseArc3DEndpoint<T>>::end_point(arc);
                 Point3D::new(x, y, z)
+            }
+            Self::Nurbs(curve) => {
+                let (_, u_max) =
+                    <TopoNurbsCurve3D<T> as NurbsCurve3DProperties<T>>::parameter_domain(curve);
+                let point = curve.evaluate_at(u_max);
+                Point3D::new(point.x(), point.y(), point.z())
             }
         }
     }
@@ -118,6 +131,14 @@ impl<T: Scalar> CurveRef<T> {
                     <TopoEllipseArc3D<T> as EllipseArc3DEvaluation<T>>::point_at_parameter(arc, t);
                 Point3D::new(x, y, z)
             }
+            Self::Nurbs(curve) => {
+                <TopoNurbsCurve3D<T> as NurbsCurve3DEvaluation<T>>::evaluate(curve, t)
+                    .map(|(x, y, z)| Point3D::new(x, y, z))
+                    .unwrap_or_else(|| {
+                        let p = curve.evaluate_at(t);
+                        Point3D::new(p.x(), p.y(), p.z())
+                    })
+            }
         }
     }
 
@@ -126,6 +147,7 @@ impl<T: Scalar> CurveRef<T> {
             Self::Line(line) => line.length(),
             Self::Arc(arc) => <TopoArc3D<T> as geo_contracts::Arc3DDerived<T>>::length(arc),
             Self::EllipseArc(arc) => <TopoEllipseArc3D<T> as EllipseArc3DDerived<T>>::length(arc),
+            Self::Nurbs(curve) => curve.approximate_length(100),
         }
     }
 }
@@ -304,7 +326,8 @@ impl<T: Scalar> Edge<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::TopoInfiniteLine3D;
+    use crate::{TopoInfiniteLine3D, TopoNurbsCurve3D};
+    use geo_contracts::NurbsCurve3DConstructor;
 
     #[test]
     fn edge_new_rejects_invalid_range() {
@@ -387,5 +410,57 @@ mod tests {
         assert!(edge.is_binding_consistent(1e-9));
         assert!(edge.is_ideal_endpoint_consistent(1e-9));
         assert!(!edge.is_evaluated_endpoint_consistent(1e-9));
+    }
+
+    #[test]
+    fn curve_ref_nurbs_supports_ideal_endpoints_and_native_parameter_evaluation() {
+        let curve = <TopoNurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(
+            (0.0, 0.0, 0.0),
+            (2.0, 0.0, 0.0),
+        )
+        .unwrap();
+
+        let curve_ref = CurveRef::Nurbs(curve);
+
+        let start = curve_ref.ideal_start_point();
+        let end = curve_ref.ideal_end_point();
+
+        assert!((start.x() - 0.0).abs() < 1.0e-12);
+        assert!((start.y() - 0.0).abs() < 1.0e-12);
+        assert!((start.z() - 0.0).abs() < 1.0e-12);
+        assert!((end.x() - 2.0).abs() < 1.0e-12);
+        assert!((end.y() - 0.0).abs() < 1.0e-12);
+        assert!((end.z() - 0.0).abs() < 1.0e-12);
+
+        let mid = curve_ref.point_at_parameter(0.5);
+        assert!((mid.x() - 1.0).abs() < 1.0e-9);
+        assert!((mid.y() - 0.0).abs() < 1.0e-9);
+        assert!((mid.z() - 0.0).abs() < 1.0e-9);
+    }
+
+    #[test]
+    fn edge_with_nurbs_curve_uses_native_parameter_range() {
+        let curve = <TopoNurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(
+            (0.0, 0.0, 0.0),
+            (2.0, 0.0, 0.0),
+        )
+        .unwrap();
+
+        let edge = Edge::new(
+            Arc::new(Vertex::new(Point3D::new(0.0, 0.0, 0.0))),
+            Arc::new(Vertex::new(Point3D::new(2.0, 0.0, 0.0))),
+            CurveRef::Nurbs(curve),
+            (0.0, 1.0),
+        )
+        .unwrap();
+
+        let (t0, t1) = edge.parameter_range();
+        assert!((t0 - 0.0).abs() < 1.0e-12);
+        assert!((t1 - 1.0).abs() < 1.0e-12);
+
+        let p = edge.point_at(0.5).unwrap();
+        assert!((p.x() - 1.0).abs() < 1.0e-9);
+        assert!((p.y() - 0.0).abs() < 1.0e-9);
+        assert!((p.z() - 0.0).abs() < 1.0e-9);
     }
 }

--- a/model/geo_topology/src/topology_core.rs
+++ b/model/geo_topology/src/topology_core.rs
@@ -148,7 +148,7 @@ impl<T: Scalar> CurveRef<T> {
                 let lower_bound = u_min - tolerance;
                 let upper_bound = u_max + tolerance;
                 let is_out_of_domain = t < lower_bound || t > upper_bound;
-                debug_assert!(
+                assert!(
                     !is_out_of_domain,
                     "CurveRef::point_at_parameter received out-of-domain NURBS parameter: t={:?}, domain=[{:?}, {:?}], tolerance={:?}, accepted_bounds=[{:?}, {:?}]",
                     t,


### PR DESCRIPTION
## 概要

#650 の最小実装 PR です。  
`geo_topology` に `NurbsCurve3D` を Edge の母曲線として扱える最小構成を追加しました。

## 変更内容

- `geo_topology -> geo_nurbs` 依存を追加
- `CurveRef` に `Nurbs` variant を追加
- `CurveSegment3D` に `Nurbs` segment を追加
- `CompositeCurve3D` が NURBS segment を受け入れ可能に変更
- `CurveRef::ideal_start_point` / `ideal_end_point` / `point_at_parameter` の NURBS 対応を追加
- `CurveRef::length` の NURBS 対応を追加（近似長）
- NURBS edge の native parameter range 利用を確認する unit test を追加
- `CurveSegment3D` / `CompositeCurve3D` の NURBS 対応 unit test を追加

## スコープ内で固定したこと

- `geo_topology` 側では NURBS curve の native parameter semantics をそのまま利用する
- trimmed face / surface / PCurve には踏み込まない
- `CurveRef` への追加は最小構成に留め、抽象化の先回りは行わない

## スコープ外

- trimmed NURBS face
- `Face` / `Loop` / `CoEdge` / `HalfEdge`
- surface 上の 2D trim curve / p-curve
- seam / periodic surface / singularity の扱い
- trimmed surface validation

## 検証

- `cargo clippy -p geo_topology -- -D warnings`
- `cargo fmt`
- `cargo test -p geo_topology`
- `cargo test --workspace`
- `./scripts/check_architecture_dependencies_simple.ps1`

## 関連

- Closes #650
- Related: #666, #668
