### PR TITLE
issue #686 [Phase1][A-1] cam_sim: 切削シミュレーション最小実行導線を実装

### DIFF
--- a/model/application/src/job_orchestration.rs
+++ b/model/application/src/job_orchestration.rs
@@ -336,6 +336,41 @@ mod tests {
     }
 
     #[test]
+    fn cutting_simulation_submit_and_result_query_work_with_cam_parent() {
+        let mut orchestrator = JobWorkflowOrchestrator::new();
+
+        let cam_submit = orchestrator
+            .submit_workflow(JobWorkflowSubmitRequest {
+                job_type: CamJobType::CamProcess,
+                input_ref: "input://cam/sample".to_string(),
+                parent_job_id: None,
+            })
+            .expect("cam process should succeed");
+
+        let sim_submit = orchestrator
+            .submit_workflow(JobWorkflowSubmitRequest {
+                job_type: CamJobType::CuttingSimulation,
+                input_ref: "input://sim/sample".to_string(),
+                parent_job_id: Some(cam_submit.job_id),
+            })
+            .expect("cutting simulation should succeed");
+
+        assert_eq!(sim_submit.status, CamJobStatus::Succeeded);
+
+        let result = orchestrator
+            .query_result(JobWorkflowResultQuery {
+                job_id: sim_submit.job_id,
+            })
+            .expect("result query should succeed");
+
+        assert_eq!(result.job.status, CamJobStatus::Succeeded);
+        assert_eq!(
+            result.active_result_ref.as_deref(),
+            Some("result://sim/2/ok")
+        );
+    }
+
+    #[test]
     fn nc_post_from_cam_requires_parent_job_id() {
         let mut orchestrator = JobWorkflowOrchestrator::new();
         let error = orchestrator

--- a/model/cam_sim/src/job_adapter.rs
+++ b/model/cam_sim/src/job_adapter.rs
@@ -82,7 +82,7 @@ impl CamJobExecutorAdapter {
                 status: JobStatus::Failed,
                 elapsed_millis: 30,
                 result_ref: None,
-                log_ref: Some(format!("log://sim/{}/sim-failed", job.id.0)),
+                log_ref: Some(format!("log://sim/{}/sim-failure", job.id.0)),
                 error: Some(format!("failed to run cutting simulation: {}", err)),
             };
         }

--- a/model/cam_sim/src/job_adapter.rs
+++ b/model/cam_sim/src/job_adapter.rs
@@ -2,11 +2,13 @@ use std::io::Cursor;
 
 use cam_core::{
     ArtifactHeaderV1, ArtifactKind, BinaryFormatError, ContourLevelPath, CuttingDirection,
-    InterferenceEvent, InterferenceKind, InterferencePayload, PathSegment, SegmentType, ToolPath,
-    read_toolpath_artifact_v1, write_interference_payload_v1, write_toolpath_payload_v1,
+    InterferenceEvent, InterferenceKind, InterferencePayload, PathSegment, SegmentType, Tool,
+    ToolPath, read_toolpath_artifact_v1, write_interference_payload_v1, write_toolpath_payload_v1,
 };
-use geo_algorithms::Point3D;
+use geo_algorithms::{Aabb3D, Point3D, octree::VoxelOctree};
 use job_runtime::{JobExecutionResult, JobExecutor, JobRecord, JobStatus, JobType};
+
+use crate::{CuttingSimulator, SnapshotInterval};
 
 /// cam_sim から JobManager へ接続する初期アダプタ
 #[derive(Debug, Default, Clone, Copy)]
@@ -47,6 +49,41 @@ impl CamJobExecutorAdapter {
                     "invalid input_ref for cutting simulation: {}",
                     job.spec.input_ref
                 )),
+            };
+        }
+
+        let toolpath = match read_mock_toolpath_from_sim_input_ref(&job.spec.input_ref) {
+            Ok(toolpath) => toolpath,
+            Err(message) => {
+                return JobExecutionResult {
+                    status: JobStatus::Failed,
+                    elapsed_millis: 20,
+                    result_ref: None,
+                    log_ref: Some(format!("log://sim/{}/artifact-read-failed", job.id.0)),
+                    error: Some(message),
+                };
+            }
+        };
+
+        let mut simulator = CuttingSimulator::new(
+            VoxelOctree::new(
+                Aabb3D::new(
+                    Point3D::new(0.0, 0.0, 0.0),
+                    Point3D::new(100.0, 100.0, 100.0),
+                ),
+                4,
+            ),
+            SnapshotInterval::default(),
+        );
+        let tool = Tool::flat_end_mill("sim-tool".to_string(), 10.0, 30.0);
+
+        if let Err(err) = simulator.simulate(&toolpath, &tool) {
+            return JobExecutionResult {
+                status: JobStatus::Failed,
+                elapsed_millis: 30,
+                result_ref: None,
+                log_ref: Some(format!("log://sim/{}/sim-failed", job.id.0)),
+                error: Some(format!("failed to run cutting simulation: {}", err)),
             };
         }
 
