### PR TITLE
issue #302 [Phase1][PR-C-1] job_runtime: InputRef/ResultRef 契約検証を追加

### DIFF
--- a/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
+++ b/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
@@ -591,9 +591,19 @@ Digest: executed image digest
 - Job Manager: メタデータ契約の検証のみを行う
   - 必須項目の欠落
   - digest/hash/size の形式検証
-  - `ResultRef` 不在時の reject
+  - `InputRef` / `ResultRef` 不在時の reject
+  - `format_version` 不一致時の reject
 - Worker / Domain: artifact本体生成と `artifact_manifest.json` 作成を担う
 - ViewModel / View: `ResultRef` / `LogRef` / manifest由来メタデータの表示に専念する
+
+実装上の最小入口:
+
+- `ArtifactManifest::validate()`
+  - manifest単体の形式検証
+- `validate_output_contract(result_ref, manifest)`
+  - `ResultRef` + manifest の最小検証
+- `validate_io_contract(input_ref, result_ref, manifest, expected_format_version)`
+  - `InputRef` / `ResultRef` / `format_version` を含む契約検証
 
 運用ルール:
 

--- a/model/job_runtime/src/artifact_manifest.rs
+++ b/model/job_runtime/src/artifact_manifest.rs
@@ -260,6 +260,16 @@ mod tests {
     }
 
     #[test]
+    fn validate_io_contract_requires_input_scheme() {
+        let manifest = sample_manifest();
+
+        assert!(matches!(
+            validate_io_contract("output://job-42", "result://artifact-1", &manifest, "v1"),
+            Err(ArtifactManifestError::InvalidInputRef(_))
+        ));
+    }
+
+    #[test]
     fn validate_io_contract_rejects_version_mismatch() {
         let mut manifest = sample_manifest();
         manifest.format_version = "v2".to_string();

--- a/model/job_runtime/src/artifact_manifest.rs
+++ b/model/job_runtime/src/artifact_manifest.rs
@@ -163,7 +163,11 @@ where
         return Err(missing_error);
     }
 
