### PR TITLE
issue #689 [Phase1][A-1] cam solver: 工程テンプレート運用契約の同期

### DIFF
--- a/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
+++ b/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
@@ -235,3 +235,23 @@ CAM solver の最小出力を `toolpath` artifact binary v0.1 へ接続し、`Nc
 
 - #679 は本節の接続契約を前提に `NcPostFromCam` 読込導線を維持する
 - #680-#683 は本節の wire contract を変更せず NC post 拡張を行う
+
+---
+
+## #689 工程テンプレート由来メタデータ追跡（Step A）
+
+本節は、工程テンプレート適用結果を `Status=succeeded` の成果物で再現可能にするための最小メタデータ契約を定義する。
+
+### succeeded時に記録する項目
+
+- `tolerance_profile`（例: `press_rough` / `mold_finish`）
+- `tolerance_value_mm`
+- `machining_stage`（`rough` / `semi_finish` / `finish`）
+- `operation_type`
+- `boundary_mode`（`edge_projected_2d` / `rectangle`）
+
+### 運用ルール
+
+- `Status=succeeded` 以外では上記項目を必須化しない
+- Job Manager は値の意味を解釈せず、参照整合のみ扱う
+- Model/CAM 側が生成時に値を確定し、reader/writer 契約で保持する

--- a/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
+++ b/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
@@ -256,13 +256,13 @@ CAM solver の最小出力を `toolpath` artifact binary v0.1 へ接続し、`Nc
 
 ### 格納領域
 
-- 本節の項目は `ToolPath payload.ext_attributes` に保持する
-- 共通ヘッダ `ext_attributes` には保持しない
+- toolpath artifact は `ToolPath payload.ext_attributes` に保持する
+- interference artifact は共通ヘッダ `ext_attributes` に保持する
 - manifest には監査・検索用の最小メタデータのみを保持し、payload と同一粒度の重複保持は必須化しない
 
 ### TLV 表現
 
-`ToolPath payload.ext_attributes` の各項目は次の TLV で保持する。`tag` は `i16 little-endian`、`data_len` は `u16 little-endian`、文字列は UTF-8（NUL終端なし）とする。
+toolpath payload / interference 共通ヘッダの `ext_attributes` は同一 TLV 形式を使用する。`tag` は `i16 little-endian`、`data_len` は `u16 little-endian`、文字列は UTF-8（NUL終端なし）とする。
 
 | 項目 | TLV tag | data 形式 | 備考 |
 | --- | --- | --- | --- |
@@ -277,8 +277,8 @@ CAM solver の最小出力を `toolpath` artifact binary v0.1 へ接続し、`Nc
 ### 運用ルール
 
 - `Status=succeeded` 以外では上記項目を必須化しない
-- `Status=succeeded` の toolpath artifact では上表の全項目を必須とする
-- `Status=succeeded` の interference artifact では `machining_direction` を任意、それ以外を必須とする
+- `Status=succeeded` の toolpath artifact では上表の全項目を payload 側 `ext_attributes` に必須とする
+- `Status=succeeded` の interference artifact では `machining_direction` を任意、それ以外を共通ヘッダ側 `ext_attributes` に必須とする
 - Job Manager は値の意味を解釈せず、参照整合のみ扱う
 - Model/CAM 側が生成時に値を確定し、reader/writer は本節の TLV 契約に従って保持する
 - reader は `Status=succeeded` の場合に必須項目欠落を不正データとして扱う

--- a/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
+++ b/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
@@ -249,9 +249,11 @@ CAM solver の最小出力を `toolpath` artifact binary v0.1 へ接続し、`Nc
 - `machining_stage`（`rough` / `semi_finish` / `finish`）
 - `operation_type`
 - `boundary_mode`（`edge_projected_2d` / `rectangle`）
+- `machining_direction`
 
 ### 運用ルール
 
 - `Status=succeeded` 以外では上記項目を必須化しない
 - Job Manager は値の意味を解釈せず、参照整合のみ扱う
 - Model/CAM 側が生成時に値を確定し、reader/writer 契約で保持する
+- `machining_direction` は #689 の最小入力契約との再現性整合のため、succeeded 成果物でも保持する

