### PR TITLE
issue #671 [Phase4][C-1] geo_nurbs: remove unused tolerance constants and align docs/tests

### DIFF
--- a/dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md
+++ b/dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md
@@ -176,7 +176,7 @@ integration テストで `ToleranceSettings` を使ってよい理由は次の�
 4. 無次元判定（内積・外積誤差）には無次元しきい値を使用し、単位付き距離トレランスを混在させない。
 5. `f64` 専用の極小固定値を `T::from_f64(...)` で generic に流用しない。`f32`/`f64` の両対応が必要な固定しきい値は、型別定義または `default_*` wrapper を経由して選択する。
 
-## #671 実施準備: geo_nurbs 数値定数の型別方針
+## #671 実施結果: geo_nurbs 数値定数の型別方針
 
 ### 目的
 
@@ -204,33 +204,40 @@ integration テストで `ToleranceSettings` を使ってよい理由は次の�
 2. domain 判定を省略するデフォルト実装は、互換維持の暫定ラッパであることを doc へ明示する。
 3. checked/unchecked の責務差は trait定義コメントと実装で一致させる。
 
-### 実施順（#671）
+### 実施結果（#671）
 
-1. `geo_nurbs` の実装コードを対象に、数値リテラルと tolerance 参照の棚卸しを確定する。
-2. 参照入口の分類（カーネルゼロ判定 / 幾何意味判定 / 解法しきい値）をファイル単位で紐付ける。
-3. 置換単位を小PRへ分割し、`cargo clippy -> cargo fmt -> cargo test` を各単位で通す。
-4. 最後に docs と実装の契約整合を再確認する。
+1. `geo_nurbs` 実装コードの棚卸しと参照入口分類を確定した。
+2. PR-A で `curve_3d.rs` の公開経路退化判定を `default_kernel_numerical_zero_tolerance<T>()` へ統一した。
+3. PR-B で `lib.rs` に `constants::tolerance` / `constants::solver` の型別入口を導入し、`geo_nurbs` 内参照を切替した。
+4. PR-C で docs と tests の整合を固定し、型別入口と互換定数の意味を回帰で担保した。
 
 ### 実装コード限定の棚卸し結果（#671 Step 1 確定）
 
 対象は `model/geo_nurbs/src` 配下の実装コードのみとし、`#[cfg(test)]` 以降は除外した。
 
-| 分類 | ファイル | 該当箇所 | 現状 | 初期方針 |
+| 分類 | ファイル | 該当箇所 | 棚卸し時点 | 対応結果 |
 | --- | --- | --- | --- | --- |
 | カーネルゼロ判定 | `curve_2d_transform.rs` | `default_kernel_numerical_zero_tolerance::<T>()` | 参照入口は方針準拠 | 維持 |
 | カーネルゼロ判定 | `curve_3d_transform.rs` | `default_kernel_numerical_zero_tolerance::<T>()` | 参照入口は方針準拠 | 維持 |
 | カーネルゼロ判定 | `surface_3d_transform.rs` | `default_kernel_numerical_zero_tolerance::<T>()` | 参照入口は方針準拠 | 維持 |
 | カーネルゼロ判定 | `curve_3d_extensions.rs` | `tolerance.max(default_kernel_numerical_zero_tolerance::<T>())` | 下限ガードとして方針準拠 | 維持 |
