### PR TITLE
[Phase 1] #672 checked evaluation API 追加による fail-fast 段階移行の初手

### DIFF
--- a/dev/architecture/GEOMETRY_SHAPE_SEMANTICS_DESIGN.md
+++ b/dev/architecture/GEOMETRY_SHAPE_SEMANTICS_DESIGN.md
@@ -418,6 +418,35 @@ parameter semantics の正本は「`#558` parameter semantics の正本」を参
 
 ### 5. evaluation と boundary access は別 capability とする
 
+## `#672` 段階移行方針（fail-fast 収束）
+
+`#672` では、parameter 範囲外入力の扱いを一括で破壊的変更せず、次の段階移行で収束させる。
+
+1. checked evaluation API を追加する
+2. 既存 evaluation API は互換維持する
+3. 呼び出し側を checked API へ順次移行する
+4. 最終段で fail-fast 契約を正本として固定する
+
+### checked API の位置づけ
+
+- checked API は「入力 domain が有効か」を判定し、範囲外を `None` または `Result::Err` で明示する
+- unchecked API は内部実装や互換層に限定し、新規の公開呼び出し経路では優先しない
+- これにより release ビルドでの沈黙クランプを避けつつ、既存呼び出しを即時破壊しない
+
+### LineSegment2D/3D の統一方針
+
+- `point_at_parameter` の既存挙動は互換維持する
+- 新規の checked 入口で `0 <= t <= 1` 判定を共通化する
+- 呼び出し側は「範囲外を失敗として扱いたい経路」から checked 入口へ移行する
+
+### NURBS 評価の統一方針
+
+- NURBS では native parameter domain を正本とする
+- checked 入口で domain 判定を明示し、範囲外は失敗として返す
+- 微分・法線など派生評価は checked 入口を利用する経路へ順次寄せる
+
+この方針により、API 互換性を維持したまま fail-fast 契約へ収束する。
+
 - `point_at_parameter` / `point_at_angle` は evaluation capability に置く
 - `start_point` / `end_point` は境界付き曲線に限って endpoint capability に置く
 - `point_at_parameter(0.5)` のような parameter midpoint は evaluation の一例であり、endpoint 語彙へ昇格させない

--- a/dev/architecture/GEOMETRY_SHAPE_SEMANTICS_DESIGN.md
+++ b/dev/architecture/GEOMETRY_SHAPE_SEMANTICS_DESIGN.md
@@ -430,6 +430,7 @@ parameter semantics の正本は「`#558` parameter semantics の正本」を参
 ### checked API の位置づけ
 
 - checked API は「入力 domain が有効か」を判定し、範囲外を `None` または `Result::Err` で明示する
+- ただし段階移行中の trait定義デフォルト実装は、互換維持のため domain 判定を省略した暫定ラッパを許容し、実装側 override で domain 判定へ収束させる
 - unchecked API は内部実装や互換層に限定し、新規の公開呼び出し経路では優先しない
 - これにより release ビルドでの沈黙クランプを避けつつ、既存呼び出しを即時破壊しない
 

--- a/dev/architecture/GEOMETRY_SHAPE_SEMANTICS_DESIGN.md
+++ b/dev/architecture/GEOMETRY_SHAPE_SEMANTICS_DESIGN.md
@@ -418,7 +418,7 @@ parameter semantics の正本は「`#558` parameter semantics の正本」を参
 
 ### 5. evaluation と boundary access は別 capability とする
 
-## `#672` 段階移行方針（fail-fast 収束）
+### 6. `#672` 段階移行方針（fail-fast 収束）
 
 `#672` では、parameter 範囲外入力の扱いを一括で破壊的変更せず、次の段階移行で収束させる。
 

