### PR TITLE
issue #692 [Phase1][A-1] vscode: settings 非推奨キー置換と承認ルール追記

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -273,11 +273,5 @@
 
   // === Debugging ===
   "debug.allowBreakpointsEverywhere": true,
-  "debug.showInStatusBar": "onFirstSessionStart",
-  "chat.tools.terminal.autoApprove": {
-    "/^git status -sb; git branch --show-current; git remote -v \\| Select-Object -First 2$/": {
-      "approve": true,
-      "matchCommandLine": true
-    }
-  }
+  "debug.showInStatusBar": "onFirstSessionStart"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -256,7 +256,7 @@
   },
 
   // === Performance Settings ===
-  "typescript.preferences.includePackageJsonAutoImports": "off",
+  "js/ts.preferences.includePackageJsonAutoImports": "off",
   "extensions.ignoreRecommendations": false,
 
   // === Testing & Development ===
@@ -273,5 +273,11 @@
 
   // === Debugging ===
   "debug.allowBreakpointsEverywhere": true,
-  "debug.showInStatusBar": "onFirstSessionStart"
+  "debug.showInStatusBar": "onFirstSessionStart",
+  "chat.tools.terminal.autoApprove": {
+    "/^git status -sb; git branch --show-current; git remote -v \\| Select-Object -First 2$/": {
+      "approve": true,
+      "matchCommandLine": true
+    }
+  }
 }


### PR DESCRIPTION
## スコープ
- 含む単位: Phase1 / A-1（ワークスペース設定の最小修正）
- 含めない単位: Issue #693 の extensions 責務整理（別PRで継続）
- 補足: Phase は実施段階、PR系列は変更単位として分離

## 概要
.vscode/settings.json の軽微修正を行い、非推奨設定キーを推奨キーへ置換しました。

- `typescript.preferences.includePackageJsonAutoImports` → `js/ts.preferences.includePackageJsonAutoImports`

## 変更ファイル
- `.vscode/settings.json`

## 影響
- エディタ警告（非推奨キー）の解消

## 関連
- Ref: #692