### PR TITLE
issue #729 [Phase1][sat-cut-1] cam_sim: SAT-Cut PoC trait定義とprimitive set実装

### DIFF
--- a/dev/architecture/CUTTING_SIMULATION_DESIGN.md
+++ b/dev/architecture/CUTTING_SIMULATION_DESIGN.md
@@ -310,7 +310,9 @@ Issue #729 の比較基盤を使って高精度方式を評価するため、ワ
 ここで `p` は工具種別ごとの解析プリミティブで表現する。
 
 - FlatEndMill: `SweptCylinder(segment, radius)`
-- BallEndMill: `Capsule(segment + z_offset(radius), radius)`
+- BallEndMill: `Capsule(segment, radius)`
+
+PoCでは参照点補正を別責務にせず、工具中心軌跡として渡された `segment` をそのまま使う。`z_offset(radius)` による補正を入れる場合は、`cam_sim` 側の工具参照点変換に責務を分離してから導入する。
 
 #### データ構造（最小）
 

--- a/dev/architecture/CUTTING_SIMULATION_DESIGN.md
+++ b/dev/architecture/CUTTING_SIMULATION_DESIGN.md
@@ -1,9 +1,9 @@
 # 切削シミュレーション設計書
 
 **作成日**: 2026年2月12日  
-**最終更新**: 2026年5月30日  
+**最終更新**: 2026年7月4日  
 **ステータス**: 設計・段階実装中  
-**関連Issue**: [#214](https://github.com/RedRing2020/RedRing/issues/214), [#246](https://github.com/RedRing2020/RedRing/issues/246), [#716](https://github.com/RedRing2020/RedRing/issues/716)
+**関連Issue**: [#214](https://github.com/RedRing2020/RedRing/issues/214), [#246](https://github.com/RedRing2020/RedRing/issues/246), [#716](https://github.com/RedRing2020/RedRing/issues/716), [#726](https://github.com/RedRing2020/RedRing/issues/726), [#729](https://github.com/RedRing2020/RedRing/issues/729)
 
 ---
 
@@ -289,6 +289,70 @@ UI実装コードは `view/app` を正本とし、本書は入力項目（間隔
 
 ## 技術仕様
 
+### Issue #729 先行設計: SAT-Cut 内部表現（Voxel/Octree非正本）
+
+Issue #729 の比較基盤を使って高精度方式を評価するため、ワーク形状の正本を Voxel/Octree から分離する。
+
+#### 目的
+
+- 工具掃引による除去結果を分解能依存の離散表現から切り離す
+- 「除去計算の正本」と「表示キャッシュ」を責務分離する
+- Flat/Ball を同一演算系で扱える拡張可能な核を定義する
+
+#### 正本モデル
+
+ワーク正本は差分集合として保持する。
+
+- 初期ワーク: `W0`
+- 掃引プリミティブ集合: `P = {p1, p2, ... pn}`
+- 現在ワーク: `W = W0 \ (p1 ∪ p2 ∪ ... ∪ pn)`
+
+ここで `p` は工具種別ごとの解析プリミティブで表現する。
+
+- FlatEndMill: `SweptCylinder(segment, radius)`
+- BallEndMill: `Capsule(segment + z_offset(radius), radius)`
+
+#### データ構造（最小）
+
+- `ExactWorkCore`
+   - `base_solid`: 初期素材（AABB または解析ソリッド）
+   - `removed_primitives`: 掃引プリミティブ列（時系列）
+   - `spatial_index`: プリミティブ候補絞り込み用インデックス（BVH/Grid）
+- `ExactQueryKernel`
+   - `contains_material(point) -> bool`
+   - `nearest_removed_surface_distance(point) -> f64`
+   - `estimate_remaining_volume(sample_pitch) -> f64`
+- `DisplayProjectionCache`
+   - 表示専用の再投影キャッシュ（Octree/mesh）
+   - dirty-region 更新のみ受け持つ
+
+#### 演算フロー
+
+1. ToolPath を線分列へ正規化する
+2. 線分ごとに掃引プリミティブを生成する
+3. `removed_primitives` に追記し、`spatial_index` を更新する
+4. 問い合わせは `ExactQueryKernel` で実施する
+5. 表示が必要な場合のみ `DisplayProjectionCache` を部分更新する
+
+#### 不変条件
+
+- 体積単調減少: 切削で体積が増えない
+- 決定性: 同一入力で同一結果になる
+- 表示独立性: 表示キャッシュの有無で正本結果が変わらない
+
+#### #729 で先に固定する評価接続点
+
+- 体積差分: `ExactWorkCore` と既存方式を同一ケースで比較
+- 境界誤差: `nearest_removed_surface_distance` ベースで評価
+- 性能: `contains_material`/体積推定の計測を分離して観測
+- メモリ: `removed_primitives` と索引サイズを別々に記録
+
+#### 非目標（本節）
+
+- 厳密CSGカーネルの全面実装
+- GPU最適化
+- 表示専用キャッシュの本番切替
+
 ### セグメント長の計算
 
 距離計算ロジックは ToolPath/PathSegment 実装を正本とし、本書では「距離ベーススナップショットに必要な実距離計算が成立していること」を要件とする。
@@ -467,6 +531,7 @@ CAM計算および切削シミュレーションで使用するツールセッ�
 
 | 日付 | 変更内容 | 担当 |
 |------|---------|------|
+| 2026-07-04 | Issue #729 先行設計: SAT-Cut 内部表現（Voxel/Octree非正本）を追記 | AI開発者 |
 | 2026-05-30 | 設計正本化: 進捗/残件/チェックリストを削減し、段階定義へ整理 | AI開発者 |
 | 2026-05-30 | Issue #716 反映: View起点の正導線（本番）とデモ限定導線、禁止経路を追記 | AI開発者 |
 | 2026-05-30 | Issue #716 反映: 本番導線の入力前提条件（ポスト由来条件を含む）を追記 | AI開発者 |

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -61,7 +61,7 @@ impl PrimitiveSetExactWork {
     }
 
     fn contains_material(&self, point: &Point3D<f64>) -> bool {
-        if !point_in_aabb(point, &self.bounds) {
+        if !self.bounds.contains(point) {
             return false;
         }
         !self
@@ -88,11 +88,7 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
                     (point_to_segment_distance(point, segment) - *radius).abs()
                 }
                 ExactToolPrimitive::Flat { segment, radius } => {
-                    let distance = point_to_flat_swept_distance(point, segment);
-                    if !distance.is_finite() {
-                        continue;
-                    }
-                    (distance - *radius).abs()
+                    point_to_flat_swept_surface_distance(point, segment, *radius)
                 }
             };
             best = best.min(surface_distance);
@@ -103,6 +99,12 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
     fn estimate_remaining_volume(&self, sample_pitch: f64) -> f64 {
         if sample_pitch <= f64::EPSILON {
             return 0.0;
+        }
+
+        if self.removed_primitives.is_empty() {
+            let min = self.bounds.min();
+            let max = self.bounds.max();
+            return (max.x() - min.x()) * (max.y() - min.y()) * (max.z() - min.z());
         }
 
         let min = self.bounds.min();
@@ -135,24 +137,13 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
     }
 }
 
-fn point_in_aabb(point: &Point3D<f64>, aabb: &Aabb3D<f64>) -> bool {
-    let min = aabb.min();
-    let max = aabb.max();
-    point.x() >= min.x()
-        && point.x() <= max.x()
-        && point.y() >= min.y()
-        && point.y() <= max.y()
-        && point.z() >= min.z()
-        && point.z() <= max.z()
-}
-
 fn primitive_contains(primitive: &ExactToolPrimitive<f64>, point: &Point3D<f64>) -> bool {
     match primitive {
         ExactToolPrimitive::Ball { segment, radius } => {
             point_to_segment_distance(point, segment) <= *radius
         }
         ExactToolPrimitive::Flat { segment, radius } => {
-            point_to_flat_swept_distance(point, segment) <= *radius
+            flat_swept_contains(point, segment, *radius)
         }
     }
 }
@@ -192,7 +183,11 @@ fn point_to_segment_distance(point: &Point3D<f64>, segment: &LineSegment3D<f64>)
     (dx * dx + dy * dy + dz * dz).sqrt()
 }
 
