### PR TITLE
issue #684 [Phase0][A-1] cam_solver: 最小導線契約の設計固定

### DIFF
--- a/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
+++ b/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
@@ -202,3 +202,36 @@ Read/Write の片側だけが変わって契約が壊れることを防ぐため
 - `#412` は API 名称と wire format 表記の関係整理で本書を参照する
 - `#257` 相当の後続実装は、本書の責務境界・ヘッダ仕様・互換性ポリシーを前提にする
 - `NcPostFromCam` は本書を唯一の I/O 契約参照入口として扱う
+
+---
+
+## #684 solver 出力接続ルール（Option A / Step A）
+
+### 目的
+
+CAM solver の最小出力を `toolpath` artifact binary v0.1 へ接続し、`NcPostFromCam` で再利用可能にする。
+
+### 接続契約
+
+- solver 成功時:
+  - `toolpath` payload を本書の ToolPath Payload v0.1 で出力する
+  - `ResultRef` は上記 payload を指す不変参照を返す
+  - manifest は `artifact_type=toolpath` を必須とする
+- solver 失敗時:
+  - `ResultRef` を生成しない
+  - 失敗分類（`invalid_input` / `no_solution` / `convergence_failure`）を返す
+
+### 互換性判定
+
+- `version_major=0` かつ `version_minor=1` 以外は reject
+- `convert` は本Issueでは扱わない（strict reject）
+
+### 責務境界
+
+- Job Manager: `ResultRef`/manifest の契約検証のみ
+- Model/CAM: payload 生成・read/write・失敗分類を担当
+
+### 後続参照
+
+- #679 は本節の接続契約を前提に `NcPostFromCam` 読込導線を維持する
+- #680-#683 は本節の wire contract を変更せず NC post 拡張を行う