--- a/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
+++ b/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
@@ -240,20 +240,45 @@ CAM solver の最小出力を `toolpath` artifact binary v0.1 へ接続し、`Nc
 
 ## #689 工程テンプレート由来メタデータ追跡（Step A）
 
-本節は、工程テンプレート適用結果を `Status=succeeded` の成果物で再現可能にするための最小メタデータ契約を定義する。
+本節は、工程テンプレート適用結果を `Status=succeeded` の成果物で再現可能にするための最小メタデータ契約を定義する。reader/writer 実装可能性を担保するため、項目名だけでなく格納領域と data 形式を固定する。
 
 ### succeeded時に記録する項目
 
 - `tolerance_profile`（例: `press_rough` / `mold_finish`）
 - `tolerance_value_mm`
+- `template_revision`
 - `machining_stage`（`rough` / `semi_finish` / `finish`）
 - `operation_type`
 - `boundary_mode`（`edge_projected_2d` / `rectangle`）
 - `machining_direction`
 
+`template_revision` はテンプレート version 相当の追跡キーであり、`tolerance_profile` と `tolerance_value_mm` だけでは区別できない改訂差分を識別するため必須とする。
+
+### 格納領域
+
+- 本節の項目は `ToolPath payload.ext_attributes` に保持する
+- 共通ヘッダ `ext_attributes` には保持しない
+- manifest には監査・検索用の最小メタデータのみを保持し、payload と同一粒度の重複保持は必須化しない
+
+### TLV 表現
+
+`ToolPath payload.ext_attributes` の各項目は次の TLV で保持する。`tag` は `i16 little-endian`、`data_len` は `u16 little-endian`、文字列は UTF-8（NUL終端なし）とする。
+
+| 項目 | TLV tag | data 形式 | 備考 |
+| --- | --- | --- | --- |
+| `tolerance_profile` | `+689` | UTF-8 文字列 | `press_rough` / `mold_finish` |
+| `tolerance_value_mm` | `+690` | `f64 little-endian` | 単位は mm |
+| `template_revision` | `+691` | UTF-8 文字列 | 例: `v1`, `press_rough@3` |
+| `machining_stage` | `+692` | UTF-8 文字列 | `rough` / `semi_finish` / `finish` |
+| `operation_type` | `+693` | UTF-8 文字列 | canonical token |
+| `boundary_mode` | `+694` | UTF-8 文字列 | `edge_projected_2d` / `rectangle` |
+| `machining_direction` | `+695` | UTF-8 文字列 | `+X` / `-X` / `+Y` / `-Y` / `+Z` / `-Z` |
+
 ### 運用ルール
 
 - `Status=succeeded` 以外では上記項目を必須化しない
+- `Status=succeeded` の toolpath artifact では上表の全項目を必須とする
+- `Status=succeeded` の interference artifact では `machining_direction` を任意、それ以外を必須とする
 - Job Manager は値の意味を解釈せず、参照整合のみ扱う
-- Model/CAM 側が生成時に値を確定し、reader/writer 契約で保持する
-- `machining_direction` は #689 の最小入力契約との再現性整合のため、succeeded 成果物でも保持する
+- Model/CAM 側が生成時に値を確定し、reader/writer は本節の TLV 契約に従って保持する
+- reader は `Status=succeeded` の場合に必須項目欠落を不正データとして扱う

--- a/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
+++ b/dev/architecture/ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md
@@ -250,9 +250,9 @@ CAM solver の最小出力を `toolpath` artifact binary v0.1 へ接続し、`Nc
 - `machining_stage`（`rough` / `semi_finish` / `finish`）
 - `operation_type`
 - `boundary_mode`（`edge_projected_2d` / `rectangle`）
-- `machining_direction`
+- `machining_direction`（toolpath artifact では必須、interference artifact では任意）
 
-`template_revision` はテンプレート version 相当の追跡キーであり、`tolerance_profile` と `tolerance_value_mm` だけでは区別できない改訂差分を識別するため必須とする。
+`template_revision` はテンプレート version 相当の追跡キーであり、`tolerance_profile` と `tolerance_value_mm` だけでは区別できない改訂差分を識別するため必須とする。`machining_direction` を interference artifact で任意にするのは、同 artifact が干渉イベント監査を主目的とし、CAM 実行方向を常に再現に要求しないためである。
 
 ### 格納領域
 
@@ -266,19 +266,19 @@ toolpath payload / interference 共通ヘッダの `ext_attributes` は同一 TL
 
 | 項目 | TLV tag | data 形式 | 備考 |
 | --- | --- | --- | --- |
