### PR TITLE
issue #708 [Phase1][A-1] geo_contracts/geo_primitives: BasicIntersection から tolerance 引数を削除

### DIFF
--- a/model/geo_contracts/src/geometry/operations/intersection.rs
+++ b/model/geo_contracts/src/geometry/operations/intersection.rs
@@ -13,13 +13,15 @@ pub trait BasicIntersection<T: Scalar, Other> {
 
     /// 他のオブジェクトとの交点を取得
     ///
+    /// 数値安定性（平行判定・共面判定等）のトレランスは各実装が内部既定値を使用する。
+    /// アプリケーショントレランスが必要な場合は専用 trait を別途用意する。
+    ///
     /// # 引数
     /// * `other` - 交点を計算する相手オブジェクト
-    /// * `tolerance` - 計算精度の許容誤差
     ///
     /// # 戻り値
     /// 交点が存在する場合は `Some(point)`、存在しない場合は `None`
-    fn intersection_with(&self, other: &Other, tolerance: T) -> Option<Self::Point>;
+    fn intersection_with(&self, other: &Other) -> Option<Self::Point>;
 }
 
 /// 複数交点計算トレイト

--- a/model/geo_primitives/src/cylindrical_solid_3d.rs
+++ b/model/geo_primitives/src/cylindrical_solid_3d.rs
@@ -616,7 +616,7 @@ impl<T: Scalar> CylindricalSolid3DProjection<T> for CylindricalSolid3D<T> {
 impl<T: Scalar> BasicIntersection<T, InfiniteLine3D<T>> for CylindricalSolid3D<T> {
     type Point = (T, T, T);
 
-    fn intersection_with(&self, _other: &InfiniteLine3D<T>, _tolerance: T) -> Option<Self::Point> {
+    fn intersection_with(&self, _other: &InfiniteLine3D<T>) -> Option<Self::Point> {
         None
     }
 }

--- a/model/geo_primitives/src/cylindrical_solid_3d_tests.rs
+++ b/model/geo_primitives/src/cylindrical_solid_3d_tests.rs
@@ -295,7 +295,7 @@ mod tests {
         .unwrap();
         let line = InfiniteLine3D::new(Point3D::new(-10.0, 0.0, 5.0), Vector3D::unit_x()).unwrap();
 
-        let intersection = BasicIntersection::intersection_with(&cylindrical_solid, &line, 1e-10);
+        let intersection = BasicIntersection::intersection_with(&cylindrical_solid, &line);
 
         assert!(intersection.is_none());
     }

--- a/model/geo_primitives/src/infinite_line_2d.rs
+++ b/model/geo_primitives/src/infinite_line_2d.rs
@@ -380,7 +380,7 @@ impl<T: Scalar> InfiniteLine2DTransform<T> for InfiniteLine2D<T> {
 impl<T: Scalar> BasicIntersection<T, Self> for InfiniteLine2D<T> {
     type Point = (T, T);
 
-    fn intersection_with(&self, other: &Self, _tolerance: T) -> Option<Self::Point> {
+    fn intersection_with(&self, other: &Self) -> Option<Self::Point> {
         InfiniteLine2D::intersection(self, other).map(|point| (point.x(), point.y()))
     }
 }

--- a/model/geo_primitives/src/infinite_line_3d.rs
+++ b/model/geo_primitives/src/infinite_line_3d.rs
@@ -538,9 +538,7 @@ impl<T: Scalar> CrossDistance<T, Self> for InfiniteLine3D<T> {
 impl<T: Scalar> BasicIntersection<T, Self> for InfiniteLine3D<T> {
     type Point = (T, T, T);
 
-    fn intersection_with(&self, other: &Self, _tolerance: T) -> Option<Self::Point> {
-        // NOTE: この実装は既存挙動維持のため内部の既定トレランス判定を使用する。
-        // `_tolerance` の設計見直しは別 Issue で扱う。
+    fn intersection_with(&self, other: &Self) -> Option<Self::Point> {
         if self.is_parallel_to(other) {
             return None;
         }
@@ -565,9 +563,7 @@ impl<T: Scalar> BasicIntersection<T, Self> for InfiniteLine3D<T> {
 impl<T: Scalar> BasicIntersection<T, Plane3D<T>> for InfiniteLine3D<T> {
     type Point = (T, T, T);
 
-    fn intersection_with(&self, other: &Plane3D<T>, _tolerance: T) -> Option<Self::Point> {
-        // NOTE: この実装は既存挙動維持のため内部の既定トレランス判定を使用する。
-        // `_tolerance` の設計見直しは別 Issue で扱う。
+    fn intersection_with(&self, other: &Plane3D<T>) -> Option<Self::Point> {
         let plane_point = other.origin();
         let plane_normal = other.normal().as_vector();
         let line_dir = Vector3D::new(self.direction.x(), self.direction.y(), self.direction.z());

--- a/model/geo_primitives/src/plane_3d.rs
+++ b/model/geo_primitives/src/plane_3d.rs
@@ -484,7 +484,7 @@ impl<T: Scalar + From<f64>> Plane3DTransform<T> for Plane3D<T> {
 impl<T: Scalar + From<f64>> BasicIntersection<T, Self> for Plane3D<T> {
     type Point = ((T, T, T), (T, T, T));
 
-    fn intersection_with(&self, other: &Self, _tolerance: T) -> Option<Self::Point> {
+    fn intersection_with(&self, other: &Self) -> Option<Self::Point> {
         let n1 = self.normal.as_vector();
         let n2 = other.normal.as_vector();
 

--- a/model/geo_primitives/src/ray_2d.rs
+++ b/model/geo_primitives/src/ray_2d.rs
@@ -432,7 +432,7 @@ impl<T: Scalar> Ray2DTransform<T> for Ray2D<T> {
 impl<T: Scalar> BasicIntersection<T, Self> for Ray2D<T> {
     type Point = (T, T);
 
-    fn intersection_with(&self, other: &Self, _tolerance: T) -> Option<Self::Point> {
+    fn intersection_with(&self, other: &Self) -> Option<Self::Point> {
         let this_dir = Vector2D::new(self.direction_internal().x(), self.direction_internal().y());
         let other_dir = Vector2D::new(
             other.direction_internal().x(),


### PR DESCRIPTION
## このPRに含む単位 / 含めない単位

- **含む**: A-1（`BasicIntersection::intersection_with` の `tolerance` 引数削除）
- **含めない**: 数値安定性トレランスの各実装への伝播修正（別途検討）、NURBS 向け `IntersectionWithTolerance` trait 設計（別 Issue）

Phase と PR 系列の関係: Phase1 = A-1 のみ（単一 PR で完結）

---

## 変更概要

Issue #708 で問題提起された `BasicIntersection::intersection_with` の `tolerance` 引数混在問題を、**案A（引数削除）** で解消する。

### 背景

全 6 実装が `_tolerance`（未使用）であり、trait 定義と実装挙動が不整合だった。

- 数値安定性トレランス（平行判定・共面判定）は各実装が内部既定値で処理する
- アプリケーショントレランスが必要な場合は専用 trait を別途設計する方針

### 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `geo_contracts/src/geometry/operations/intersection.rs` | `intersection_with` シグネチャから `tolerance: T` を削除。数値安定性は実装内部責務である旨を doc に明記 |
| `geo_primitives/src/infinite_line_2d.rs` | `_tolerance: T` 引数を削除 |
| `geo_primitives/src/infinite_line_3d.rs` (×2) | `_tolerance: T` 引数を削除（NOTE コメントも除去） |
| `geo_primitives/src/plane_3d.rs` | `_tolerance: T` 引数を削除 |
| `geo_primitives/src/ray_2d.rs` | `_tolerance: T` 引数を削除 |
| `geo_primitives/src/cylindrical_solid_3d.rs` | `_tolerance: T` 引数を削除 |
| `geo_primitives/src/cylindrical_solid_3d_tests.rs` | 呼び出し側の `1e-10` 引数を削除 |

### 検証

- `cargo build --workspace`: ✅
- `cargo test --workspace`: ✅ 全 PASSED
- `cargo clippy --workspace --all-targets -- -D warnings`: ✅ 警告なし
- `cargo fmt --all -- --check`: ✅ 差分なし