### PR TITLE
issue #300 [Phase3][A-2] cam_core: artifact binary I/O正本仕様を実装整合

### DIFF
--- a/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
+++ b/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
@@ -30,7 +30,7 @@
 
 ## 共通ヘッダ仕様
 
-全 artifact は先頭に固定長ヘッダを持つ。
+全 artifact は先頭に固定長ヘッダ部を持ち、その直後に可変長拡張属性を持てる。
 
 - `magic: [u8; 4]`
   - `toolpath`: `RRTP`
@@ -70,6 +70,11 @@
 - `cutting_direction: u8`
   - 0 = Down
   - 1 = Up
+- `ext_attributes_count: u32`
+- `ext_attributes[]`
+  - `tag: i16` (`0` は予約値のため reject)
+  - `data_len: u16`
+  - `data: [u8; data_len]`
 - `approach_count: u32`
 - `contour_level_count: u32`
 - `retract_count: u32`
@@ -193,5 +198,5 @@ Read/Write の片側だけが変わって契約が壊れることを防ぐため
 
 - `#411` は読込導線の標準入口として本書を参照する
 - `#412` は API 名称と wire format 表記の関係整理で本書を参照する
-- `#257` / `#260` 相当の後続実装は、本書の責務境界・ヘッダ仕様・互換性ポリシーを前提にする
-- `NcPostFromCam`（#260）は本書を唯一の I/O 契約参照入口として扱う
+- `#257` 相当の後続実装は、本書の責務境界・ヘッダ仕様・互換性ポリシーを前提にする
+- `NcPostFromCam` は本書を唯一の I/O 契約参照入口として扱う

--- a/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
+++ b/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
@@ -41,8 +41,21 @@
   - 1 = Millimeter
 - `coordinate_frame: u8`
   - 1 = WorldRightHandedZUp
-- `reserved: [u8; 4]`
+- `ext_block_len: u32`
+  - ヘッダ直後に続く `ext_attributes` ブロックの総バイト長
+  - 0 の場合は拡張属性なし
 - `payload_len: u64`
+
+### ext_attributes (TLV)
+
+ヘッダ直後に可変長で配置される。`ext_block_len` で終端を判定する。
+
+- `tag: i16`
+  - 負値: システム属性
+  - 正値: ユーザー属性
+  - `0`: 予約値（reject）
+- `data_len: u16`
+- `data: [u8; data_len]`
 
 エンディアンは little-endian 固定とする。
 
@@ -73,10 +86,15 @@
   - 4 PassRetract
 - `feed_rate: f64`
   - Rapid は `0.0`
-- `start: [f64; 3]`
+- `ext_attributes_count: u32`
+- `ext_attributes[]`
+  - `tag: i16` (`0` は予約値のため reject)
+  - `data_len: u16`
+  - `data: [u8; data_len]`
 - `geometry_type: u8`
   - 0 Line
   - 1 Arc
+- `start: [f64; 3]`
 - `line_end: [f64; 3]` (Line時のみ)
 - `arc_end: [f64; 3]` (Arc時のみ)
 - `arc_center: [f64; 3]` (Arc時のみ)
@@ -176,3 +194,4 @@ Read/Write の片側だけが変わって契約が壊れることを防ぐため
 - `#411` は読込導線の標準入口として本書を参照する
 - `#412` は API 名称と wire format 表記の関係整理で本書を参照する
 - `#257` / `#260` 相当の後続実装は、本書の責務境界・ヘッダ仕様・互換性ポリシーを前提にする
+- `NcPostFromCam`（#260）は本書を唯一の I/O 契約参照入口として扱う

--- a/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
+++ b/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
@@ -45,6 +45,8 @@
   - ヘッダ直後に続く `ext_attributes` ブロックの総バイト長
   - 0 の場合は拡張属性なし
 - `payload_len: u64`
+  - `ext_attributes` を含まない payload 本体の総バイト長
+  - 可変長領域全体長は `ext_block_len + payload_len`
 
 ### ext_attributes (TLV)
 


### PR DESCRIPTION
## 概要
Issue #300 の Phase 3 における契約固定作業として、artifact binary I/O 正本ドキュメントを現行 `cam_core` 実装の wire layout と整合させました。

## 含む単位
- A-2（設計正本整合）
- `dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md`
  - 共通ヘッダの `reserved` 記述を `ext_block_len` + TLV `ext_attributes` へ修正
  - ToolPath セグメントの `ext_attributes_count` / `ext_attributes[]` を仕様へ明記
  - geometry 項目の並び順を実装（`geometry_type` 後に `start`）へ整合
  - 後続参照ルールに `NcPostFromCam`（#260）の参照入口を明記

## 含めない単位
- `cam_core` 実装コードの変更
- Job Manager 側ロジック変更
- 追加の binary reader/writer 機能追加

## Phase と PR系列
- Phase: 3
- PR系列: A-2（A-1で固定した実装に対する正本仕様整合）
- 本PRは実装変更ではなく、I/O 契約の正本記述を実コードへ一致させる変更です。

## 検証
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## 関連
- Refs #300
- Refs #260