-| `tolerance_profile` | `+689` | UTF-8 文字列 | `press_rough` / `mold_finish` |
-| `tolerance_value_mm` | `+690` | `f64 little-endian` | 単位は mm |
-| `template_revision` | `+691` | UTF-8 文字列 | 例: `v1`, `press_rough@3` |
-| `machining_stage` | `+692` | UTF-8 文字列 | `rough` / `semi_finish` / `finish` |
-| `operation_type` | `+693` | UTF-8 文字列 | canonical token |
-| `boundary_mode` | `+694` | UTF-8 文字列 | `edge_projected_2d` / `rectangle` |
-| `machining_direction` | `+695` | UTF-8 文字列 | `+X` / `-X` / `+Y` / `-Y` / `+Z` / `-Z` |
+| `tolerance_profile` | `689` | UTF-8 文字列 | `press_rough` / `mold_finish` |
+| `tolerance_value_mm` | `690` | `f64 little-endian` | 単位は mm |
+| `template_revision` | `691` | UTF-8 文字列 | 例: `v1`, `press_rough@3` |
+| `machining_stage` | `692` | UTF-8 文字列 | `rough` / `semi_finish` / `finish` |
+| `operation_type` | `693` | UTF-8 文字列 | canonical token |
+| `boundary_mode` | `694` | UTF-8 文字列 | `edge_projected_2d` / `rectangle` |
+| `machining_direction` | `695` | UTF-8 文字列 | `+X` / `-X` / `+Y` / `-Y` / `+Z` / `-Z`。toolpath artifact では必須、interference artifact では任意 |
 
 ### 運用ルール
 
 - `Status=succeeded` 以外では上記項目を必須化しない
 - `Status=succeeded` の toolpath artifact では上表の全項目を payload 側 `ext_attributes` に必須とする
-- `Status=succeeded` の interference artifact では `machining_direction` を任意、それ以外を共通ヘッダ側 `ext_attributes` に必須とする
+- `Status=succeeded` の interference artifact では、共通ヘッダ側 `ext_attributes` に上表の各項目を記録する。このうち `machining_direction` は任意、それ以外は必須とする
 - Job Manager は値の意味を解釈せず、参照整合のみ扱う
 - Model/CAM 側が生成時に値を確定し、reader/writer は本節の TLV 契約に従って保持する
-- reader は `Status=succeeded` の場合に必須項目欠落を不正データとして扱う
+- reader は `Status=succeeded` の場合、toolpath artifact では上表の全項目、interference artifact では `machining_direction` を除く上表の項目が欠落していれば不正データとして扱う

--- a/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
+++ b/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
@@ -882,6 +882,7 @@ Job Manager は以下を reject とする。
 - `machining_stage`: `rough` / `semi_finish` / `finish`
 - `operation_type`
 - `boundary_mode`: `edge_projected_2d` / `rectangle`
+- `machining_direction`
 - `tolerance_profile`: `press_rough` / `mold_finish`
 - `stock_ref`（中加工で必須のオペレーション時）
 
@@ -889,15 +890,17 @@ Job Manager は以下を reject とする。
 
 - mm を基準単位とする
 - `press_rough = 0.001mm`、`mold_finish = 0.0001mm` を初期既定とする
-- `unit_mismatch` は reject とし、暗黙変換で継続しない
+- `unit_mismatch` は Model/CAM/solver 側の入力不正分類とし、暗黙変換で継続しない
 
 ### 22.3 検証条件
 
-- 常に reject:
+- Job Manager が受付時に reject:
   - missing `InputRef`
+- Model/CAM/solver が `InputRef` 解決後に失敗分類:
   - `invalid_tolerance_profile`
   - `missing_tolerance_profile`
-- `Status=succeeded` の場合のみ reject:
+  - `unit_mismatch`
+- Job Manager が `Status=succeeded` の監査時に reject:
   - missing `ResultRef`
   - manifest の hash/digest 形式不正
   - `format_version` 不一致
@@ -911,3 +914,4 @@ Job Manager は以下を reject とする。
 - `operation_type`
 - `machining_stage`
 - `boundary_mode`
+- `machining_direction`

--- a/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
+++ b/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
@@ -911,6 +911,7 @@ Job Manager は以下を reject とする。
 
 - `tolerance_profile`
 - `tolerance_value_mm`
+- `template_revision`
 - `operation_type`
 - `machining_stage`
 - `boundary_mode`
@@ -918,12 +919,13 @@ Job Manager は以下を reject とする。
 
 格納先と責務:
 
-- 正本の格納先は artifact binary payload の `ext_attributes` TLV とする
+- toolpath artifact の正本格納先は payload の `ext_attributes` TLV とする
+- interference artifact の正本格納先は共通ヘッダの `ext_attributes` TLV とする
 - manifest には監査・検索用の最小メタデータのみを持たせ、値の意味解釈は行わない
-- payload 内への重複保持は任意とし、必須要件は `ext_attributes` 側で満たす
+- payload またはヘッダへの重複保持は任意とし、reader は artifact 種別ごとの正本領域を優先して解釈する
 - 格納規則の詳細（tag/data 形式・reader/writer 規約）は `ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md` の #689 節に従う
 
 必須化範囲:
 
