### PR TITLE
issue #709 [Phase1-3][A-1] geo_algorithms: 同形状交差計算の共通関数導入と IntersectionResult 移行

### DIFF
--- a/model/geo_algorithms/src/collision/pair_base.rs
+++ b/model/geo_algorithms/src/collision/pair_base.rs
@@ -128,7 +128,7 @@ pub fn infinite_line3d_ray3d_collides<T: Scalar>(
 
 pub fn ray3d_ray3d_collides<T: Scalar>(ray1: &Ray3D<T>, ray2: &Ray3D<T>, tolerance: T) -> bool {
     // Ray の有効範囲（t >= 0）は intersection 側で判定済み。
-    ray3d_ray3d_intersection(ray1, ray2, tolerance).is_some()
+    ray3d_ray3d_intersection(ray1, ray2, tolerance).intersects()
 }
 
 pub fn ray3d_line_segment3d_collides<T: Scalar>(

--- a/model/geo_algorithms/src/collision/pair_base.rs
+++ b/model/geo_algorithms/src/collision/pair_base.rs
@@ -99,7 +99,7 @@ pub fn line_segment3d_line_segment3d_collides<T: Scalar>(
     tolerance: T,
 ) -> bool {
     // 交点が一意に求まるケースを衝突ありとみなす。
-    line_segment3d_line_segment3d_intersection(segment1, segment2, tolerance).is_some()
+    line_segment3d_line_segment3d_intersection(segment1, segment2, tolerance).intersects()
 }
 
 pub fn infinite_line3d_infinite_line3d_collides<T: Scalar>(

--- a/model/geo_algorithms/src/intersection/common.rs
+++ b/model/geo_algorithms/src/intersection/common.rs
@@ -5,6 +5,21 @@
 use crate::{InfiniteLine3D, Point3D, Vector3D};
 use geo_contracts::{default_parallel_cross_error_tolerance, InfiniteLine3DProperties, Scalar};
 
+/// 分母が有効（非ゼロ・非極小）かチェック
+///
+/// 外積ベースで無次元化した分母 `denom_sq`（`|d1 × d2|²` 相当）を `tolerance_sq` と比較する。
+///
+/// # 引数
+/// - `denom_sq`: 無次元の分母（通常は外積の大きさの二乗）
+/// - `tolerance_sq`: 比較閾値の二乗（通常は `default_parallel_cross_error_tolerance()²`）
+///
+/// # 戻り値
+/// 分母が閾値より十分に大きい場合 `true`（有効）。平行またはほぼ平行の場合 `false`（無効）。
+#[inline]
+pub(crate) fn check_denominator_validity<T: Scalar>(denom_sq: T, tolerance_sq: T) -> bool {
+    denom_sq > tolerance_sq
+}
+
 /// 2つの無限直線の交点計算（生の計算）
 ///
 /// 平行またはほぼ平行の場合は `None` を返す。
@@ -38,7 +53,7 @@ pub(crate) fn line_line_intersection_raw<T: Scalar>(
     // denom_sq は無次元量（sin²θ 相当）。par_tol と同じ無次元軸で比較する。
     let denom_sq = cross_d1_d2.dot(&cross_d1_d2);
     let par_tol = default_parallel_cross_error_tolerance::<T>();
-    if denom_sq <= par_tol * par_tol {
+    if !check_denominator_validity(denom_sq, par_tol * par_tol) {
         return None;
     }
 
@@ -51,6 +66,38 @@ mod tests {
     use super::*;
 
     const STANDARD_TEST_TOLERANCE_F64: f64 = analysis::test_constants::DISTANCE_TOLERANCE_F64;
+
+    #[test]
+    fn check_denominator_validity_ゼロ分母は無効() {
+        let par_tol = default_parallel_cross_error_tolerance::<f64>();
+        let tolerance_sq = par_tol * par_tol;
+        assert!(!check_denominator_validity(0.0_f64, tolerance_sq));
+    }
+
+    #[test]
+    fn check_denominator_validity_極小分母は無効() {
+        let par_tol = default_parallel_cross_error_tolerance::<f64>();
+        let tolerance_sq = par_tol * par_tol;
+        let denom_sq = tolerance_sq * 0.5; // 閾値の半分
+        assert!(!check_denominator_validity(denom_sq, tolerance_sq));
+    }
+
+    #[test]
+    fn check_denominator_validity_閾値と同値は無効() {
+        // check_denominator_validity は denom_sq > tolerance_sq の厳密不等号なので
+        // 閾値と等しい場合は無効（None 側）
+        let par_tol = default_parallel_cross_error_tolerance::<f64>();
+        let tolerance_sq = par_tol * par_tol;
+        assert!(!check_denominator_validity(tolerance_sq, tolerance_sq));
+    }
+
+    #[test]
+    fn check_denominator_validity_十分な分母は有効() {
+        let par_tol = default_parallel_cross_error_tolerance::<f64>();
+        let tolerance_sq = par_tol * par_tol;
+        let denom_sq = tolerance_sq * 2.0;
+        assert!(check_denominator_validity(denom_sq, tolerance_sq));
+    }
 
     #[test]
     fn line_line_intersection_raw_交差する直線は交点を返す() {

--- a/model/geo_algorithms/src/intersection/common.rs
+++ b/model/geo_algorithms/src/intersection/common.rs
@@ -2,7 +2,7 @@
 //!
 //! pair_base と primitive_3d が共有する基礎計算を提供する。
 
-use crate::{InfiniteLine3D, Point3D, Ray3D, Vector3D};
+use crate::{InfiniteLine3D, LineSegment3D, Point3D, Ray3D, Vector3D};
 use geo_contracts::{default_parallel_cross_error_tolerance, InfiniteLine3DProperties, Scalar};
 
 /// 分母が有効（非ゼロ・非極小）かチェック
@@ -77,6 +77,28 @@ pub(crate) fn ray_ray_intersection_raw<T: Scalar>(
     let line2 = InfiniteLine3D::new(ray2.origin(), ray2.direction_vector())?;
     let point = line_line_intersection_raw(&line1, &line2)?;
     if ray1.contains_point(&point, tolerance) && ray2.contains_point(&point, tolerance) {
+        Some(point)
+    } else {
+        None
+    }
+}
+
+/// 2つのLineSegment3Dの交点計算（生の計算）
+///
+/// `line_line_intersection_raw` を使い外積ベースで平行判定したうえで、
+/// 両セグメントの有効範囲を `contains_point` で検証する。
+/// `LineSegment3D::line()` が返す正規化済み `InfiniteLine3D` 経由で計算するため、
+/// 外積ベース無次元化が Ray×Ray と同じ軸で一貫して機能する。
+///
+/// # 戻り値
+/// 両セグメントが同一点を共有する場合 `Some(point)`。平行・スキュー・範囲外は `None`。
+pub(crate) fn segment_segment_intersection_raw<T: Scalar>(
+    seg1: &LineSegment3D<T>,
+    seg2: &LineSegment3D<T>,
+    tolerance: T,
+) -> Option<Point3D<T>> {
+    let point = line_line_intersection_raw(seg1.line(), seg2.line())?;
+    if seg1.contains_point(&point, tolerance) && seg2.contains_point(&point, tolerance) {
         Some(point)
     } else {
         None
@@ -257,5 +279,45 @@ mod tests {
 
         let result = line_line_intersection_raw(&line1, &line2);
         assert!(result.is_some());
+    }
+
+    #[test]
+    fn segment_segment_intersection_raw_交差するセグメントは交点を返す() {
+        use crate::LineSegment3D;
+        let seg1 = LineSegment3D::new(Point3D::new(0.0_f64, 0.0, 0.0), Point3D::new(1.0, 1.0, 0.0))
+            .unwrap();
+        let seg2 = LineSegment3D::new(Point3D::new(0.0_f64, 1.0, 0.0), Point3D::new(1.0, 0.0, 0.0))
+            .unwrap();
+
+        let result = segment_segment_intersection_raw(&seg1, &seg2, STANDARD_TEST_TOLERANCE_F64);
+        assert!(result.is_some());
+        let p = result.unwrap();
+        assert!((p.x() - 0.5).abs() < STANDARD_TEST_TOLERANCE_F64);
+        assert!((p.y() - 0.5).abs() < STANDARD_TEST_TOLERANCE_F64);
+    }
+
+    #[test]
+    fn segment_segment_intersection_raw_平行セグメントはnoneを返す() {
+        use crate::LineSegment3D;
+        let seg1 = LineSegment3D::new(Point3D::new(0.0_f64, 0.0, 0.0), Point3D::new(1.0, 0.0, 0.0))
+            .unwrap();
+        let seg2 = LineSegment3D::new(Point3D::new(0.0_f64, 1.0, 0.0), Point3D::new(1.0, 1.0, 0.0))
+            .unwrap();
+
+        let result = segment_segment_intersection_raw(&seg1, &seg2, STANDARD_TEST_TOLERANCE_F64);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn segment_segment_intersection_raw_セグメント範囲外はnoneを返す() {
+        // 延長線上では交わるが、どちらかのセグメント範囲外
+        use crate::LineSegment3D;
+        let seg1 = LineSegment3D::new(Point3D::new(2.0_f64, 0.0, 0.0), Point3D::new(3.0, 1.0, 0.0))
+            .unwrap();
+        let seg2 = LineSegment3D::new(Point3D::new(0.0_f64, 1.0, 0.0), Point3D::new(1.0, 0.0, 0.0))
+            .unwrap();
+
+        let result = segment_segment_intersection_raw(&seg1, &seg2, STANDARD_TEST_TOLERANCE_F64);
+        assert!(result.is_none());
     }
 }

--- a/model/geo_algorithms/src/intersection/common.rs
+++ b/model/geo_algorithms/src/intersection/common.rs
@@ -2,7 +2,7 @@
 //!
 //! pair_base と primitive_3d が共有する基礎計算を提供する。
 
-use crate::{InfiniteLine3D, Point3D, Vector3D};
+use crate::{InfiniteLine3D, Point3D, Ray3D, Vector3D};
 use geo_contracts::{default_parallel_cross_error_tolerance, InfiniteLine3DProperties, Scalar};
 
 /// 分母が有効（非ゼロ・非極小）かチェック
@@ -61,6 +61,28 @@ pub(crate) fn line_line_intersection_raw<T: Scalar>(
     Some(Point3D::new(px1 + t * dx1, py1 + t * dy1, pz1 + t * dz1))
 }
 
+/// 2つのRayの交点計算（生の計算）
+///
+/// `line_line_intersection_raw` を使い外積ベースで平行判定したうえで、
+/// Ray の有効範囲（t >= 0）を `contains_point` で検証する。
+///
+/// # 戻り値
+/// 両 Ray が同一点を共有する場合 `Some(point)`。平行・スキュー・Ray 範囲外は `None`。
+pub(crate) fn ray_ray_intersection_raw<T: Scalar>(
+    ray1: &Ray3D<T>,
+    ray2: &Ray3D<T>,
+    tolerance: T,
+) -> Option<Point3D<T>> {
+    let line1 = InfiniteLine3D::new(ray1.origin(), ray1.direction_vector())?;
+    let line2 = InfiniteLine3D::new(ray2.origin(), ray2.direction_vector())?;
+    let point = line_line_intersection_raw(&line1, &line2)?;
+    if ray1.contains_point(&point, tolerance) && ray2.contains_point(&point, tolerance) {
+        Some(point)
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -97,6 +119,64 @@ mod tests {
         let tolerance_sq = par_tol * par_tol;
         let denom_sq = tolerance_sq * 2.0;
         assert!(check_denominator_validity(denom_sq, tolerance_sq));
+    }
+
+    #[test]
+    fn ray_ray_intersection_raw_交差するrayは交点を返す() {
+        use crate::Vector3D;
+        let ray1 = Ray3D::new(
+            Point3D::new(-1.0_f64, 0.0, 0.0),
+            Vector3D::new(1.0, 0.0, 0.0),
+        )
+        .unwrap();
+        let ray2 = Ray3D::new(
+            Point3D::new(0.0, -1.0_f64, 0.0),
+            Vector3D::new(0.0, 1.0, 0.0),
+        )
+        .unwrap();
+
+        let result = ray_ray_intersection_raw(&ray1, &ray2, STANDARD_TEST_TOLERANCE_F64);
+        assert!(result.is_some());
+        let p = result.unwrap();
+        assert!(p.x().abs() < STANDARD_TEST_TOLERANCE_F64);
+        assert!(p.y().abs() < STANDARD_TEST_TOLERANCE_F64);
+    }
+
+    #[test]
+    fn ray_ray_intersection_raw_平行rayはnoneを返す() {
+        use crate::Vector3D;
+        let ray1 = Ray3D::new(
+            Point3D::new(0.0_f64, 0.0, 0.0),
+            Vector3D::new(1.0, 0.0, 0.0),
+        )
+        .unwrap();
+        let ray2 = Ray3D::new(
+            Point3D::new(0.0_f64, 1.0, 0.0),
+            Vector3D::new(1.0, 0.0, 0.0),
+        )
+        .unwrap();
+
+        let result = ray_ray_intersection_raw(&ray1, &ray2, STANDARD_TEST_TOLERANCE_F64);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn ray_ray_intersection_raw_ray範囲外はnoneを返す() {
+        use crate::Vector3D;
+        // 互いに反対方向を向いており、延長線上では交わるが Ray 範囲外
+        let ray1 = Ray3D::new(
+            Point3D::new(1.0_f64, 0.0, 0.0),
+            Vector3D::new(1.0, 0.0, 0.0),
+        )
+        .unwrap();
+        let ray2 = Ray3D::new(
+            Point3D::new(0.0, 1.0_f64, 0.0),
+            Vector3D::new(0.0, 1.0, 0.0),
+        )
+        .unwrap();
+
+        let result = ray_ray_intersection_raw(&ray1, &ray2, STANDARD_TEST_TOLERANCE_F64);
+        assert!(result.is_none());
     }
 
     #[test]

--- a/model/geo_algorithms/src/intersection/common.rs
+++ b/model/geo_algorithms/src/intersection/common.rs
@@ -73,9 +73,7 @@ pub(crate) fn ray_ray_intersection_raw<T: Scalar>(
     ray2: &Ray3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    let line1 = InfiniteLine3D::new(ray1.origin(), ray1.direction_vector())?;
-    let line2 = InfiniteLine3D::new(ray2.origin(), ray2.direction_vector())?;
-    let point = line_line_intersection_raw(&line1, &line2)?;
+    let point = line_line_intersection_raw(&ray1.to_line(), &ray2.to_line())?;
     if ray1.contains_point(&point, tolerance) && ray2.contains_point(&point, tolerance) {
         Some(point)
     } else {
@@ -202,6 +200,27 @@ mod tests {
     }
 
     #[test]
+    fn ray_ray_intersection_raw_スキューrayはnoneを返す() {
+        use crate::Vector3D;
+        // X方向の Ray と、Z=1 平面上で Y方向に進む Ray（非共面）
+        // line_line_intersection_raw は最近接点候補を返し得るが、
+        // 交点は実際には両 Ray 上に乗らないため None になることを確認する。
+        let ray1 = Ray3D::new(
+            Point3D::new(0.0_f64, 0.0, 0.0),
+            Vector3D::new(1.0, 0.0, 0.0),
+        )
+        .unwrap();
+        let ray2 = Ray3D::new(
+            Point3D::new(0.0_f64, 0.0, 1.0),
+            Vector3D::new(0.0, 1.0, 0.0),
+        )
+        .unwrap();
+
+        let result = ray_ray_intersection_raw(&ray1, &ray2, STANDARD_TEST_TOLERANCE_F64);
+        assert!(result.is_none());
+    }
+
+    #[test]
     fn line_line_intersection_raw_交差する直線は交点を返す() {
         // X軸と Y軸が原点で交差
         let line1 = InfiniteLine3D::from_two_points(
@@ -316,6 +335,27 @@ mod tests {
             .unwrap();
         let seg2 = LineSegment3D::new(Point3D::new(0.0_f64, 1.0, 0.0), Point3D::new(1.0, 0.0, 0.0))
             .unwrap();
+
+        let result = segment_segment_intersection_raw(&seg1, &seg2, STANDARD_TEST_TOLERANCE_F64);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn segment_segment_intersection_raw_スキュー線分はnoneを返す() {
+        // Z=0 平面と Z=1 平面に属する非共面な線分
+        // line_line_intersection_raw は最近接点候補を返し得るが、
+        // contains_point フィルタにより両線分上に乗らないため None になることを確認する。
+        use crate::LineSegment3D;
+        let seg1 = LineSegment3D::new(
+            Point3D::new(-1.0_f64, 0.0, 0.0),
+            Point3D::new(1.0, 0.0, 0.0),
+        )
+        .unwrap();
+        let seg2 = LineSegment3D::new(
+            Point3D::new(0.0_f64, -1.0, 1.0),
+            Point3D::new(0.0, 1.0, 1.0),
+        )
+        .unwrap();
 
         let result = segment_segment_intersection_raw(&seg1, &seg2, STANDARD_TEST_TOLERANCE_F64);
         assert!(result.is_none());

--- a/model/geo_algorithms/src/intersection/pair_base.rs
+++ b/model/geo_algorithms/src/intersection/pair_base.rs
@@ -3,9 +3,10 @@
 //! 型ごとの trait実装とは分離し、形状ペア単位の幾何計算を集約する。
 
 use super::common::line_line_intersection_raw;
+use super::common::ray_ray_intersection_raw;
 use crate::{
-    Arc2D, Circle2D, InfiniteLine3D, LineSegment2D, LineSegment3D, Plane3D, Point2D, Point3D,
-    Ray3D, SphericalSurface3D, Triangle3D, Vector3D,
+    Arc2D, Circle2D, InfiniteLine3D, IntersectionResult, LineSegment2D, LineSegment3D, Plane3D,
+    Point2D, Point3D, Ray3D, SphericalSurface3D, Triangle3D, Vector3D,
 };
 use geo_contracts::{
     Arc2DProperties, Circle2DProperties, InfiniteLine3DProperties, LineSegment2DProperties, Scalar,
@@ -569,40 +570,12 @@ pub fn ray3d_ray3d_intersection<T: Scalar>(
     ray1: &Ray3D<T>,
     ray2: &Ray3D<T>,
     tolerance: T,
-) -> Option<Point3D<T>> {
-    let p1 = ray1.origin();
-    let p2 = ray2.origin();
-    let d1 = ray1.direction_vector();
-    let d2 = ray2.direction_vector();
-
-    let r = Vector3D::from_points(&p2, &p1);
-
-    let a = d1.dot(&d1);
-    let b = d1.dot(&d2);
-    let c = d2.dot(&d2);
-    let d = d1.dot(&r);
-    let e = d2.dot(&r);
-
-    let denom = a * c - b * b;
-    if denom.abs() <= tolerance {
-        return None; // 平行
-    }
-
-    let s = (b * e - c * d) / denom;
-    let t = (a * e - b * d) / denom;
-
-    if s < T::ZERO || t < T::ZERO {
-        return None; // Ray 範囲外
-    }
-
-    let point1 = ray1.point_at_parameter(s);
-    let point2 = ray2.point_at_parameter(t);
-
-    if point1.distance_to(&point2) <= tolerance {
-        Some(point1)
-    } else {
-        None
-    }
+) -> IntersectionResult<T> {
+    IntersectionResult::from_option_point(
+        ray_ray_intersection_raw(ray1, ray2, tolerance),
+        false,
+        tolerance,
+    )
 }
 
 pub fn ray3d_line_segment3d_intersection<T: Scalar>(
@@ -1014,11 +987,14 @@ mod tests {
         let ray1 = Ray3D::new(Point3D::new(-1.0, 0.0, 0.0), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
         let ray2 = Ray3D::new(Point3D::new(0.0, -1.0, 0.0), Vector3D::new(0.0, 1.0, 0.0)).unwrap();
 
-        let p = ray3d_ray3d_intersection(&ray1, &ray2, super::STANDARD_TEST_TOLERANCE_F64);
-        assert!(p.is_some());
-        let p = p.unwrap();
-        assert!(p.x().abs() < super::STANDARD_TEST_TOLERANCE_F64);
-        assert!(p.y().abs() < super::STANDARD_TEST_TOLERANCE_F64);
+        let result = ray3d_ray3d_intersection(&ray1, &ray2, super::STANDARD_TEST_TOLERANCE_F64);
+        assert!(result.intersects());
+        if let crate::IntersectionGeometry::Point(p) = result.geometry {
+            assert!(p.x().abs() < super::STANDARD_TEST_TOLERANCE_F64);
+            assert!(p.y().abs() < super::STANDARD_TEST_TOLERANCE_F64);
+        } else {
+            panic!("Expected single point intersection");
+        }
     }
 
     #[test]
@@ -1027,8 +1003,8 @@ mod tests {
         let ray1 = Ray3D::new(Point3D::new(1.0, 0.0, 0.0), Vector3D::new(1.0, 0.0, 0.0)).unwrap();
         let ray2 = Ray3D::new(Point3D::new(0.0, 1.0, 0.0), Vector3D::new(0.0, 1.0, 0.0)).unwrap();
 
-        let p = ray3d_ray3d_intersection(&ray1, &ray2, super::STANDARD_TEST_TOLERANCE_F64);
-        assert!(p.is_none());
+        let result = ray3d_ray3d_intersection(&ray1, &ray2, super::STANDARD_TEST_TOLERANCE_F64);
+        assert!(!result.intersects());
     }
 
     #[test]

--- a/model/geo_algorithms/src/intersection/pair_base.rs
+++ b/model/geo_algorithms/src/intersection/pair_base.rs
@@ -4,6 +4,7 @@
 
 use super::common::line_line_intersection_raw;
 use super::common::ray_ray_intersection_raw;
+use super::common::segment_segment_intersection_raw;
 use crate::{
     Arc2D, Circle2D, InfiniteLine3D, IntersectionResult, LineSegment2D, LineSegment3D, Plane3D,
     Point2D, Point3D, Ray3D, SphericalSurface3D, Triangle3D, Vector3D,
@@ -266,50 +267,12 @@ pub fn line_segment3d_line_segment3d_intersection<T: Scalar>(
     seg1: &LineSegment3D<T>,
     seg2: &LineSegment3D<T>,
     tolerance: T,
-) -> Option<Point3D<T>> {
-    let p1 = seg1.start();
-    let p2 = seg1.end();
-    let p3 = seg2.start();
-    let p4 = seg2.end();
-
-    let d1 = Vector3D::from_points(&p1, &p2);
-    let d2 = Vector3D::from_points(&p3, &p4);
-    let r = Vector3D::from_points(&p3, &p1);
-
-    let a = d1.dot(&d1);
-    let b = d1.dot(&d2);
-    let c = d2.dot(&d2);
-    let d = d1.dot(&r);
-    let e = d2.dot(&r);
-
-    let denom = a * c - b * b;
-    if denom.abs() < T::EPSILON {
-        return None;
-    }
-
-    let s = (b * e - c * d) / denom;
-    let t = (a * e - b * d) / denom;
-
-    if s >= T::ZERO && s <= T::ONE && t >= T::ZERO && t <= T::ONE {
-        let point1 = Point3D::new(
-            p1.x() + s * d1.x(),
-            p1.y() + s * d1.y(),
-            p1.z() + s * d1.z(),
-        );
-        let point2 = Point3D::new(
-            p3.x() + t * d2.x(),
-            p3.y() + t * d2.y(),
-            p3.z() + t * d2.z(),
-        );
-
-        if point1.distance_to(&point2) <= tolerance {
-            Some(point1)
-        } else {
-            None
-        }
-    } else {
-        None
-    }
+) -> IntersectionResult<T> {
+    IntersectionResult::from_option_point(
+        segment_segment_intersection_raw(seg1, seg2, tolerance),
+        false,
+        tolerance,
+    )
 }
 
 pub fn infinite_line3d_infinite_line3d_intersection<T: Scalar>(
@@ -814,12 +777,12 @@ mod tests {
         let seg2 =
             LineSegment3D::new(Point3D::new(0.0, 1.0, 0.0), Point3D::new(1.0, 0.0, 0.0)).unwrap();
 
-        let p = line_segment3d_line_segment3d_intersection(
+        let result = line_segment3d_line_segment3d_intersection(
             &seg1,
             &seg2,
             super::STANDARD_TEST_TOLERANCE_F64,
         );
-        assert!(p.is_some());
+        assert!(result.intersects());
     }
 
     #[test]

--- a/model/geo_algorithms/src/intersection/primitive_3d/linear_family.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d/linear_family.rs
@@ -1,4 +1,6 @@
-use super::super::common::{line_line_intersection_raw, ray_ray_intersection_raw};
+use super::super::common::{
+    line_line_intersection_raw, ray_ray_intersection_raw, segment_segment_intersection_raw,
+};
 use super::planar_and_mesh_family::{
     plane3d_line_segment3d_intersection, plane3d_ray3d_intersection,
 };
@@ -212,49 +214,7 @@ fn line_segment3d_line_segment3d_intersection_raw<T: Scalar>(
     seg_b: &LineSegment3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    let p1 = seg_a.start();
-    let p2 = seg_a.end();
-    let p3 = seg_b.start();
-    let p4 = seg_b.end();
-
-    let d1 = Vector3D::from_points(&p1, &p2);
-    let d2 = Vector3D::from_points(&p3, &p4);
-    let r = Vector3D::from_points(&p3, &p1);
-
-    let a = d1.dot(&d1);
-    let b = d1.dot(&d2);
-    let c = d2.dot(&d2);
-    let d = d1.dot(&r);
-    let e = d2.dot(&r);
-
-    let denom = a * c - b * b;
-    if denom.abs() <= tolerance {
-        return None;
-    }
-
-    let s = (b * e - c * d) / denom;
-    let t = (a * e - b * d) / denom;
-
-    if s >= T::ZERO && s <= T::ONE && t >= T::ZERO && t <= T::ONE {
-        let point1 = Point3D::new(
-            p1.x() + s * d1.x(),
-            p1.y() + s * d1.y(),
-            p1.z() + s * d1.z(),
-        );
-        let point2 = Point3D::new(
-            p3.x() + t * d2.x(),
-            p3.y() + t * d2.y(),
-            p3.z() + t * d2.z(),
-        );
-
-        if point1.distance_to(&point2) <= tolerance {
-            Some(point1)
-        } else {
-            None
-        }
-    } else {
-        None
-    }
+    segment_segment_intersection_raw(seg_a, seg_b, tolerance)
 }
 
 pub fn line_segment3d_line_segment3d_intersection<T: Scalar>(

--- a/model/geo_algorithms/src/intersection/primitive_3d/linear_family.rs
+++ b/model/geo_algorithms/src/intersection/primitive_3d/linear_family.rs
@@ -1,4 +1,4 @@
-use super::super::common::line_line_intersection_raw;
+use super::super::common::{line_line_intersection_raw, ray_ray_intersection_raw};
 use super::planar_and_mesh_family::{
     plane3d_line_segment3d_intersection, plane3d_ray3d_intersection,
 };
@@ -76,36 +76,7 @@ fn ray3d_ray3d_intersection_raw<T: Scalar>(
     ray_b: &Ray3D<T>,
     tolerance: T,
 ) -> Option<Point3D<T>> {
-    let origin_a = ray_a.origin();
-    let origin_b = ray_b.origin();
-    let direction_a = ray_a.direction_vector();
-    let direction_b = ray_b.direction_vector();
-    let origin_offset = Vector3D::from_points(&origin_b, &origin_a);
-
-    let a = direction_a.dot(&direction_a);
-    let b = direction_a.dot(&direction_b);
-    let c = direction_b.dot(&direction_b);
-    let d = direction_a.dot(&origin_offset);
-    let e = direction_b.dot(&origin_offset);
-
-    let denominator = a * c - b * b;
-    if denominator.abs() <= tolerance {
-        return None;
-    }
-
-    let s = (b * e - c * d) / denominator;
-    let t = (a * e - b * d) / denominator;
-    if s < T::ZERO || t < T::ZERO {
-        return None;
-    }
-
-    let point_a = ray_a.point_at_parameter(s);
-    let point_b = ray_b.point_at_parameter(t);
-    if point_a.distance_to(&point_b) <= tolerance {
-        Some(point_a)
-    } else {
-        None
-    }
+    ray_ray_intersection_raw(ray_a, ray_b, tolerance)
 }
 
 pub fn ray3d_ray3d_intersection<T: Scalar>(

--- a/model/geo_primitives/src/direction_3d.rs
+++ b/model/geo_primitives/src/direction_3d.rs
@@ -35,6 +35,15 @@ impl<T: Scalar> Direction3D<T> {
         }
     }
 
+    /// 正規化済みベクトルから方向を作成（再正規化なし）
+    ///
+    /// 呼び出し元が `vector` の長さが 1 であることを保証した場合のみ使用すること。
+    /// `Ray3D` や `InfiniteLine3D` の内部フィールド経由など、
+    /// 既に正規化が保証された文脈専用。
+    pub(crate) fn from_normalized(vector: Vector3D<T>) -> Self {
+        Self { vector }
+    }
+
     /// X、Y、Z成分から方向を作成
     pub fn new(x: T, y: T, z: T) -> Option<Self> {
         Self::from_vector(Vector3D::new(x, y, z))

--- a/model/geo_primitives/src/infinite_line_3d.rs
+++ b/model/geo_primitives/src/infinite_line_3d.rs
@@ -51,6 +51,14 @@ impl<T: Scalar> InfiniteLine3D<T> {
         })
     }
 
+    /// 正規化済み方向ベクトルから無限直線を作成（再正規化なし）
+    ///
+    /// `Direction3D` は既に正規化済みであることが型で保証されるため、
+    /// `new` と異なり sqrt を呼ばない。
+    pub fn from_direction(point: Point3D<T>, direction: Direction3D<T>) -> Self {
+        Self { point, direction }
+    }
+
     /// 2点から無限直線を作成
     pub fn from_two_points(p1: Point3D<T>, p2: Point3D<T>) -> Option<Self> {
         let direction = Vector3D::from_points(&p1, &p2);

--- a/model/geo_primitives/src/ray_3d.rs
+++ b/model/geo_primitives/src/ray_3d.rs
@@ -4,7 +4,7 @@
 //! パラメータ t は 0 ≤ t < ∞ の範囲で定義されます。
 //! Core Traits実装（Constructor, Properties, Measure）も含む
 
-use crate::{Direction3D, Point3D, Vector3D};
+use crate::{Direction3D, InfiniteLine3D, Point3D, Vector3D};
 use geo_contracts::{
     AngleBetween, CrossDistance, DirectionalRelation, ParallelRelation, PointsTowards,
     Ray3DConstructor, Ray3DContainment, Ray3DDistance, Ray3DEvaluation, Ray3DProjection,
@@ -75,6 +75,14 @@ impl<T: Scalar> Ray3D<T> {
     /// 内部方向ベクトルを取得（Vector3D型）
     pub fn direction_vector(&self) -> Vector3D<T> {
         self.direction
+    }
+
+    /// この Ray が乗る無限直線を返す（再正規化なし）
+    ///
+    /// `Ray3D` は内部で正規化済みの方向ベクトルを保持しているため、
+    /// `InfiniteLine3D::new` が行う再正規化（sqrt）を回避できる。
+    pub fn to_line(&self) -> InfiniteLine3D<T> {
+        InfiniteLine3D::from_direction(self.origin, Direction3D::from_normalized(self.direction))
     }
 
     /// パラメータ t での点を計算


### PR DESCRIPTION
## このPRに含む単位

- A-1: Phase 1〜3 の共通関数導入と IntersectionResult 移行（3コミット一括）

## このPRに含めない単位

- Phase 4（設計検討・別 Issue）

---

## 変更概要

Issue #709「同形状交差計算の段階的共通化」の Phase 1〜3 実装。

`model/geo_algorithms/src/intersection/common.rs` に共通ヘルパー関数群を集約し、
`pair_base.rs` / `primitive_3d/linear_family.rs` の重複実装を削除。
合わせて `Option<Point3D<T>>` 返却だった関数を `IntersectionResult<T>` に移行。

---

## 変更詳細

### Phase 1: `check_denominator_validity` 導入

- `common.rs` に `check_denominator_validity<T: Scalar>(denom_sq, tolerance_sq) -> bool` を追加
- 外積ベース無次元化（`|d1 × d2|²` を `default_parallel_cross_error_tolerance()²` と比較）で平行判定を一箇所に統一
- `line_line_intersection_raw` を `check_denominator_validity` 経由に更新
- テスト4ケース追加（ゼロ・極小・同値・十分な分母）

### Phase 2: `ray_ray_intersection_raw` 共通化

- `common.rs` に `ray_ray_intersection_raw` を追加（`InfiniteLine3D` 経由 + `contains_point` で範囲チェック）
- `primitive_3d/linear_family.rs` の内部実装を委譲パターンに置き換え
- `pair_base.rs` の `ray3d_ray3d_intersection` を `Option<Point3D<T>>` → `IntersectionResult<T>` に移行
- `collision/pair_base.rs` の `.is_some()` → `.intersects()` に修正
- テスト3ケース追加（交差・平行・Ray 範囲外）

### Phase 3: `segment_segment_intersection_raw` 共通化

- `common.rs` に `segment_segment_intersection_raw` を追加（`segment.line()` 経由で外積ベース統一）
- `primitive_3d/linear_family.rs` の内部実装（旧 50 行）を委譲 7 行に置き換え
- `pair_base.rs` の `line_segment3d_line_segment3d_intersection` を `IntersectionResult<T>` に移行（旧実装は `T::EPSILON` 比較で不整合があったため修正）
- `collision/pair_base.rs` の `.is_some()` → `.intersects()` に修正
- テスト3ケース追加（交差・平行・セグメント範囲外）

---

## 品質チェック結果

- `cargo fmt --all -- --check`: ✅ 差分なし
- `cargo clippy --workspace --all-targets -- -D warnings`: ✅ 警告なし
- `cargo test --workspace`: ✅ 全テスト pass（311 → 314 件、+3ケース）