-    if !value.starts_with(expected_scheme) {
+    let Some(suffix) = value.strip_prefix(expected_scheme) else {
+        return Err(invalid_error(value.to_string()));
+    };
+
+    if suffix.trim().is_empty() {
         return Err(invalid_error(value.to_string()));
     }
 
@@ -250,6 +254,16 @@ mod tests {
     }
 
     #[test]
+    fn validate_output_contract_rejects_empty_result_suffix() {
+        let manifest = sample_manifest();
+
+        assert!(matches!(
+            validate_output_contract("result://   ", &manifest),
+            Err(ArtifactManifestError::InvalidResultRef(_))
+        ));
+    }
+
+    #[test]
     fn validate_io_contract_rejects_missing_input_ref() {
         let manifest = sample_manifest();
 
@@ -265,6 +279,16 @@ mod tests {
 
         assert!(matches!(
             validate_io_contract("output://job-42", "result://artifact-1", &manifest, "v1"),
+            Err(ArtifactManifestError::InvalidInputRef(_))
+        ));
+    }
+
+    #[test]
+    fn validate_io_contract_rejects_empty_input_suffix() {
+        let manifest = sample_manifest();
+
+        assert!(matches!(
+            validate_io_contract("input://   ", "result://artifact-1", &manifest, "v1"),
             Err(ArtifactManifestError::InvalidInputRef(_))
         ));
     }

--- a/model/job_runtime/src/artifact_manifest.rs
+++ b/model/job_runtime/src/artifact_manifest.rs
@@ -34,10 +34,13 @@ pub struct ArtifactManifest {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ArtifactManifestError {
+    MissingInputRef,
+    InvalidInputRef(String),
     MissingResultRef,
     InvalidResultRef(String),
     EmptyFormat,
     EmptyFormatVersion,
+    FormatVersionMismatch { expected: String, actual: String },
     InvalidImageDigest(String),
     InvalidSha256(String),
     InvalidCreatedAtUtc(String),
@@ -46,10 +49,17 @@ pub enum ArtifactManifestError {
 impl Display for ArtifactManifestError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::MissingInputRef => write!(f, "input_ref is required"),
+            Self::InvalidInputRef(value) => write!(f, "invalid input_ref: {}", value),
             Self::MissingResultRef => write!(f, "result_ref is required"),
             Self::InvalidResultRef(value) => write!(f, "invalid result_ref: {}", value),
             Self::EmptyFormat => write!(f, "format is required"),
             Self::EmptyFormatVersion => write!(f, "format_version is required"),
+            Self::FormatVersionMismatch { expected, actual } => write!(
+                f,
+                "format_version mismatch: expected={}, actual={}",
+                expected, actual
+            ),
             Self::InvalidImageDigest(value) => write!(f, "invalid image_digest: {}", value),
             Self::InvalidSha256(value) => write!(f, "invalid sha256: {}", value),
             Self::InvalidCreatedAtUtc(value) => write!(f, "invalid created_at_utc: {}", value),
@@ -94,17 +104,70 @@ pub fn validate_output_contract(
     result_ref: &str,
     manifest: &ArtifactManifest,
 ) -> Result<(), ArtifactManifestError> {
-    if result_ref.trim().is_empty() {
-        return Err(ArtifactManifestError::MissingResultRef);
+    validate_ref(
+        result_ref,
+        "result://",
+        ArtifactManifestError::MissingResultRef,
+        ArtifactManifestError::InvalidResultRef,
+    )?;
+
+    manifest.validate()?;
+
+    Ok(())
+}
+
+/// Job Manager責務: InputRef/ResultRefとmanifestバージョン契約を検証する。
+pub fn validate_io_contract(
+    input_ref: &str,
+    result_ref: &str,
+    manifest: &ArtifactManifest,
+    expected_format_version: &str,
+) -> Result<(), ArtifactManifestError> {
+    validate_ref(
+        input_ref,
+        "input://",
+        ArtifactManifestError::MissingInputRef,
+        ArtifactManifestError::InvalidInputRef,
+    )?;
+
+    validate_ref(
+        result_ref,
+        "result://",
+        ArtifactManifestError::MissingResultRef,
+        ArtifactManifestError::InvalidResultRef,
+    )?;
+
+    manifest.validate()?;
+
+    // 非互換なmanifest versionは受理せずrejectする。
+    if manifest.format_version != expected_format_version {
+        return Err(ArtifactManifestError::FormatVersionMismatch {
+            expected: expected_format_version.to_string(),
+            actual: manifest.format_version.clone(),
+        });
     }
 
-    if !result_ref.starts_with("result://") {
-        return Err(ArtifactManifestError::InvalidResultRef(
-            result_ref.to_string(),
-        ));
+    Ok(())
+}
+
+fn validate_ref<F>(
+    value: &str,
+    expected_scheme: &str,
+    missing_error: ArtifactManifestError,
+    invalid_error: F,
+) -> Result<(), ArtifactManifestError>
+where
+    F: FnOnce(String) -> ArtifactManifestError,
+{
+    if value.trim().is_empty() {
+        return Err(missing_error);
     }
 
-    manifest.validate()
+    if !value.starts_with(expected_scheme) {
+        return Err(invalid_error(value.to_string()));
+    }
+
+    Ok(())
 }
 
 fn is_valid_image_digest(value: &str) -> bool {
@@ -130,7 +193,10 @@ fn is_likely_rfc3339_utc(value: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{ArtifactManifest, ArtifactManifestError, ArtifactType, validate_output_contract};
+    use super::{
+        ArtifactManifest, ArtifactManifestError, ArtifactType, validate_io_contract,
+        validate_output_contract,
+    };
     use crate::types::JobId;
 
     fn sample_manifest() -> ArtifactManifest {
@@ -181,5 +247,39 @@ mod tests {
             validate_output_contract("output://artifact", &manifest),
             Err(ArtifactManifestError::InvalidResultRef(_))
         ));
+    }
+
+    #[test]
+    fn validate_io_contract_rejects_missing_input_ref() {
+        let manifest = sample_manifest();
+
+        assert_eq!(
+            validate_io_contract("", "result://artifact-1", &manifest, "v1"),
+            Err(ArtifactManifestError::MissingInputRef)
+        );
+    }
+
+    #[test]
+    fn validate_io_contract_rejects_version_mismatch() {
+        let mut manifest = sample_manifest();
+        manifest.format_version = "v2".to_string();
+
+        assert_eq!(
+            validate_io_contract("input://job-42", "result://artifact-1", &manifest, "v1"),
+            Err(ArtifactManifestError::FormatVersionMismatch {
+                expected: "v1".to_string(),
+                actual: "v2".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn validate_io_contract_accepts_valid_minimum_set() {
+        let manifest = sample_manifest();
+
+        assert_eq!(
+            validate_io_contract("input://job-42", "result://artifact-1", &manifest, "v1"),
+            Ok(())
+        );
     }
 }

--- a/model/job_runtime/src/lib.rs
+++ b/model/job_runtime/src/lib.rs
@@ -9,7 +9,8 @@ pub mod manager;
 pub mod types;
 
 pub use artifact_manifest::{
-    ArtifactManifest, ArtifactManifestError, ArtifactType, validate_output_contract,
+    ArtifactManifest, ArtifactManifestError, ArtifactType, validate_io_contract,
+    validate_output_contract,
 };
 pub use events::JobEvent;
 pub use executor::{JobExecutionResult, JobExecutor};


### PR DESCRIPTION
## 概要
Issue #302 の Step A として、Artifact Manifest のI/O契約検証を job_runtime に追加しました。

## 含む単位
- model/job_runtime/src/artifact_manifest.rs
  - ArtifactManifestError に InputRef 系エラーと format_version mismatch を追加
  - validate_io_contract(input_ref, result_ref, manifest, expected_format_version) を追加
  - validate_ref 共通関数で input/result スキーム検証を統一
  - スキーム一致に加えて、スキーム以降のサフィックスが空/空白のみの ref を reject する検証を追加
  - テスト追加:
    - validate_io_contract_rejects_missing_input_ref
    - validate_io_contract_requires_input_scheme
    - validate_io_contract_rejects_empty_input_suffix
    - validate_io_contract_rejects_version_mismatch
    - validate_io_contract_accepts_valid_minimum_set
    - validate_output_contract_rejects_empty_result_suffix
- model/job_runtime/src/lib.rs
  - validate_io_contract の公開 re-export を追加
- dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
  - 17.6 節に InputRef/ResultRef 検証責務と format_version 不一致 reject を追記

## 含めない単位
- Job Manager の実行制御フロー変更
- geo_* クレート群の tolerance/solver 実装変更
- 永続化レイヤ・ストレージ実装の変更

## 検証
- cargo clippy -p job_runtime -- -D warnings
- cargo fmt
- cargo test -p job_runtime