-- toolpath artifact: 上記 6 項目を必須保持する
-- interference artifact: `machining_direction` を任意とし、それ以外を必須保持する
+- toolpath artifact: 上記 7 項目を payload 側 `ext_attributes` TLV に必須保持する
+- interference artifact: `machining_direction` を任意とし、それ以外を共通ヘッダ側 `ext_attributes` TLV に必須保持する

--- a/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
+++ b/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
@@ -889,17 +889,19 @@ Job Manager は以下を reject とする。
 ### 22.2 単位・トレランス変換
 
 - mm を基準単位とする
-- `press_rough = 0.001mm`、`mold_finish = 0.0001mm` を初期既定とする
+- `press_rough = 0.001mm`、`mold_finish = 0.0001mm` を工程テンプレート定義時の初期既定とする
+- 上記初期既定はテンプレート定義の欠落補完にのみ適用し、`InputRef` 解決後の実行 payload では `tolerance_profile` を必須とする
 - `unit_mismatch` は Model/CAM/solver 側の入力不正分類とし、暗黙変換で継続しない
 
 ### 22.3 検証条件
 
 - Job Manager が受付時に reject:
   - missing `InputRef`
-- Model/CAM/solver が `InputRef` 解決後に失敗分類:
+- Model/CAM/solver が `InputRef` 解決後に失敗分類（本節では単位・トレランス関連の最低限を列挙）:
   - `invalid_tolerance_profile`
   - `missing_tolerance_profile`
   - `unit_mismatch`
+  - CAM 固有の内部分類を含む完全一覧は `CAM_ALGORITHMS_DESIGN.md` の #689 節に従う（例: `boundary_projection_failed` など）
 - Job Manager が `Status=succeeded` の監査時に reject:
   - missing `ResultRef`
   - manifest の hash/digest 形式不正

--- a/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
+++ b/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
@@ -921,13 +921,13 @@ Job Manager は以下を reject とする。
 
 格納先と責務:
 
-- toolpath artifact の正本格納先は payload の `ext_attributes` TLV とする
+- toolpath artifact の正本格納先は payload のファイル単位メタ側 `ext_attributes[]` TLV とする
 - interference artifact の正本格納先は共通ヘッダの `ext_attributes` TLV とする
 - manifest には監査・検索用の最小メタデータのみを持たせ、値の意味解釈は行わない
-- payload またはヘッダへの重複保持は任意とし、reader は artifact 種別ごとの正本領域を優先して解釈する
+- payload またはヘッダへの重複保持は任意とし、reader は artifact 種別ごとの正本領域（toolpath は payload のファイル単位メタ側 `ext_attributes[]`、interference は共通ヘッダ側 `ext_attributes`）を優先して解釈する
 - 格納規則の詳細（tag/data 形式・reader/writer 規約）は `ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md` の #689 節に従う
 
 必須化範囲:
 
-- toolpath artifact: 上記 7 項目を payload 側 `ext_attributes` TLV に必須保持する
+- toolpath artifact: 上記 7 項目を payload のファイル単位メタ側 `ext_attributes[]` TLV に必須保持する
 - interference artifact: 干渉イベント監査を主目的とするため `machining_direction` を任意とし、それ以外を共通ヘッダ側 `ext_attributes` TLV に必須保持する

--- a/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
+++ b/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
@@ -915,3 +915,15 @@ Job Manager は以下を reject とする。
 - `machining_stage`
 - `boundary_mode`
 - `machining_direction`
+
+格納先と責務:
+
+- 正本の格納先は artifact binary payload の `ext_attributes` TLV とする
+- manifest には監査・検索用の最小メタデータのみを持たせ、値の意味解釈は行わない
+- payload 内への重複保持は任意とし、必須要件は `ext_attributes` 側で満たす
+- 格納規則の詳細（tag/data 形式・reader/writer 規約）は `ARTIFACT_BINARY_IO_CONTRACT_DESIGN.md` の #689 節に従う
+
+必須化範囲:
+
+- toolpath artifact: 上記 6 項目を必須保持する
+- interference artifact: `machining_direction` を任意とし、それ以外を必須保持する

--- a/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
+++ b/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
@@ -880,11 +880,13 @@ Job Manager は以下を reject とする。
 `InputRef` が指す payload に、以下の最小項目を含める。
 
 - `machining_stage`: `rough` / `semi_finish` / `finish`
-- `operation_type`
+- `operation_type`: `contour_offset` / `rest_machining` / `scanline` / `surface_follow`
 - `boundary_mode`: `edge_projected_2d` / `rectangle`
 - `machining_direction`
 - `tolerance_profile`: `press_rough` / `mold_finish`