--- a/model/geo_contracts/src/geometry/core/linesegment_traits.rs
+++ b/model/geo_contracts/src/geometry/core/linesegment_traits.rs
@@ -155,7 +155,7 @@ pub trait LineSegment2DEvaluation<T: Scalar> {
 
     /// checked 入口: 範囲外入力を失敗として扱う評価
     fn point_at_parameter_checked(&self, t: T) -> Option<(T, T)> {
-        if t < T::ZERO || t > T::ONE {
+        if !t.is_finite() || t < T::ZERO || t > T::ONE {
             None
         } else {
             Some(self.point_at_parameter(t))
@@ -194,7 +194,7 @@ pub trait LineSegment3DEvaluation<T: Scalar> {
 
     /// checked 入口: 範囲外入力を失敗として扱う評価
     fn point_at_parameter_checked(&self, t: T) -> Option<(T, T, T)> {
-        if t < T::ZERO || t > T::ONE {
+        if !t.is_finite() || t < T::ZERO || t > T::ONE {
             None
         } else {
             Some(self.point_at_parameter(t))

--- a/model/geo_contracts/src/geometry/core/linesegment_traits.rs
+++ b/model/geo_contracts/src/geometry/core/linesegment_traits.rs
@@ -152,6 +152,15 @@ pub trait LineSegment2DEvaluation<T: Scalar> {
     ///
     /// `t=0/1` は bounded curve primitive の ideal start/end endpoint と整合する。
     fn point_at_parameter(&self, t: T) -> (T, T);
+
+    /// checked 入口: 範囲外入力を失敗として扱う評価
+    fn point_at_parameter_checked(&self, t: T) -> Option<(T, T)> {
+        if t < T::ZERO || t > T::ONE {
+            None
+        } else {
+            Some(self.point_at_parameter(t))
+        }
+    }
 }
 
 pub trait LineSegment2DProjection<T: Scalar> {
@@ -182,6 +191,15 @@ pub trait LineSegment3DEvaluation<T: Scalar> {
     ///
     /// `t=0/1` は bounded curve primitive の ideal start/end endpoint と整合する。
     fn point_at_parameter(&self, t: T) -> (T, T, T);
+
+    /// checked 入口: 範囲外入力を失敗として扱う評価
+    fn point_at_parameter_checked(&self, t: T) -> Option<(T, T, T)> {
+        if t < T::ZERO || t > T::ONE {
+            None
+        } else {
+            Some(self.point_at_parameter(t))
+        }
+    }
 }
 
 pub trait LineSegment3DProjection<T: Scalar> {

--- a/model/geo_contracts/src/geometry/core/nurbs_curve_2d_traits.rs
+++ b/model/geo_contracts/src/geometry/core/nurbs_curve_2d_traits.rs
@@ -65,12 +65,17 @@ pub trait NurbsCurve2DEvaluation<T: Scalar> {
 
     /// checked 入口として使うための評価メソッド。
     ///
-    /// デフォルト実装は後方互換のため `point_at` を `Some(...)` で包む
-    /// unchecked ラッパであり、この trait定義だけでは domain 判定を行わない。
+    /// デフォルト実装は後方互換のため `point_at` を `Some(...)` で包むが、
+    /// checked 入口として最低限の fail-fast を担保するため、
+    /// 非有限値（NaN/Inf）は `None` として扱う。
     ///
     /// 範囲外入力を `None` として扱う必要がある実装では、このメソッドを
     /// override して各型の parameter domain 判定を行うこと。
     fn point_at_checked(&self, t: T) -> Option<(T, T)> {
+        if !t.is_finite() {
+            return None;
+        }
+
         Some(self.point_at(t))
     }
 

--- a/model/geo_contracts/src/geometry/core/nurbs_curve_2d_traits.rs
+++ b/model/geo_contracts/src/geometry/core/nurbs_curve_2d_traits.rs
@@ -63,7 +63,13 @@ pub trait NurbsCurve2DEvaluation<T: Scalar> {
     /// パラメータ t での曲線上の点を計算
     fn point_at(&self, t: T) -> (T, T);
 
-    /// checked 入口: 範囲外入力を失敗として扱う評価
+    /// checked 入口として使うための評価メソッド。
+    ///
+    /// デフォルト実装は後方互換のため `point_at` を `Some(...)` で包む
+    /// unchecked ラッパであり、この trait定義だけでは domain 判定を行わない。
+    ///
+    /// 範囲外入力を `None` として扱う必要がある実装では、このメソッドを
+    /// override して各型の parameter domain 判定を行うこと。
     fn point_at_checked(&self, t: T) -> Option<(T, T)> {
         Some(self.point_at(t))
     }

--- a/model/geo_contracts/src/geometry/core/nurbs_curve_2d_traits.rs
+++ b/model/geo_contracts/src/geometry/core/nurbs_curve_2d_traits.rs
@@ -63,6 +63,11 @@ pub trait NurbsCurve2DEvaluation<T: Scalar> {
     /// パラメータ t での曲線上の点を計算
     fn point_at(&self, t: T) -> (T, T);
 
+    /// checked 入口: 範囲外入力を失敗として扱う評価
+    fn point_at_checked(&self, t: T) -> Option<(T, T)> {
+        Some(self.point_at(t))
+    }
+
     /// パラメータ t での接線ベクトルを計算
     fn tangent_at(&self, t: T) -> (T, T);
 }

--- a/model/geo_contracts/src/geometry/core/nurbs_curve_3d_traits.rs
+++ b/model/geo_contracts/src/geometry/core/nurbs_curve_3d_traits.rs
@@ -74,7 +74,15 @@ pub trait NurbsCurve3DEvaluation<T: Scalar> {
     /// 指定されたパラメータ値における曲線上の点を評価
     fn evaluate(&self, u: T) -> Option<(T, T, T)>;
 
-    /// checked 入口: 範囲外入力を失敗として扱う評価
+    /// checked 入口として使うための評価メソッド。
+    ///
+    /// デフォルト実装は互換維持のため `evaluate` へ委譲する暫定ラッパであり、
+    /// parameter domain 判定はこの trait定義だけでは行わない。
+    /// ただし checked 入口として最低限の fail-fast を担保するため、
+    /// 非有限値（NaN/Inf）は `None` として扱う。
+    ///
+    /// 範囲外入力を `None` として扱う必要がある実装では、このメソッドを
+    /// override して各型の parameter domain 判定を行うこと。
     fn evaluate_checked(&self, u: T) -> Option<(T, T, T)> {
         if !u.is_finite() {
             return None;

--- a/model/geo_contracts/src/geometry/core/nurbs_curve_3d_traits.rs
+++ b/model/geo_contracts/src/geometry/core/nurbs_curve_3d_traits.rs
@@ -73,6 +73,11 @@ pub trait NurbsCurve3DEvaluation<T: Scalar> {
 
     /// 指定されたパラメータ値における曲線上の点を評価
     fn evaluate(&self, u: T) -> Option<(T, T, T)>;
+
+    /// checked 入口: 範囲外入力を失敗として扱う評価
+    fn evaluate_checked(&self, u: T) -> Option<(T, T, T)> {
+        self.evaluate(u)
+    }
 }
 
 /// NurbsCurve3D の互換 Core trait

--- a/model/geo_contracts/src/geometry/core/nurbs_curve_3d_traits.rs
+++ b/model/geo_contracts/src/geometry/core/nurbs_curve_3d_traits.rs
@@ -76,6 +76,10 @@ pub trait NurbsCurve3DEvaluation<T: Scalar> {
 
     /// checked 入口: 範囲外入力を失敗として扱う評価
     fn evaluate_checked(&self, u: T) -> Option<(T, T, T)> {
+        if !u.is_finite() {
+            return None;
+        }
+
         self.evaluate(u)
     }
 }

--- a/model/geo_contracts/src/geometry/core/nurbs_surface_3d_traits.rs
+++ b/model/geo_contracts/src/geometry/core/nurbs_surface_3d_traits.rs
@@ -76,12 +76,17 @@ pub trait NurbsSurface3DEvaluation<T: Scalar> {
 
     /// checked 入口。
     ///
-    /// このデフォルト実装は互換維持のための暫定ラッパであり、domain 判定を行わず
-    /// `Some(self.point_at_uv(u, v))` をそのまま返す。
+    /// このデフォルト実装は互換維持のための暫定ラッパであり、domain 判定は行わない。
+    /// ただし checked 入口として最低限の fail-fast を担保するため、
+    /// `u` / `v` が非有限値（NaN/Inf）の場合は `None` を返す。
     ///
     /// 範囲外入力を失敗として扱いたい実装は、このメソッドを override して
     /// u/v の有効範囲を判定し、範囲外では `None` を返すことを想定している。
     fn point_at_uv_checked(&self, u: T, v: T) -> Option<(T, T, T)> {
+        if !u.is_finite() || !v.is_finite() {
+            return None;
+        }
+
         Some(self.point_at_uv(u, v))
     }
 

--- a/model/geo_contracts/src/geometry/core/nurbs_surface_3d_traits.rs
+++ b/model/geo_contracts/src/geometry/core/nurbs_surface_3d_traits.rs
@@ -74,7 +74,13 @@ pub trait NurbsSurface3DEvaluation<T: Scalar> {
     /// パラメータ座標(u, v)でのサーフェス上の点を計算
     fn point_at_uv(&self, u: T, v: T) -> (T, T, T);
 
-    /// checked 入口: 範囲外入力を失敗として扱う評価
+    /// checked 入口。
+    ///
+    /// このデフォルト実装は互換維持のための暫定ラッパであり、domain 判定を行わず
+    /// `Some(self.point_at_uv(u, v))` をそのまま返す。
+    ///
+    /// 範囲外入力を失敗として扱いたい実装は、このメソッドを override して
+    /// u/v の有効範囲を判定し、範囲外では `None` を返すことを想定している。
     fn point_at_uv_checked(&self, u: T, v: T) -> Option<(T, T, T)> {
         Some(self.point_at_uv(u, v))
     }

--- a/model/geo_contracts/src/geometry/core/nurbs_surface_3d_traits.rs
+++ b/model/geo_contracts/src/geometry/core/nurbs_surface_3d_traits.rs
@@ -74,6 +74,11 @@ pub trait NurbsSurface3DEvaluation<T: Scalar> {
     /// パラメータ座標(u, v)でのサーフェス上の点を計算
     fn point_at_uv(&self, u: T, v: T) -> (T, T, T);
 
+    /// checked 入口: 範囲外入力を失敗として扱う評価
+    fn point_at_uv_checked(&self, u: T, v: T) -> Option<(T, T, T)> {
+        Some(self.point_at_uv(u, v))
+    }
+
     /// パラメータ座標(u, v)での法線ベクトルを計算
     fn normal_at(&self, u: T, v: T) -> (T, T, T);
 

--- a/model/geo_nurbs/src/curve_2d.rs
+++ b/model/geo_nurbs/src/curve_2d.rs
@@ -312,6 +312,15 @@ impl<T: Scalar> NurbsCurve2DEvaluation<T> for NurbsCurve2D<T> {
         (point.x(), point.y())
     }
 
+    fn point_at_checked(&self, t: T) -> Option<(T, T)> {
+        let (t_min, t_max) = self.parameter_domain();
+        if t < t_min || t > t_max {
+            return None;
+        }
+
+        Some(self.point_at(t))
+    }
+
     fn tangent_at(&self, t: T) -> (T, T) {
         let derivative = self.derivative_at(t);
         let len_sq = derivative.x() * derivative.x() + derivative.y() * derivative.y();
@@ -426,5 +435,27 @@ mod tests {
 
         // 直線に近い曲線なので長さは約2.0
         assert!((length - 2.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_point_at_checked_returns_none_for_out_of_domain_parameter() {
+        use geo_contracts::{NurbsCurve2DConstructor, NurbsCurve2DEvaluation};
+
+        let control_points = &[(0.0, 0.0), (1.0, 0.0)];
+        let curve = <NurbsCurve2D<f64> as NurbsCurve2DConstructor<f64>>::new(
+            control_points,
+            None,
+            vec![2.0, 2.0, 3.0, 3.0],
+            1,
+        )
+        .unwrap();
+
+        let in_domain =
+            <NurbsCurve2D<f64> as NurbsCurve2DEvaluation<f64>>::point_at_checked(&curve, 2.5);
+        let out_of_domain =
+            <NurbsCurve2D<f64> as NurbsCurve2DEvaluation<f64>>::point_at_checked(&curve, 1.9);
+
+        assert!(in_domain.is_some());
+        assert!(out_of_domain.is_none());
     }
 }

--- a/model/geo_nurbs/src/curve_2d.rs
+++ b/model/geo_nurbs/src/curve_2d.rs
@@ -313,6 +313,10 @@ impl<T: Scalar> NurbsCurve2DEvaluation<T> for NurbsCurve2D<T> {
     }
 
     fn point_at_checked(&self, t: T) -> Option<(T, T)> {
+        if !t.is_finite() {
+            return None;
+        }
+
         let (t_min, t_max) = self.parameter_domain();
         if t < t_min || t > t_max {
             return None;
@@ -457,5 +461,23 @@ mod tests {
 
         assert!(in_domain.is_some());
         assert!(out_of_domain.is_none());
+    }
+
+    #[test]
+    fn test_point_at_checked_returns_none_for_nan_parameter() {
+        use geo_contracts::{NurbsCurve2DConstructor, NurbsCurve2DEvaluation};
+
+        let curve = <NurbsCurve2D<f64> as NurbsCurve2DConstructor<f64>>::new(
+            &[(0.0, 0.0), (1.0, 0.0)],
+            None,
+            vec![2.0, 2.0, 3.0, 3.0],
+            1,
+        )
+        .unwrap();
+
+        let value =
+            <NurbsCurve2D<f64> as NurbsCurve2DEvaluation<f64>>::point_at_checked(&curve, f64::NAN);
+
+        assert!(value.is_none());
     }
 }

--- a/model/geo_nurbs/src/curve_3d_bounds.rs
+++ b/model/geo_nurbs/src/curve_3d_bounds.rs
@@ -171,4 +171,20 @@ mod tests {
         let point = point_opt.unwrap();
         assert!((point.0 - 1.5).abs() < 1e-10);
     }
+
+    #[test]
+    fn test_evaluate_checked_rejects_nan_parameter() {
+        use geo_contracts::{NurbsCurve3DConstructor, NurbsCurve3DEvaluation};
+
+        let curve = <NurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(
+            (0.0, 0.0, 0.0),
+            (1.0, 0.0, 0.0),
+        )
+        .unwrap();
+
+        let value =
+            <NurbsCurve3D<f64> as NurbsCurve3DEvaluation<f64>>::evaluate_checked(&curve, f64::NAN);
+
+        assert!(value.is_none());
+    }
 }

--- a/model/geo_nurbs/src/curve_3d_bounds.rs
+++ b/model/geo_nurbs/src/curve_3d_bounds.rs
@@ -186,5 +186,18 @@ mod tests {
             <NurbsCurve3D<f64> as NurbsCurve3DEvaluation<f64>>::evaluate_checked(&curve, f64::NAN);
 
         assert!(value.is_none());
+
+        let (u_min, u_max) = curve.parameter_domain();
+        let below_domain = <NurbsCurve3D<f64> as NurbsCurve3DEvaluation<f64>>::evaluate_checked(
+            &curve,
+            u_min - 0.1,
+        );
+        let above_domain = <NurbsCurve3D<f64> as NurbsCurve3DEvaluation<f64>>::evaluate_checked(
+            &curve,
+            u_max + 0.1,
+        );
+
+        assert!(below_domain.is_none());
+        assert!(above_domain.is_none());
     }
 }

--- a/model/geo_nurbs/src/surface_3d.rs
+++ b/model/geo_nurbs/src/surface_3d.rs
@@ -531,6 +531,15 @@ impl<T: Scalar> NurbsSurface3DEvaluation<T> for NurbsSurface3D<T> {
         (point.x(), point.y(), point.z())
     }
 
+    fn point_at_uv_checked(&self, u: T, v: T) -> Option<(T, T, T)> {
+        let ((u_min, u_max), (v_min, v_max)) = self.parameter_domain();
+        if u < u_min || u > u_max || v < v_min || v > v_max {
+            return None;
+        }
+
+        Some(self.point_at_uv(u, v))
+    }
+
     fn normal_at(&self, u: T, v: T) -> (T, T, T) {
         let _h = T::from_f64(constants::DERIVATIVE_STEP);
 
@@ -658,5 +667,36 @@ mod tests {
         assert!((point.x() - 0.5).abs() < 1e-10);
         assert!((point.y() - 0.5).abs() < 1e-10);
         assert!((point.z() - 0.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_point_at_uv_checked_returns_none_for_out_of_domain_parameter() {
+        use geo_contracts::NurbsSurface3DEvaluation;
+
+        let control_points = vec![
+            vec![(0.0, 0.0, 0.0), (0.0, 1.0, 0.0)],
+            vec![(1.0, 0.0, 0.0), (1.0, 1.0, 0.0)],
+        ];
+        let weights = vec![vec![1.0, 1.0], vec![1.0, 1.0]];
+        let surface = <NurbsSurface3D<f64> as NurbsSurface3DConstructor<f64>>::new(
+            control_points,
+            Some(weights),
+            vec![2.0, 2.0, 3.0, 3.0],
+            vec![5.0, 5.0, 6.0, 6.0],
+            1,
+            1,
+        )
+        .unwrap();
+
+        let in_domain = <NurbsSurface3D<f64> as NurbsSurface3DEvaluation<f64>>::point_at_uv_checked(
+            &surface, 2.5, 5.5,
+        );
+        let out_of_domain =
+            <NurbsSurface3D<f64> as NurbsSurface3DEvaluation<f64>>::point_at_uv_checked(
+                &surface, 1.9, 5.5,
+            );
+
+        assert!(in_domain.is_some());
+        assert!(out_of_domain.is_none());
     }
 }

--- a/model/geo_nurbs/src/surface_3d.rs
+++ b/model/geo_nurbs/src/surface_3d.rs
@@ -532,6 +532,10 @@ impl<T: Scalar> NurbsSurface3DEvaluation<T> for NurbsSurface3D<T> {
     }
 
     fn point_at_uv_checked(&self, u: T, v: T) -> Option<(T, T, T)> {
+        if !u.is_finite() || !v.is_finite() {
+            return None;
+        }
+
         let ((u_min, u_max), (v_min, v_max)) = self.parameter_domain();
         if u < u_min || u > u_max || v < v_min || v > v_max {
             return None;
@@ -698,5 +702,39 @@ mod tests {
 
         assert!(in_domain.is_some());
         assert!(out_of_domain.is_none());
+    }
+
+    #[test]
+    fn test_point_at_uv_checked_returns_none_for_nan_parameter() {
+        use geo_contracts::NurbsSurface3DEvaluation;
+
+        let control_points = vec![
+            vec![(0.0, 0.0, 0.0), (0.0, 1.0, 0.0)],
+            vec![(1.0, 0.0, 0.0), (1.0, 1.0, 0.0)],
+        ];
+        let weights = vec![vec![1.0, 1.0], vec![1.0, 1.0]];
+        let surface = <NurbsSurface3D<f64> as NurbsSurface3DConstructor<f64>>::new(
+            control_points,
+            Some(weights),
+            vec![2.0, 2.0, 3.0, 3.0],
+            vec![5.0, 5.0, 6.0, 6.0],
+            1,
+            1,
+        )
+        .unwrap();
+
+        let nan_u = <NurbsSurface3D<f64> as NurbsSurface3DEvaluation<f64>>::point_at_uv_checked(
+            &surface,
+            f64::NAN,
+            5.5,
+        );
+        let nan_v = <NurbsSurface3D<f64> as NurbsSurface3DEvaluation<f64>>::point_at_uv_checked(
+            &surface,
+            2.5,
+            f64::NAN,
+        );
+
+        assert!(nan_u.is_none());
+        assert!(nan_v.is_none());
     }
 }

--- a/model/geo_primitives/src/line_segment_2d.rs
+++ b/model/geo_primitives/src/line_segment_2d.rs
@@ -407,14 +407,6 @@ impl<T: Scalar> LineSegment2DEvaluation<T> for LineSegment2D<T> {
         let p = self.point_at_normalized_parameter(t);
         (p.x(), p.y())
     }
-
-    fn point_at_parameter_checked(&self, t: T) -> Option<(T, T)> {
-        if !t.is_finite() || t < T::ZERO || t > T::ONE {
-            return None;
-        }
-
-        Some(self.point_at_parameter(t))
-    }
 }
 
 impl<T: Scalar> LineSegment2DProjection<T> for LineSegment2D<T> {

--- a/model/geo_primitives/src/line_segment_2d.rs
+++ b/model/geo_primitives/src/line_segment_2d.rs
@@ -407,6 +407,14 @@ impl<T: Scalar> LineSegment2DEvaluation<T> for LineSegment2D<T> {
         let p = self.point_at_normalized_parameter(t);
         (p.x(), p.y())
     }
+
+    fn point_at_parameter_checked(&self, t: T) -> Option<(T, T)> {
+        if t < T::ZERO || t > T::ONE {
+            return None;
+        }
+
+        Some(self.point_at_parameter(t))
+    }
 }
 
 impl<T: Scalar> LineSegment2DProjection<T> for LineSegment2D<T> {
@@ -457,5 +465,25 @@ mod tests {
         assert_eq!(segment.length(), 2.0);
         assert_eq!(segment.constraint_length(), 2.0);
         assert_eq!(segment.ideal_length(), 2.0);
+    }
+
+    #[test]
+    fn checked_parameter_evaluation_rejects_out_of_range_input() {
+        use geo_contracts::LineSegment2DEvaluation;
+
+        let segment = LineSegment2D::new(Point2D::new(0.0_f64, 0.0), Point2D::new(2.0, 0.0))
+            .expect("segment creation should succeed");
+
+        let in_range =
+            <LineSegment2D<f64> as LineSegment2DEvaluation<f64>>::point_at_parameter_checked(
+                &segment, 0.5,
+            );
+        let out_of_range =
+            <LineSegment2D<f64> as LineSegment2DEvaluation<f64>>::point_at_parameter_checked(
+                &segment, 1.1,
+            );
+
+        assert!(in_range.is_some());
+        assert!(out_of_range.is_none());
     }
 }

--- a/model/geo_primitives/src/line_segment_2d.rs
+++ b/model/geo_primitives/src/line_segment_2d.rs
@@ -409,7 +409,7 @@ impl<T: Scalar> LineSegment2DEvaluation<T> for LineSegment2D<T> {
     }
 
     fn point_at_parameter_checked(&self, t: T) -> Option<(T, T)> {
-        if t < T::ZERO || t > T::ONE {
+        if !t.is_finite() || t < T::ZERO || t > T::ONE {
             return None;
         }
 
@@ -485,5 +485,21 @@ mod tests {
 
         assert!(in_range.is_some());
         assert!(out_of_range.is_none());
+    }
+
+    #[test]
+    fn checked_parameter_evaluation_rejects_nan_input() {
+        use geo_contracts::LineSegment2DEvaluation;
+
+        let segment = LineSegment2D::new(Point2D::new(0.0_f64, 0.0), Point2D::new(2.0, 0.0))
+            .expect("segment creation should succeed");
+
+        let value =
+            <LineSegment2D<f64> as LineSegment2DEvaluation<f64>>::point_at_parameter_checked(
+                &segment,
+                f64::NAN,
+            );
+
+        assert!(value.is_none());
     }
 }

--- a/model/geo_primitives/src/line_segment_3d.rs
+++ b/model/geo_primitives/src/line_segment_3d.rs
@@ -325,6 +325,16 @@ impl<T: Scalar> LineSegment3DEvaluation<T> for LineSegment3D<T> {
         let p = self.line.point_at_parameter(param);
         (p.x(), p.y(), p.z())
     }
+
+    fn point_at_parameter_checked(&self, t: T) -> Option<(T, T, T)> {
+        if t < T::ZERO || t > T::ONE {
+            return None;
+        }
+
+        let param = self.start_param + t * (self.end_param - self.start_param);
+        let p = self.line.point_at_parameter(param);
+        Some((p.x(), p.y(), p.z()))
+    }
 }
 
 impl<T: Scalar> LineSegment3DProjection<T> for LineSegment3D<T> {
@@ -403,5 +413,26 @@ mod tests {
         assert_eq!(segment.length(), 2.0);
         assert_eq!(segment.constraint_length(), 2.0);
         assert_eq!(segment.ideal_length(), 2.0);
+    }
+
+    #[test]
+    fn checked_parameter_evaluation_rejects_out_of_range_input() {
+        use geo_contracts::LineSegment3DEvaluation;
+
+        let segment =
+            LineSegment3D::new(Point3D::new(0.0_f64, 0.0, 0.0), Point3D::new(2.0, 0.0, 0.0))
+                .expect("segment creation should succeed");
+
+        let in_range =
+            <LineSegment3D<f64> as LineSegment3DEvaluation<f64>>::point_at_parameter_checked(
+                &segment, 0.5,
+            );
+        let out_of_range =
+            <LineSegment3D<f64> as LineSegment3DEvaluation<f64>>::point_at_parameter_checked(
+                &segment, 1.1,
+            );
+
+        assert!(in_range.is_some());
+        assert!(out_of_range.is_none());
     }
 }

--- a/model/geo_primitives/src/line_segment_3d.rs
+++ b/model/geo_primitives/src/line_segment_3d.rs
@@ -327,13 +327,13 @@ impl<T: Scalar> LineSegment3DEvaluation<T> for LineSegment3D<T> {
     }
 
     fn point_at_parameter_checked(&self, t: T) -> Option<(T, T, T)> {
-        if t < T::ZERO || t > T::ONE {
+        if !t.is_finite() || t < T::ZERO || t > T::ONE {
             return None;
         }
 
-        let param = self.start_param + t * (self.end_param - self.start_param);
-        let p = self.line.point_at_parameter(param);
-        Some((p.x(), p.y(), p.z()))
+        Some(<Self as LineSegment3DEvaluation<T>>::point_at_parameter(
+            self, t,
+        ))
     }
 }
 
@@ -434,5 +434,22 @@ mod tests {
 
         assert!(in_range.is_some());
         assert!(out_of_range.is_none());
+    }
+
+    #[test]
+    fn checked_parameter_evaluation_rejects_nan_input() {
+        use geo_contracts::LineSegment3DEvaluation;
+
+        let segment =
+            LineSegment3D::new(Point3D::new(0.0_f64, 0.0, 0.0), Point3D::new(2.0, 0.0, 0.0))
+                .expect("segment creation should succeed");
+
+        let value =
+            <LineSegment3D<f64> as LineSegment3DEvaluation<f64>>::point_at_parameter_checked(
+                &segment,
+                f64::NAN,
+            );
+
+        assert!(value.is_none());
     }
 }

--- a/model/geo_primitives/src/line_segment_3d.rs
+++ b/model/geo_primitives/src/line_segment_3d.rs
@@ -325,16 +325,6 @@ impl<T: Scalar> LineSegment3DEvaluation<T> for LineSegment3D<T> {
         let p = self.line.point_at_parameter(param);
         (p.x(), p.y(), p.z())
     }
-
-    fn point_at_parameter_checked(&self, t: T) -> Option<(T, T, T)> {
-        if !t.is_finite() || t < T::ZERO || t > T::ONE {
-            return None;
-        }
-
-        Some(<Self as LineSegment3DEvaluation<T>>::point_at_parameter(
-            self, t,
-        ))
-    }
 }
 
 impl<T: Scalar> LineSegment3DProjection<T> for LineSegment3D<T> {


### PR DESCRIPTION
## 概要

#672 の方針（案A: 段階移行）に沿って、既存API互換を維持したまま checked evaluation 入口を追加しました。

本PRは fail-fast の最終固定ではなく、
- 既存APIを壊さない
- 範囲外入力を明示失敗できる入口を先に揃える
という第1段です。

## 変更内容

### 1. 設計文書の先行更新
- `dev/architecture/GEOMETRY_SHAPE_SEMANTICS_DESIGN.md`
  - #672 の段階移行方針を追記
  - checked/unchecked の責務分離と移行順を明文化

### 2. `geo_contracts` に checked API を追加（デフォルト実装）
- `NurbsCurve3DEvaluation::evaluate_checked`
- `NurbsCurve2DEvaluation::point_at_checked`
- `NurbsSurface3DEvaluation::point_at_uv_checked`
- `LineSegment2DEvaluation::point_at_parameter_checked`
- `LineSegment3DEvaluation::point_at_parameter_checked`

> 既存メソッドは維持し、デフォルト実装で後方互換を確保しています。

### 3. `geo_nurbs` 実装で domain 判定つき checked 経路を実装
- `model/geo_nurbs/src/curve_2d.rs`
  - `point_at_checked` を override（domain外は `None`）
- `model/geo_nurbs/src/surface_3d.rs`
  - `point_at_uv_checked` を override（domain外は `None`）

### 4. `geo_primitives` 実装で LineSegment 2D/3D の checked 経路を統一
- `model/geo_primitives/src/line_segment_2d.rs`
- `model/geo_primitives/src/line_segment_3d.rs`
  - `0 <= t <= 1` を checked 入口で判定し、範囲外は `None`

### 5. 回帰テスト追加
- NurbsCurve2D: 範囲外で `None`
- NurbsSurface3D: 範囲外で `None`
- LineSegment2D/3D: 範囲外で `None`

## 検証

- `cargo clippy -p geo_contracts -p geo_nurbs -p geo_primitives -- -D warnings`
- `cargo fmt`
- `cargo test -p geo_nurbs -p geo_primitives`

いずれも成功。

## スコープ外

- 既存 evaluation API の fail-fast への一括置換
- 呼び出し側全面移行（`geo_topology` / `geo_algorithms` の checked 経路一本化）
- derivative/normal 経路の checked 収束

## 関連

- Refs #672