### PR TITLE
issue #704 [Phase1][refactor-1] LinearSolver: &[Vec<T>] シグネチャを DynamicMatrix 対応に統一

### DIFF
--- a/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
+++ b/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
@@ -657,7 +657,7 @@ fn solve_linear_2x2<T: Scalar>(
 
 #### Phase A 実装スコープ（2026年4月8日着手）
 
-- 初手の実装は `DynamicMatrix<T>` 単体に限定し、既存 `LinearSolver<T>` trait と `GaussianSolver<T>` / `LUSolver<T>` / `CramerSolver<T>` の受け取り型は変更しない
+- 初手の実装は `DynamicMatrix<T>` 単体に限定し、既存 `LinearSolver<T>` trait と `GaussianSolver<T>` / `LUSolver<T>` / `CramerSolver<T>` の受け取り型は変更しない（**Issue #704 で変更済み。現在は `DynamicMatrix<T>` を直接受け取る**）
 - 内部表現は row-major の `Vec<T>` とし、shape は `rows` と `cols` を明示保持する
 - 初回に入れる API は `new`、`zeros`、`from_rows`、`rows`、`cols`、`shape`、`get`、`set`、`as_slice`、`to_vec2d`、`transpose`、`mul_vector` を基本とする
 - `Vec<Vec<T>>` からの完全移行は Phase C で扱い、Phase A では変換補助と `Vector<T>` 連携までに留める
@@ -674,7 +674,7 @@ fn solve_linear_2x2<T: Scalar>(
 
 - 新規入口として `newton_solve_multivariate` と `newton_solve_multivariate_with_solver` を追加する
 - `system` は `&Vector<T>` を受け取り、`(Vector<T>, DynamicMatrix<T>)` を返す形に統一する
-- 既定の更新ステップは `GaussianSolver<T>` + `DynamicMatrixLinearSolver<T>` adapter を使って解く
+- 既定の更新ステップは `GaussianSolver<T>` + `LinearSolver<T>` を使って解く（`DynamicMatrixLinearSolver<T>` adapter は Issue #704 で廃止済み）
 - solver 差し替えが必要な利用者向けに `..._with_solver` を併設し、`LUSolver<T>` などを注入可能にする
 - 返り値は既存 Newton 系との整合を優先して `Option<Vector<T>>` とし、shape 不整合・特異 Jacobian・非収束は `None` で表す
 - 収束判定は residual norm と step norm の両方を使い、既存 2変数 solver より明示的な多変数収束条件を採る
@@ -685,13 +685,13 @@ fn solve_linear_2x2<T: Scalar>(
 - 既存 solver を `Vec<Vec<T>>` のまま維持するか、`DynamicMatrix<T>` 受け取りへ拡張するかを比較する
 - 多変数 Newton の更新ステップ専用 helper を設けるか、既存 solver を直接使うかを決める
 
-#### Phase C 接続方針（2026年4月8日合意）
+#### Phase C 接続方針（2026年4月8日合意・2026年5月5日 Issue #704 にて更新）
 
-- 初手では既存 `LinearSolver<T>` trait の `Vec<Vec<T>>` 受け取りを維持し、破壊的変更を避ける
-- その代わり、`DynamicMatrix<T>` と `Vector<T>` を既存 solver へ橋渡しする adapter 層を追加し、多変数 Newton 側からは `DynamicMatrix<T>` ベースで呼べる経路を先に整える
-- 将来の新規 generic solver は `DynamicMatrix<T>` ベースで追加し、既存 solver 群とは一定期間共存させる
-- その後、利用実績と API 安定性を見ながら `Vec<Vec<T>>` ベース solver から段階移行する
-- したがって現段階では「既存 solver を変える」のではなく、「DynamicMatrix ベースの新規利用経路を先に正本化する」を優先する
+- ~~初手では既存 `LinearSolver<T>` trait の `Vec<Vec<T>>` 受け取りを維持し、破壊的変更を避ける~~
+- **Issue #704 完了**: `LinearSolver<T>::solve` のシグネチャを `&DynamicMatrix<T>` 直接受け取りに変更し、`DynamicMatrixLinearSolver<T>` adapter と `to_vec2d()` 経由の変換を廃止した
+- 既存 solver（gaussian / lu / cramer）はすべて `DynamicMatrix<T>` を直接受け取るよう更新済み
+- `DynamicMatrixLinearSolver<T>` trait は削除済み。Newton 法内では `LinearSolver<T>` の型境界を直接使用する
+- `to_vec2d()` メソッドは `DynamicMatrix` のテスト用途で引き続き存在するが、solver 経路では不要
 
 #### Phase D: follow-up 実装計画への分割
 
@@ -807,7 +807,7 @@ pub fn newton_solve_multivariate_bounded_with_solver<T, F, S>(
 where
 	T: Scalar,
 	F: Fn(&Vector<T>) -> (Vector<T>, DynamicMatrix<T>),
-	S: DynamicMatrixLinearSolver<T>;
+	S: LinearSolver<T>;  // Issue #704: DynamicMatrixLinearSolver から変更
 ```
 
 #### `MultivariateNewtonBounds<T>` の責務

--- a/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
+++ b/dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md
@@ -786,7 +786,7 @@ pub struct MultivariateNewtonOptions<T: Scalar> {
 
 #### 推奨 API 形状
 
-```rust
+```text
 pub fn newton_solve_multivariate_bounded<T, F>(
 	system: F,
 	initial: Vector<T>,

--- a/foundation/analysis/src/linalg/mod.rs
+++ b/foundation/analysis/src/linalg/mod.rs
@@ -28,8 +28,8 @@ pub mod quaternion_tests;
 pub use matrix::{DynamicMatrix, Matrix2x2, Matrix3x3, Matrix4x4};
 pub use quaternion::{Quaternion, Quaterniond, Quaternionf};
 pub use solver::{
-    CramerSolver, DynamicMatrixLinearSolver, GaussianSolver, LUSolver, LinearSolver,
-    MultivariateNewtonBounds, MultivariateNewtonOptions,
+    CramerSolver, GaussianSolver, LUSolver, LinearSolver, MultivariateNewtonBounds,
+    MultivariateNewtonOptions,
 };
 pub use vector::{Vector, Vector2, Vector3, Vector4};
 

--- a/foundation/analysis/src/linalg/solver/cramer.rs
+++ b/foundation/analysis/src/linalg/solver/cramer.rs
@@ -89,6 +89,20 @@ impl<T: Scalar> CramerSolver<T> {
 impl<T: Scalar> LinearSolver<T> for CramerSolver<T> {
     fn solve(&self, matrix: &DynamicMatrix<T>, rhs: &[T]) -> Result<SolutionInfo<T>, String> {
         let n = matrix.rows();
+        if matrix.cols() != n {
+            return Err(format!(
+                "Cramer's rule requires a square matrix, got {}x{}",
+                n,
+                matrix.cols()
+            ));
+        }
+        if rhs.len() != n {
+            return Err(format!(
+                "RHS dimension mismatch: expected {}, got {}",
+                n,
+                rhs.len()
+            ));
+        }
 
         match n {
             2 => {

--- a/foundation/analysis/src/linalg/solver/cramer.rs
+++ b/foundation/analysis/src/linalg/solver/cramer.rs
@@ -4,6 +4,7 @@
 //! 行列式を直接計算して解を求める
 use super::{LinearSolver, SolutionInfo};
 use crate::abstract_types::Scalar;
+use crate::linalg::DynamicMatrix;
 use crate::linalg::{Matrix2x2, Matrix3x3, Vector2, Vector3};
 
 /// Cramerの公式ソルバー
@@ -86,14 +87,18 @@ impl<T: Scalar> CramerSolver<T> {
 }
 
 impl<T: Scalar> LinearSolver<T> for CramerSolver<T> {
-    fn solve(&self, matrix: &[Vec<T>], rhs: &[T]) -> Result<SolutionInfo<T>, String> {
-        let n = matrix.len();
+    fn solve(&self, matrix: &DynamicMatrix<T>, rhs: &[T]) -> Result<SolutionInfo<T>, String> {
+        let n = matrix.rows();
 
         match n {
             2 => {
                 // 2x2の場合
-                let matrix_2x2 =
-                    Matrix2x2::new(matrix[0][0], matrix[0][1], matrix[1][0], matrix[1][1]);
+                let matrix_2x2 = Matrix2x2::new(
+                    matrix.get(0, 0),
+                    matrix.get(0, 1),
+                    matrix.get(1, 0),
+                    matrix.get(1, 1),
+                );
                 let rhs_2x2 = Vector2::new(rhs[0], rhs[1]);
 
                 let solution_vec = self.solve_2x2(&matrix_2x2, &rhs_2x2)?;
@@ -106,15 +111,15 @@ impl<T: Scalar> LinearSolver<T> for CramerSolver<T> {
             3 => {
                 // 3x3の場合
                 let matrix_3x3 = Matrix3x3::new(
-                    matrix[0][0],
-                    matrix[0][1],
-                    matrix[0][2],
-                    matrix[1][0],
-                    matrix[1][1],
-                    matrix[1][2],
-                    matrix[2][0],
-                    matrix[2][1],
-                    matrix[2][2],
+                    matrix.get(0, 0),
+                    matrix.get(0, 1),
+                    matrix.get(0, 2),
+                    matrix.get(1, 0),
+                    matrix.get(1, 1),
+                    matrix.get(1, 2),
+                    matrix.get(2, 0),
+                    matrix.get(2, 1),
+                    matrix.get(2, 2),
                 );
                 let rhs_3x3 = Vector3::new(rhs[0], rhs[1], rhs[2]);
 
@@ -132,15 +137,15 @@ impl<T: Scalar> LinearSolver<T> for CramerSolver<T> {
 
 impl<T: Scalar> CramerSolver<T> {
     /// 残差を計算
-    fn calculate_residual(&self, matrix: &[Vec<T>], rhs: &[T], solution: &[T]) -> T {
-        let n = matrix.len();
+    fn calculate_residual(&self, matrix: &DynamicMatrix<T>, rhs: &[T], solution: &[T]) -> T {
+        let n = matrix.rows();
         let mut residual = T::ZERO;
 
+        #[allow(clippy::needless_range_loop)]
         for i in 0..n {
             let mut sum = T::ZERO;
-            #[allow(clippy::needless_range_loop)]
             for j in 0..n {
-                sum += matrix[i][j] * solution[j];
+                sum += matrix.get(i, j) * solution[j];
             }
             let diff = sum - rhs[i];
             residual += diff * diff;

--- a/foundation/analysis/src/linalg/solver/cramer_tests.rs
+++ b/foundation/analysis/src/linalg/solver/cramer_tests.rs
@@ -1,5 +1,6 @@
 use super::{CramerSolver, LinearSolver};
 use crate::consts::test_constants::{SOLVER_TOLERANCE_F32, SOLVER_TOLERANCE_F64, TOLERANCE_F64};
+use crate::linalg::DynamicMatrix;
 
 #[cfg(test)]
 mod tests {
@@ -7,7 +8,7 @@ mod tests {
 
     #[test]
     fn test_cramer_2x2() {
-        let matrix = vec![vec![2.0, 1.0], vec![1.0, 3.0]];
+        let matrix = DynamicMatrix::<f64>::from_rows(vec![vec![2.0, 1.0], vec![1.0, 3.0]]).unwrap();
         let rhs = vec![5.0, 6.0];
 
         let solver = CramerSolver::<f64>::new(SOLVER_TOLERANCE_F64);
@@ -20,11 +21,12 @@ mod tests {
 
     #[test]
     fn test_cramer_3x3() {
-        let matrix = vec![
+        let matrix = DynamicMatrix::<f64>::from_rows(vec![
             vec![2.0, 1.0, -1.0],
             vec![-3.0, -1.0, 2.0],
             vec![-2.0, 1.0, 2.0],
-        ];
+        ])
+        .unwrap();
         let rhs = vec![8.0, -11.0, -3.0];
 
         let solver = CramerSolver::<f64>::new(SOLVER_TOLERANCE_F64);
@@ -37,12 +39,13 @@ mod tests {
 
     #[test]
     fn test_cramer_4x4_unsupported() {
-        let matrix = vec![
+        let matrix = DynamicMatrix::<f64>::from_rows(vec![
             vec![1.0, 0.0, 0.0, 0.0],
             vec![0.0, 1.0, 0.0, 0.0],
             vec![0.0, 0.0, 1.0, 0.0],
             vec![0.0, 0.0, 0.0, 1.0],
-        ];
+        ])
+        .unwrap();
         let rhs = vec![1.0, 2.0, 3.0, 4.0];
 
         let solver = CramerSolver::<f64>::new(SOLVER_TOLERANCE_F64);
@@ -54,7 +57,9 @@ mod tests {
 
     #[test]
     fn test_cramer_2x2_f32() {
-        let matrix = vec![vec![2.0_f32, 1.0_f32], vec![1.0_f32, 3.0_f32]];
+        let matrix =
+            DynamicMatrix::<f32>::from_rows(vec![vec![2.0_f32, 1.0_f32], vec![1.0_f32, 3.0_f32]])
+                .unwrap();
         let rhs = vec![5.0_f32, 6.0_f32];
 
         let solver = CramerSolver::<f32>::new(SOLVER_TOLERANCE_F32);

--- a/foundation/analysis/src/linalg/solver/gaussian.rs
+++ b/foundation/analysis/src/linalg/solver/gaussian.rs
@@ -4,6 +4,7 @@
 //! 数値安定性を考慮した一般的な直接法
 use super::{LinearSolver, SolutionInfo};
 use crate::abstract_types::Scalar;
+use crate::linalg::DynamicMatrix;
 
 /// ガウス消去法ソルバー
 pub struct GaussianSolver<T: Scalar> {
@@ -27,12 +28,13 @@ impl<T: Scalar> GaussianSolver<T> {
     }
 
     /// 拡張行列を作成
-    fn create_augmented_matrix(&self, matrix: &[Vec<T>], rhs: &[T]) -> Vec<Vec<T>> {
-        let n = matrix.len();
+    fn create_augmented_matrix(&self, matrix: &DynamicMatrix<T>, rhs: &[T]) -> Vec<Vec<T>> {
+        let n = matrix.rows();
         let mut aug_matrix = Vec::with_capacity(n);
 
+        #[allow(clippy::needless_range_loop)]
         for i in 0..n {
-            let mut row = matrix[i].clone();
+            let mut row: Vec<T> = (0..n).map(|j| matrix.get(i, j)).collect();
             row.push(rhs[i]);
             aug_matrix.push(row);
         }
@@ -117,15 +119,15 @@ impl<T: Scalar> GaussianSolver<T> {
     }
 
     /// 残差を計算
-    fn calculate_residual(&self, matrix: &[Vec<T>], rhs: &[T], solution: &[T]) -> T {
-        let n = matrix.len();
+    fn calculate_residual(&self, matrix: &DynamicMatrix<T>, rhs: &[T], solution: &[T]) -> T {
+        let n = matrix.rows();
         let mut residual = T::ZERO;
 
+        #[allow(clippy::needless_range_loop)]
         for i in 0..n {
             let mut sum = T::ZERO;
-            #[allow(clippy::needless_range_loop)]
             for j in 0..n {
-                sum += matrix[i][j] * solution[j];
+                sum += matrix.get(i, j) * solution[j];
             }
             let diff = sum - rhs[i];
             residual += diff * diff;
@@ -136,18 +138,12 @@ impl<T: Scalar> GaussianSolver<T> {
 }
 
 impl<T: Scalar> LinearSolver<T> for GaussianSolver<T> {
-    fn solve(&self, matrix: &[Vec<T>], rhs: &[T]) -> Result<SolutionInfo<T>, String> {
-        let n = matrix.len();
+    fn solve(&self, matrix: &DynamicMatrix<T>, rhs: &[T]) -> Result<SolutionInfo<T>, String> {
+        let n = matrix.rows();
 
         // 入力検証
-        if n == 0 || matrix[0].len() != n || rhs.len() != n {
+        if n == 0 || matrix.cols() != n || rhs.len() != n {
             return Err("Invalid matrix dimensions".to_string());
-        }
-
-        for row in matrix {
-            if row.len() != n {
-                return Err("Matrix must be square".to_string());
-            }
         }
 
         // 拡張行列を作成

--- a/foundation/analysis/src/linalg/solver/gaussian_tests.rs
+++ b/foundation/analysis/src/linalg/solver/gaussian_tests.rs
@@ -1,5 +1,6 @@
 use super::{GaussianSolver, LinearSolver};
 use crate::consts::test_constants::{SOLVER_TOLERANCE_F32, SOLVER_TOLERANCE_F64, TOLERANCE_F64};
+use crate::linalg::DynamicMatrix;
 
 #[cfg(test)]
 mod tests {
@@ -7,7 +8,7 @@ mod tests {
 
     #[test]
     fn test_gaussian_2x2() {
-        let matrix = vec![vec![2.0, 1.0], vec![1.0, 3.0]];
+        let matrix = DynamicMatrix::<f64>::from_rows(vec![vec![2.0, 1.0], vec![1.0, 3.0]]).unwrap();
         let rhs = vec![5.0, 6.0];
 
         let solver = GaussianSolver::<f64>::new(SOLVER_TOLERANCE_F64);
@@ -20,11 +21,12 @@ mod tests {
 
     #[test]
     fn test_gaussian_3x3() {
-        let matrix = vec![
+        let matrix = DynamicMatrix::<f64>::from_rows(vec![
             vec![2.0, 1.0, -1.0],
             vec![-3.0, -1.0, 2.0],
             vec![-2.0, 1.0, 2.0],
-        ];
+        ])
+        .unwrap();
         let rhs = vec![8.0, -11.0, -3.0];
 
         let solver = GaussianSolver::<f64>::new(SOLVER_TOLERANCE_F64);
@@ -37,7 +39,7 @@ mod tests {
 
     #[test]
     fn test_gaussian_singular_matrix() {
-        let matrix = vec![vec![1.0, 2.0], vec![2.0, 4.0]];
+        let matrix = DynamicMatrix::<f64>::from_rows(vec![vec![1.0, 2.0], vec![2.0, 4.0]]).unwrap();
         let rhs = vec![3.0, 6.0];
 
         let solver = GaussianSolver::<f64>::new(SOLVER_TOLERANCE_F64);
@@ -46,7 +48,8 @@ mod tests {
 
     #[test]
     fn test_gaussian_without_pivoting() {
-        let matrix = vec![vec![0.001, 1.0], vec![2.0, 1.0]];
+        let matrix =
+            DynamicMatrix::<f64>::from_rows(vec![vec![0.001, 1.0], vec![2.0, 1.0]]).unwrap();
         let rhs = vec![1.0, 3.0];
 
         let solver = GaussianSolver::<f64>::new(SOLVER_TOLERANCE_F64).with_pivoting(false);
@@ -57,7 +60,9 @@ mod tests {
 
     #[test]
     fn test_gaussian_2x2_f32() {
-        let matrix = vec![vec![2.0_f32, 1.0_f32], vec![1.0_f32, 3.0_f32]];
+        let matrix =
+            DynamicMatrix::<f32>::from_rows(vec![vec![2.0_f32, 1.0_f32], vec![1.0_f32, 3.0_f32]])
+                .unwrap();
         let rhs = vec![5.0_f32, 6.0_f32];
 
         let solver = GaussianSolver::<f32>::new(SOLVER_TOLERANCE_F32);

--- a/foundation/analysis/src/linalg/solver/lu.rs
+++ b/foundation/analysis/src/linalg/solver/lu.rs
@@ -4,6 +4,7 @@
 //! 部分ピボット選択付きで数値安定性を確保
 use super::{LinearSolver, SolutionInfo};
 use crate::abstract_types::Scalar;
+use crate::linalg::DynamicMatrix;
 
 /// LU分解ソルバー
 pub struct LUSolver<T: Scalar> {
@@ -35,22 +36,18 @@ impl<T: Scalar> LUSolver<T> {
     }
 
     /// LU分解を実行（Doolittle法）
-    pub fn decompose(&self, matrix: &[Vec<T>]) -> Result<LUDecomposition<T>, String> {
-        let n = matrix.len();
+    pub fn decompose(&self, matrix: &DynamicMatrix<T>) -> Result<LUDecomposition<T>, String> {
+        let n = matrix.rows();
 
         // 入力検証
-        if n == 0 || matrix[0].len() != n {
+        if n == 0 || matrix.cols() != n {
             return Err("Matrix must be square".to_string());
         }
 
-        for row in matrix {
-            if row.len() != n {
-                return Err("Matrix must be square".to_string());
-            }
-        }
-
         // LU行列を初期化（元の行列をコピー）
-        let mut lu_matrix = matrix.to_vec();
+        let mut lu_matrix: Vec<Vec<T>> = (0..n)
+            .map(|i| (0..n).map(|j| matrix.get(i, j)).collect())
+            .collect();
         let mut permutation: Vec<usize> = (0..n).collect();
         let mut determinant_sign = 1i32;
 
@@ -168,15 +165,15 @@ impl<T: Scalar> LUSolver<T> {
     }
 
     /// 残差を計算
-    fn calculate_residual(&self, matrix: &[Vec<T>], rhs: &[T], solution: &[T]) -> T {
-        let n = matrix.len();
+    fn calculate_residual(&self, matrix: &DynamicMatrix<T>, rhs: &[T], solution: &[T]) -> T {
+        let n = matrix.rows();
         let mut residual = T::ZERO;
 
+        #[allow(clippy::needless_range_loop)]
         for i in 0..n {
             let mut sum = T::ZERO;
-            #[allow(clippy::needless_range_loop)]
             for j in 0..n {
-                sum += matrix[i][j] * solution[j];
+                sum += matrix.get(i, j) * solution[j];
             }
             let diff = sum - rhs[i];
             residual += diff * diff;
@@ -187,7 +184,7 @@ impl<T: Scalar> LUSolver<T> {
 }
 
 impl<T: Scalar> LinearSolver<T> for LUSolver<T> {
-    fn solve(&self, matrix: &[Vec<T>], rhs: &[T]) -> Result<SolutionInfo<T>, String> {
+    fn solve(&self, matrix: &DynamicMatrix<T>, rhs: &[T]) -> Result<SolutionInfo<T>, String> {
         // LU分解を実行
         let lu_decomp = self.decompose(matrix)?;
 

--- a/foundation/analysis/src/linalg/solver/lu_tests.rs
+++ b/foundation/analysis/src/linalg/solver/lu_tests.rs
@@ -1,5 +1,6 @@
 use super::{LUSolver, LinearSolver};
 use crate::consts::test_constants::{SOLVER_TOLERANCE_F32, SOLVER_TOLERANCE_F64, TOLERANCE_F64};
+use crate::linalg::DynamicMatrix;
 
 #[cfg(test)]
 mod tests {
@@ -7,14 +8,14 @@ mod tests {
 
     #[test]
     fn test_lu_decomposition_2x2() {
-        let matrix = vec![vec![2.0, 1.0], vec![1.0, 3.0]];
+        let matrix = DynamicMatrix::<f64>::from_rows(vec![vec![2.0, 1.0], vec![1.0, 3.0]]).unwrap();
         let solver = LUSolver::<f64>::new(SOLVER_TOLERANCE_F64);
 
         let decomp = solver.decompose(&matrix).unwrap();
 
-        let n = matrix.len();
+        let n = matrix.rows();
         for i in 0..n {
-            for (j, _) in matrix.iter().enumerate().take(n) {
+            for j in 0..matrix.cols() {
                 let mut reconstructed = 0.0;
                 for k in 0..n {
                     let l_ik = if i > k {
@@ -27,7 +28,7 @@ mod tests {
                     let u_kj = if k <= j { decomp.lu_matrix[k][j] } else { 0.0 };
                     reconstructed += l_ik * u_kj;
                 }
-                let original = matrix[decomp.permutation[i]][j];
+                let original = matrix.get(decomp.permutation[i], j);
                 assert!((reconstructed - original).abs() < TOLERANCE_F64);
             }
         }
@@ -35,7 +36,7 @@ mod tests {
 
     #[test]
     fn test_lu_solver_2x2() {
-        let matrix = vec![vec![2.0, 1.0], vec![1.0, 3.0]];
+        let matrix = DynamicMatrix::<f64>::from_rows(vec![vec![2.0, 1.0], vec![1.0, 3.0]]).unwrap();
         let rhs = vec![5.0, 6.0];
         let solver = LUSolver::<f64>::new(SOLVER_TOLERANCE_F64);
 
@@ -47,11 +48,12 @@ mod tests {
 
     #[test]
     fn test_lu_solver_3x3() {
-        let matrix = vec![
+        let matrix = DynamicMatrix::<f64>::from_rows(vec![
             vec![2.0, 1.0, -1.0],
             vec![-3.0, -1.0, 2.0],
             vec![-2.0, 1.0, 2.0],
-        ];
+        ])
+        .unwrap();
         let rhs = vec![8.0, -11.0, -3.0];
         let solver = LUSolver::<f64>::new(SOLVER_TOLERANCE_F64);
 
@@ -64,7 +66,7 @@ mod tests {
 
     #[test]
     fn test_lu_determinant() {
-        let matrix = vec![vec![2.0, 1.0], vec![1.0, 3.0]];
+        let matrix = DynamicMatrix::<f64>::from_rows(vec![vec![2.0, 1.0], vec![1.0, 3.0]]).unwrap();
         let solver = LUSolver::<f64>::new(SOLVER_TOLERANCE_F64);
 
         let decomp = solver.decompose(&matrix).unwrap();
@@ -75,14 +77,16 @@ mod tests {
 
     #[test]
     fn test_lu_singular_matrix() {
-        let matrix = vec![vec![1.0, 2.0], vec![2.0, 4.0]];
+        let matrix = DynamicMatrix::<f64>::from_rows(vec![vec![1.0, 2.0], vec![2.0, 4.0]]).unwrap();
         let solver = LUSolver::<f64>::new(SOLVER_TOLERANCE_F64);
         assert!(solver.decompose(&matrix).is_err());
     }
 
     #[test]
     fn test_lu_solver_2x2_f32() {
-        let matrix = vec![vec![2.0_f32, 1.0_f32], vec![1.0_f32, 3.0_f32]];
+        let matrix =
+            DynamicMatrix::<f32>::from_rows(vec![vec![2.0_f32, 1.0_f32], vec![1.0_f32, 3.0_f32]])
+                .unwrap();
         let rhs = vec![5.0_f32, 6.0_f32];
         let solver = LUSolver::<f32>::new(SOLVER_TOLERANCE_F32);
 

--- a/foundation/analysis/src/linalg/solver/mod.rs
+++ b/foundation/analysis/src/linalg/solver/mod.rs
@@ -81,7 +81,6 @@ impl<T: Scalar> SolutionInfo<T> {
 /// ソルバーの共通トレイト
 ///
 /// 数値安定性トレランス（特異性判定など）は各実装の内部責務とする。
-/// アプリケーショントレランスが必要な場合は専用の trait を別途使用すること。
 pub trait LinearSolver<T: Scalar> {
     /// 連立方程式 Ax = b を解く
     fn solve(&self, matrix: &DynamicMatrix<T>, rhs: &[T]) -> Result<SolutionInfo<T>, String>;

--- a/foundation/analysis/src/linalg/solver/mod.rs
+++ b/foundation/analysis/src/linalg/solver/mod.rs
@@ -46,7 +46,7 @@ pub use gaussian::GaussianSolver;
 pub use lu::LUSolver;
 
 use crate::abstract_types::Scalar;
-use crate::linalg::{DynamicMatrix, Vector};
+use crate::linalg::DynamicMatrix;
 
 /// 連立方程式の解法結果
 #[derive(Debug, Clone)]
@@ -79,32 +79,10 @@ impl<T: Scalar> SolutionInfo<T> {
 }
 
 /// ソルバーの共通トレイト
+///
+/// 数値安定性トレランス（特異性判定など）は各実装の内部責務とする。
+/// アプリケーショントレランスが必要な場合は専用の trait を別途使用すること。
 pub trait LinearSolver<T: Scalar> {
     /// 連立方程式 Ax = b を解く
-    fn solve(&self, matrix: &[Vec<T>], rhs: &[T]) -> Result<SolutionInfo<T>, String>;
-}
-
-/// DynamicMatrix ベースの入力を既存 solver へ橋渡しする拡張 trait
-pub trait DynamicMatrixLinearSolver<T: Scalar>: LinearSolver<T> {
-    /// `DynamicMatrix<T>` と `Vector<T>` を受けて既存 solver を実行する
-    fn solve_dynamic(
-        &self,
-        matrix: &DynamicMatrix<T>,
-        rhs: &Vector<T>,
-    ) -> Result<SolutionInfo<T>, String> {
-        if matrix.rows() != matrix.cols() {
-            return Err("Matrix must be square".to_string());
-        }
-
-        if rhs.len() != matrix.rows() {
-            return Err("RHS dimension mismatch".to_string());
-        }
-
-        self.solve(&matrix.to_vec2d(), rhs.data())
-    }
-}
-
-impl<T: Scalar, TLinearSolver> DynamicMatrixLinearSolver<T> for TLinearSolver where
-    TLinearSolver: LinearSolver<T>
-{
+    fn solve(&self, matrix: &DynamicMatrix<T>, rhs: &[T]) -> Result<SolutionInfo<T>, String>;
 }

--- a/foundation/analysis/src/linalg/solver/mod_tests.rs
+++ b/foundation/analysis/src/linalg/solver/mod_tests.rs
@@ -1,7 +1,5 @@
 use crate::consts::test_constants::{SOLVER_TOLERANCE_F64, TOLERANCE_F64};
-use crate::linalg::solver::{
-    CramerSolver, DynamicMatrixLinearSolver, GaussianSolver, LUSolver, LinearSolver,
-};
+use crate::linalg::solver::{CramerSolver, GaussianSolver, LUSolver, LinearSolver};
 use crate::linalg::{DynamicMatrix, Vector};
 
 #[cfg(test)]
@@ -9,19 +7,20 @@ mod tests {
     use super::*;
 
     /// 共通テストデータ
-    fn get_test_2x2() -> (Vec<Vec<f64>>, Vec<f64>, Vec<f64>) {
-        let matrix = vec![vec![2.0, 1.0], vec![1.0, 3.0]];
+    fn get_test_2x2() -> (DynamicMatrix<f64>, Vec<f64>, Vec<f64>) {
+        let matrix = DynamicMatrix::from_rows(vec![vec![2.0, 1.0], vec![1.0, 3.0]]).unwrap();
         let rhs = vec![5.0, 6.0];
         let expected = vec![1.8, 1.4];
         (matrix, rhs, expected)
     }
 
-    fn get_test_3x3() -> (Vec<Vec<f64>>, Vec<f64>, Vec<f64>) {
-        let matrix = vec![
+    fn get_test_3x3() -> (DynamicMatrix<f64>, Vec<f64>, Vec<f64>) {
+        let matrix = DynamicMatrix::from_rows(vec![
             vec![2.0, 1.0, -1.0],
             vec![-3.0, -1.0, 2.0],
             vec![-2.0, 1.0, 2.0],
-        ];
+        ])
+        .unwrap();
         let rhs = vec![8.0, -11.0, -3.0];
         let expected = vec![2.0, 3.0, -1.0];
         (matrix, rhs, expected)
@@ -89,7 +88,7 @@ mod tests {
 
     #[test]
     fn test_singular_matrix() {
-        let matrix = vec![vec![1.0, 2.0], vec![2.0, 4.0]]; // 特異行列
+        let matrix = DynamicMatrix::<f64>::from_rows(vec![vec![1.0, 2.0], vec![2.0, 4.0]]).unwrap();
         let rhs = vec![3.0, 6.0];
 
         let solver = GaussianSolver::new(SOLVER_TOLERANCE_F64);
@@ -112,12 +111,12 @@ mod tests {
     }
 
     #[test]
-    fn test_gaussian_solver_dynamic_matrix_adapter() {
+    fn test_gaussian_solver_with_dynamic_matrix() {
         let matrix = DynamicMatrix::<f64>::from_rows(vec![vec![2.0, 1.0], vec![1.0, 3.0]]).unwrap();
-        let rhs = Vector::new(vec![5.0, 6.0]);
+        let rhs = vec![5.0_f64, 6.0];
         let solver = GaussianSolver::new(SOLVER_TOLERANCE_F64);
 
-        let result = solver.solve_dynamic(&matrix, &rhs).unwrap();
+        let result = solver.solve(&matrix, &rhs).unwrap();
 
         assert!((result.solution[0] - 1.8).abs() < TOLERANCE_F64);
         assert!((result.solution[1] - 1.4).abs() < TOLERANCE_F64);
@@ -125,12 +124,12 @@ mod tests {
     }
 
     #[test]
-    fn test_lu_solver_dynamic_matrix_adapter() {
+    fn test_lu_solver_with_dynamic_matrix() {
         let matrix = DynamicMatrix::<f64>::from_rows(vec![vec![2.0, 1.0], vec![1.0, 3.0]]).unwrap();
-        let rhs = Vector::new(vec![5.0, 6.0]);
+        let rhs = vec![5.0_f64, 6.0];
         let solver = LUSolver::new(SOLVER_TOLERANCE_F64);
 
-        let result = solver.solve_dynamic(&matrix, &rhs).unwrap();
+        let result = solver.solve(&matrix, &rhs).unwrap();
 
         assert!((result.solution[0] - 1.8).abs() < TOLERANCE_F64);
         assert!((result.solution[1] - 1.4).abs() < TOLERANCE_F64);
@@ -138,12 +137,17 @@ mod tests {
     }
 
     #[test]
-    fn test_dynamic_matrix_adapter_rejects_rhs_mismatch() {
+    fn test_solver_rejects_rhs_mismatch() {
         let matrix = DynamicMatrix::<f64>::from_rows(vec![vec![2.0, 1.0], vec![1.0, 3.0]]).unwrap();
-        let rhs = Vector::new(vec![5.0]);
+        let rhs = vec![5.0_f64]; // 長さ不一致
         let solver = GaussianSolver::new(SOLVER_TOLERANCE_F64);
 
-        let error = solver.solve_dynamic(&matrix, &rhs).unwrap_err();
-        assert_eq!(error, "RHS dimension mismatch");
+        assert!(solver.solve(&matrix, &rhs).is_err());
+    }
+
+    // Vector は引き続き他の用途で使用可能
+    #[allow(dead_code)]
+    fn _uses_vector() {
+        let _v = Vector::new(vec![1.0_f64, 2.0]);
     }
 }

--- a/foundation/analysis/src/linalg/solver/mod_tests.rs
+++ b/foundation/analysis/src/linalg/solver/mod_tests.rs
@@ -1,6 +1,6 @@
 use crate::consts::test_constants::{SOLVER_TOLERANCE_F64, TOLERANCE_F64};
 use crate::linalg::solver::{CramerSolver, GaussianSolver, LUSolver, LinearSolver};
-use crate::linalg::{DynamicMatrix, Vector};
+use crate::linalg::DynamicMatrix;
 
 #[cfg(test)]
 mod tests {
@@ -143,11 +143,5 @@ mod tests {
         let solver = GaussianSolver::new(SOLVER_TOLERANCE_F64);
 
         assert!(solver.solve(&matrix, &rhs).is_err());
-    }
-
-    // Vector は引き続き他の用途で使用可能
-    #[allow(dead_code)]
-    fn _uses_vector() {
-        let _v = Vector::new(vec![1.0_f64, 2.0]);
     }
 }

--- a/foundation/analysis/src/linalg/solver/mod_tests.rs
+++ b/foundation/analysis/src/linalg/solver/mod_tests.rs
@@ -111,29 +111,25 @@ mod tests {
     }
 
     #[test]
-    fn test_gaussian_solver_with_dynamic_matrix() {
-        let matrix = DynamicMatrix::<f64>::from_rows(vec![vec![2.0, 1.0], vec![1.0, 3.0]]).unwrap();
-        let rhs = vec![5.0_f64, 6.0];
+    fn test_gaussian_solver_rejects_non_square_matrix() {
+        // 非正方行列（2x3）は Err を返す
+        let matrix =
+            DynamicMatrix::<f64>::from_rows(vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]])
+                .unwrap();
+        let rhs = vec![1.0_f64, 2.0];
         let solver = GaussianSolver::new(SOLVER_TOLERANCE_F64);
 
-        let result = solver.solve(&matrix, &rhs).unwrap();
-
-        assert!((result.solution[0] - 1.8).abs() < TOLERANCE_F64);
-        assert!((result.solution[1] - 1.4).abs() < TOLERANCE_F64);
-        assert!(result.converged);
+        assert!(solver.solve(&matrix, &rhs).is_err());
     }
 
     #[test]
-    fn test_lu_solver_with_dynamic_matrix() {
+    fn test_lu_solver_rejects_rhs_mismatch() {
+        // rhs 長さ不一致は Err を返す
         let matrix = DynamicMatrix::<f64>::from_rows(vec![vec![2.0, 1.0], vec![1.0, 3.0]]).unwrap();
-        let rhs = vec![5.0_f64, 6.0];
+        let rhs = vec![5.0_f64]; // 長さ不一致
         let solver = LUSolver::new(SOLVER_TOLERANCE_F64);
 
-        let result = solver.solve(&matrix, &rhs).unwrap();
-
-        assert!((result.solution[0] - 1.8).abs() < TOLERANCE_F64);
-        assert!((result.solution[1] - 1.4).abs() < TOLERANCE_F64);
-        assert!(result.converged);
+        assert!(solver.solve(&matrix, &rhs).is_err());
     }
 
     #[test]

--- a/foundation/analysis/src/linalg/solver/newton.rs
+++ b/foundation/analysis/src/linalg/solver/newton.rs
@@ -9,7 +9,7 @@ use crate::consts::numerical::{
     DERIVATIVE_ZERO_THRESHOLD_F32, DERIVATIVE_ZERO_THRESHOLD_F64, LINEAR_SOLVER_TOLERANCE_F32,
     LINEAR_SOLVER_TOLERANCE_F64,
 };
-use crate::linalg::{DynamicMatrix, DynamicMatrixLinearSolver, GaussianSolver, Vector};
+use crate::linalg::{DynamicMatrix, GaussianSolver, LinearSolver, Vector};
 use crate::Scalar;
 
 #[inline]
@@ -50,9 +50,9 @@ fn solve_linear_dynamic<T, S>(
 ) -> Option<Vector<T>>
 where
     T: Scalar,
-    S: DynamicMatrixLinearSolver<T>,
+    S: LinearSolver<T>,
 {
-    let solution = solver.solve_dynamic(jacobian, residual).ok()?;
+    let solution = solver.solve(jacobian, residual.data()).ok()?;
     if solution.solution.len() != residual.len() {
         return None;
     }
@@ -324,7 +324,7 @@ pub fn newton_solve_multivariate_with_solver<T, F, S>(
 where
     T: Scalar,
     F: Fn(&Vector<T>) -> (Vector<T>, DynamicMatrix<T>),
-    S: DynamicMatrixLinearSolver<T>,
+    S: LinearSolver<T>,
 {
     let mut current = initial;
 
@@ -383,7 +383,7 @@ pub fn newton_solve_multivariate_bounded_with_solver<T, F, S>(
 where
     T: Scalar,
     F: Fn(&Vector<T>) -> (Vector<T>, DynamicMatrix<T>),
-    S: DynamicMatrixLinearSolver<T>,
+    S: LinearSolver<T>,
 {
     let mut current = bounds.clamp(&initial).ok()?;
 


### PR DESCRIPTION
## 概要

Issue #704「LinearSolver trait の `&[Vec<T>]` シグネチャを DynamicMatrix 対応に統一する」の実装。

## 含む単位

- `LinearSolver<T>::solve` シグネチャ変更: `&[Vec<T>]` → `&DynamicMatrix<T>`
- `DynamicMatrixLinearSolver<T>` trait の削除（不要になったため）
- `GaussianSolver`, `LUSolver`, `CramerSolver` の `DynamicMatrix` 直接受け取り対応
- `newton.rs` 型境界変更: `S: DynamicMatrixLinearSolver<T>` → `S: LinearSolver<T>`
- Newton 法反復ループ内の `to_vec2d()` 毎反復アロケーション除去
- 各 solver のテスト更新（`vec![vec![...]]` → `DynamicMatrix::from_rows`）
- 設計ドキュメント更新（Phase C 完了内容の追記）

## 含めない単位

- `DynamicMatrix` 自体の API 変更
- Newton solver の新機能追加
- 他クレートへの影響（foundation/analysis のみ変更）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `foundation/analysis/src/linalg/solver/mod.rs` | `LinearSolver::solve` シグネチャ変更、`DynamicMatrixLinearSolver` 削除 |
| `foundation/analysis/src/linalg/solver/gaussian.rs` | `DynamicMatrix` 直接受け取りに変更 |
| `foundation/analysis/src/linalg/solver/lu.rs` | `DynamicMatrix` 直接受け取りに変更 |
| `foundation/analysis/src/linalg/solver/cramer.rs` | `DynamicMatrix` 直接受け取りに変更 |
| `foundation/analysis/src/linalg/solver/newton.rs` | 型境界変更、`to_vec2d()` 除去 |
| `foundation/analysis/src/linalg/mod.rs` | `DynamicMatrixLinearSolver` 再エクスポート削除 |
| テスト 4 本 | `DynamicMatrix::from_rows` に統一 |
| `dev/architecture/ANALYSIS_NEWTON_SOLVER_GENERICIZATION_DESIGN.md` | Phase C 完了内容追記 |

## 確認済み

- `cargo test --workspace`: 全 PASSED
- `cargo clippy --workspace --all-targets -- -D warnings`: 警告ゼロ
- `cargo fmt --all`: 適用済み

Closes #704