-- `stock_ref`（中加工で必須のオペレーション時）
+- `stock_ref`（`machining_stage = semi_finish` かつ `operation_type = rest_machining` の時に必須）
+
+`operation_type` は本章で列挙した canonical token のみを受理し、実装側での別名 token 追加は許可しない。
 
 ### 22.2 単位・トレランス変換
 

--- a/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
+++ b/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
@@ -915,7 +915,7 @@ Job Manager は以下を reject とする。
 - `operation_type`
 - `machining_stage`
 - `boundary_mode`
-- `machining_direction`
+- `machining_direction`（toolpath artifact では必須、interference artifact では任意）
 
 格納先と責務:
 
@@ -928,4 +928,4 @@ Job Manager は以下を reject とする。
 必須化範囲:
 
 - toolpath artifact: 上記 7 項目を payload 側 `ext_attributes` TLV に必須保持する
-- interference artifact: `machining_direction` を任意とし、それ以外を共通ヘッダ側 `ext_attributes` TLV に必須保持する
+- interference artifact: 干渉イベント監査を主目的とするため `machining_direction` を任意とし、それ以外を共通ヘッダ側 `ext_attributes` TLV に必須保持する

--- a/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
+++ b/dev/architecture/BATCH_COMPUTE_PLATFORM_DESIGN.md
@@ -868,3 +868,46 @@ Job Manager は以下を reject とする。
 - #679 は本章の `ResultRef` 契約に依存して `NcPostFromCam` を実行する
 - #680-#683 は本章の責務境界を維持した上で NC post 拡張を行う
 - 本章は Option A の Step A（設計固定）に相当し、solver 高度化は後続Issueで扱う
+
+---
+
+## 22. #689 工程テンプレート適用規約（Step A）
+
+本章は、工程テンプレート由来の精度プロファイルとオペレーション指定を `JobType + InputRef -> ResultRef` 契約のまま運用するための規約を固定する。
+
+### 22.1 適用入力
+
+`InputRef` が指す payload に、以下の最小項目を含める。
+
+- `machining_stage`: `rough` / `semi_finish` / `finish`
+- `operation_type`
+- `boundary_mode`: `edge_projected_2d` / `rectangle`
+- `tolerance_profile`: `press_rough` / `mold_finish`
+- `stock_ref`（中加工で必須のオペレーション時）
+
+### 22.2 単位・トレランス変換
+
+- mm を基準単位とする
+- `press_rough = 0.001mm`、`mold_finish = 0.0001mm` を初期既定とする
+- `unit_mismatch` は reject とし、暗黙変換で継続しない
+
+### 22.3 検証条件
+
+- 常に reject:
+  - missing `InputRef`
+  - `invalid_tolerance_profile`
+  - `missing_tolerance_profile`
+- `Status=succeeded` の場合のみ reject:
+  - missing `ResultRef`
+  - manifest の hash/digest 形式不正
+  - `format_version` 不一致
+
+### 22.4 成果物追跡（succeeded時）
+
+`Status=succeeded` の成果物には、最低限以下の追跡情報を残す。
+
+- `tolerance_profile`
+- `tolerance_value_mm`
+- `operation_type`
+- `machining_stage`
+- `boundary_mode`

--- a/dev/architecture/CAM_ALGORITHMS_DESIGN.md
+++ b/dev/architecture/CAM_ALGORITHMS_DESIGN.md
@@ -527,6 +527,18 @@ ToolPathの複雑化抑制のため、以下を分離する。
 
 ### 9.2 `operation_type` 決定規約
 
+`operation_type` で受理する canonical token は以下に固定する。
+実装・保存・artifact 追跡では、別名や自然言語ではなくこれらの token を用いる。
+
+- `contour_offset`
+  - 等高線オフセット加工。荒加工での外周からの段階切込み、およびストック入力ありの等高線オフセット加工を含む
+- `rest_machining`
+  - 等高残加工。前工程や大径工具で残った未加工領域を小径工具などで追い込む加工
+- `scanline`
+  - スキャン加工。一定方向の往復または片方向走査で面を仕上げる加工
+- `surface_follow`
+  - 面沿い加工。対象面の法線・曲率・パラメトリック流れに追従して経路を生成する加工
+
 `operation_type` の適用優先順位:
 
 1. `operation_type` 明示指定
@@ -538,19 +550,20 @@ ToolPathの複雑化抑制のため、以下を分離する。
 `machining_stage` は実行順序を強制するための状態ではなく、工程テンプレート上のタグ分類として扱う。
 
 - 荒加工（rough）
-  - 等高線オフセット加工
+  - 等高線オフセット加工（`contour_offset`）
 - 中加工（semi_finish）
