### PR TITLE
issue #702 fix: check_pr_preflight.ps1 に -AllowDirty オプションを追加

### DIFF
--- a/scripts/check_pr_preflight.ps1
+++ b/scripts/check_pr_preflight.ps1
@@ -39,7 +39,7 @@ function Run-Or-Throw {
 
 Write-Step "Check git status"
 $branch = (git branch --show-current).Trim()
-$statusShort = git status --short
+$statusLines = @(git status --short)
 $statusBranch = git status --short --branch | Select-Object -First 1
 
 if ([string]::IsNullOrWhiteSpace($branch)) {
@@ -50,9 +50,10 @@ if ($branch -eq "develop" -and -not $AllowDevelop) {
     throw "Running on develop is not allowed. Use a feature branch or pass -AllowDevelop."
 }
 
-if (-not [string]::IsNullOrWhiteSpace($statusShort)) {
+if ($statusLines.Count -gt 0) {
     if ($AllowDirty) {
-        Write-Warn "Working tree is dirty (allowed by -AllowDirty):`n$statusShort"
+        $statusText = ($statusLines -join "`n").TrimEnd()
+        Write-Warn "Working tree is dirty (allowed by -AllowDirty):`n$statusText"
     } else {
         throw "Working tree is dirty. Commit or stash changes first."
     }

--- a/scripts/check_pr_preflight.ps1
+++ b/scripts/check_pr_preflight.ps1
@@ -1,7 +1,8 @@
 param(
     [switch]$SkipClippy,
     [switch]$SkipTests,
-    [switch]$AllowDevelop
+    [switch]$AllowDevelop,
+    [switch]$AllowDirty
 )
 
 Set-StrictMode -Version Latest
@@ -50,7 +51,11 @@ if ($branch -eq "develop" -and -not $AllowDevelop) {
 }
 
 if (-not [string]::IsNullOrWhiteSpace($statusShort)) {
-    throw "Working tree is dirty. Commit or stash changes first."
+    if ($AllowDirty) {
+        Write-Warn "Working tree is dirty (allowed by -AllowDirty):`n$statusShort"
+    } else {
+        throw "Working tree is dirty. Commit or stash changes first."
+    }
 }
 
 if ($statusBranch -match "ahead") {


### PR DESCRIPTION
## スコープ
- このPRに含む単位: `scripts/check_pr_preflight.ps1` への `-AllowDirty` パラメータ追加
- このPRに含めない単位: 他スクリプトの変更

## 概要
未コミット変更（dirty working tree）がある状態でも `-AllowDirty` オプションを指定することで preflight を実行できるようにしました。

## 変更内容

### `scripts/check_pr_preflight.ps1`
- `param` ブロックに `[switch]$AllowDirty` を追加
- dirty チェックを `-AllowDirty` 指定時は `[WARN]` 警告のみに変更し、処理を続行
- `-AllowDirty` なし（デフォルト）は従来通り `throw` で失敗

## 動作確認
```
# dirty 状態で -AllowDirty なし → 従来通り失敗
[STEP] Check git status
Working tree is dirty. Commit or stash changes first.

# dirty 状態で -AllowDirty あり → 警告付きで続行
[STEP] Check git status
[WARN] Working tree is dirty (allowed by -AllowDirty):
 M scripts/check_pr_preflight.ps1
[OK] Check git status
```

## 関連Issue
- Closes #702