--- a/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
+++ b/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
@@ -223,8 +223,8 @@ CAM solver の最小出力を `toolpath` artifact binary v0.1 へ接続し、`Nc
 
 ### 互換性判定
 
-- `version_major=0` かつ `version_minor=1` 以外は reject
-- `convert` は本Issueでは扱わない（strict reject）
+- 全体の互換性ポリシーに従う
+- 本Issue時点では `convert` は未実装のため、`version_major=0` かつ `version_minor=1` の payload のみを受理し、それ以外は reject とする
 
 ### 責務境界
 

--- a/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
+++ b/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
@@ -850,10 +850,17 @@ docker run --rm \
 
 Job Manager は以下を reject とする。
 
-- missing `InputRef`
-- missing `ResultRef`
-- manifest の hash/digest 形式不正
-- `format_version` 不一致
+- 常に reject:
+  - missing `InputRef`
+- 成果物を返す契約が適用される場合のみ reject:
+  - missing `ResultRef`
+  - manifest の hash/digest 形式不正
+  - `format_version` 不一致
+
+補足:
+
+- ここでの `ResultRef` / manifest 検証は、正常終了時など「成果物を返す」ケースの契約検証に限る
+- solver 失敗時は失敗分類を返し、`ResultRef` を生成しない運用を許容する
 
 ### 21.4 #679 / #680系との関係
 

--- a/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
+++ b/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
@@ -591,7 +591,8 @@ Digest: executed image digest
 - Job Manager: メタデータ契約の検証のみを行う
   - 必須項目の欠落
   - digest/hash/size の形式検証
-  - `InputRef` / `ResultRef` 不在時の reject
+  - `InputRef` 不在時の reject
+  - `Status=succeeded` で成果物返却が必須のケースにおける `ResultRef` 不在時の reject
   - `format_version` 不一致時の reject
 - Worker / Domain: artifact本体生成と `artifact_manifest.json` 作成を担う
 - ViewModel / View: `ResultRef` / `LogRef` / manifest由来メタデータの表示に専念する
@@ -615,7 +616,7 @@ PR-B（検証ルール + 互換性ポリシー）で固定する判定:
 
 | 検証項目 | 代表エラー | 判定 |
 | --- | --- | --- |
-| missing ref | `MissingInputRef` / `MissingResultRef` | reject |
+| missing ref | `MissingInputRef` / `MissingResultRef` | `MissingInputRef` は常に reject、`MissingResultRef` は `Status=succeeded` で成果物返却必須時に reject |
 | 参照形式不正 | `InvalidInputRef` / `InvalidResultRef` | reject |
 | format version不一致 | `FormatVersionMismatch` | reject |
 | hash形式不正 | `InvalidImageDigest` / `InvalidSha256` | reject |
@@ -852,14 +853,14 @@ Job Manager は以下を reject とする。
 
 - 常に reject:
   - missing `InputRef`
-- 成果物を返す契約が適用される場合のみ reject:
+- `Status=succeeded` の場合のみ reject:
   - missing `ResultRef`
   - manifest の hash/digest 形式不正
   - `format_version` 不一致
 
 補足:
 
-- ここでの `ResultRef` / manifest 検証は、正常終了時など「成果物を返す」ケースの契約検証に限る
+- ここでの `ResultRef` / manifest 検証は、`Status=succeeded` で成果物返却が必須となるケースにのみ適用する
 - solver 失敗時は失敗分類を返し、`ResultRef` を生成しない運用を許容する
 
 ### 21.4 #679 / #680系との関係

--- a/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
+++ b/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
@@ -818,3 +818,45 @@ docker run --rm \
 - すべてのジョブ結果に `image_digest` を記録する
 - ログ、結果アーティファクト、digest を同一 `job_id` に紐づける
 - digest 未記録ジョブは失敗扱いとして再投入対象にする
+
+---
+
+## 21. #684 CAMソルバー最小導線の責務接続（Option A / Step A）
+
+本章は、`JobType + InputRef -> ResultRef` 契約を維持しつつ、CAM solver 導線を最小構成で接続するための責務境界を固定する。
+
+### 21.1 Job Manager の責務（固定）
+
+- `InputRef` / `ResultRef` の存在と形式を検証する
+- 実行イメージ参照、ログ参照、manifest 参照のメタデータ整合を検証する
+- 実行状態と失敗分類（コード）を管理する
+
+非責務:
+
+- 形状データ（NURBSを含む）や ToolPath の幾何データを解釈しない
+- solver の収束判定ロジックを実装しない
+
+### 21.2 Model/CAM 側の責務（固定）
+
+- `InputRef` の実体復元（形状データ: 曲線群/面群/NURBS等）
+- solver 実行と ToolPath 生成
+- solver 失敗分類の決定
+  - `invalid_input`
+  - `no_solution`
+  - `convergence_failure`
+- `toolpath` artifact binary v0.1 と `ResultRef` の生成
+
+### 21.3 検証ルール（最小）
+
+Job Manager は以下を reject とする。
+
+- missing `InputRef`
+- missing `ResultRef`
+- manifest の hash/digest 形式不正
+- `format_version` 不一致
+
+### 21.4 #679 / #680系との関係
+
+- #679 は本章の `ResultRef` 契約に依存して `NcPostFromCam` を実行する
+- #680-#683 は本章の責務境界を維持した上で NC post 拡張を行う
+- 本章は Option A の Step A（設計固定）に相当し、solver 高度化は後続Issueで扱う

--- a/dev/architecture/CAM_ALGORITHMS_DESIGN.md
+++ b/dev/architecture/CAM_ALGORITHMS_DESIGN.md
@@ -452,7 +452,7 @@ ToolPathの複雑化抑制のため、以下を分離する。
 
 ### 8.2 入力モデル（最小）
 
-最小入力は `SolverInputRef` が指す payload とし、以下を必須項目とする。
+最小入力は `InputRef`（solver 入力を指す参照）が指す payload とし、以下を必須項目とする。
 
 - `geometry_kind`
   - `nurbs_surface_set`

--- a/dev/architecture/CAM_ALGORITHMS_DESIGN.md
+++ b/dev/architecture/CAM_ALGORITHMS_DESIGN.md
@@ -438,3 +438,72 @@ ToolPathの複雑化抑制のため、以下を分離する。
 - variant の表現（String許容か、enum化するか）
 
 上記3点の合意を、Issue #504 の実装開始条件とする。
+
+---
+
+## 8️⃣ #684 CAMソルバー最小導線契約（Option A / Step A）
+
+本節は Issue #684 の設計固定を目的とし、実装前提となる最小契約を定義する。
+
+### 8.1 目的
+
+- 形状データ（NURBSを含む）入力から ToolPath artifact を生成し、`NcPostFromCam` へ接続可能な最小導線を固定する
+- `JobType + InputRef -> ResultRef` 契約を維持したまま、solver 導線を明文化する
+
+### 8.2 入力モデル（最小）
+
+最小入力は `SolverInputRef` が指す payload とし、以下を必須項目とする。
+
+- `geometry_kind`
+  - `nurbs_surface_set`
+  - `nurbs_curve_set`
+  - `curve_chain_2p5d`
+- `tool_id`
+- `operation_id`
+- `units`
+- `coordinate_frame`
+
+補足:
+
+- Solver は `InputRef` 参照先を解決して入力を復元する
+- `cam_sim` 側で参照解決するが、Job Manager は payload 本体を解釈しない
+
+### 8.3 solver 最小責務
+
+- 入力契約の検証
+- ToolPath 生成（最小形）
+- 失敗分類の返却
+  - `invalid_input`
+  - `no_solution`
+  - `convergence_failure`
+- 生成結果を `toolpath` artifact binary v0.1 に接続
+
+非責務（本Issueの非スコープ）:
+
+- 加工時間最小化などの高度最適化
+- コントローラ固有 post 最適化
+- UI編集機能
+
+### 8.4 最小導線シーケンス
+
+1. `JobType::CamProcess` で `InputRef` を受理
+2. `InputRef` から solver 入力を復元
+3. solver を実行して ToolPath を生成
+4. `toolpath` artifact binary v0.1 として永続化
+5. `ResultRef` を返却し、後続 `NcPostFromCam` が参照する
+
+### 8.5 失敗分類と契約境界
+
+- `invalid_input`
+  - 必須項目欠落、型不一致、units/frame 不整合
+- `no_solution`
+  - 幾何制約下で有効経路を構築できない
+- `convergence_failure`
+  - 反復解法が収束条件を満たさない
+
+いずれも Job Manager には失敗種別のみ伝達し、幾何計算の内部状態は公開しない。
+
+### 8.6 後続Issueへの接続
+
+- #679: `NcPostFromCam` の artifact 読込導線は本節の `ResultRef` 契約を前提とする
+- #680-#683: NC post 拡張系列は、本節で固定した solver->toolpath 導線を前提とする

--- a/dev/architecture/CAM_ALGORITHMS_DESIGN.md
+++ b/dev/architecture/CAM_ALGORITHMS_DESIGN.md
@@ -465,7 +465,7 @@ ToolPathの複雑化抑制のため、以下を分離する。
 
 補足:
 
-- Solver は `InputRef` 参照先を解決して入力を復元する
+- solver は `InputRef` 参照先を解決して入力を復元する
 - `cam_sim` 側で参照解決するが、Job Manager は payload 本体を解釈しない
 
 ### 8.3 solver 最小責務


### PR DESCRIPTION
このPRに含む単位:
- #684 Option A / Step A（設計固定）
- CAM solver 最小導線の契約定義（ドキュメント）

このPRに含めない単位:
- solver 実装コードの追加・変更
- cam_sim/job_runtime/application の実行ロジック変更
- #680-#683 の拡張実装

## 概要
Issue #684 の Option A として、実装前に CAM solver 最小導線契約を設計文書へ固定しました。
NURBS限定に見える表現は「形状データ（NURBSを含む）」へ統一しています。

## 主な変更
- dev/architecture/CAM_ALGORITHMS_DESIGN.md
  - #684 Step A 節を追加
  - 入力モデル最小契約、solver最小責務、失敗分類、最小導線シーケンスを明記
- dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
  - Job Manager と Model/CAM の責務境界を #684 文脈で固定
  - missing ref / hash形式不正 / format_version不一致の reject ルールを明記
- dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
  - solver 出力の toolpath artifact v0.1 接続契約を追加
  - strict reject 方針と後続Issue参照を明記

## 検証
- powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check_pr_preflight.ps1 ✅

## 関連Issue
- Refs #684
