### PR TITLE
issue #717 [Phase1][demo-route-2] cam_sim/view: mock経路隔離とNotReady固定

### DIFF
--- a/model/cam_sim/src/job_adapter.rs
+++ b/model/cam_sim/src/job_adapter.rs
@@ -29,6 +29,22 @@ impl CamJobExecutorAdapter {
             };
         }
 
+        #[cfg(not(any(test, debug_assertions)))]
+        {
+            return JobExecutionResult {
+                status: JobStatus::Failed,
+                elapsed_millis: 20,
+                result_ref: None,
+                artifact_bytes: None,
+                log_ref: Some(format!("log://cam/{}/not-ready", job.id.0)),
+                error: Some(
+                    "cam process artifact provider is not configured in production build"
+                        .to_string(),
+                ),
+            };
+        }
+
+        #[cfg(any(test, debug_assertions))]
         let artifact_bytes = match build_cam_process_artifact_bytes(&job.spec.input_ref) {
             Ok(bytes) => bytes,
             Err(err) => {
@@ -280,7 +296,7 @@ impl CamJobExecutorAdapter {
 fn build_cam_process_artifact_bytes(input_ref: &str) -> Result<Vec<u8>, BinaryFormatError> {
     let _ = input_ref;
 
-    #[cfg(test)]
+    #[cfg(any(test, debug_assertions))]
     {
         if input_ref.ends_with("/kind-mismatch") {
             return make_interference_artifact_bytes();
@@ -320,7 +336,7 @@ fn classify_artifact_read_error(error: &BinaryFormatError) -> &'static str {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, debug_assertions))]
 #[allow(dead_code)]
 fn make_empty_toolpath_artifact_bytes() -> Result<Vec<u8>, BinaryFormatError> {
     let toolpath = ToolPath::new(
@@ -372,7 +388,7 @@ fn make_toolpath_artifact_bytes(version_minor: u16) -> Result<Vec<u8>, BinaryFor
     Ok(bytes)
 }
 
-#[cfg(test)]
+#[cfg(any(test, debug_assertions))]
 fn make_interference_artifact_bytes() -> Result<Vec<u8>, BinaryFormatError> {
     let interference = cam_core::InterferencePayload {
         events: vec![cam_core::InterferenceEvent {

--- a/view/app/src/app_state/input_actions.rs
+++ b/view/app/src/app_state/input_actions.rs
@@ -159,18 +159,10 @@ impl AppState {
                     self.toggle_settings_panel();
                 }
                 "k" => {
-                    if self.debug_snapshot.series.is_some() {
-                        self.cycle_debug_simulation_snapshot();
-                    } else {
-                        self.load_debug_simulation_snapshots();
-                    }
+                    self.cycle_debug_simulation_snapshot();
                 }
                 "j" => {
-                    if self.debug_snapshot.series.is_some() {
-                        self.rewind_debug_simulation_snapshot();
-                    } else {
-                        self.load_debug_simulation_snapshots();
-                    }
+                    self.rewind_debug_simulation_snapshot();
                 }
                 "J" => {
                     self.stop_auto_snapshot_playback();

--- a/view/app/src/app_state/mouse_actions.rs
+++ b/view/app/src/app_state/mouse_actions.rs
@@ -37,8 +37,8 @@ impl AppState {
 
                 if let Some(cursor) = self.cursor_position {
                     if self.is_cursor_on_snapshot_track(cursor) {
-                        if self.debug_snapshot.series.is_none() {
-                            self.load_debug_simulation_snapshots();
+                        if !self.ensure_snapshot_series_ready("snapshot scrub") {
+                            return;
                         }
                         self.snapshot_scrub_active = true;
                         self.mouse_input.cancel_operation();

--- a/view/app/src/app_state/snapshot_playback.rs
+++ b/view/app/src/app_state/snapshot_playback.rs
@@ -3,12 +3,28 @@
 use super::debug_snapshot_state::SnapshotPlaybackMode;
 use super::AppState;
 use crate::selection_rect::SelectionRect;
+use cam_demo::CamSimulationDemoScenario;
 use std::time::Instant;
 
 const AUTO_PLAY_BASE_DURATION_SEC: f64 = 12.0;
 const PLAYBACK_SPEED_MIN: f64 = 0.1;
 const PLAYBACK_SPEED_MAX: f64 = 10.0;
 const SEGMENT_WEIGHT_RATIO: f64 = 0.5;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SnapshotLoadReadiness {
+    Ready(CamSimulationDemoScenario),
+    NotReady,
+}
+
+fn resolve_snapshot_load_readiness(
+    current_cam_demo_scenario: Option<CamSimulationDemoScenario>,
+) -> SnapshotLoadReadiness {
+    match current_cam_demo_scenario {
+        Some(scenario) => SnapshotLoadReadiness::Ready(scenario),
+        None => SnapshotLoadReadiness::NotReady,
+    }
+}
 
 fn select_frame_index_by_distance_target(distances: &[f64], target_distance: f64) -> usize {
     if distances.len() <= 1 {
@@ -97,6 +113,25 @@ fn build_segment_weighted_progress_axis(
 }
 
 impl AppState {
+    pub(super) fn ensure_snapshot_series_ready(&mut self, trigger_label: &str) -> bool {
+        if self.debug_snapshot.series.is_some() {
+            return true;
+        }
+
+        let scenario = match resolve_snapshot_load_readiness(self.current_cam_demo_scenario) {
+            SnapshotLoadReadiness::Ready(scenario) => scenario,
+            SnapshotLoadReadiness::NotReady => {
+                tracing::warn!(
+                    "CAMシミュレーションデモが未開始です。Shift+B または Shift+F で開始してください"
+                );
+                return false;
+            }
+        };
+
+        self.load_sample_toolpath_with_scenario(scenario, trigger_label);
+        self.debug_snapshot.series.is_some()
+    }
+
     pub(super) fn rebuild_snapshot_weighted_progress_axis_cache(&mut self) {
         let Some(series) = &self.debug_snapshot.series else {
             self.debug_snapshot.weighted_progress_axis = None;
@@ -146,8 +181,11 @@ impl AppState {
 
     /// デバッグ用: 次フレームへ進めて内容をログ表示
     pub fn cycle_debug_simulation_snapshot(&mut self) {
+        if !self.ensure_snapshot_series_ready("k") {
+            return;
+        }
+
         let Some(series) = &self.debug_snapshot.series else {
-            self.load_debug_simulation_snapshots();
             return;
         };
 
@@ -165,8 +203,11 @@ impl AppState {
 
     /// デバッグ用: 前フレームへ戻して内容をログ表示
     pub fn rewind_debug_simulation_snapshot(&mut self) {
+        if !self.ensure_snapshot_series_ready("j") {
+            return;
+        }
+
         let Some(series) = &self.debug_snapshot.series else {
-            self.load_debug_simulation_snapshots();
             return;
         };
 
@@ -187,9 +228,10 @@ impl AppState {
     }
 
     pub fn toggle_auto_snapshot_playback(&mut self) {
-        if self.debug_snapshot.series.is_none() {
-            self.load_debug_simulation_snapshots();
+        if !self.ensure_snapshot_series_ready("Space") {
+            return;
         }
+
         let Some(series) = &self.debug_snapshot.series else {
             return;
         };
@@ -218,9 +260,10 @@ impl AppState {
     }
 
     pub(crate) fn pause_auto_snapshot_playback(&mut self) {
-        if self.debug_snapshot.series.is_none() {
-            self.load_debug_simulation_snapshots();
+        if !self.ensure_snapshot_series_ready("pause") {
+            return;
         }
+
         let Some(series) = &self.debug_snapshot.series else {
             return;
         };
@@ -535,5 +578,28 @@ impl AppState {
         if let Some(progress) = self.snapshot_weighted_progress_from_cursor() {
             self.debug_snapshot.playback_progress = progress;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cam_demo::CamSimulationDemoScenario;
+
+    use super::{resolve_snapshot_load_readiness, SnapshotLoadReadiness};
+
+    #[test]
+    fn resolve_snapshot_load_readiness_returns_not_ready_when_scenario_is_absent() {
+        assert_eq!(
+            resolve_snapshot_load_readiness(None),
+            SnapshotLoadReadiness::NotReady
+        );
+    }
+
+    #[test]
+    fn resolve_snapshot_load_readiness_returns_ready_when_scenario_exists() {
+        assert_eq!(
+            resolve_snapshot_load_readiness(Some(CamSimulationDemoScenario::SuccessFlatEndMill)),
+            SnapshotLoadReadiness::Ready(CamSimulationDemoScenario::SuccessFlatEndMill)
+        );
     }
 }

--- a/view/app/src/app_state/snapshot_playback.rs
+++ b/view/app/src/app_state/snapshot_playback.rs
@@ -147,38 +147,6 @@ impl AppState {
         self.debug_snapshot.weighted_progress_axis = Some(axis);
     }
 
-    /// デバッグ用: cam_sim 実行結果をスナップショット系列として読み込む
-    pub fn load_debug_simulation_snapshots(&mut self) {
-        match cam_demo::load_demo_cam_snapshot_domain_series() {
-            Ok(series) => {
-                let frame_count = series.frames.len();
-                self.debug_snapshot.series = Some(series);
-                self.rebuild_snapshot_weighted_progress_axis_cache();
-                self.debug_snapshot.wireframes = None;
-                self.debug_snapshot.solids = None;
-                self.debug_snapshot.toolpath_lines = None;
-                self.debug_snapshot.tool_lines = None;
-                self.debug_snapshot.shaded_mode = false;
-                self.debug_snapshot.cursor = 0;
-                self.debug_snapshot.playback_mode = SnapshotPlaybackMode::Manual;
-                self.debug_snapshot.playback_progress = 0.0;
-                self.debug_snapshot.last_playback_tick = None;
-                tracing::info!(
-                    "シミュレーションスナップショット読込完了: {} フレーム",
-                    frame_count
-                );
-                self.log_current_snapshot_frame(true);
-            }
-            Err(error) => {
-                tracing::error!(
-                    error_kind = logging_foundation::ERROR_KIND_SIMULATION,
-                    "cam simulation snapshot load failed: {}",
-                    error
-                );
-            }
-        }
-    }
-
     /// デバッグ用: 次フレームへ進めて内容をログ表示
     pub fn cycle_debug_simulation_snapshot(&mut self) {
         if !self.ensure_snapshot_series_ready("k") {


### PR DESCRIPTION
含む単位:
- [Phase1][demo-route-2] として、Issue #717 の残タスクのうち本番導線保護と NotReady 固定を実施
- model/cam_sim の CamProcess mock artifact 経路を本番コードパスから除外（test/debug_assertions 限定）
- view/app の k/j/Space/スクラブでの暗黙デモロードを廃止し、Shift+B/Shift+F 起点シナリオがある場合のみ内部再ロード
- view/app の NotReady 判定（シナリオ未設定）を unit test で固定

含めない単位:
- CAMデモ入力生成の本番経路移管（ViewModel -> Application -> cam_sim の完全一本化）
- NotReady の統合/E2E テスト追加（UI操作を跨ぐ結合テスト）
- 製品形状取り込み・干渉精度向上・性能最適化

Phase と PR系列の関係:
- Phase1 は「cutting simulation 本丸導線の成立」
- 本PRはその中の PR系列 demo-route の 2本目（demo-route-2）として、mock隔離と NotReady 契約の最小固定に限定

実装ファイル:
- model/cam_sim/src/job_adapter.rs
- view/app/src/app_state/snapshot_playback.rs
- view/app/src/app_state/input_actions.rs
- view/app/src/app_state/mouse_actions.rs

検証:
- cargo clippy -- -D warnings
- cargo fmt
- cargo test --workspace

Issue:
- Closes #717