### PR TITLE
issue #679 [Phase1][A-1] cam_sim: NcPostFromCam artifact binary 読込導線を実装

### DIFF
--- a/model/application/src/job_orchestration.rs
+++ b/model/application/src/job_orchestration.rs
@@ -196,6 +196,13 @@ fn submit_to_runtime(
             let mut submitter = CamWorkflowSubmitter::new(manager);
             Ok(submitter.submit_cutting_simulation(JobId(parent_job_id), spec)?)
         }
+        (CamJobType::NcPostFromCam, None) => Err(JobOrchestrationError::InvalidRequest(
+            "nc post from cam requires parent_job_id".to_string(),
+        )),
+        (CamJobType::NcPostFromCam, Some(parent_job_id)) => {
+            let mut submitter = CamWorkflowSubmitter::new(manager);
+            Ok(submitter.submit_child_under(JobId(parent_job_id), spec)?)
+        }
         (CamJobType::CamProcess, Some(parent_job_id)) => {
             let mut submitter = CamWorkflowSubmitter::new(manager);
             Ok(submitter.submit_child_under(JobId(parent_job_id), spec)?)
@@ -207,6 +214,7 @@ fn map_job_type(job_type: CamJobType) -> JobType {
     match job_type {
         CamJobType::CamProcess => JobType::CamProcess,
         CamJobType::CuttingSimulation => JobType::CuttingSimulation,
+        CamJobType::NcPostFromCam => JobType::NcPostFromCam,
     }
 }
 
@@ -324,6 +332,23 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "cutting simulation requires parent_job_id".to_string()
+        );
+    }
+
+    #[test]
+    fn nc_post_from_cam_requires_parent_job_id() {
+        let mut orchestrator = JobWorkflowOrchestrator::new();
+        let error = orchestrator
+            .submit_workflow(JobWorkflowSubmitRequest {
+                job_type: CamJobType::NcPostFromCam,
+                input_ref: "result://cam/1/ok".to_string(),
+                parent_job_id: None,
+            })
+            .expect_err("nc post from cam without parent should be rejected");
+
+        assert_eq!(
+            error.to_string(),
+            "nc post from cam requires parent_job_id".to_string()
         );
     }
 }