-  - ストック入力あり等高線オフセット加工
-  - 等高残加工
+  - ストック入力あり等高線オフセット加工（`contour_offset`）
+  - 等高残加工（`rest_machining`）
 - 仕上げ（finish）
-  - スキャン加工
-  - 面沿い加工
-  - 小径工具による等高残加工（等高中加工後の追い込み用途）
+  - スキャン加工（`scanline`）
+  - 面沿い加工（`surface_follow`）
+  - 小径工具による等高残加工（`rest_machining`、等高中加工後の追い込み用途）
 
 補足:
 
 - 等高残加工は `semi_finish` を基本配置とするが、小径工具での追い込み時は `finish` でも許容する
 - `machining_stage` タグと `operation_type` の組み合わせで運用し、単純な前後関係だけで reject しない
+- `machining_stage` と `operation_type` は直交する属性とし、`finish` だから常に `surface_follow` になる、といった自動推論は行わない
 
 ### 9.4 加工範囲指定方式
 
@@ -566,7 +579,7 @@ ToolPathの複雑化抑制のため、以下を分離する。
 - `boundary_mode`
 - `machining_direction`
 - `tolerance_profile`
-- `stock_ref`（中加工の該当オペレーションで必須）
+- `stock_ref`（`machining_stage = semi_finish` かつ `operation_type = rest_machining` の時に必須）
 
 必須フィールド制約:
 
@@ -583,6 +596,9 @@ ToolPathの複雑化抑制のため、以下を分離する。
 - `tolerance_profile`
   - 許容値は `press_rough` / `mold_finish` のみとする
   - 未指定は `missing_tolerance_profile`、未知値は `invalid_tolerance_profile` として失敗分類する
+- `operation_type`
+  - 許容値は `contour_offset` / `rest_machining` / `scanline` / `surface_follow` のみとする
+  - 別名 token の導入は許可しない
 
 ### 9.5 失敗分類（初期・内部分類）
 

--- a/dev/architecture/CAM_ALGORITHMS_DESIGN.md
+++ b/dev/architecture/CAM_ALGORITHMS_DESIGN.md
@@ -527,6 +527,8 @@ ToolPathの複雑化抑制のため、以下を分離する。
 
 ### 9.2 加工ステージ別オペレーション
 
+`machining_stage` は実行順序を強制するための状態ではなく、工程テンプレート上のタグ分類として扱う。
+
 - 荒加工（rough）
   - 等高線オフセット加工
 - 中加工（semi_finish）
@@ -535,6 +537,12 @@ ToolPathの複雑化抑制のため、以下を分離する。
 - 仕上げ（finish）
   - スキャン加工
   - 面沿い加工
+  - 小径工具による等高残加工（等高中加工後の追い込み用途）
+
+補足:
+
+- 等高残加工は `semi_finish` を基本配置とするが、小径工具での追い込み時は `finish` でも許容する
+- `machining_stage` タグと `operation_type` の組み合わせで運用し、単純な前後関係だけで reject しない
 
 ### 9.3 加工範囲指定方式
 
@@ -566,3 +574,9 @@ ToolPathの複雑化抑制のため、以下を分離する。
 
 - Job Manager はテンプレート本体を解釈せず、`InputRef` / `ResultRef` 契約を維持する
 - Model/CAM 側がテンプレートを解決し、profile と operation を solver へ適用する
+
+### 9.6 工程順序ポリシー
+
+- 工程順序チェックは設定可能な警告として扱う（既定は warning、hard error にはしない）
+- 例: `finish` が `semi_finish` より先行する場合、設定有効時に警告を出す
+- 警告出力の有無はテンプレート設定で制御し、`JobType + InputRef -> ResultRef` 契約は維持する

--- a/dev/architecture/CAM_ALGORITHMS_DESIGN.md
+++ b/dev/architecture/CAM_ALGORITHMS_DESIGN.md
@@ -519,13 +519,21 @@ ToolPathの複雑化抑制のため、以下を分離する。
 - `press_rough`: 0.001mm
 - `mold_finish`: 0.0001mm
 
-適用優先順位:
+`tolerance_profile` の適用優先順位:
+
+1. オペレーション定義の `tolerance_profile` 明示指定
+2. 工程テンプレートの `tolerance_profile` 既定値
+3. solver の `tolerance_profile` 既定値
+
+### 9.2 `operation_type` 決定規約
+
+`operation_type` の適用優先順位:
 
 1. `operation_type` 明示指定
 2. 工程テンプレートの `operation_type` 既定値
 3. solver の `operation_type` 既定値
 