@@ -123,6 +160,42 @@ fn build_mock_artifact_from_result_ref(result_ref: &str) -> Result<Vec<u8>, Stri
     }
 
     make_toolpath_artifact_bytes(cam_core::FORMAT_VERSION_MINOR_V1)
+}
+
+fn read_mock_toolpath_from_sim_input_ref(input_ref: &str) -> Result<ToolPath<f64>, String> {
+    let artifact_bytes = if input_ref.ends_with("/artifact-read-failed") {
+        vec![0_u8, 1, 2, 3]
+    } else if input_ref.ends_with("/sim-failure") {
+        make_empty_toolpath_artifact_bytes()?
+    } else {
+        make_toolpath_artifact_bytes(cam_core::FORMAT_VERSION_MINOR_V1)?
+    };
+
+    let mut cursor = Cursor::new(artifact_bytes);
+    let (_, toolpath) = read_toolpath_artifact_v1(&mut cursor)
+        .map_err(|err| format!("failed to read cutting simulation input artifact: {}", err))?;
+
+    Ok(toolpath)
+}
+
+fn make_empty_toolpath_artifact_bytes() -> Result<Vec<u8>, String> {
+    let toolpath = ToolPath::new(
+        "sim-src".to_string(),
+        CuttingDirection::Down,
+        vec![],
+        vec![],
+        vec![],
+    );
+
+    let mut payload = Vec::new();
+    write_toolpath_payload_v1(&mut payload, &toolpath).map_err(|err| err.to_string())?;
+
+    let header = ArtifactHeaderV1::new(ArtifactKind::ToolPath, payload.len() as u64);
+    let mut bytes = Vec::new();
+    header.write_to(&mut bytes).map_err(|err| err.to_string())?;
+    bytes.extend_from_slice(&payload);
+
+    Ok(bytes)
 }
 
 fn make_toolpath_artifact_bytes(version_minor: u16) -> Result<Vec<u8>, String> {

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -402,6 +402,42 @@ fn test_job_adapter_rejects_invalid_input_ref() {
 }
 
 #[test]
+fn test_job_adapter_surfaces_cutting_sim_artifact_read_failure() {
+    let mut manager = JobManager::new();
+    let adapter = CamJobExecutorAdapter;
+
+    let id = manager.submit(sim_spec("input://sim/artifact-read-failed"));
+    manager.execute_with(id, &adapter).unwrap();
+
+    let job = manager.get(id).unwrap();
+    assert_eq!(job.status, JobStatus::Failed);
+    assert!(
+        job.last_error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("failed to read cutting simulation input artifact")
+    );
+}
+
+#[test]
+fn test_job_adapter_surfaces_cutting_sim_execution_failure() {
+    let mut manager = JobManager::new();
+    let adapter = CamJobExecutorAdapter;
+
+    let id = manager.submit(sim_spec("input://sim/sim-failure"));
+    manager.execute_with(id, &adapter).unwrap();
+
+    let job = manager.get(id).unwrap();
+    assert_eq!(job.status, JobStatus::Failed);
+    assert!(
+        job.last_error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("failed to run cutting simulation")
+    );
+}
+
+#[test]
 fn test_job_adapter_runs_nc_post_from_cam_with_toolpath_artifact() {
     let mut manager = JobManager::new();
     let adapter = CamJobExecutorAdapter;


### PR DESCRIPTION
## このPRに含む単位
- A-1: cutting simulation の最小実行導線（application -> cam_sim -> job_runtime）
- A-1: `CamJobExecutorAdapter::run_cutting_simulation` のスタブ置換（既存 `CuttingSimulator` 呼び出し）
- A-1: 異常系（artifact読込失敗 / sim実行失敗）の返却と最小回帰テスト

## このPRに含めない単位
- workpiece/stock 入力契約の新設
- 干渉チェック仕様の拡張（workpiece/stock 前提）
- 高精度化・最適化・UI再生体験

## 概要
issue #686 の Phase1 として、切削シミュレーションを実際に実行する最小導線を実装しました。
これまで成功固定だった cutting simulation スタブを、既存 `CuttingSimulator` 実行へ置換しています。

## 主な変更
- `model/cam_sim/src/job_adapter.rs`
  - `run_cutting_simulation` で最小シミュレーションを実行
  - `input://sim/artifact-read-failed` と `input://sim/sim-failure` の異常系を追加
- `model/cam_sim/src/tests.rs`
  - cutting simulation の異常系テストを2件追加
- `model/application/src/job_orchestration.rs`
  - CAM親付き cutting simulation submit -> result query の導線テストを1件追加

## 受け入れ条件トレーサビリティ（#686）
- [x] 起動導線疎通（application -> cam_sim -> job_runtime）
- [x] 正常系で `result://sim/...` を返却
- [x] 異常系（input/artifact/sim failure）で失敗理由を返却
- [x] 追加テストで回帰防止

## テスト結果
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check_pr_preflight.ps1`: PASS
- `cargo clippy -p cam_sim -p application -p job_domain -p viewmodel -- -D warnings`: PASS
- `cargo fmt`: PASS
- `cargo test -p cam_sim -p application -p job_domain -p viewmodel`: PASS

## 関連
- Closes #686
- Depends on #684
- Refs #530
- Refs #517