--- a/model/application/src/job_orchestration.rs
+++ b/model/application/src/job_orchestration.rs
@@ -201,7 +201,7 @@ fn submit_to_runtime(
         )),
         (CamJobType::NcPostFromCam, Some(parent_job_id)) => {
             let mut submitter = CamWorkflowSubmitter::new(manager);
-            Ok(submitter.submit_child_under(JobId(parent_job_id), spec)?)
+            Ok(submitter.submit_nc_post_from_cam(JobId(parent_job_id), spec)?)
         }
         (CamJobType::CamProcess, Some(parent_job_id)) => {
             let mut submitter = CamWorkflowSubmitter::new(manager);

--- a/model/cam_sim/src/job_adapter.rs
+++ b/model/cam_sim/src/job_adapter.rs
@@ -1,9 +1,9 @@
 use std::io::Cursor;
 
 use cam_core::{
-    ArtifactHeaderV1, ArtifactKind, ArtifactPayload, ContourLevelPath, CuttingDirection,
-    InterferenceEvent, InterferenceKind, InterferencePayload, PathSegment, SegmentType, ToolPath,
-    read_artifact_v1, write_interference_payload_v1, write_toolpath_payload_v1,
+    ArtifactHeaderV1, ArtifactKind, ContourLevelPath, CuttingDirection, InterferenceEvent,
+    InterferenceKind, InterferencePayload, PathSegment, SegmentType, ToolPath,
+    read_toolpath_payload_v1, write_interference_payload_v1, write_toolpath_payload_v1,
 };
 use geo_algorithms::Point3D;
 use job_runtime::{JobExecutionResult, JobExecutor, JobRecord, JobStatus, JobType};
@@ -87,8 +87,8 @@ impl CamJobExecutorAdapter {
         };
 
         let mut cursor = Cursor::new(artifact_bytes);
-        let (_, payload) = match read_artifact_v1(&mut cursor) {
-            Ok(result) => result,
+        let header = match ArtifactHeaderV1::read_from(&mut cursor) {
+            Ok(header) => header,
             Err(err) => {
                 return JobExecutionResult {
                     status: JobStatus::Failed,
@@ -100,15 +100,18 @@ impl CamJobExecutorAdapter {
             }
         };
 
-        match payload {
-            ArtifactPayload::ToolPath(_) => JobExecutionResult {
-                status: JobStatus::Succeeded,
-                elapsed_millis: 240,
-                result_ref: Some(format!("result://nc-post/{}/ok", job.id.0)),
-                log_ref: Some(format!("log://nc-post/{}/ok", job.id.0)),
-                error: None,
-            },
-            ArtifactPayload::Interference(_) => JobExecutionResult {
+        if let Err(err) = header.ensure_acceptable_version() {
+            return JobExecutionResult {
+                status: JobStatus::Failed,
+                elapsed_millis: 20,
+                result_ref: None,
+                log_ref: Some(format!("log://nc-post/{}/artifact-read-failed", job.id.0)),
+                error: Some(format!("failed to read artifact binary: {}", err)),
+            };
+        }
+
+        if header.kind != ArtifactKind::ToolPath {
+            return JobExecutionResult {
                 status: JobStatus::Failed,
                 elapsed_millis: 20,
                 result_ref: None,
@@ -117,7 +120,25 @@ impl CamJobExecutorAdapter {
                     "artifact kind mismatch: expected toolpath artifact for nc post from cam"
                         .to_string(),
                 ),
-            },
+            };
+        }
+
+        if let Err(err) = read_toolpath_payload_v1(&mut cursor) {
+            return JobExecutionResult {
+                status: JobStatus::Failed,
+                elapsed_millis: 20,
+                result_ref: None,
+                log_ref: Some(format!("log://nc-post/{}/artifact-read-failed", job.id.0)),
+                error: Some(format!("failed to read artifact binary: {}", err)),
+            };
+        }
+
+        JobExecutionResult {
+            status: JobStatus::Succeeded,
+            elapsed_millis: 240,
+            result_ref: Some(format!("result://nc-post/{}/ok", job.id.0)),
+            log_ref: Some(format!("log://nc-post/{}/ok", job.id.0)),
+            error: None,
         }
     }
 }

--- a/model/cam_sim/src/job_adapter.rs
+++ b/model/cam_sim/src/job_adapter.rs
@@ -1,3 +1,11 @@
+use std::io::Cursor;
+
+use cam_core::{
+    ArtifactHeaderV1, ArtifactKind, ArtifactPayload, ContourLevelPath, CuttingDirection,
+    InterferenceEvent, InterferenceKind, InterferencePayload, PathSegment, SegmentType, ToolPath,
+    read_artifact_v1, write_interference_payload_v1, write_toolpath_payload_v1,
+};
+use geo_algorithms::Point3D;
 use job_runtime::{JobExecutionResult, JobExecutor, JobRecord, JobStatus, JobType};
 
 /// cam_sim から JobManager へ接続する初期アダプタ
@@ -50,6 +58,133 @@ impl CamJobExecutorAdapter {
             error: None,
         }
     }
+
+    fn run_nc_post_from_cam(&self, job: &JobRecord) -> JobExecutionResult {
+        if !job.spec.input_ref.starts_with("result://cam/") {
+            return JobExecutionResult {
+                status: JobStatus::Failed,
+                elapsed_millis: 10,
+                result_ref: None,
+                log_ref: Some(format!("log://nc-post/{}/invalid", job.id.0)),
+                error: Some(format!(
+                    "invalid input_ref for nc post from cam: {}",
+                    job.spec.input_ref
+                )),
+            };
+        }
+
+        let artifact_bytes = match build_mock_artifact_from_result_ref(&job.spec.input_ref) {
+            Ok(bytes) => bytes,
+            Err(message) => {
+                return JobExecutionResult {
+                    status: JobStatus::Failed,
+                    elapsed_millis: 20,
+                    result_ref: None,
+                    log_ref: Some(format!("log://nc-post/{}/artifact-error", job.id.0)),
+                    error: Some(message),
+                };
+            }
+        };
+
+        let mut cursor = Cursor::new(artifact_bytes);
+        let (_, payload) = match read_artifact_v1(&mut cursor) {
+            Ok(result) => result,
+            Err(err) => {
+                return JobExecutionResult {
+                    status: JobStatus::Failed,
+                    elapsed_millis: 20,
+                    result_ref: None,
+                    log_ref: Some(format!("log://nc-post/{}/artifact-read-failed", job.id.0)),
+                    error: Some(format!("failed to read artifact binary: {}", err)),
+                };
+            }
+        };
+
+        match payload {
+            ArtifactPayload::ToolPath(_) => JobExecutionResult {
+                status: JobStatus::Succeeded,
+                elapsed_millis: 240,
+                result_ref: Some(format!("result://nc-post/{}/ok", job.id.0)),
+                log_ref: Some(format!("log://nc-post/{}/ok", job.id.0)),
+                error: None,
+            },
+            ArtifactPayload::Interference(_) => JobExecutionResult {
+                status: JobStatus::Failed,
+                elapsed_millis: 20,
+                result_ref: None,
+                log_ref: Some(format!("log://nc-post/{}/kind-mismatch", job.id.0)),
+                error: Some(
+                    "artifact kind mismatch: expected toolpath artifact for nc post from cam"
+                        .to_string(),
+                ),
+            },
+        }
+    }
+}
+
+fn build_mock_artifact_from_result_ref(result_ref: &str) -> Result<Vec<u8>, String> {
+    if result_ref.ends_with("/kind-mismatch") {
+        return make_interference_artifact_bytes();
+    }
+
+    if result_ref.ends_with("/version-mismatch") {
+        return make_toolpath_artifact_bytes(999);
+    }
+
+    make_toolpath_artifact_bytes(cam_core::FORMAT_VERSION_MINOR_V1)
+}
+
+fn make_toolpath_artifact_bytes(version_minor: u16) -> Result<Vec<u8>, String> {
+    let toolpath = ToolPath::new(
+        "nc-post-src".to_string(),
+        CuttingDirection::Down,
+        vec![],
+        vec![ContourLevelPath::new(
+            0,
+            0.0,
+            vec![PathSegment::new_line(
+                Point3D::new(0.0, 0.0, 0.0),
+                Point3D::new(1.0, 0.0, 0.0),
+                SegmentType::Cutting { feed_rate: 1.0 },
+            )],
+        )],
+        vec![],
+    );
+
+    let mut payload = Vec::new();
+    write_toolpath_payload_v1(&mut payload, &toolpath).map_err(|err| err.to_string())?;
+
+    let mut header = ArtifactHeaderV1::new(ArtifactKind::ToolPath, payload.len() as u64);
+    header.version_minor = version_minor;
+
+    let mut bytes = Vec::new();
+    header.write_to(&mut bytes).map_err(|err| err.to_string())?;
+    bytes.extend_from_slice(&payload);
+
+    Ok(bytes)
+}
+
+fn make_interference_artifact_bytes() -> Result<Vec<u8>, String> {
+    let interference = InterferencePayload {
+        events: vec![InterferenceEvent {
+            sample_index: 0,
+            tool_id: "nc-post-src".to_string(),
+            position: Point3D::new(0.0, 0.0, 0.0),
+            normal: Point3D::new(0.0, 0.0, 1.0),
+            penetration_depth: 0.1,
+            kind: InterferenceKind::Tool,
+        }],
+    };
+
+    let mut payload = Vec::new();
+    write_interference_payload_v1(&mut payload, &interference).map_err(|err| err.to_string())?;
+
+    let header = ArtifactHeaderV1::new(ArtifactKind::Interference, payload.len() as u64);
+    let mut bytes = Vec::new();
+    header.write_to(&mut bytes).map_err(|err| err.to_string())?;
+    bytes.extend_from_slice(&payload);
+
+    Ok(bytes)
 }
 
 impl JobExecutor for CamJobExecutorAdapter {
@@ -57,6 +192,7 @@ impl JobExecutor for CamJobExecutorAdapter {
         match job.spec.job_type {
             JobType::CamProcess => self.run_cam_process(job),
             JobType::CuttingSimulation => self.run_cutting_simulation(job),
+            JobType::NcPostFromCam => self.run_nc_post_from_cam(job),
         }
     }
 }

--- a/model/cam_sim/src/job_adapter.rs
+++ b/model/cam_sim/src/job_adapter.rs
@@ -1,9 +1,9 @@
 use std::io::Cursor;
 
 use cam_core::{
-    ArtifactHeaderV1, ArtifactKind, ContourLevelPath, CuttingDirection, InterferenceEvent,
-    InterferenceKind, InterferencePayload, PathSegment, SegmentType, ToolPath,
-    read_toolpath_payload_v1, write_interference_payload_v1, write_toolpath_payload_v1,
+    ArtifactHeaderV1, ArtifactKind, BinaryFormatError, ContourLevelPath, CuttingDirection,
+    InterferenceEvent, InterferenceKind, InterferencePayload, PathSegment, SegmentType, ToolPath,
+    read_toolpath_artifact_v1, write_interference_payload_v1, write_toolpath_payload_v1,
 };
 use geo_algorithms::Point3D;
 use job_runtime::{JobExecutionResult, JobExecutor, JobRecord, JobStatus, JobType};
@@ -87,48 +87,18 @@ impl CamJobExecutorAdapter {
         };
 
         let mut cursor = Cursor::new(artifact_bytes);
-        let header = match ArtifactHeaderV1::read_from(&mut cursor) {
-            Ok(header) => header,
-            Err(err) => {
-                return JobExecutionResult {
-                    status: JobStatus::Failed,
-                    elapsed_millis: 20,
-                    result_ref: None,
-                    log_ref: Some(format!("log://nc-post/{}/artifact-read-failed", job.id.0)),
-                    error: Some(format!("failed to read artifact binary: {}", err)),
-                };
-            }
-        };
-
-        if let Err(err) = header.ensure_acceptable_version() {
-            return JobExecutionResult {
-                status: JobStatus::Failed,
-                elapsed_millis: 20,
-                result_ref: None,
-                log_ref: Some(format!("log://nc-post/{}/artifact-read-failed", job.id.0)),
-                error: Some(format!("failed to read artifact binary: {}", err)),
+        if let Err(err) = read_toolpath_artifact_v1(&mut cursor) {
+            let log_ref = match err {
+                BinaryFormatError::ArtifactKindMismatch { .. } => {
+                    format!("log://nc-post/{}/kind-mismatch", job.id.0)
+                }
+                _ => format!("log://nc-post/{}/artifact-read-failed", job.id.0),
             };
-        }
-
-        if header.kind != ArtifactKind::ToolPath {
             return JobExecutionResult {
                 status: JobStatus::Failed,
                 elapsed_millis: 20,
                 result_ref: None,
-                log_ref: Some(format!("log://nc-post/{}/kind-mismatch", job.id.0)),
-                error: Some(
-                    "artifact kind mismatch: expected toolpath artifact for nc post from cam"
-                        .to_string(),
-                ),
-            };
-        }
-
-        if let Err(err) = read_toolpath_payload_v1(&mut cursor) {
-            return JobExecutionResult {
-                status: JobStatus::Failed,
-                elapsed_millis: 20,
-                result_ref: None,
-                log_ref: Some(format!("log://nc-post/{}/artifact-read-failed", job.id.0)),
+                log_ref: Some(log_ref),
                 error: Some(format!("failed to read artifact binary: {}", err)),
             };
         }

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -31,6 +31,15 @@ fn sim_spec(input: &str) -> JobSpec {
     }
 }
 
+fn nc_post_from_cam_spec(input: &str) -> JobSpec {
+    JobSpec {
+        job_type: JobType::NcPostFromCam,
+        input_ref: input.to_string(),
+        timeout_secs: 30,
+        retry_policy: RetryPolicy::default(),
+    }
+}
+
 fn roundtrip_toolpath_via_artifact(toolpath: &ToolPath<f64>) -> ToolPath<f64> {
     let mut payload_bytes = Vec::new();
     write_toolpath_payload_v1(&mut payload_bytes, toolpath).unwrap();
@@ -369,6 +378,61 @@ fn test_job_adapter_rejects_invalid_input_ref() {
             .as_deref()
             .unwrap_or_default()
             .contains("invalid input_ref")
+    );
+}
+
+#[test]
+fn test_job_adapter_runs_nc_post_from_cam_with_toolpath_artifact() {
+    let mut manager = JobManager::new();
+    let adapter = CamJobExecutorAdapter;
+
+    let id = manager.submit(nc_post_from_cam_spec("result://cam/42/ok"));
+    manager.execute_with(id, &adapter).unwrap();
+
+    let job = manager.get(id).unwrap();
+    assert_eq!(job.status, JobStatus::Succeeded);
+    assert!(
+        manager
+            .active_result_ref(id)
+            .unwrap()
+            .unwrap_or_default()
+            .starts_with("result://nc-post/")
+    );
+}
+
+#[test]
+fn test_job_adapter_rejects_nc_post_from_cam_kind_mismatch() {
+    let mut manager = JobManager::new();
+    let adapter = CamJobExecutorAdapter;
+
+    let id = manager.submit(nc_post_from_cam_spec("result://cam/42/kind-mismatch"));
+    manager.execute_with(id, &adapter).unwrap();
+
+    let job = manager.get(id).unwrap();
+    assert_eq!(job.status, JobStatus::Failed);
+    assert!(
+        job.last_error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("artifact kind mismatch")
+    );
+}
+
+#[test]
+fn test_job_adapter_surfaces_nc_post_from_cam_version_incompatibility() {
+    let mut manager = JobManager::new();
+    let adapter = CamJobExecutorAdapter;
+
+    let id = manager.submit(nc_post_from_cam_spec("result://cam/42/version-mismatch"));
+    manager.execute_with(id, &adapter).unwrap();
+
+    let job = manager.get(id).unwrap();
+    assert_eq!(job.status, JobStatus::Failed);
+    assert!(
+        job.last_error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("failed to read artifact binary")
     );
 }
 

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -358,6 +358,26 @@ fn test_workflow_rejects_child_under_simulation() {
 }
 
 #[test]
+fn test_workflow_rejects_nc_post_submission_with_wrong_job_type() {
+    let mut manager = JobManager::new();
+    let mut workflow = CamWorkflowSubmitter::new(&mut manager);
+
+    let cam_id = workflow
+        .submit_cam_process(cam_spec("input://cam/for-nc-post"))
+        .unwrap();
+
+    let result = workflow.submit_nc_post_from_cam(cam_id, sim_spec("input://sim/wrong-type"));
+
+    assert!(matches!(
+        result,
+        Err(CamWorkflowError::InvalidJobType {
+            expected: JobType::NcPostFromCam,
+            actual: JobType::CuttingSimulation,
+        })
+    ));
+}
+
+#[test]
 fn test_job_adapter_rejects_invalid_input_ref() {
     let mut manager = JobManager::new();
     let adapter = CamJobExecutorAdapter;

--- a/model/cam_sim/src/workflow.rs
+++ b/model/cam_sim/src/workflow.rs
@@ -13,6 +13,8 @@ pub enum CamWorkflowError {
     JobRuntime(JobError),
     /// 親ジョブ未指定
     MissingParent,
+    /// 投入ジョブ種別が不正
+    InvalidJobType { expected: JobType, actual: JobType },
     /// 親ジョブ種別が不正
     InvalidParentType { expected: JobType, actual: JobType },
     /// SIM は CAM 工程ごとに 1 件のみ
@@ -26,9 +28,14 @@ impl Display for CamWorkflowError {
         match self {
             Self::JobRuntime(err) => write!(f, "job runtime error: {}", err),
             Self::MissingParent => write!(f, "parent job is required for this submission"),
+            Self::InvalidJobType { expected, actual } => write!(
+                f,
+                "invalid job type: expected={:?}, actual={:?}",
+                expected, actual
+            ),
             Self::InvalidParentType { expected, actual } => write!(
                 f,
-                "invalid parent type for cutting simulation: expected={:?}, actual={:?}",
+                "invalid parent type: expected={:?}, actual={:?}",
                 expected, actual
             ),
             Self::SimulationAlreadyExists { parent_cam_job_id } => write!(
@@ -69,7 +76,7 @@ impl<'a> CamWorkflowSubmitter<'a> {
 
     pub fn submit_cam_process(&mut self, spec: JobSpec) -> Result<JobId, CamWorkflowError> {
         if spec.job_type != JobType::CamProcess {
-            return Err(CamWorkflowError::InvalidParentType {
+            return Err(CamWorkflowError::InvalidJobType {
                 expected: JobType::CamProcess,
                 actual: spec.job_type,
             });
@@ -85,7 +92,7 @@ impl<'a> CamWorkflowSubmitter<'a> {
         spec: JobSpec,
     ) -> Result<JobId, CamWorkflowError> {
         if spec.job_type != JobType::CuttingSimulation {
-            return Err(CamWorkflowError::InvalidParentType {
+            return Err(CamWorkflowError::InvalidJobType {
                 expected: JobType::CuttingSimulation,
                 actual: spec.job_type,
             });
@@ -106,7 +113,7 @@ impl<'a> CamWorkflowSubmitter<'a> {
         spec: JobSpec,
     ) -> Result<JobId, CamWorkflowError> {
         if spec.job_type != JobType::NcPostFromCam {
-            return Err(CamWorkflowError::InvalidParentType {
+            return Err(CamWorkflowError::InvalidJobType {
                 expected: JobType::NcPostFromCam,
                 actual: spec.job_type,
             });

--- a/model/cam_sim/src/workflow.rs
+++ b/model/cam_sim/src/workflow.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter};
 
 use job_domain::{
     CamWorkflowPolicy, DomainRuleViolation, JOB_TYPE_CAM_PROCESS, JOB_TYPE_CUTTING_SIMULATION,
-    JobDomainService, JobNode, JobSubmissionRequest, WorkflowSnapshot,
+    JOB_TYPE_NC_POST_FROM_CAM, JobDomainService, JobNode, JobSubmissionRequest, WorkflowSnapshot,
 };
 use job_runtime::{JobError, JobId, JobManager, JobRelation, JobSpec, JobType};
 
@@ -157,6 +157,7 @@ fn job_type_to_domain_name(job_type: &JobType) -> &'static str {
     match job_type {
         JobType::CamProcess => JOB_TYPE_CAM_PROCESS,
         JobType::CuttingSimulation => JOB_TYPE_CUTTING_SIMULATION,
+        JobType::NcPostFromCam => JOB_TYPE_NC_POST_FROM_CAM,
     }
 }
 
@@ -164,6 +165,7 @@ fn domain_name_to_job_type(name: &str) -> Option<JobType> {
     match name {
         JOB_TYPE_CAM_PROCESS => Some(JobType::CamProcess),
         JOB_TYPE_CUTTING_SIMULATION => Some(JobType::CuttingSimulation),
+        JOB_TYPE_NC_POST_FROM_CAM => Some(JobType::NcPostFromCam),
         _ => None,
     }
 }

--- a/model/cam_sim/src/workflow.rs
+++ b/model/cam_sim/src/workflow.rs
@@ -100,6 +100,27 @@ impl<'a> CamWorkflowSubmitter<'a> {
         )
     }
 
+    pub fn submit_nc_post_from_cam(
+        &mut self,
+        parent_cam_job_id: JobId,
+        spec: JobSpec,
+    ) -> Result<JobId, CamWorkflowError> {
+        if spec.job_type != JobType::NcPostFromCam {
+            return Err(CamWorkflowError::InvalidParentType {
+                expected: JobType::NcPostFromCam,
+                actual: spec.job_type,
+            });
+        }
+
+        self.submit_with_domain_validation(
+            spec,
+            JobRelation {
+                parent_job_id: Some(parent_cam_job_id),
+                group_id: None,
+            },
+        )
+    }
+
     /// 末尾制約: SIM を親にする投入は禁止
     pub fn submit_child_under(
         &mut self,

--- a/model/job_domain/src/cam_policy.rs
+++ b/model/job_domain/src/cam_policy.rs
@@ -38,13 +38,22 @@ impl WorkflowPolicy for CamWorkflowPolicy {
                             parent_id,
                         });
                     }
+                } else if request.job_type == JOB_TYPE_NC_POST_FROM_CAM {
+                    if parent.job_type != JOB_TYPE_CAM_PROCESS {
+                        return Err(DomainRuleViolation::InvalidParentType {
+                            expected: JOB_TYPE_CAM_PROCESS,
+                            actual: parent.job_type.clone(),
+                        });
+                    }
                 } else if parent.job_type == JOB_TYPE_CUTTING_SIMULATION {
                     // SIMは末尾工程。SIM配下への投入は禁止。
                     return Err(DomainRuleViolation::TerminalConstraintViolation { parent_id });
                 }
             }
             None => {
-                if request.job_type == JOB_TYPE_CUTTING_SIMULATION {
+                if request.job_type == JOB_TYPE_CUTTING_SIMULATION
+                    || request.job_type == JOB_TYPE_NC_POST_FROM_CAM
+                {
                     return Err(DomainRuleViolation::MissingParent);
                 }
             }
@@ -56,7 +65,10 @@ impl WorkflowPolicy for CamWorkflowPolicy {
 
 #[cfg(test)]
 mod tests {
-    use super::{CamWorkflowPolicy, JOB_TYPE_CAM_PROCESS, JOB_TYPE_CUTTING_SIMULATION};
+    use super::{
+        CamWorkflowPolicy, JOB_TYPE_CAM_PROCESS, JOB_TYPE_CUTTING_SIMULATION,
+        JOB_TYPE_NC_POST_FROM_CAM,
+    };
     use crate::policy::{DomainRuleViolation, WorkflowPolicy};
     use crate::types::{JobNode, JobSubmissionRequest, WorkflowSnapshot};
 
@@ -72,6 +84,14 @@ mod tests {
         JobNode {
             id,
             job_type: JOB_TYPE_CUTTING_SIMULATION.to_string(),
+            parent_job_id,
+        }
+    }
+
+    fn nc_post_job(id: u64, parent_job_id: Option<u64>) -> JobNode {
+        JobNode {
+            id,
+            job_type: JOB_TYPE_NC_POST_FROM_CAM.to_string(),
             parent_job_id,
         }
     }
@@ -140,6 +160,61 @@ mod tests {
         let request = JobSubmissionRequest {
             job_type: JOB_TYPE_CUTTING_SIMULATION.to_string(),
             input_ref: "input://sim/first".to_string(),
+            parent_job_id: Some(1),
+            group_id: None,
+        };
+
+        assert_eq!(policy.validate_submit(&request, &snapshot), Ok(()));
+    }
+
+    #[test]
+    fn rejects_nc_post_without_parent() {
+        let policy = CamWorkflowPolicy;
+        let snapshot = WorkflowSnapshot::default();
+        let request = JobSubmissionRequest {
+            job_type: JOB_TYPE_NC_POST_FROM_CAM.to_string(),
+            input_ref: "result://cam/1/ok".to_string(),
+            parent_job_id: None,
+            group_id: None,
+        };
+
+        assert_eq!(
+            policy.validate_submit(&request, &snapshot),
+            Err(DomainRuleViolation::MissingParent)
+        );
+    }
+
+    #[test]
+    fn rejects_nc_post_under_non_cam_parent() {
+        let policy = CamWorkflowPolicy;
+        let snapshot = WorkflowSnapshot {
+            jobs: vec![cam_job(1, None), sim_job(2, Some(1))],
+        };
+        let request = JobSubmissionRequest {
+            job_type: JOB_TYPE_NC_POST_FROM_CAM.to_string(),
+            input_ref: "result://cam/2/ok".to_string(),
+            parent_job_id: Some(2),
+            group_id: None,
+        };
+
+        assert_eq!(
+            policy.validate_submit(&request, &snapshot),
+            Err(DomainRuleViolation::InvalidParentType {
+                expected: JOB_TYPE_CAM_PROCESS,
+                actual: JOB_TYPE_CUTTING_SIMULATION.to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn allows_nc_post_under_cam_parent() {
+        let policy = CamWorkflowPolicy;
+        let snapshot = WorkflowSnapshot {
+            jobs: vec![cam_job(1, None), nc_post_job(3, Some(1))],
+        };
+        let request = JobSubmissionRequest {
+            job_type: JOB_TYPE_NC_POST_FROM_CAM.to_string(),
+            input_ref: "result://cam/1/ok".to_string(),
             parent_job_id: Some(1),
             group_id: None,
         };

--- a/model/job_domain/src/cam_policy.rs
+++ b/model/job_domain/src/cam_policy.rs
@@ -3,6 +3,7 @@ use crate::types::{JobSubmissionRequest, WorkflowSnapshot};
 
 pub const JOB_TYPE_CAM_PROCESS: &str = "cam_process";
 pub const JOB_TYPE_CUTTING_SIMULATION: &str = "cutting_simulation";
+pub const JOB_TYPE_NC_POST_FROM_CAM: &str = "nc_post_from_cam";
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct CamWorkflowPolicy;

--- a/model/job_domain/src/cam_policy.rs
+++ b/model/job_domain/src/cam_policy.rs
@@ -39,6 +39,10 @@ impl WorkflowPolicy for CamWorkflowPolicy {
                         });
                     }
                 } else if request.job_type == JOB_TYPE_NC_POST_FROM_CAM {
+                    if parent.job_type == JOB_TYPE_CUTTING_SIMULATION {
+                        return Err(DomainRuleViolation::TerminalConstraintViolation { parent_id });
+                    }
+
                     if parent.job_type != JOB_TYPE_CAM_PROCESS {
                         return Err(DomainRuleViolation::InvalidParentType {
                             expected: JOB_TYPE_CAM_PROCESS,
@@ -185,7 +189,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_nc_post_under_non_cam_parent() {
+    fn rejects_nc_post_under_sim_parent_as_terminal_constraint() {
         let policy = CamWorkflowPolicy;
         let snapshot = WorkflowSnapshot {
             jobs: vec![cam_job(1, None), sim_job(2, Some(1))],
@@ -199,9 +203,28 @@ mod tests {
 
         assert_eq!(
             policy.validate_submit(&request, &snapshot),
+            Err(DomainRuleViolation::TerminalConstraintViolation { parent_id: 2 })
+        );
+    }
+
+    #[test]
+    fn rejects_nc_post_under_non_cam_non_sim_parent() {
+        let policy = CamWorkflowPolicy;
+        let snapshot = WorkflowSnapshot {
+            jobs: vec![cam_job(1, None), nc_post_job(3, Some(1))],
+        };
+        let request = JobSubmissionRequest {
+            job_type: JOB_TYPE_NC_POST_FROM_CAM.to_string(),
+            input_ref: "result://cam/3/ok".to_string(),
+            parent_job_id: Some(3),
+            group_id: None,
+        };
+
+        assert_eq!(
+            policy.validate_submit(&request, &snapshot),
             Err(DomainRuleViolation::InvalidParentType {
                 expected: JOB_TYPE_CAM_PROCESS,
-                actual: JOB_TYPE_CUTTING_SIMULATION.to_string(),
+                actual: JOB_TYPE_NC_POST_FROM_CAM.to_string(),
             })
         );
     }

--- a/model/job_domain/src/job_view_bridge.rs
+++ b/model/job_domain/src/job_view_bridge.rs
@@ -6,6 +6,7 @@ use job_runtime::{JobEvent, JobOutputValidity, JobRecord, JobStatus, JobType};
 pub enum CamJobType {
     CamProcess,
     CuttingSimulation,
+    NcPostFromCam,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -94,6 +95,7 @@ impl From<JobType> for CamJobType {
         match value {
             JobType::CamProcess => Self::CamProcess,
             JobType::CuttingSimulation => Self::CuttingSimulation,
+            JobType::NcPostFromCam => Self::NcPostFromCam,
         }
     }
 }

--- a/model/job_domain/src/lib.rs
+++ b/model/job_domain/src/lib.rs
@@ -8,7 +8,9 @@ pub mod policy;
 pub mod service;
 pub mod types;
 
-pub use cam_policy::{CamWorkflowPolicy, JOB_TYPE_CAM_PROCESS, JOB_TYPE_CUTTING_SIMULATION};
+pub use cam_policy::{
+    CamWorkflowPolicy, JOB_TYPE_CAM_PROCESS, JOB_TYPE_CUTTING_SIMULATION, JOB_TYPE_NC_POST_FROM_CAM,
+};
 pub use job_view_bridge::{
     CamJobEvent, CamJobOutputRecord, CamJobOutputValidity, CamJobRecord, CamJobSpec, CamJobStatus,
     CamJobType,

--- a/model/job_runtime/src/manager.rs
+++ b/model/job_runtime/src/manager.rs
@@ -540,6 +540,7 @@ mod tests {
             let result_ref = match job.spec.job_type {
                 JobType::CamProcess => Some("result://cam".to_string()),
                 JobType::CuttingSimulation => Some("result://sim".to_string()),
+                JobType::NcPostFromCam => Some("result://nc-post".to_string()),
             };
 
             if self.succeed {

--- a/model/job_runtime/src/types.rs
+++ b/model/job_runtime/src/types.rs
@@ -12,6 +12,8 @@ pub enum JobType {
     CamProcess,
     /// シミュレーションジョブ
     CuttingSimulation,
+    /// CAM成果物を入力とするNCポスト処理ジョブ
+    NcPostFromCam,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/viewmodel/converter/src/job_converter.rs
+++ b/viewmodel/converter/src/job_converter.rs
@@ -249,6 +249,7 @@ fn job_type_key(job_type: CamJobType) -> &'static str {
     match job_type {
         CamJobType::CamProcess => "job.type.cam_process",
         CamJobType::CuttingSimulation => "job.type.cutting_simulation",
+        CamJobType::NcPostFromCam => "job.type.nc_post_from_cam",
     }
 }
 


### PR DESCRIPTION
## このPRに含む単位
- A-1: `NcPostFromCam` のジョブ種別/境界DTOマッピング追加
- A-2: `read_artifact_v1` を使った読込導線と異常系ハンドリング実装
- A-2: 最小統合テスト（正常系1件、異常系2件）追加

## このPRに含めない単位
- `NcPostStandalone` 側の仕様/実装
- wire format 再設計（#300 正本改定）
- NCコード生成アルゴリズム高度化

## 概要
issue #679 の受け入れ条件に対応し、`NcPostFromCam` で `toolpath` artifact binary v0.1 を読込む実装導線を追加しました。

主な変更:
- `JobType` / `CamJobType` に `NcPostFromCam` を追加
- `cam_sim::job_adapter` に `read_artifact_v1` 経路を実装
- `ArtifactKind::ToolPath` 以外（Interference）受信時を明示 reject
- version 非互換を読込エラーとして伝播
- orchestration / workflow / job_domain 側マッピングを同期
- 正常系・異常系テストを追加

## 受け入れ条件トレーサビリティ（#679）
- [x] `NcPostFromCam` で `toolpath` artifact を読込できる
- [x] artifact kind 不一致時に明示的に reject される
- [x] version 非互換時の reject/convert 必要判定がエラーとして伝播する
- [x] Job Manager がバイナリ本体を解釈しない責務境界が維持される
- [x] 統合テストで正常系・異常系が検証される

## 検証結果
- `cargo clippy -p job_runtime -p job_domain -p cam_sim -p application -- -D warnings` : PASS
- `cargo fmt` : PASS
- `cargo test -p job_runtime -p job_domain -p cam_sim -p application` : PASS

## 変更ファイル
- model/job_runtime/src/types.rs
- model/job_runtime/src/manager.rs
- model/job_domain/src/job_view_bridge.rs
- model/job_domain/src/cam_policy.rs
- model/job_domain/src/lib.rs
- model/cam_sim/src/workflow.rs
- model/cam_sim/src/job_adapter.rs
- model/cam_sim/src/tests.rs
- model/application/src/job_orchestration.rs

## 関連
- Closes #679
- Ref #300
- Ref #301