### PR TITLE
issue #530 [Phase3.1][Playback-1] app: segment重み付き再生（案C）を実装

### DIFF
--- a/view/app/src/app_state/debug_scene/toolpath.rs
+++ b/view/app/src/app_state/debug_scene/toolpath.rs
@@ -103,6 +103,7 @@ impl AppState {
         let stage_wireframes = data.snapshot_wireframes.clone();
 
         self.debug_snapshot.series = Some(data.snapshot_series);
+        self.rebuild_snapshot_weighted_progress_axis_cache();
         self.debug_snapshot.wireframes = Some(data.snapshot_wireframes);
         self.debug_snapshot.solids = Some(data.snapshot_solids);
         self.debug_snapshot.toolpath_lines = Some(data.toolpath_lines);

--- a/view/app/src/app_state/debug_snapshot_state.rs
+++ b/view/app/src/app_state/debug_snapshot_state.rs
@@ -14,7 +14,6 @@ pub(super) enum SnapshotPlaybackMode {
 pub(super) struct DebugSnapshotState {
     pub(super) series: Option<DomainSnapshotSeries<CamSimulationSnapshotInput>>,
     pub(super) weighted_progress_axis: Option<Vec<f64>>,
-    pub(super) weighted_progress_axis_is_non_decreasing: bool,
     pub(super) wireframes: Option<Vec<Vec<WireframeVertex>>>,
     pub(super) solids: Option<Vec<(Vec<MeshVertex>, Vec<u32>)>>,
     pub(super) toolpath_lines: Option<Vec<MeshVertex>>,
@@ -33,7 +32,6 @@ impl Default for DebugSnapshotState {
         Self {
             series: None,
             weighted_progress_axis: None,
-            weighted_progress_axis_is_non_decreasing: true,
             wireframes: None,
             solids: None,
             toolpath_lines: None,
@@ -53,7 +51,6 @@ impl DebugSnapshotState {
     pub(super) fn clear(&mut self) {
         self.series = None;
         self.weighted_progress_axis = None;
-        self.weighted_progress_axis_is_non_decreasing = true;
         self.wireframes = None;
         self.solids = None;
         self.toolpath_lines = None;

--- a/view/app/src/app_state/debug_snapshot_state.rs
+++ b/view/app/src/app_state/debug_snapshot_state.rs
@@ -13,6 +13,8 @@ pub(super) enum SnapshotPlaybackMode {
 
 pub(super) struct DebugSnapshotState {
     pub(super) series: Option<DomainSnapshotSeries<CamSimulationSnapshotInput>>,
+    pub(super) weighted_progress_axis: Option<Vec<f64>>,
+    pub(super) weighted_progress_axis_is_non_decreasing: bool,
     pub(super) wireframes: Option<Vec<Vec<WireframeVertex>>>,
     pub(super) solids: Option<Vec<(Vec<MeshVertex>, Vec<u32>)>>,
     pub(super) toolpath_lines: Option<Vec<MeshVertex>>,
@@ -30,6 +32,8 @@ impl Default for DebugSnapshotState {
     fn default() -> Self {
         Self {
             series: None,
+            weighted_progress_axis: None,
+            weighted_progress_axis_is_non_decreasing: true,
             wireframes: None,
             solids: None,
             toolpath_lines: None,
@@ -48,6 +52,8 @@ impl Default for DebugSnapshotState {
 impl DebugSnapshotState {
     pub(super) fn clear(&mut self) {
         self.series = None;
+        self.weighted_progress_axis = None;
+        self.weighted_progress_axis_is_non_decreasing = true;
         self.wireframes = None;
         self.solids = None;
         self.toolpath_lines = None;

--- a/view/app/src/app_state/snapshot_playback.rs
+++ b/view/app/src/app_state/snapshot_playback.rs
@@ -32,31 +32,6 @@ fn select_frame_index_by_distance_target(distances: &[f64], target_distance: f64
     index
 }
 
-fn is_non_decreasing(distances: &[f64]) -> bool {
-    distances
-        .windows(2)
-        .all(|pair| pair[0] <= pair[1] || (pair[0] - pair[1]).abs() <= f64::EPSILON)
-}
-
-fn select_nearest_frame_index_by_distance_target(distances: &[f64], target_distance: f64) -> usize {
-    distances
-        .iter()
-        .enumerate()
-        .min_by(|(left_index, left), (right_index, right)| {
-            let left_diff = (*left - target_distance).abs();
-            let right_diff = (*right - target_distance).abs();
-            match left_diff
-                .partial_cmp(&right_diff)
-                .unwrap_or(std::cmp::Ordering::Equal)
-            {
-                std::cmp::Ordering::Equal => left_index.cmp(right_index),
-                order => order,
-            }
-        })
-        .map(|(index, _)| index)
-        .unwrap_or(0)
-}
-
 fn build_segment_weighted_progress_axis(
     frames: &[viewmodel::snapshot_converter::DomainSnapshotFrame<
         viewmodel::snapshot_converter::CamSimulationSnapshotInput,
@@ -125,18 +100,15 @@ impl AppState {
     pub(super) fn rebuild_snapshot_weighted_progress_axis_cache(&mut self) {
         let Some(series) = &self.debug_snapshot.series else {
             self.debug_snapshot.weighted_progress_axis = None;
-            self.debug_snapshot.weighted_progress_axis_is_non_decreasing = true;
             return;
         };
 
         if series.frames.is_empty() {
             self.debug_snapshot.weighted_progress_axis = None;
-            self.debug_snapshot.weighted_progress_axis_is_non_decreasing = true;
             return;
         }
 
         let axis = build_segment_weighted_progress_axis(&series.frames);
-        self.debug_snapshot.weighted_progress_axis_is_non_decreasing = is_non_decreasing(&axis);
         self.debug_snapshot.weighted_progress_axis = Some(axis);
     }
 
@@ -540,15 +512,7 @@ impl AppState {
         }
 
         let target_progress = progress.clamp(0.0, 1.0);
-        if self.debug_snapshot.weighted_progress_axis_is_non_decreasing {
-            return Some(select_frame_index_by_distance_target(axis, target_progress));
-        }
-
-        // Guard path: if axis is non-monotonic, lower-bound is invalid.
-        Some(select_nearest_frame_index_by_distance_target(
-            axis,
-            target_progress,
-        ))
+        Some(select_frame_index_by_distance_target(axis, target_progress))
     }
 
     fn set_snapshot_cursor_from_progress(&mut self, progress: f64, emit_log: bool) {

--- a/view/app/src/app_state/snapshot_playback.rs
+++ b/view/app/src/app_state/snapshot_playback.rs
@@ -70,24 +70,31 @@ fn build_segment_weighted_progress_axis(
     }
 
     let mut distance_deltas = Vec::with_capacity(frames.len().saturating_sub(1));
+    let mut segment_deltas = Vec::with_capacity(frames.len().saturating_sub(1));
+    let mut positive_distance_sum = 0.0;
+    let mut positive_count = 0usize;
     for pair in frames.windows(2) {
-        let prev = pair[0].payload.accumulated_distance_mm;
-        let curr = pair[1].payload.accumulated_distance_mm;
-        distance_deltas.push((curr - prev).max(0.0));
+        let prev = pair[0].payload;
+        let curr = pair[1].payload;
+
+        let distance_delta = (curr.accumulated_distance_mm - prev.accumulated_distance_mm).max(0.0);
+        if distance_delta > f64::EPSILON {
+            positive_distance_sum += distance_delta;
+            positive_count += 1;
+        }
+
+        let prev_segment_pos = prev.segment_index as f64 + prev.segment_t.clamp(0.0, 1.0);
+        let curr_segment_pos = curr.segment_index as f64 + curr.segment_t.clamp(0.0, 1.0);
+        let segment_delta = (curr_segment_pos - prev_segment_pos).max(0.0);
+
+        distance_deltas.push(distance_delta);
+        segment_deltas.push(segment_delta);
     }
 
-    let positive_count = distance_deltas
-        .iter()
-        .filter(|delta| **delta > f64::EPSILON)
-        .count();
     let mean_positive_distance_delta = if positive_count == 0 {
         0.0
     } else {
-        distance_deltas
-            .iter()
-            .filter(|delta| **delta > f64::EPSILON)
-            .sum::<f64>()
-            / positive_count as f64
+        positive_distance_sum / positive_count as f64
     };
 
     let segment_weight_mm = mean_positive_distance_delta * SEGMENT_WEIGHT_RATIO;
@@ -95,15 +102,7 @@ fn build_segment_weighted_progress_axis(
     cumulative.push(0.0);
     let mut running = 0.0;
 
-    for pair in frames.windows(2) {
-        let prev = pair[0].payload;
-        let curr = pair[1].payload;
-
-        let distance_delta = (curr.accumulated_distance_mm - prev.accumulated_distance_mm).max(0.0);
-        let prev_segment_pos = prev.segment_index as f64 + prev.segment_t.clamp(0.0, 1.0);
-        let curr_segment_pos = curr.segment_index as f64 + curr.segment_t.clamp(0.0, 1.0);
-        let segment_delta = (curr_segment_pos - prev_segment_pos).max(0.0);
-
+    for (distance_delta, segment_delta) in distance_deltas.into_iter().zip(segment_deltas) {
         // Segment progression adds a small contribution to smooth perceived speed near boundaries.
         let weighted_delta = distance_delta + segment_weight_mm * segment_delta;
         running += weighted_delta;
@@ -123,12 +122,31 @@ fn build_segment_weighted_progress_axis(
 }
 
 impl AppState {
+    pub(super) fn rebuild_snapshot_weighted_progress_axis_cache(&mut self) {
+        let Some(series) = &self.debug_snapshot.series else {
+            self.debug_snapshot.weighted_progress_axis = None;
+            self.debug_snapshot.weighted_progress_axis_is_non_decreasing = true;
+            return;
+        };
+
+        if series.frames.is_empty() {
+            self.debug_snapshot.weighted_progress_axis = None;
+            self.debug_snapshot.weighted_progress_axis_is_non_decreasing = true;
+            return;
+        }
+
+        let axis = build_segment_weighted_progress_axis(&series.frames);
+        self.debug_snapshot.weighted_progress_axis_is_non_decreasing = is_non_decreasing(&axis);
+        self.debug_snapshot.weighted_progress_axis = Some(axis);
+    }
+
     /// デバッグ用: cam_sim 実行結果をスナップショット系列として読み込む
     pub fn load_debug_simulation_snapshots(&mut self) {
         match viewmodel::snapshot_converter::load_demo_cam_snapshot_domain_series() {
             Ok(series) => {
                 let frame_count = series.frames.len();
                 self.debug_snapshot.series = Some(series);
+                self.rebuild_snapshot_weighted_progress_axis_cache();
                 self.debug_snapshot.wireframes = None;
                 self.debug_snapshot.solids = None;
                 self.debug_snapshot.toolpath_lines = None;
@@ -485,12 +503,8 @@ impl AppState {
         }
     }
 
-    fn snapshot_weighted_progress_axis(&self) -> Option<Vec<f64>> {
-        let series = self.debug_snapshot.series.as_ref()?;
-        if series.frames.is_empty() {
-            return None;
-        }
-        Some(build_segment_weighted_progress_axis(&series.frames))
+    fn snapshot_weighted_progress_axis(&self) -> Option<&[f64]> {
+        self.debug_snapshot.weighted_progress_axis.as_deref()
     }
 
     fn snapshot_weighted_progress_from_cursor(&self) -> Option<f64> {
@@ -526,16 +540,13 @@ impl AppState {
         }
 
         let target_progress = progress.clamp(0.0, 1.0);
-        if is_non_decreasing(&axis) {
-            return Some(select_frame_index_by_distance_target(
-                &axis,
-                target_progress,
-            ));
+        if self.debug_snapshot.weighted_progress_axis_is_non_decreasing {
+            return Some(select_frame_index_by_distance_target(axis, target_progress));
         }
 
         // Guard path: if axis is non-monotonic, lower-bound is invalid.
         Some(select_nearest_frame_index_by_distance_target(
-            &axis,
+            axis,
             target_progress,
         ))
     }

--- a/view/app/src/app_state/snapshot_playback.rs
+++ b/view/app/src/app_state/snapshot_playback.rs
@@ -8,6 +8,7 @@ use std::time::Instant;
 const AUTO_PLAY_BASE_DURATION_SEC: f64 = 12.0;
 const PLAYBACK_SPEED_MIN: f64 = 0.1;
 const PLAYBACK_SPEED_MAX: f64 = 10.0;
+const SEGMENT_WEIGHT_RATIO: f64 = 0.5;
 
 fn select_frame_index_by_distance_target(distances: &[f64], target_distance: f64) -> usize {
     if distances.len() <= 1 {
@@ -54,6 +55,71 @@ fn select_nearest_frame_index_by_distance_target(distances: &[f64], target_dista
         })
         .map(|(index, _)| index)
         .unwrap_or(0)
+}
+
+fn build_segment_weighted_progress_axis(
+    frames: &[viewmodel::snapshot_converter::DomainSnapshotFrame<
+        viewmodel::snapshot_converter::CamSimulationSnapshotInput,
+    >],
+) -> Vec<f64> {
+    if frames.is_empty() {
+        return Vec::new();
+    }
+    if frames.len() == 1 {
+        return vec![1.0];
+    }
+
+    let mut distance_deltas = Vec::with_capacity(frames.len().saturating_sub(1));
+    for pair in frames.windows(2) {
+        let prev = pair[0].payload.accumulated_distance_mm;
+        let curr = pair[1].payload.accumulated_distance_mm;
+        distance_deltas.push((curr - prev).max(0.0));
+    }
+
+    let positive_count = distance_deltas
+        .iter()
+        .filter(|delta| **delta > f64::EPSILON)
+        .count();
+    let mean_positive_distance_delta = if positive_count == 0 {
+        0.0
+    } else {
+        distance_deltas
+            .iter()
+            .filter(|delta| **delta > f64::EPSILON)
+            .sum::<f64>()
+            / positive_count as f64
+    };
+
+    let segment_weight_mm = mean_positive_distance_delta * SEGMENT_WEIGHT_RATIO;
+    let mut cumulative = Vec::with_capacity(frames.len());
+    cumulative.push(0.0);
+    let mut running = 0.0;
+
+    for pair in frames.windows(2) {
+        let prev = pair[0].payload;
+        let curr = pair[1].payload;
+
+        let distance_delta = (curr.accumulated_distance_mm - prev.accumulated_distance_mm).max(0.0);
+        let prev_segment_pos = prev.segment_index as f64 + prev.segment_t.clamp(0.0, 1.0);
+        let curr_segment_pos = curr.segment_index as f64 + curr.segment_t.clamp(0.0, 1.0);
+        let segment_delta = (curr_segment_pos - prev_segment_pos).max(0.0);
+
+        // Segment progression adds a small contribution to smooth perceived speed near boundaries.
+        let weighted_delta = distance_delta + segment_weight_mm * segment_delta;
+        running += weighted_delta;
+        cumulative.push(running);
+    }
+
+    if running.abs() <= f64::EPSILON {
+        return (0..frames.len())
+            .map(|index| index as f64 / (frames.len() as f64 - 1.0))
+            .collect();
+    }
+
+    cumulative
+        .into_iter()
+        .map(|value| value / running)
+        .collect()
 }
 
 impl AppState {
@@ -372,7 +438,7 @@ impl AppState {
     pub(super) fn snapshot_progress_ratio(&self) -> Option<f32> {
         self.debug_snapshot.series.as_ref()?;
         // Keep overlay in sync with the currently displayed frame.
-        self.snapshot_distance_progress_from_cursor()
+        self.snapshot_weighted_progress_from_cursor()
             .map(|p| p as f32)
             .or(Some(self.debug_snapshot.playback_progress as f32))
     }
@@ -397,7 +463,7 @@ impl AppState {
         self.debug_snapshot.playback_mode = SnapshotPlaybackMode::Manual;
         let rect = self.snapshot_track_rect();
         let progress = ((x - rect.x) / rect.width).clamp(0.0, 1.0) as f64;
-        let next_index = self.index_from_distance_progress(progress).unwrap_or(0);
+        let next_index = self.index_from_progress(progress).unwrap_or(0);
 
         if next_index != self.debug_snapshot.cursor {
             self.debug_snapshot.cursor = next_index;
@@ -419,35 +485,33 @@ impl AppState {
         }
     }
 
-    fn snapshot_distance_bounds(&self) -> Option<(f64, f64)> {
-        let series = self.debug_snapshot.series.as_ref()?;
-        let first = series.frames.first()?.payload.accumulated_distance_mm;
-        let last = series.frames.last()?.payload.accumulated_distance_mm;
-        Some((first, last))
-    }
-
-    fn snapshot_distance_progress_from_cursor(&self) -> Option<f64> {
+    fn snapshot_weighted_progress_axis(&self) -> Option<Vec<f64>> {
         let series = self.debug_snapshot.series.as_ref()?;
         if series.frames.is_empty() {
+            return None;
+        }
+        Some(build_segment_weighted_progress_axis(&series.frames))
+    }
+
+    fn snapshot_weighted_progress_from_cursor(&self) -> Option<f64> {
+        let series = self.debug_snapshot.series.as_ref()?;
+        if series.frames.is_empty() {
+            return None;
+        }
+        let axis = self.snapshot_weighted_progress_axis()?;
+        if axis.is_empty() {
             return None;
         }
         let index = self
             .debug_snapshot
             .cursor
             .min(series.frames.len().saturating_sub(1));
-        let distance = series.frames.get(index)?.payload.accumulated_distance_mm;
-        let (min_distance, max_distance) = self.snapshot_distance_bounds()?;
-        let span = max_distance - min_distance;
-        if span.abs() < f64::EPSILON {
-            if series.frames.len() <= 1 {
-                return Some(1.0);
-            }
-            return Some(index as f64 / (series.frames.len() as f64 - 1.0));
-        }
-        Some(((distance - min_distance) / span).clamp(0.0, 1.0))
+        axis.get(index)
+            .copied()
+            .map(|progress| progress.clamp(0.0, 1.0))
     }
 
-    fn index_from_distance_progress(&self, progress: f64) -> Option<usize> {
+    fn index_from_progress(&self, progress: f64) -> Option<usize> {
         let series = self.debug_snapshot.series.as_ref()?;
         if series.frames.is_empty() {
             return None;
@@ -456,38 +520,29 @@ impl AppState {
             return Some(0);
         }
 
-        let (min_distance, max_distance) = self.snapshot_distance_bounds()?;
-        let span = max_distance - min_distance;
-        if span.abs() < f64::EPSILON {
-            return Some(
-                (progress.clamp(0.0, 1.0) * (series.frames.len() as f64 - 1.0)).round() as usize,
-            );
+        let axis = self.snapshot_weighted_progress_axis()?;
+        if axis.is_empty() {
+            return None;
         }
 
-        let target_distance = min_distance + span * progress.clamp(0.0, 1.0);
-        let distances: Vec<f64> = series
-            .frames
-            .iter()
-            .map(|frame| frame.payload.accumulated_distance_mm)
-            .collect();
-        if is_non_decreasing(&distances) {
+        let target_progress = progress.clamp(0.0, 1.0);
+        if is_non_decreasing(&axis) {
             return Some(select_frame_index_by_distance_target(
-                &distances,
-                target_distance,
+                &axis,
+                target_progress,
             ));
         }
 
-        // Guard path: if distances are non-monotonic, lower-bound is invalid.
+        // Guard path: if axis is non-monotonic, lower-bound is invalid.
         Some(select_nearest_frame_index_by_distance_target(
-            &distances,
-            target_distance,
+            &axis,
+            target_progress,
         ))
     }
 
     fn set_snapshot_cursor_from_progress(&mut self, progress: f64, emit_log: bool) {
         self.debug_snapshot.playback_progress = progress.clamp(0.0, 1.0);
-        let Some(next_index) =
-            self.index_from_distance_progress(self.debug_snapshot.playback_progress)
+        let Some(next_index) = self.index_from_progress(self.debug_snapshot.playback_progress)
         else {
             return;
         };
@@ -502,7 +557,7 @@ impl AppState {
     }
 
     fn sync_playback_progress_from_cursor(&mut self) {
-        if let Some(progress) = self.snapshot_distance_progress_from_cursor() {
+        if let Some(progress) = self.snapshot_weighted_progress_from_cursor() {
             self.debug_snapshot.playback_progress = progress;
         }
     }

--- a/viewmodel/graphics/src/camera.rs
+++ b/viewmodel/graphics/src/camera.rs
@@ -203,7 +203,7 @@ impl Camera {
     pub fn set_projection_mode(&mut self, mode: ProjectionMode) {
         let old_mode = self.projection_mode;
         self.projection_mode = mode;
-        tracing::warn!("🔄 投影モード変更: {:?} → {:?}", old_mode, mode);
+        tracing::info!("投影モード変更: {:?} → {:?}", old_mode, mode);
     }
 
     /// 直交投影モード時の表示範囲を設定

--- a/viewmodel/graphics/src/camera_projection.rs
+++ b/viewmodel/graphics/src/camera_projection.rs
@@ -22,7 +22,7 @@ pub(crate) fn projection_matrix(
             let near = (distance * 0.01).max(0.001);
             let far = (distance * 100.0).min(1000.0);
 
-            tracing::warn!("⚠️ 透視投影が使用されています！ CAM可視化では平行投影を使用すべきです");
+            tracing::info!("透視投影を使用: CAM可視化では通常は平行投影を推奨");
 
             Matrix4x4::perspective_rh_01(45.0 * PI / 180.0, aspect, near, far).to_column_major()
         }


### PR DESCRIPTION
## 含む単位
- `snapshot_playback` に segment重み付き進捗軸（距離 + segment進行寄与）を導入
- 自動再生時の進捗→フレーム選択を重み付き軸へ切替
- 進捗オーバーレイ表示とスクラブ時のカーソル同期を重み付き軸へ統一
- 重み付き進捗軸のキャッシュ化（series差し替え時に再構築）
- 到達不能だった非単調フォールバック分岐の削除
- 透視投影/投影モード切替ログの `warn` -> `info` 緩和（運用ノイズ低減）

## 含めない単位
- payload trait定義拡張
- eguiベースのUI刷新
- Octree状態の連続補間

## 変更ファイル
- `view/app/src/app_state/snapshot_playback.rs`
- `view/app/src/app_state/debug_snapshot_state.rs`
- `view/app/src/app_state/debug_scene/toolpath.rs`
- `viewmodel/graphics/src/camera_projection.rs`
- `viewmodel/graphics/src/camera.rs`

## 検証
- `cargo clippy -p viewmodel -p redring -- -D warnings`
- `cargo fmt`
- `cargo test -p viewmodel -p redring`
- `cargo clippy -p viewmodel-graphics -- -D warnings`
- `cargo test -p viewmodel-graphics`
- 実機確認（A/B/C）: セグメント境界の速度段差低減、0.1x/10x追従、手動互換を確認

## 関連
- Closes #530
- Refs #517