-### 9.2 加工ステージ別オペレーション
+### 9.3 加工ステージ別オペレーション
 
 `machining_stage` は実行順序を強制するための状態ではなく、工程テンプレート上のタグ分類として扱う。
 
@@ -544,7 +552,7 @@ ToolPathの複雑化抑制のため、以下を分離する。
 - 等高残加工は `semi_finish` を基本配置とするが、小径工具での追い込み時は `finish` でも許容する
 - `machining_stage` タグと `operation_type` の組み合わせで運用し、単純な前後関係だけで reject しない
 
-### 9.3 加工範囲指定方式
+### 9.4 加工範囲指定方式
 
 - `edge_projected_2d`
   - エッジ指示を加工方向へ投影した2D境界を使用
@@ -576,7 +584,7 @@ ToolPathの複雑化抑制のため、以下を分離する。
   - 許容値は `press_rough` / `mold_finish` のみとする
   - 未指定は `missing_tolerance_profile`、未知値は `invalid_tolerance_profile` として失敗分類する
 
-### 9.4 失敗分類（初期・内部分類）
+### 9.5 失敗分類（初期・内部分類）
 
 - `invalid_tolerance_profile`
 - `missing_tolerance_profile`
@@ -600,12 +608,12 @@ ToolPathの複雑化抑制のため、以下を分離する。
   - `stock_required_but_missing`
   - 上記はすべて `invalid_input` へマップする
 
-### 9.5 責務境界
+### 9.6 責務境界
 
 - Job Manager はテンプレート本体を解釈せず、`InputRef` / `ResultRef` 契約を維持する
 - Model/CAM 側がテンプレートを解決し、profile と operation を solver へ適用する
 
-### 9.6 工程順序ポリシー
+### 9.7 工程順序ポリシー
 
 - 工程順序チェックは設定可能な警告として扱う（既定は warning、hard error にはしない）
 - 例: `finish` が `semi_finish` より先行する場合、設定有効時に警告を出す

--- a/dev/architecture/CAM_ALGORITHMS_DESIGN.md
+++ b/dev/architecture/CAM_ALGORITHMS_DESIGN.md
@@ -507,3 +507,62 @@ ToolPathの複雑化抑制のため、以下を分離する。
 
 - #679: `NcPostFromCam` の artifact 読込導線は本節の `ResultRef` 契約を前提とする
 - #680-#683: NC post 拡張系列は、本節で固定した solver->toolpath 導線を前提とする
+
+---
+
+## 9️⃣ #689 工程テンプレート精度プロファイル運用契約（Step A）
+
+本節は Issue #689 の設計固定を目的とし、加工ステージ別オペレーションと精度プロファイル適用契約を定義する。
+
+### 9.1 精度プロファイル
+
+- `press_rough`: 0.001mm
+- `mold_finish`: 0.0001mm
+
+適用優先順位:
+
+1. operation 明示指定
+2. 工程テンプレート既定値
+3. solver 既定値
+
+### 9.2 加工ステージ別オペレーション
+
+- 荒加工（rough）
+  - 等高線オフセット加工
+- 中加工（semi_finish）
+  - ストック入力あり等高線オフセット加工
+  - 等高残加工
+- 仕上げ（finish）
+  - スキャン加工
+  - 面沿い加工
+
+### 9.3 加工範囲指定方式
+
+- `edge_projected_2d`
+  - エッジ指示を加工方向へ投影した2D境界を使用
+- `rectangle`
+  - 矩形座標値（min/max）を直接指定
+
+入力契約（最小）:
+
+- `operation_type`
+- `machining_stage`
+- `boundary_mode`
+- `machining_direction`
+- `tolerance_profile`
+- `stock_ref`（中加工の該当オペレーションで必須）
+
+### 9.4 失敗分類（初期）
+
+- `invalid_tolerance_profile`
+- `missing_tolerance_profile`
+- `unit_mismatch`
+- `boundary_projection_failed`
+- `empty_projected_boundary`
+- `operation_boundary_out_of_domain`
+- `stock_required_but_missing`
+
+### 9.5 責務境界
+
+- Job Manager はテンプレート本体を解釈せず、`InputRef` / `ResultRef` 契約を維持する
+- Model/CAM 側がテンプレートを解決し、profile と operation を solver へ適用する

--- a/dev/architecture/CAM_ALGORITHMS_DESIGN.md
+++ b/dev/architecture/CAM_ALGORITHMS_DESIGN.md
@@ -560,7 +560,23 @@ ToolPathの複雑化抑制のため、以下を分離する。
 - `tolerance_profile`
 - `stock_ref`（中加工の該当オペレーションで必須）
 