-| 公開経路の退化判定 | `curve_3d.rs` | `distance_sq <= T::EPSILON * T::EPSILON` | 公開経路で `T::EPSILON` 直接参照 | `default_kernel_numerical_zero_tolerance<T>()` 経由へ置換 |
-| 解法しきい値（f64固定） | `lib.rs` | `DEFAULT_TOLERANCE=1e-10`, `MIN_KNOT_INTERVAL=1e-12`, `NEWTON_TOLERANCE=1e-10`, `NEWTON_DIFF_STEP=1e-7`, `DERIVATIVE_STEP=1e-8` | 型非依存の f64 固定値が集約 | 用途別に型別参照入口を導入して段階置換 |
+| 公開経路の退化判定 | `curve_3d.rs` | `distance_sq <= T::EPSILON * T::EPSILON` | 公開経路で `T::EPSILON` 直接参照 | `default_kernel_numerical_zero_tolerance<T>()` 経由へ置換済み |
+| 解法しきい値（f64固定） | `lib.rs` | `DEFAULT_TOLERANCE=1e-10`, `MIN_KNOT_INTERVAL=1e-12`, `NEWTON_TOLERANCE=1e-10`, `NEWTON_DIFF_STEP=1e-7`, `DERIVATIVE_STEP=1e-8` | 型非依存の f64 固定値が集約 | 実使用がある `constants::solver` の型別入口へ再配置し、旧f64互換定数と未使用入口は削除 |
 | 数学係数（意味付き） | `curve_2d.rs` | `powf(T::from_f64(1.5))` | 曲率式の指数係数 | 置換対象外（マジックナンバー扱いにしない） |
 | 数学係数（意味付き） | `surface_3d.rs` | `du / T::from_f64(2.0)`, `dv / T::from_f64(2.0)` | セル中心サンプリング係数 | 置換対象外（マジックナンバー扱いにしない） |
 
-### 小PR分割（#671 初期案）
+### 小PR分割（#671 完了記録）
 
-1. PR-A: `curve_3d.rs` の `T::EPSILON` 直接参照を `default_kernel_numerical_zero_tolerance<T>()` へ置換
-2. PR-B: `lib.rs` の f64 固定解法定数を用途別に再配置し、`geo_nurbs` 内の参照を型別入口経由へ切替
-3. PR-C: docs と tests の整合調整（置換後の意味と参照入口を固定）
+1. PR-A: `curve_3d.rs` の `T::EPSILON` 直接参照を `default_kernel_numerical_zero_tolerance<T>()` へ置換（完了）
+2. PR-B: `lib.rs` の f64 固定解法定数を用途別に再配置し、`geo_nurbs` 内の参照を型別入口経由へ切替（完了）
+3. PR-C: docs と tests の整合調整（置換後の意味と参照入口を固定）（完了）
+
+### PR-C で固定した tests 契約
+
+1. `constants::solver` の型別入口は f32/f64 それぞれで対応する定数値を返すこと。
+2. `line_segment` の退化判定は kernel tolerance に基づき、f64 だけでなく f32 でも境界ケースを満たすこと。
+3. `Err(String)` の文言に依存せず、失敗/成功の挙動を契約として検証すること。
+4. 旧f64互換定数（`DEFAULT_TOLERANCE` など）へ依存せず、実使用される `constants::solver::*` 入口を正本として検証すること。
 
 備考:
 

--- a/dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md
+++ b/dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md
@@ -208,8 +208,8 @@ integration テストで `ToleranceSettings` を使ってよい理由は次の�
 
 1. `geo_nurbs` 実装コードの棚卸しと参照入口分類を確定した。
 2. PR-A で `curve_3d.rs` の公開経路退化判定を `default_kernel_numerical_zero_tolerance<T>()` へ統一した。
-3. PR-B で `lib.rs` に `constants::tolerance` / `constants::solver` の型別入口を導入し、`geo_nurbs` 内参照を切替した。
-4. PR-C で docs と tests の整合を固定し、型別入口と互換定数の意味を回帰で担保した。
+3. PR-B では移行段階として `lib.rs` に `constants::tolerance` / `constants::solver` の型別入口を導入し、`geo_nurbs` 内参照を段階的に切替した。
+4. PR-C で未使用だった `constants::tolerance` を削除して `constants::solver` に集約し、docs と tests の整合を固定した。現行の参照正本は `constants::solver::*` である。
 
 ### 実装コード限定の棚卸し結果（#671 Step 1 確定）
 

--- a/model/geo_algorithms/src/collision/nurbs_3d.rs
+++ b/model/geo_algorithms/src/collision/nurbs_3d.rs
@@ -92,8 +92,8 @@ impl<T: Scalar> NurbsCurveCollider<T> {
             u_min,
             u_max,
             constants::NEWTON_MAX_ITER,
-            T::from_f64(constants::NEWTON_TOLERANCE),
-            T::from_f64(constants::NEWTON_DIFF_STEP),
+            constants::solver::newton_tolerance::<T>(),
+            constants::solver::newton_diff_step::<T>(),
         );
 
         maybe_u.unwrap_or_else(|| initial_u.clamp(u_min, u_max))