-fn point_to_flat_swept_distance(point: &Point3D<f64>, segment: &LineSegment3D<f64>) -> f64 {
+fn point_to_flat_swept_surface_distance(
+    point: &Point3D<f64>,
+    segment: &LineSegment3D<f64>,
+    radius: f64,
+) -> f64 {
     let start_x = segment.start().x();
     let start_y = segment.start().y();
     let start_z = segment.start().z();
@@ -203,28 +198,87 @@ fn point_to_flat_swept_distance(point: &Point3D<f64>, segment: &LineSegment3D<f6
     let axis_x = end_x - start_x;
     let axis_y = end_y - start_y;
     let axis_z = end_z - start_z;
-    let axis_len_sq = axis_x * axis_x + axis_y * axis_y + axis_z * axis_z;
-    if axis_len_sq <= f64::EPSILON {
+    let axis_len = (axis_x * axis_x + axis_y * axis_y + axis_z * axis_z).sqrt();
+    if axis_len <= f64::EPSILON {
         let dx = point.x() - start_x;
         let dy = point.y() - start_y;
         let dz = point.z() - start_z;
-        return (dx * dx + dy * dy + dz * dz).sqrt();
+        return ((dx * dx + dy * dy + dz * dz).sqrt() - radius).abs();
     }
 
     let point_x = point.x() - start_x;
     let point_y = point.y() - start_y;
     let point_z = point.z() - start_z;
-    let t = (point_x * axis_x + point_y * axis_y + point_z * axis_z) / axis_len_sq;
-    // PoCでは端点側も含めた有限距離を返し、境界評価が破綻しないようにする。
-    let t = t.clamp(0.0, 1.0);
+    let axis_dir_x = axis_x / axis_len;
+    let axis_dir_y = axis_y / axis_len;
+    let axis_dir_z = axis_z / axis_len;
+    let axial = point_x * axis_dir_x + point_y * axis_dir_y + point_z * axis_dir_z;
 
-    let closest_x = start_x + axis_x * t;
-    let closest_y = start_y + axis_y * t;
-    let closest_z = start_z + axis_z * t;
-    let dx = point.x() - closest_x;
-    let dy = point.y() - closest_y;
-    let dz = point.z() - closest_z;
-    (dx * dx + dy * dy + dz * dz).sqrt()
+    let proj_x = start_x + axis_dir_x * axial;
+    let proj_y = start_y + axis_dir_y * axial;
+    let proj_z = start_z + axis_dir_z * axial;
+    let radial_x = point.x() - proj_x;
+    let radial_y = point.y() - proj_y;
+    let radial_z = point.z() - proj_z;
+    let radial = (radial_x * radial_x + radial_y * radial_y + radial_z * radial_z).sqrt();
+
+    if axial < 0.0 {
+        let axial_excess = -axial;
+        if radial <= radius {
+            axial_excess
+        } else {
+            axial_excess.hypot(radial - radius)
+        }
+    } else if axial > axis_len {
+        let axial_excess = axial - axis_len;
+        if radial <= radius {
+            axial_excess
+        } else {
+            axial_excess.hypot(radial - radius)
+        }
+    } else {
+        (radial - radius).abs()
+    }
+}
+
+fn flat_swept_contains(point: &Point3D<f64>, segment: &LineSegment3D<f64>, radius: f64) -> bool {
+    let start_x = segment.start().x();
+    let start_y = segment.start().y();
+    let start_z = segment.start().z();
+    let end_x = segment.end().x();
+    let end_y = segment.end().y();
+    let end_z = segment.end().z();
+
+    let axis_x = end_x - start_x;
+    let axis_y = end_y - start_y;
+    let axis_z = end_z - start_z;
+    let axis_len = (axis_x * axis_x + axis_y * axis_y + axis_z * axis_z).sqrt();
+    if axis_len <= f64::EPSILON {
+        let dx = point.x() - start_x;
+        let dy = point.y() - start_y;
+        let dz = point.z() - start_z;
+        return (dx * dx + dy * dy + dz * dz).sqrt() <= radius;
+    }
+
+    let point_x = point.x() - start_x;
+    let point_y = point.y() - start_y;
+    let point_z = point.z() - start_z;
+    let axis_dir_x = axis_x / axis_len;
+    let axis_dir_y = axis_y / axis_len;
+    let axis_dir_z = axis_z / axis_len;
+    let axial = point_x * axis_dir_x + point_y * axis_dir_y + point_z * axis_dir_z;
+
+    if !(0.0..=axis_len).contains(&axial) {
+        return false;
+    }
+
+    let proj_x = start_x + axis_dir_x * axial;
+    let proj_y = start_y + axis_dir_y * axial;
+    let proj_z = start_z + axis_dir_z * axial;
+    let radial_x = point.x() - proj_x;
+    let radial_y = point.y() - proj_y;
+    let radial_z = point.z() - proj_z;
+    (radial_x * radial_x + radial_y * radial_y + radial_z * radial_z).sqrt() <= radius
 }
 
 #[cfg(test)]
@@ -304,5 +358,28 @@ mod tests {
         let after = work.estimate_remaining_volume(2.0);
 
         assert!(before > after, "before={} after={}", before, after);
+    }
+
+    #[test]
+    fn primitive_set_exact_work_distinguishes_flat_from_ball_on_segment_endpoint_side() {
+        let bounds = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(10.0, 10.0, 10.0));
+        let segment = LineSegment3D::new(Point3D::new(2.0, 5.0, 5.0), Point3D::new(8.0, 5.0, 5.0))
+            .expect("segment must be valid");
+
+        let mut flat_work = PrimitiveSetExactWork::new(bounds);
+        flat_work.apply_primitive(ExactToolPrimitive::Flat {
+            segment,
+            radius: 1.0,
+        });
+
+        let mut ball_work = PrimitiveSetExactWork::new(bounds);
+        ball_work.apply_primitive(ExactToolPrimitive::Ball {
+            segment,
+            radius: 1.0,
+        });
+
+        let endpoint_side = Point3D::new(1.5, 5.0, 5.0);
+        assert!(flat_work.contains_material_at(&endpoint_side));
+        assert!(!ball_work.contains_material_at(&endpoint_side));
     }
 }

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -63,6 +63,17 @@ pub enum ExactWorkError {
     InvalidBounds,
 }
 
+impl std::fmt::Display for ExactWorkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NonFiniteBounds => write!(f, "bounds coordinates must be finite"),
+            Self::InvalidBounds => write!(f, "invalid bounds (min > max)"),
+        }
+    }
+}
+
+impl std::error::Error for ExactWorkError {}
+
 impl PrimitiveSetExactWork {
     /// 不正入力を `Result` として扱う初期化関数。
     pub fn try_new(bounds: Aabb3D<f64>) -> Result<Self, ExactWorkError> {

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -17,6 +17,12 @@ pub enum ExactToolPrimitive<T: Scalar> {
 /// Voxel/Octree非依存のワーク正本を扱うためのtrait定義。
 pub trait ExactWorkModel<T: Scalar> {
     /// 掃引プリミティブを正本へ適用する。
+    ///
+    /// # Panics
+    ///
+    /// 実装によっては次の場合に panic し得る:
+    /// - 線分端点が非有限値（NaN/inf）
+    /// - 工具半径が非有限値または負値
     fn apply_primitive(&mut self, primitive: ExactToolPrimitive<T>);
 
     /// 点が材料内部かどうかを返す。
@@ -127,6 +133,10 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
     }
 
     fn nearest_removed_surface_distance(&self, point: &Point3D<f64>) -> f64 {
+        if !point_is_finite(point) {
+            return f64::INFINITY;
+        }
+
         let mut best = f64::INFINITY;
         for primitive in &self.removed_primitives {
             let surface_distance = match primitive {
@@ -208,11 +218,7 @@ fn aabb_is_finite(aabb: &Aabb3D<f64>) -> bool {
 }
 
 fn bounds_contains_point(bounds: &Aabb3D<f64>, point: &Point3D<f64>) -> bool {
-    let min = bounds.min();
-    let max = bounds.max();
-    (min.x()..=max.x()).contains(&point.x())
-        && (min.y()..=max.y()).contains(&point.y())
-        && (min.z()..=max.z()).contains(&point.z())
+    bounds.contains_point(point)
 }
 
 fn axis_sample_count(span: f64, sample_pitch: f64) -> usize {
@@ -603,5 +609,20 @@ mod tests {
         let near_cap_but_outside = Point3D::new(2.1, 6.2, 5.0);
         let distance = work.nearest_removed_surface_distance(&near_cap_but_outside);
         assert!((distance - 0.2).abs() <= 1.0e-9, "distance={}", distance);
+    }
+
+    #[test]
+    fn primitive_set_exact_work_nearest_distance_non_finite_point_returns_infinity() {
+        let bounds = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(10.0, 10.0, 10.0));
+        let mut work = PrimitiveSetExactWork::new(bounds);
+        let segment = LineSegment3D::new(Point3D::new(2.0, 5.0, 5.0), Point3D::new(8.0, 5.0, 5.0))
+            .expect("segment must be valid");
+        work.apply_primitive(ExactToolPrimitive::Ball {
+            segment,
+            radius: 1.0,
+        });
+
+        let distance = work.nearest_removed_surface_distance(&Point3D::new(f64::NAN, 5.0, 5.0));
+        assert!(distance.is_infinite());
     }
 }

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -50,8 +50,32 @@ pub struct PrimitiveSetExactWork {
     removed_primitives: Vec<ExactToolPrimitive<f64>>,
 }
 
+/// `PrimitiveSetExactWork` の初期化失敗を表すエラー。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExactWorkError {
+    NonFiniteBounds,
+    InvalidBounds,
+}
+
 impl PrimitiveSetExactWork {
+    /// 不正入力を `Result` として扱う初期化関数。
+    pub fn try_new(bounds: Aabb3D<f64>) -> Result<Self, ExactWorkError> {
+        if !aabb_is_finite(&bounds) {
+            return Err(ExactWorkError::NonFiniteBounds);
+        }
+        if bounds.is_empty() {
+            return Err(ExactWorkError::InvalidBounds);
+        }
+
+        Ok(Self {
+            bounds,
+            removed_primitives: Vec::new(),
+        })
+    }
+
     /// 新しい `PrimitiveSetExactWork` を生成する。
+    ///
+    /// 不正入力を回復可能に扱いたい場合は `try_new` を使用する。
     ///
     /// # Panics
     ///
@@ -59,15 +83,12 @@ impl PrimitiveSetExactWork {
     /// - `bounds` の座標に非有限値（NaN/inf）が含まれる
     /// - `bounds` が不正（min > max）
     pub fn new(bounds: Aabb3D<f64>) -> Self {
-        assert!(aabb_is_finite(&bounds), "bounds coordinates must be finite");
-        assert!(
-            !bounds.is_empty(),
-            "PrimitiveSetExactWork::new received invalid bounds (min > max)"
-        );
-        Self {
-            bounds,
-            removed_primitives: Vec::new(),
-        }
+        Self::try_new(bounds).unwrap_or_else(|err| match err {
+            ExactWorkError::NonFiniteBounds => panic!("bounds coordinates must be finite"),
+            ExactWorkError::InvalidBounds => {
+                panic!("PrimitiveSetExactWork::new received invalid bounds (min > max)")
+            }
+        })
     }
 
     pub fn estimate_memory_bytes(&self) -> usize {
@@ -321,7 +342,8 @@ fn flat_swept_contains(point: &Point3D<f64>, segment: &LineSegment3D<f64>, radiu
 #[cfg(test)]
 mod tests {
     use super::{
-        ExactToolPrimitive, ExactWorkModel, ExactWorkProjectionCache, PrimitiveSetExactWork,
+        ExactToolPrimitive, ExactWorkError, ExactWorkModel, ExactWorkProjectionCache,
+        PrimitiveSetExactWork,
     };
     use geo_algorithms::{Aabb3D, LineSegment3D, Point3D};
 
@@ -473,9 +495,26 @@ mod tests {
             radius: 1.0,
         });
 
-        let volume = work.estimate_remaining_volume(f64::EPSILON * 0.5);
+        let volume = work.estimate_remaining_volume(0.5);
         assert!(volume > 0.0);
         assert!(volume <= bounds.volume());
+    }
+
+    #[test]
+    fn primitive_set_exact_work_try_new_rejects_invalid_bounds() {
+        let invalid_bounds = Aabb3D::new(Point3D::new(1.0, 0.0, 0.0), Point3D::new(0.0, 1.0, 1.0));
+        let result = PrimitiveSetExactWork::try_new(invalid_bounds);
+        assert!(matches!(result, Err(ExactWorkError::InvalidBounds)));
+    }
+
+    #[test]
+    fn primitive_set_exact_work_try_new_rejects_non_finite_bounds() {
+        let invalid_bounds = Aabb3D::new(
+            Point3D::new(f64::NAN, 0.0, 0.0),
+            Point3D::new(1.0, 1.0, 1.0),
+        );
+        let result = PrimitiveSetExactWork::try_new(invalid_bounds);
+        assert!(matches!(result, Err(ExactWorkError::NonFiniteBounds)));
     }
 
     #[test]

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -215,9 +215,8 @@ fn point_to_flat_swept_distance(point: &Point3D<f64>, segment: &LineSegment3D<f6
     let point_y = point.y() - start_y;
     let point_z = point.z() - start_z;
     let t = (point_x * axis_x + point_y * axis_y + point_z * axis_z) / axis_len_sq;
-    if !(0.0..=1.0).contains(&t) {
-        return f64::INFINITY;
-    }
+    // PoCでは端点側も含めた有限距離を返し、境界評価が破綻しないようにする。
+    let t = t.clamp(0.0, 1.0);
 
     let closest_x = start_x + axis_x * t;
     let closest_y = start_y + axis_y * t;

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -260,7 +260,9 @@ fn point_to_flat_swept_surface_distance(
             axial_excess.hypot(radial - radius)
         }
     } else {
-        (radial - radius).abs()
+        let side_distance = (radial - radius).abs();
+        let cap_distance = axial.min(axis_len - axial);
+        side_distance.min(cap_distance)
     }
 }
 
@@ -501,5 +503,21 @@ mod tests {
             segment,
             radius: 1.0,
         });
+    }
+
+    #[test]
+    fn primitive_set_exact_work_flat_nearest_distance_uses_end_cap_when_closer() {
+        let bounds = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(10.0, 10.0, 10.0));
+        let mut work = PrimitiveSetExactWork::new(bounds);
+        let segment = LineSegment3D::new(Point3D::new(2.0, 5.0, 5.0), Point3D::new(8.0, 5.0, 5.0))
+            .expect("segment must be valid");
+        work.apply_primitive(ExactToolPrimitive::Flat {
+            segment,
+            radius: 1.0,
+        });
+
+        let near_start_cap_axis = Point3D::new(2.1, 5.0, 5.0);
+        let distance = work.nearest_removed_surface_distance(&near_start_cap_axis);
+        assert!((distance - 0.1).abs() <= 1.0e-9, "distance={}", distance);
     }
 }

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -97,7 +97,7 @@ impl PrimitiveSetExactWork {
     }
 
     fn contains_material(&self, point: &Point3D<f64>) -> bool {
-        if !self.bounds.contains(point) {
+        if !bounds_contains_point(&self.bounds, point) {
             return false;
         }
         !self
@@ -205,6 +205,14 @@ fn segment_is_finite(segment: &LineSegment3D<f64>) -> bool {
 
 fn aabb_is_finite(aabb: &Aabb3D<f64>) -> bool {
     point_is_finite(&aabb.min()) && point_is_finite(&aabb.max())
+}
+
+fn bounds_contains_point(bounds: &Aabb3D<f64>, point: &Point3D<f64>) -> bool {
+    let min = bounds.min();
+    let max = bounds.max();
+    (min.x()..=max.x()).contains(&point.x())
+        && (min.y()..=max.y()).contains(&point.y())
+        && (min.z()..=max.z()).contains(&point.z())
 }
 
 fn axis_sample_count(span: f64, sample_pitch: f64) -> usize {

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -1,0 +1,309 @@
+use geo_algorithms::{Aabb3D, LineSegment3D, Point3D, Scalar};
+
+/// SAT-Cut PoCで扱う工具掃引プリミティブ。
+#[derive(Debug, Clone, Copy)]
+pub enum ExactToolPrimitive<T: Scalar> {
+    Flat {
+        segment: LineSegment3D<T>,
+        radius: T,
+    },
+    Ball {
+        segment: LineSegment3D<T>,
+        radius: T,
+    },
+}
+
+/// Voxel/Octree非依存のワーク正本を扱うためのtrait定義。
+pub trait ExactWorkModel<T: Scalar> {
+    /// 掃引プリミティブを正本へ適用する。
+    fn apply_primitive(&mut self, primitive: ExactToolPrimitive<T>);
+
+    /// 点が材料内部かどうかを返す。
+    fn contains_material_at(&self, point: &Point3D<T>) -> bool;
+
+    /// 除去境界までの最近傍距離を返す。
+    fn nearest_removed_surface_distance(&self, point: &Point3D<T>) -> T;
+
+    /// サンプリングで残存体積を推定する。
+    fn estimate_remaining_volume(&self, sample_pitch: T) -> T;
+
+    /// 正本が保持している掃引プリミティブ数を返す。
+    fn primitive_count(&self) -> usize;
+}
+
+/// 表示キャッシュ側の更新境界を分離するためのtrait定義。
+pub trait ExactWorkProjectionCache<T: Scalar> {
+    /// 指定領域のみを再投影して表示キャッシュを更新する。
+    fn update_from_exact_work(&mut self, work: &dyn ExactWorkModel<T>, dirty_region: &Aabb3D<T>);
+
+    /// キャッシュを破棄して初期状態へ戻す。
+    fn clear(&mut self);
+}
+
+/// 掃引プリミティブ集合を正本として保持する最小PoC実装。
+#[derive(Debug, Clone)]
+pub struct PrimitiveSetExactWork {
+    bounds: Aabb3D<f64>,
+    removed_primitives: Vec<ExactToolPrimitive<f64>>,
+}
+
+impl PrimitiveSetExactWork {
+    pub fn new(bounds: Aabb3D<f64>) -> Self {
+        Self {
+            bounds,
+            removed_primitives: Vec::new(),
+        }
+    }
+
+    pub fn estimate_memory_bytes(&self) -> usize {
+        std::mem::size_of::<Self>()
+            + self.removed_primitives.capacity() * std::mem::size_of::<ExactToolPrimitive<f64>>()
+    }
+
+    fn contains_material(&self, point: &Point3D<f64>) -> bool {
+        if !point_in_aabb(point, &self.bounds) {
+            return false;
+        }
+        !self
+            .removed_primitives
+            .iter()
+            .any(|primitive| primitive_contains(primitive, point))
+    }
+}
+
+impl ExactWorkModel<f64> for PrimitiveSetExactWork {
+    fn apply_primitive(&mut self, primitive: ExactToolPrimitive<f64>) {
+        self.removed_primitives.push(primitive);
+    }
+
+    fn contains_material_at(&self, point: &Point3D<f64>) -> bool {
+        self.contains_material(point)
+    }
+
+    fn nearest_removed_surface_distance(&self, point: &Point3D<f64>) -> f64 {
+        let mut best = f64::INFINITY;
+        for primitive in &self.removed_primitives {
+            let surface_distance = match primitive {
+                ExactToolPrimitive::Ball { segment, radius } => {
+                    (point_to_segment_distance(point, segment) - *radius).abs()
+                }
+                ExactToolPrimitive::Flat { segment, radius } => {
+                    let distance = point_to_flat_swept_distance(point, segment);
+                    if !distance.is_finite() {
+                        continue;
+                    }
+                    (distance - *radius).abs()
+                }
+            };
+            best = best.min(surface_distance);
+        }
+        best
+    }
+
+    fn estimate_remaining_volume(&self, sample_pitch: f64) -> f64 {
+        if sample_pitch <= f64::EPSILON {
+            return 0.0;
+        }
+
+        let min = self.bounds.min();
+        let max = self.bounds.max();
+        let half = sample_pitch * 0.5;
+
+        let mut solid_count = 0usize;
+        let mut x = min.x() + half;
+        while x < max.x() {
+            let mut y = min.y() + half;
+            while y < max.y() {
+                let mut z = min.z() + half;
+                while z < max.z() {
+                    let point = Point3D::new(x, y, z);
+                    if self.contains_material(&point) {
+                        solid_count += 1;
+                    }
+                    z += sample_pitch;
+                }
+                y += sample_pitch;
+            }
+            x += sample_pitch;
+        }
+
+        (solid_count as f64) * sample_pitch.powi(3)
+    }
+
+    fn primitive_count(&self) -> usize {
+        self.removed_primitives.len()
+    }
+}
+
+fn point_in_aabb(point: &Point3D<f64>, aabb: &Aabb3D<f64>) -> bool {
+    let min = aabb.min();
+    let max = aabb.max();
+    point.x() >= min.x()
+        && point.x() <= max.x()
+        && point.y() >= min.y()
+        && point.y() <= max.y()
+        && point.z() >= min.z()
+        && point.z() <= max.z()
+}
+
+fn primitive_contains(primitive: &ExactToolPrimitive<f64>, point: &Point3D<f64>) -> bool {
+    match primitive {
+        ExactToolPrimitive::Ball { segment, radius } => {
+            point_to_segment_distance(point, segment) <= *radius
+        }
+        ExactToolPrimitive::Flat { segment, radius } => {
+            point_to_flat_swept_distance(point, segment) <= *radius
+        }
+    }
+}
+
+fn point_to_segment_distance(point: &Point3D<f64>, segment: &LineSegment3D<f64>) -> f64 {
+    let start_x = segment.start().x();
+    let start_y = segment.start().y();
+    let start_z = segment.start().z();
+    let end_x = segment.end().x();
+    let end_y = segment.end().y();
+    let end_z = segment.end().z();
+
+    let axis_x = end_x - start_x;
+    let axis_y = end_y - start_y;
+    let axis_z = end_z - start_z;
+    let axis_len_sq = axis_x * axis_x + axis_y * axis_y + axis_z * axis_z;
+
+    if axis_len_sq <= f64::EPSILON {
+        let dx = point.x() - start_x;
+        let dy = point.y() - start_y;
+        let dz = point.z() - start_z;
+        return (dx * dx + dy * dy + dz * dz).sqrt();
+    }
+
+    let point_x = point.x() - start_x;
+    let point_y = point.y() - start_y;
+    let point_z = point.z() - start_z;
+    let t =
+        ((point_x * axis_x + point_y * axis_y + point_z * axis_z) / axis_len_sq).clamp(0.0, 1.0);
+
+    let closest_x = start_x + axis_x * t;
+    let closest_y = start_y + axis_y * t;
+    let closest_z = start_z + axis_z * t;
+    let dx = point.x() - closest_x;
+    let dy = point.y() - closest_y;
+    let dz = point.z() - closest_z;
+    (dx * dx + dy * dy + dz * dz).sqrt()
+}
+
+fn point_to_flat_swept_distance(point: &Point3D<f64>, segment: &LineSegment3D<f64>) -> f64 {
+    let start_x = segment.start().x();
+    let start_y = segment.start().y();
+    let start_z = segment.start().z();
+    let end_x = segment.end().x();
+    let end_y = segment.end().y();
+    let end_z = segment.end().z();
+
+    let axis_x = end_x - start_x;
+    let axis_y = end_y - start_y;
+    let axis_z = end_z - start_z;
+    let axis_len_sq = axis_x * axis_x + axis_y * axis_y + axis_z * axis_z;
+    if axis_len_sq <= f64::EPSILON {
+        let dx = point.x() - start_x;
+        let dy = point.y() - start_y;
+        let dz = point.z() - start_z;
+        return (dx * dx + dy * dy + dz * dz).sqrt();
+    }
+
+    let point_x = point.x() - start_x;
+    let point_y = point.y() - start_y;
+    let point_z = point.z() - start_z;
+    let t = (point_x * axis_x + point_y * axis_y + point_z * axis_z) / axis_len_sq;
+    if !(0.0..=1.0).contains(&t) {
+        return f64::INFINITY;
+    }
+
+    let closest_x = start_x + axis_x * t;
+    let closest_y = start_y + axis_y * t;
+    let closest_z = start_z + axis_z * t;
+    let dx = point.x() - closest_x;
+    let dy = point.y() - closest_y;
+    let dz = point.z() - closest_z;
+    (dx * dx + dy * dy + dz * dz).sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ExactToolPrimitive, ExactWorkModel, ExactWorkProjectionCache, PrimitiveSetExactWork,
+    };
+    use geo_algorithms::{Aabb3D, LineSegment3D, Point3D};
+
+    #[derive(Default)]
+    struct DummyProjectionCache {
+        updated_count: usize,
+    }
+
+    impl ExactWorkProjectionCache<f64> for DummyProjectionCache {
+        fn update_from_exact_work(
+            &mut self,
+            _work: &dyn ExactWorkModel<f64>,
+            _dirty_region: &Aabb3D<f64>,
+        ) {
+            self.updated_count += 1;
+        }
+
+        fn clear(&mut self) {
+            self.updated_count = 0;
+        }
+    }
+
+    #[test]
+    fn primitive_set_exact_work_implements_trait_contract() {
+        let bounds = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(10.0, 10.0, 10.0));
+        let mut work = PrimitiveSetExactWork::new(bounds);
+        let mut cache = DummyProjectionCache::default();
+
+        let segment = LineSegment3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(1.0, 0.0, 0.0))
+            .expect("segment must be valid");
+        work.apply_primitive(ExactToolPrimitive::Flat {
+            segment,
+            radius: 1.0,
+        });
+
+        assert_eq!(work.primitive_count(), 1);
+
+        let dirty = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(2.0, 2.0, 2.0));
+        cache.update_from_exact_work(&work, &dirty);
+        assert_eq!(cache.updated_count, 1);
+    }
+
+    #[test]
+    fn primitive_set_exact_work_removes_material_for_flat_primitive() {
+        let bounds = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(10.0, 10.0, 10.0));
+        let mut work = PrimitiveSetExactWork::new(bounds);
+        let segment = LineSegment3D::new(Point3D::new(1.0, 5.0, 5.0), Point3D::new(9.0, 5.0, 5.0))
+            .expect("segment must be valid");
+        work.apply_primitive(ExactToolPrimitive::Flat {
+            segment,
+            radius: 1.0,
+        });
+
+        assert!(!work.contains_material_at(&Point3D::new(5.0, 5.0, 5.0)));
+        assert!(work.contains_material_at(&Point3D::new(5.0, 8.0, 8.0)));
+        assert!(work.nearest_removed_surface_distance(&Point3D::new(5.0, 5.0, 5.0)) <= 1.0);
+    }
+
+    #[test]
+    fn primitive_set_exact_work_estimate_volume_decreases_after_cutting() {
+        let bounds = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(10.0, 10.0, 10.0));
+        let mut work = PrimitiveSetExactWork::new(bounds);
+        let before = work.estimate_remaining_volume(2.0);
+
+        let segment = LineSegment3D::new(Point3D::new(1.0, 5.0, 5.0), Point3D::new(9.0, 5.0, 5.0))
+            .expect("segment must be valid");
+        work.apply_primitive(ExactToolPrimitive::Ball {
+            segment,
+            radius: 1.5,
+        });
+        let after = work.estimate_remaining_volume(2.0);
+
+        assert!(before > after, "before={} after={}", before, after);
+    }
+}

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -126,12 +126,12 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
             return 0.0;
         }
 