-### 9.4 失敗分類（初期）
+必須フィールド制約:
+
+- `machining_direction`
+  - canonical token: `+X` / `-X` / `+Y` / `-Y` / `+Z` / `-Z`
+  - 単位なしの軸方向指定として扱い、角度値や任意ベクトルは受理しない
+- `boundary_mode = edge_projected_2d`
+  - `edge_refs`（1件以上）を必須とする
+  - `edge_refs` を `machining_direction` へ投影して2D境界を構築できない場合は失敗分類とする
+- `boundary_mode = rectangle`
+  - `rect_min=(x_min,y_min)` と `rect_max=(x_max,y_max)` を必須とする
+  - 座標系はワーク局所座標、単位は mm 固定とする
+  - `x_min < x_max` かつ `y_min < y_max` を満たさない場合は失敗分類とする
+- `tolerance_profile`
+  - 許容値は `press_rough` / `mold_finish` のみとする
+  - 未指定または未知値は失敗分類とする
+
+### 9.4 失敗分類（初期・内部分類）
 
 - `invalid_tolerance_profile`
 - `missing_tolerance_profile`
@@ -569,6 +585,20 @@ ToolPathの複雑化抑制のため、以下を分離する。
 - `empty_projected_boundary`
 - `operation_boundary_out_of_domain`
 - `stock_required_but_missing`
+
+失敗分類マッピング:
+
+- 本節の列挙はテンプレート適用段階の内部分類であり、Job Manager へ直接公開する分類コードではない
+- Job Manager へ返す失敗分類は #684 で定義済みの 3 分類（`invalid_input` / `no_solution` / `convergence_failure`）に統一する
+- #689 で追加した内部分類は以下へ集約する
+  - `invalid_tolerance_profile`
+  - `missing_tolerance_profile`
+  - `unit_mismatch`
+  - `boundary_projection_failed`
+  - `empty_projected_boundary`
+  - `operation_boundary_out_of_domain`
+  - `stock_required_but_missing`
+  - 上記はすべて `invalid_input` へマップする
 
 ### 9.5 責務境界
 

--- a/dev/architecture/CAM_ALGORITHMS_DESIGN.md
+++ b/dev/architecture/CAM_ALGORITHMS_DESIGN.md
@@ -521,9 +521,9 @@ ToolPathの複雑化抑制のため、以下を分離する。
 
 適用優先順位:
 
-1. operation 明示指定
-2. 工程テンプレート既定値
-3. solver 既定値
+1. `operation_type` 明示指定
+2. 工程テンプレートの `operation_type` 既定値
+3. solver の `operation_type` 既定値
 
 ### 9.2 加工ステージ別オペレーション
 
@@ -574,7 +574,7 @@ ToolPathの複雑化抑制のため、以下を分離する。
   - `x_min < x_max` かつ `y_min < y_max` を満たさない場合は失敗分類とする
 - `tolerance_profile`
   - 許容値は `press_rough` / `mold_finish` のみとする
-  - 未指定または未知値は失敗分類とする
+  - 未指定は `missing_tolerance_profile`、未知値は `invalid_tolerance_profile` として失敗分類する
 
 ### 9.4 失敗分類（初期・内部分類）
 


### PR DESCRIPTION
## 含む単位
- A-1: #689 Step A 文書同期（工程タグ運用・等高残の仕上げ許容・順序warningポリシー）

## 含めない単位
- B-1: solver本体アルゴリズム高度化
- B-2: UI編集機能仕様の最終確定

## Phase と PR系列の関係
- Phase1 は設計固定フェーズ
- 本PRはそのうち A-1（文書契約同期）に限定

## 概要
Issue #689 の運用意図を設計文書と Issue 本文で同期しました。

## 変更内容
- CAM_ALGORITHMS_DESIGN: `machining_stage` を順序強制ではなくタグ分類として定義
- CAM_ALGORITHMS_DESIGN: 等高残加工を小径工具の追い込み用途では `finish` でも許容
- CAM_ALGORITHMS_DESIGN: 工程順序チェックを設定可能 warning（既定）として定義
- BATCH_COMPUTE_PLATFORM_DESIGN: 工程テンプレート適用規約（入力項目・単位/トレランス・succeeded時追跡）を追加
- ARTIFACT_BINARY_IO_CONTRACT_DESIGN: `Status=succeeded` 時のテンプレート由来メタデータ追跡項目を追加
- Issue #689 本文: 上記ポリシーへ同期

## 影響範囲
- ドキュメントのみ（コード変更なし）

## 検証
- `scripts/check_pr_preflight.ps1` 実行
  - `cargo fmt --all -- --check`: OK
  - `cargo clippy --workspace --all-targets -- -D warnings`: OK
  - `cargo test --workspace`: OK

## 関連
- Ref #689