--- a/model/geo_nurbs/src/curve_3d_bounds.rs
+++ b/model/geo_nurbs/src/curve_3d_bounds.rs
@@ -139,15 +139,20 @@ mod tests {
     }
 
     #[test]
-    fn test_core_traits_line_segment_rejects_points_within_kernel_tolerance() {
+    fn test_core_traits_line_segment_f64_kernel_tolerance_boundary() {
         use geo_contracts::NurbsCurve3DConstructor;
 
         let zero_tol = default_kernel_numerical_zero_tolerance::<f64>();
         let start = (0.0_f64, 0.0, 0.0);
-        let end = (zero_tol * 0.5, 0.0, 0.0);
-        let result = <NurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(start, end);
+        let inside = (zero_tol * 0.5, 0.0, 0.0);
+        let inside_result =
+            <NurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(start, inside);
+        assert!(inside_result.is_err());
 
-        assert!(result.is_err());
+        let outside = (zero_tol * 2.0, 0.0, 0.0);
+        let outside_result =
+            <NurbsCurve3D<f64> as NurbsCurve3DConstructor<f64>>::line_segment(start, outside);
+        assert!(outside_result.is_ok());
     }
 
     #[test]

--- a/model/geo_nurbs/src/lib.rs
+++ b/model/geo_nurbs/src/lib.rs
@@ -66,37 +66,6 @@ pub mod constants {
         }
     }
 
-    /// 幾何判定で使うしきい値群
-    pub mod tolerance {
-        use crate::Scalar;
-
-        use super::select_scalar_value;
-
-        /// デフォルトの数値許容誤差（f32）
-        pub const DEFAULT_TOLERANCE_F32: f32 = 1e-6;
-
-        /// デフォルトの数値許容誤差（f64）
-        pub const DEFAULT_TOLERANCE_F64: f64 = 1e-10;
-
-        /// 最小の有効なノット間隔（f32）
-        pub const MIN_KNOT_INTERVAL_F32: f32 = 1e-6;
-
-        /// 最小の有効なノット間隔（f64）
-        pub const MIN_KNOT_INTERVAL_F64: f64 = 1e-12;
-
-        /// デフォルトの数値許容誤差を型別に取得
-        #[must_use]
-        pub fn default_tolerance<T: Scalar>() -> T {
-            select_scalar_value::<T>(DEFAULT_TOLERANCE_F32, DEFAULT_TOLERANCE_F64)
-        }
-
-        /// 最小の有効なノット間隔を型別に取得
-        #[must_use]
-        pub fn min_knot_interval<T: Scalar>() -> T {
-            select_scalar_value::<T>(MIN_KNOT_INTERVAL_F32, MIN_KNOT_INTERVAL_F64)
-        }
-    }
-
     /// 数値解法で使うしきい値群
     pub mod solver {
         use crate::Scalar;
@@ -140,12 +109,6 @@ pub mod constants {
         }
     }
 
-    /// デフォルトの数値許容誤差（後方互換・f64）
-    pub const DEFAULT_TOLERANCE: f64 = tolerance::DEFAULT_TOLERANCE_F64;
-
-    /// 最小の有効なノット間隔（後方互換・f64）
-    pub const MIN_KNOT_INTERVAL: f64 = tolerance::MIN_KNOT_INTERVAL_F64;
-
     /// 最大サポート次数
     pub const MAX_DEGREE: usize = 10;
 