-        if self.removed_primitives.is_empty() {
-            return self.bounds.volume();
-        }
-
         if !sample_pitch.is_finite() || sample_pitch <= 0.0 {
             return 0.0;
+        }
+
+        if self.removed_primitives.is_empty() {
+            return self.bounds.volume();
         }
 
         let min = self.bounds.min();
@@ -440,6 +440,15 @@ mod tests {
 
     #[test]
     fn primitive_set_exact_work_estimate_volume_rejects_non_finite_pitch() {
+        let bounds = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(10.0, 10.0, 10.0));
+        let work = PrimitiveSetExactWork::new(bounds);
+
+        assert_eq!(work.estimate_remaining_volume(f64::NAN), 0.0);
+        assert_eq!(work.estimate_remaining_volume(f64::INFINITY), 0.0);
+    }
+
+    #[test]
+    fn primitive_set_exact_work_estimate_volume_rejects_non_finite_pitch_after_cutting() {
         let bounds = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(10.0, 10.0, 10.0));
         let mut work = PrimitiveSetExactWork::new(bounds);
         let segment = LineSegment3D::new(Point3D::new(2.0, 5.0, 5.0), Point3D::new(8.0, 5.0, 5.0))

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -27,6 +27,7 @@ pub trait ExactWorkModel<T: Scalar> {
     fn nearest_removed_surface_distance(&self, point: &Point3D<T>) -> T;
 
     /// サンプリングで残存体積を推定する。
+    /// `sample_pitch` が非有限値または `<= 0` の場合は `0` を返す。
     fn estimate_remaining_volume(&self, sample_pitch: T) -> T;
 
     /// 正本が保持している掃引プリミティブ数を返す。
@@ -50,6 +51,13 @@ pub struct PrimitiveSetExactWork {
 }
 
 impl PrimitiveSetExactWork {
+    /// 新しい `PrimitiveSetExactWork` を生成する。
+    ///
+    /// # Panics
+    ///
+    /// 次の場合に panic する:
+    /// - `bounds` の座標に非有限値（NaN/inf）が含まれる
+    /// - `bounds` が不正（min > max）
     pub fn new(bounds: Aabb3D<f64>) -> Self {
         assert!(aabb_is_finite(&bounds), "bounds coordinates must be finite");
         assert!(

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -1,3 +1,4 @@
+use geo_algorithms::distance::line_segment3d_point3d_distance;
 use geo_algorithms::{Aabb3D, LineSegment3D, Point3D, Scalar};
 
 /// SAT-Cut PoCで扱う工具掃引プリミティブ。
@@ -97,39 +98,45 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
     }
 
     fn estimate_remaining_volume(&self, sample_pitch: f64) -> f64 {
+        if self.removed_primitives.is_empty() {
+            return self.bounds.volume();
+        }
+
         if sample_pitch <= f64::EPSILON {
             return 0.0;
         }
 
-        if self.removed_primitives.is_empty() {
-            let min = self.bounds.min();
-            let max = self.bounds.max();
-            return (max.x() - min.x()) * (max.y() - min.y()) * (max.z() - min.z());
-        }
-
         let min = self.bounds.min();
         let max = self.bounds.max();
-        let half = sample_pitch * 0.5;
+        let width = max.x() - min.x();
+        let height = max.y() - min.y();
+        let depth = max.z() - min.z();
+
+        let x_samples = ((width / sample_pitch).ceil() as usize).max(1);
+        let y_samples = ((height / sample_pitch).ceil() as usize).max(1);
+        let z_samples = ((depth / sample_pitch).ceil() as usize).max(1);
+
+        let dx = width / (x_samples as f64);
+        let dy = height / (y_samples as f64);
+        let dz = depth / (z_samples as f64);
 
         let mut solid_count = 0usize;
-        let mut x = min.x() + half;
-        while x < max.x() {
-            let mut y = min.y() + half;
-            while y < max.y() {
-                let mut z = min.z() + half;
-                while z < max.z() {
+        for ix in 0..x_samples {
+            let x = min.x() + ((ix as f64) + 0.5) * dx;
+            for iy in 0..y_samples {
+                let y = min.y() + ((iy as f64) + 0.5) * dy;
+                for iz in 0..z_samples {
+                    let z = min.z() + ((iz as f64) + 0.5) * dz;
                     let point = Point3D::new(x, y, z);
                     if self.contains_material(&point) {
                         solid_count += 1;
                     }
-                    z += sample_pitch;
                 }
-                y += sample_pitch;
             }
-            x += sample_pitch;
         }
 
-        (solid_count as f64) * sample_pitch.powi(3)
+        let total_samples = (x_samples * y_samples * z_samples) as f64;
+        self.bounds.volume() * ((solid_count as f64) / total_samples)
     }
 
     fn primitive_count(&self) -> usize {
@@ -149,38 +156,7 @@ fn primitive_contains(primitive: &ExactToolPrimitive<f64>, point: &Point3D<f64>)
 }
 
 fn point_to_segment_distance(point: &Point3D<f64>, segment: &LineSegment3D<f64>) -> f64 {
-    let start_x = segment.start().x();
-    let start_y = segment.start().y();
-    let start_z = segment.start().z();
-    let end_x = segment.end().x();
-    let end_y = segment.end().y();
-    let end_z = segment.end().z();
-
-    let axis_x = end_x - start_x;
-    let axis_y = end_y - start_y;
-    let axis_z = end_z - start_z;
-    let axis_len_sq = axis_x * axis_x + axis_y * axis_y + axis_z * axis_z;
-
-    if axis_len_sq <= f64::EPSILON {
-        let dx = point.x() - start_x;
-        let dy = point.y() - start_y;
-        let dz = point.z() - start_z;
-        return (dx * dx + dy * dy + dz * dz).sqrt();
-    }
-
-    let point_x = point.x() - start_x;
-    let point_y = point.y() - start_y;
-    let point_z = point.z() - start_z;
-    let t =
-        ((point_x * axis_x + point_y * axis_y + point_z * axis_z) / axis_len_sq).clamp(0.0, 1.0);
-
-    let closest_x = start_x + axis_x * t;
-    let closest_y = start_y + axis_y * t;
-    let closest_z = start_z + axis_z * t;
-    let dx = point.x() - closest_x;
-    let dy = point.y() - closest_y;
-    let dz = point.z() - closest_z;
-    (dx * dx + dy * dy + dz * dz).sqrt()
+    line_segment3d_point3d_distance(segment, point)
 }
 
 fn point_to_flat_swept_surface_distance(
@@ -381,5 +357,23 @@ mod tests {
         let endpoint_side = Point3D::new(1.5, 5.0, 5.0);
         assert!(flat_work.contains_material_at(&endpoint_side));
         assert!(!ball_work.contains_material_at(&endpoint_side));
+    }
+
+    #[test]
+    fn primitive_set_exact_work_empty_returns_bounds_volume_even_with_tiny_pitch() {
+        let bounds = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(10.0, 20.0, 30.0));
+        let work = PrimitiveSetExactWork::new(bounds);
+
+        let volume = work.estimate_remaining_volume(f64::EPSILON);
+        assert!((volume - bounds.volume()).abs() <= 1.0e-9);
+    }
+
+    #[test]
+    fn primitive_set_exact_work_estimate_volume_never_exceeds_bounds_volume() {
+        let bounds = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(10.0, 10.0, 10.0));
+        let work = PrimitiveSetExactWork::new(bounds);
+
+        let volume = work.estimate_remaining_volume(6.0);
+        assert!(volume <= bounds.volume());
     }
 }

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -260,9 +260,13 @@ fn point_to_flat_swept_surface_distance(
             axial_excess.hypot(radial - radius)
         }
     } else {
-        let side_distance = (radial - radius).abs();
-        let cap_distance = axial.min(axis_len - axial);
-        side_distance.min(cap_distance)
+        if radial > radius {
+            radial - radius
+        } else {
+            let inward_side_distance = radius - radial;
+            let cap_distance = axial.min(axis_len - axial);
+            inward_side_distance.min(cap_distance)
+        }
     }
 }
 
@@ -519,5 +523,21 @@ mod tests {
         let near_start_cap_axis = Point3D::new(2.1, 5.0, 5.0);
         let distance = work.nearest_removed_surface_distance(&near_start_cap_axis);
         assert!((distance - 0.1).abs() <= 1.0e-9, "distance={}", distance);
+    }
+
+    #[test]
+    fn primitive_set_exact_work_flat_nearest_distance_uses_side_for_radial_outside() {
+        let bounds = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(10.0, 10.0, 10.0));
+        let mut work = PrimitiveSetExactWork::new(bounds);
+        let segment = LineSegment3D::new(Point3D::new(2.0, 5.0, 5.0), Point3D::new(8.0, 5.0, 5.0))
+            .expect("segment must be valid");
+        work.apply_primitive(ExactToolPrimitive::Flat {
+            segment,
+            radius: 1.0,
+        });
+
+        let near_cap_but_outside = Point3D::new(2.1, 6.2, 5.0);
+        let distance = work.nearest_removed_surface_distance(&near_cap_but_outside);
+        assert!((distance - 0.2).abs() <= 1.0e-9, "distance={}", distance);
     }
 }

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -23,6 +23,7 @@ pub trait ExactWorkModel<T: Scalar> {
     fn contains_material_at(&self, point: &Point3D<T>) -> bool;
 
     /// 除去境界までの最近傍距離を返す。
+    /// 除去プリミティブが未適用の場合は `T::INFINITY` を返す。
     fn nearest_removed_surface_distance(&self, point: &Point3D<T>) -> T;
 
     /// サンプリングで残存体積を推定する。
@@ -50,6 +51,10 @@ pub struct PrimitiveSetExactWork {
 
 impl PrimitiveSetExactWork {
     pub fn new(bounds: Aabb3D<f64>) -> Self {
+        debug_assert!(
+            !bounds.is_empty(),
+            "PrimitiveSetExactWork::new received invalid bounds (min > max)"
+        );
         Self {
             bounds,
             removed_primitives: Vec::new(),
@@ -74,6 +79,13 @@ impl PrimitiveSetExactWork {
 
 impl ExactWorkModel<f64> for PrimitiveSetExactWork {
     fn apply_primitive(&mut self, primitive: ExactToolPrimitive<f64>) {
+        let radius = match primitive {
+            ExactToolPrimitive::Flat { radius, .. } | ExactToolPrimitive::Ball { radius, .. } => {
+                radius
+            }
+        };
+        debug_assert!(radius.is_finite(), "radius must be finite");
+        debug_assert!(radius >= 0.0, "radius must be non-negative");
         self.removed_primitives.push(primitive);
     }
 
@@ -98,11 +110,15 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
     }
 
     fn estimate_remaining_volume(&self, sample_pitch: f64) -> f64 {
+        if self.bounds.is_empty() {
+            return 0.0;
+        }
+
         if self.removed_primitives.is_empty() {
             return self.bounds.volume();
         }
 
-        if sample_pitch <= f64::EPSILON {
+        if !sample_pitch.is_finite() || sample_pitch <= f64::EPSILON {
             return 0.0;
         }
 
@@ -112,9 +128,9 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
         let height = max.y() - min.y();
         let depth = max.z() - min.z();
 
-        let x_samples = ((width / sample_pitch).ceil() as usize).max(1);
-        let y_samples = ((height / sample_pitch).ceil() as usize).max(1);
-        let z_samples = ((depth / sample_pitch).ceil() as usize).max(1);
+        let x_samples = axis_sample_count(width, sample_pitch);
+        let y_samples = axis_sample_count(height, sample_pitch);
+        let z_samples = axis_sample_count(depth, sample_pitch);
 
         let dx = width / (x_samples as f64);
         let dy = height / (y_samples as f64);
@@ -142,6 +158,21 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
     fn primitive_count(&self) -> usize {
         self.removed_primitives.len()
     }
+}
+
+const MAX_AXIS_SAMPLES: usize = 128;
+
+fn axis_sample_count(span: f64, sample_pitch: f64) -> usize {
+    if !span.is_finite() || !sample_pitch.is_finite() || sample_pitch <= f64::EPSILON {
+        return 1;
+    }
+
+    let raw = (span / sample_pitch).ceil();
+    if !raw.is_finite() {
+        return MAX_AXIS_SAMPLES;
+    }
+
+    raw.clamp(1.0, MAX_AXIS_SAMPLES as f64) as usize
 }
 
 fn primitive_contains(primitive: &ExactToolPrimitive<f64>, point: &Point3D<f64>) -> bool {
@@ -375,5 +406,20 @@ mod tests {
 
         let volume = work.estimate_remaining_volume(6.0);
         assert!(volume <= bounds.volume());
+    }
+
+    #[test]
+    fn primitive_set_exact_work_estimate_volume_rejects_non_finite_pitch() {
+        let bounds = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(10.0, 10.0, 10.0));
+        let mut work = PrimitiveSetExactWork::new(bounds);
+        let segment = LineSegment3D::new(Point3D::new(2.0, 5.0, 5.0), Point3D::new(8.0, 5.0, 5.0))
+            .expect("segment must be valid");
+        work.apply_primitive(ExactToolPrimitive::Ball {
+            segment,
+            radius: 1.0,
+        });
+
+        assert_eq!(work.estimate_remaining_volume(f64::NAN), 0.0);
+        assert_eq!(work.estimate_remaining_volume(f64::INFINITY), 0.0);
     }
 }

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -51,6 +51,7 @@ pub struct PrimitiveSetExactWork {
 
 impl PrimitiveSetExactWork {
     pub fn new(bounds: Aabb3D<f64>) -> Self {
+        assert!(aabb_is_finite(&bounds), "bounds coordinates must be finite");
         assert!(
             !bounds.is_empty(),
             "PrimitiveSetExactWork::new received invalid bounds (min > max)"
@@ -79,11 +80,14 @@ impl PrimitiveSetExactWork {
 
 impl ExactWorkModel<f64> for PrimitiveSetExactWork {
     fn apply_primitive(&mut self, primitive: ExactToolPrimitive<f64>) {
-        let radius = match primitive {
-            ExactToolPrimitive::Flat { radius, .. } | ExactToolPrimitive::Ball { radius, .. } => {
-                radius
-            }
+        let (segment, radius) = match primitive {
+            ExactToolPrimitive::Flat { segment, radius }
+            | ExactToolPrimitive::Ball { segment, radius } => (segment, radius),
         };
+        assert!(
+            segment_is_finite(&segment),
+            "segment endpoints must be finite"
+        );
         assert!(radius.is_finite(), "radius must be finite");
         assert!(radius >= 0.0, "radius must be non-negative");
         self.removed_primitives.push(primitive);
@@ -161,6 +165,18 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
 }
 
 const MAX_AXIS_SAMPLES: usize = 128;
+
+fn point_is_finite(point: &Point3D<f64>) -> bool {
+    point.x().is_finite() && point.y().is_finite() && point.z().is_finite()
+}
+
+fn segment_is_finite(segment: &LineSegment3D<f64>) -> bool {
+    point_is_finite(&segment.start()) && point_is_finite(&segment.end())
+}
+
+fn aabb_is_finite(aabb: &Aabb3D<f64>) -> bool {
+    point_is_finite(&aabb.min()) && point_is_finite(&aabb.max())
+}
 
 fn axis_sample_count(span: f64, sample_pitch: f64) -> usize {
     if !span.is_finite() || !sample_pitch.is_finite() || sample_pitch <= 0.0 {
@@ -447,6 +463,16 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "bounds coordinates must be finite")]
+    fn primitive_set_exact_work_new_rejects_non_finite_bounds() {
+        let invalid_bounds = Aabb3D::new(
+            Point3D::new(f64::NAN, 0.0, 0.0),
+            Point3D::new(1.0, 1.0, 1.0),
+        );
+        let _ = PrimitiveSetExactWork::new(invalid_bounds);
+    }
+
+    #[test]
     #[should_panic(expected = "radius must be non-negative")]
     fn primitive_set_exact_work_apply_primitive_rejects_negative_radius() {
         let bounds = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(10.0, 10.0, 10.0));
@@ -457,6 +483,23 @@ mod tests {
         work.apply_primitive(ExactToolPrimitive::Flat {
             segment,
             radius: -1.0,
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "segment endpoints must be finite")]
+    fn primitive_set_exact_work_apply_primitive_rejects_non_finite_segment() {
+        let bounds = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(10.0, 10.0, 10.0));
+        let mut work = PrimitiveSetExactWork::new(bounds);
+        let segment = LineSegment3D::new(
+            Point3D::new(f64::INFINITY, 0.0, 0.0),
+            Point3D::new(1.0, 0.0, 0.0),
+        )
+        .expect("segment must be valid");
+
+        work.apply_primitive(ExactToolPrimitive::Flat {
+            segment,
+            radius: 1.0,
         });
     }
 }

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -51,7 +51,7 @@ pub struct PrimitiveSetExactWork {
 
 impl PrimitiveSetExactWork {
     pub fn new(bounds: Aabb3D<f64>) -> Self {
-        debug_assert!(
+        assert!(
             !bounds.is_empty(),
             "PrimitiveSetExactWork::new received invalid bounds (min > max)"
         );
@@ -84,8 +84,8 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
                 radius
             }
         };
-        debug_assert!(radius.is_finite(), "radius must be finite");
-        debug_assert!(radius >= 0.0, "radius must be non-negative");
+        assert!(radius.is_finite(), "radius must be finite");
+        assert!(radius >= 0.0, "radius must be non-negative");
         self.removed_primitives.push(primitive);
     }
 
@@ -118,7 +118,7 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
             return self.bounds.volume();
         }
 
-        if !sample_pitch.is_finite() || sample_pitch <= f64::EPSILON {
+        if !sample_pitch.is_finite() || sample_pitch <= 0.0 {
             return 0.0;
         }
 
@@ -163,7 +163,7 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
 const MAX_AXIS_SAMPLES: usize = 128;
 
 fn axis_sample_count(span: f64, sample_pitch: f64) -> usize {
-    if !span.is_finite() || !sample_pitch.is_finite() || sample_pitch <= f64::EPSILON {
+    if !span.is_finite() || !sample_pitch.is_finite() || sample_pitch <= 0.0 {
         return 1;
     }
 
@@ -421,5 +421,42 @@ mod tests {
 
         assert_eq!(work.estimate_remaining_volume(f64::NAN), 0.0);
         assert_eq!(work.estimate_remaining_volume(f64::INFINITY), 0.0);
+    }
+
+    #[test]
+    fn primitive_set_exact_work_accepts_tiny_positive_pitch_with_primitives() {
+        let bounds = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(10.0, 10.0, 10.0));
+        let mut work = PrimitiveSetExactWork::new(bounds);
+        let segment = LineSegment3D::new(Point3D::new(2.0, 5.0, 5.0), Point3D::new(8.0, 5.0, 5.0))
+            .expect("segment must be valid");
+        work.apply_primitive(ExactToolPrimitive::Ball {
+            segment,
+            radius: 1.0,
+        });
+
+        let volume = work.estimate_remaining_volume(f64::EPSILON * 0.5);
+        assert!(volume > 0.0);
+        assert!(volume <= bounds.volume());
+    }
+
+    #[test]
+    #[should_panic(expected = "PrimitiveSetExactWork::new received invalid bounds")]
+    fn primitive_set_exact_work_new_rejects_invalid_bounds() {
+        let invalid_bounds = Aabb3D::new(Point3D::new(1.0, 0.0, 0.0), Point3D::new(0.0, 1.0, 1.0));
+        let _ = PrimitiveSetExactWork::new(invalid_bounds);
+    }
+
+    #[test]
+    #[should_panic(expected = "radius must be non-negative")]
+    fn primitive_set_exact_work_apply_primitive_rejects_negative_radius() {
+        let bounds = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(10.0, 10.0, 10.0));
+        let mut work = PrimitiveSetExactWork::new(bounds);
+        let segment = LineSegment3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(1.0, 0.0, 0.0))
+            .expect("segment must be valid");
+
+        work.apply_primitive(ExactToolPrimitive::Flat {
+            segment,
+            radius: -1.0,
+        });
     }
 }

--- a/model/cam_sim/src/lib.rs
+++ b/model/cam_sim/src/lib.rs
@@ -15,7 +15,8 @@ mod workflow;
 pub use error::SimulationError;
 /// SAT-Cut PoC向けのExactWork trait定義・プリミティブ型・PoC実装。
 pub use exact_work::{
-    ExactToolPrimitive, ExactWorkModel, ExactWorkProjectionCache, PrimitiveSetExactWork,
+    ExactToolPrimitive, ExactWorkError, ExactWorkModel, ExactWorkProjectionCache,
+    PrimitiveSetExactWork,
 };
 /// Job Manager接続用アダプタ。
 pub use job_adapter::CamJobExecutorAdapter;

--- a/model/cam_sim/src/lib.rs
+++ b/model/cam_sim/src/lib.rs
@@ -5,12 +5,17 @@
 //! Phase 1a では 3軸固定・フラットエンドミル限定の最小実装を提供します。
 
 mod error;
+mod exact_work;
 mod job_adapter;
 mod simulator;
 mod workflow;
 
 /// シミュレーション実行時のエラー型。
 pub use error::SimulationError;
+/// SAT-Cut PoC向けのExactWork trait定義。
+pub use exact_work::{
+    ExactToolPrimitive, ExactWorkModel, ExactWorkProjectionCache, PrimitiveSetExactWork,
+};
 /// Job Manager接続用アダプタ。
 pub use job_adapter::CamJobExecutorAdapter;
 /// シミュレーション実行APIとスナップショット関連型。

--- a/model/cam_sim/src/lib.rs
+++ b/model/cam_sim/src/lib.rs
@@ -3,6 +3,7 @@
 //! CAMドメインのシミュレーション実行責務を提供します。
 //! 幾何計算カーネルは `geo_algorithms` に委譲します。
 //! Phase 1a では 3軸固定・フラットエンドミル限定の最小実装を提供します。
+//! あわせて Issue #729 向けに、SAT-Cut PoC の ExactWork API を併存公開します。
 
 mod error;
 mod exact_work;

--- a/model/cam_sim/src/lib.rs
+++ b/model/cam_sim/src/lib.rs
@@ -13,7 +13,7 @@ mod workflow;
 
 /// シミュレーション実行時のエラー型。
 pub use error::SimulationError;
-/// SAT-Cut PoC向けのExactWork trait定義。
+/// SAT-Cut PoC向けのExactWork trait定義・プリミティブ型・PoC実装。
 pub use exact_work::{
     ExactToolPrimitive, ExactWorkModel, ExactWorkProjectionCache, PrimitiveSetExactWork,
 };

--- a/model/geo_core/src/aabb_3d.rs
+++ b/model/geo_core/src/aabb_3d.rs
@@ -48,10 +48,15 @@ impl<T: Scalar> Aabb3D<T> {
     }
 
     /// 点がAABB内に含まれるか
-    pub fn contains(&self, p: &Point3D<T>) -> bool {
+    pub fn contains_point(&self, p: &Point3D<T>) -> bool {
         (self.min.x() <= p.x() && p.x() <= self.max.x())
             && (self.min.y() <= p.y() && p.y() <= self.max.y())
             && (self.min.z() <= p.z() && p.z() <= self.max.z())
+    }
+
+    /// 点がAABB内に含まれるか（後方互換エイリアス）
+    pub fn contains(&self, p: &Point3D<T>) -> bool {
+        self.contains_point(p)
     }
 
     /// 最小点を取得
@@ -234,6 +239,7 @@ mod tests {
         let min = Point3D::new(0.0, 0.0, 0.0);
         let max = Point3D::new(2.0, 2.0, 2.0);
         let aabb = Aabb3D::new(min, max);
+        assert!(aabb.contains_point(&Point3D::new(1.0, 1.0, 1.0)));
         assert!(aabb.contains(&Point3D::new(1.0, 1.0, 1.0)));
         assert!(aabb.contains(&Point3D::new(0.0, 0.0, 0.0)));
         assert!(aabb.contains(&Point3D::new(2.0, 2.0, 2.0)));


### PR DESCRIPTION
含む単位:
- [Phase1][sat-cut-1] として、#729 設計延長の最小PoCを `cam_sim` に追加
- Voxel/Octree非正本を前提とした trait定義（`ExactWorkModel` / `ExactWorkProjectionCache`）を追加
- 掃引プリミティブ集合ベースのPoC実装 `PrimitiveSetExactWork` を追加
- Flat/Ball プリミティブ適用、材料判定、境界距離、体積推定、プリミティブ数/メモリ見積もりを実装
- 設計書に SAT-Cut 内部表現（Issue #729 先行設計）を追記

含めない単位:
- #727 本体（Voxel局所適応分割・交差判定改善）の実装
- SAT-Cut の本番統合（表示キャッシュ切替、運用導線切替）
- 厳密CSGカーネル全面実装、GPU最適化

実装ファイル:
- dev/architecture/CUTTING_SIMULATION_DESIGN.md
- model/cam_sim/src/lib.rs
- model/cam_sim/src/exact_work.rs

検証:
- cargo clippy -p cam_sim -- -D warnings
- cargo fmt
- cargo test -p cam_sim

関連:
- Related #729
- #727 の比較材料として利用可能（実装配線は後続）