@@ -154,15 +117,6 @@ pub mod constants {
 
     /// NURBS最近接パラメータ探索で使う境界付きニュートン法の最大反復回数
     pub const NEWTON_MAX_ITER: usize = 20;
-
-    /// NURBS最近接パラメータ探索で使う境界付きニュートン法の収束許容誤差（後方互換・f64）
-    pub const NEWTON_TOLERANCE: f64 = solver::NEWTON_TOLERANCE_F64;
-
-    /// NURBS最近接パラメータ探索で使う数値微分ステップ幅（後方互換・f64）
-    pub const NEWTON_DIFF_STEP: f64 = solver::NEWTON_DIFF_STEP_F64;
-
-    /// NURBS導関数の中央差分近似で使う微小ステップ幅（後方互換・f64）
-    pub const DERIVATIVE_STEP: f64 = solver::DERIVATIVE_STEP_F64;
 
     /// 曲線長近似で使うデフォルト分割数
     pub const CURVE_LENGTH_SUBDIVISIONS: usize = 100;
@@ -185,42 +139,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_tolerance_usage() {
-        // 実際のNURBS計算でのトレランス使用テスト（動的な値）
-        let tolerance = constants::DEFAULT_TOLERANCE;
-        let small_diff = tolerance * 0.5;
-        assert!(
-            small_diff < tolerance,
-            "Small difference should be within tolerance"
-        );
-
-        let large_diff = tolerance * 2.0;
-        assert!(
-            large_diff > tolerance,
-            "Large difference should exceed tolerance"
-        );
-    }
-
-    #[test]
-    fn test_typed_constant_accessors_return_expected_values() {
-        assert_eq!(
-            constants::tolerance::default_tolerance::<f32>().to_bits(),
-            constants::tolerance::DEFAULT_TOLERANCE_F32.to_bits()
-        );
-        assert_eq!(
-            constants::tolerance::default_tolerance::<f64>().to_bits(),
-            constants::tolerance::DEFAULT_TOLERANCE_F64.to_bits()
-        );
-
-        assert_eq!(
-            constants::tolerance::min_knot_interval::<f32>().to_bits(),
-            constants::tolerance::MIN_KNOT_INTERVAL_F32.to_bits()
-        );
-        assert_eq!(
-            constants::tolerance::min_knot_interval::<f64>().to_bits(),
-            constants::tolerance::MIN_KNOT_INTERVAL_F64.to_bits()
-        );
-
+    fn test_solver_typed_constants_return_expected_values() {
         assert_eq!(
             constants::solver::newton_tolerance::<f32>().to_bits(),
             constants::solver::NEWTON_TOLERANCE_F32.to_bits()


### PR DESCRIPTION
## スコープ明示
- このPRに含む単位: C-1（#671 PR-C docs/tests整合）
- このPRに含めない単位: A/B（実装入口切替は #674 で完了）
- Phase と PR系列の関係: 本PRは #671 の後続整合作業として、Phase4 の C 系列のみを対象

## 概要
Issue #671 の PR-C として、未使用となった `geo_nurbs::constants::tolerance` を削除し、実使用中の `constants::solver` へ整理しました。

## 変更内容
- `model/geo_nurbs/src/lib.rs`
  - `constants::tolerance` モジュールを削除
  - tolerance専用テストを削除
  - tests を `constants::solver` 検証に限定
- `model/geo_algorithms/src/collision/nurbs_3d.rs`
  - Newton solver しきい値参照を `constants::solver::*` に統一
- `model/geo_nurbs/src/curve_3d_bounds.rs`
  - kernel tolerance 境界テスト（f32/f64）を維持
- `dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md`
  - #671 実施結果を現実装（PR-B は移行段階導入、PR-C で `constants::tolerance` 削除・`constants::solver` 集約）に合わせて更新

## 破壊的変更と移行
- 本PRは `geo_nurbs` の公開面に対して破壊的変更を含みます。
  - 削除: `geo_nurbs::constants::tolerance::*`
  - 既定参照の正本: `geo_nurbs::constants::solver::*`
- 置換先:
  - `NEWTON_TOLERANCE` 相当 -> `constants::solver::newton_tolerance::<T>()`
  - `NEWTON_DIFF_STEP` 相当 -> `constants::solver::newton_diff_step::<T>()`
  - `DERIVATIVE_STEP` 相当 -> `constants::solver::derivative_step::<T>()`
- リポジトリ内参照は全て置換済みで、`geo_nurbs` / `geo_algorithms` の回帰検証を通過しています。

## 検証
- `cargo clippy -p geo_nurbs -p geo_algorithms -- -D warnings`
- `cargo fmt`
- `cargo test -p geo_nurbs -p geo_algorithms`