### PR TITLE
issue #732 [Phase1][A-1] geo_contracts/geo_core: containsポリモーフィック層の最小導入

### DIFF
--- a/model/geo_contracts/src/geometry/operations/mod.rs
+++ b/model/geo_contracts/src/geometry/operations/mod.rs
@@ -13,7 +13,7 @@ pub use ellipse_calculation::{
 };
 pub use intersection::{BasicIntersection, MultipleIntersection, SelfIntersection};
 pub use relation::{
-    Aabb2DRelation, Aabb3DRelation, AngleBetween, AngularRelation, ClosestPointPair,
+    Aabb2DRelation, Aabb3DRelation, AngleBetween, AngularRelation, ClosestPointPair, Contains,
     DirectionalRelation, IntersectsRelation, OnPlaneRelation, ParallelRelation,
     PerpendicularRelation, PointsTowards, SameLineRelation, SkewRelation,
 };

--- a/model/geo_contracts/src/geometry/operations/relation.rs
+++ b/model/geo_contracts/src/geometry/operations/relation.rs
@@ -5,6 +5,12 @@
 use crate::Scalar;
 
 /// 対象を包含するかを返す汎用 relation
+///
+/// 命名規約:
+/// - 統一名の `contains(...)` は、呼び出し側が対象型を抽象化したい場面で使用する
+/// - 明示名の `contains_point` / `contains_bbox` / `contains_aabb` は、対象を明示して
+///   意味を固定したい場面で使用する
+/// - 既存の明示名メソッドは後方互換のため維持し、段階導入では `contains(...)` を追加層として扱う
 pub trait Contains<Target> {
     /// 対象を包含するかを返す
     fn contains(&self, target: &Target) -> bool;

--- a/model/geo_contracts/src/geometry/operations/relation.rs
+++ b/model/geo_contracts/src/geometry/operations/relation.rs
@@ -11,8 +11,6 @@ use crate::Scalar;
 /// - 明示名の `contains_point` / `contains_bbox` / `contains_aabb` は、対象を明示して
 ///   意味を固定したい場面で使用する
 /// - 既存の明示名メソッドは後方互換のため維持し、段階導入では `contains(...)` を追加層として扱う
-/// - 型固有メソッド `contains(...)` と衝突するケース（例: `Aabb3D::contains(&Point3D)`）で
-///   trait側の `contains` を呼ぶ場合は、`Contains::contains(&value, &target)` のUFCSを使う
 pub trait Contains<Target> {
     /// 対象を包含するかを返す
     fn contains(&self, target: &Target) -> bool;

--- a/model/geo_contracts/src/geometry/operations/relation.rs
+++ b/model/geo_contracts/src/geometry/operations/relation.rs
@@ -11,6 +11,8 @@ use crate::Scalar;
 /// - 明示名の `contains_point` / `contains_bbox` / `contains_aabb` は、対象を明示して
 ///   意味を固定したい場面で使用する
 /// - 既存の明示名メソッドは後方互換のため維持し、段階導入では `contains(...)` を追加層として扱う
+/// - 型固有メソッド `contains(...)` と衝突するケース（例: `Aabb3D::contains(&Point3D)`）で
+///   trait側の `contains` を呼ぶ場合は、`Contains::contains(&value, &target)` のUFCSを使う
 pub trait Contains<Target> {
     /// 対象を包含するかを返す
     fn contains(&self, target: &Target) -> bool;

--- a/model/geo_contracts/src/geometry/operations/relation.rs
+++ b/model/geo_contracts/src/geometry/operations/relation.rs
@@ -11,6 +11,8 @@ use crate::Scalar;
 /// - 明示名の `contains_point` / `contains_bbox` / `contains_aabb` は、対象を明示して
 ///   意味を固定したい場面で使用する
 /// - 既存の明示名メソッドは後方互換のため維持し、段階導入では `contains(...)` を追加層として扱う
+/// - 将来、型固有メソッド `contains(...)` と衝突する場合は、
+///   `Contains::contains(&value, &target)` のUFCS呼び出しを使用する
 pub trait Contains<Target> {
     /// 対象を包含するかを返す
     fn contains(&self, target: &Target) -> bool;

--- a/model/geo_contracts/src/geometry/operations/relation.rs
+++ b/model/geo_contracts/src/geometry/operations/relation.rs
@@ -10,9 +10,6 @@ use crate::Scalar;
 /// - 統一名の `contains(...)` は、呼び出し側が対象型を抽象化したい場面で使用する
 /// - 明示名の `contains_point` / `contains_bbox` / `contains_aabb` は、対象を明示して
 ///   意味を固定したい場面で使用する
-/// - 既存の明示名メソッドは後方互換のため維持し、段階導入では `contains(...)` を追加層として扱う
-/// - 将来、型固有メソッド `contains(...)` と衝突する場合は、
-///   `Contains::contains(&value, &target)` のUFCS呼び出しを使用する
 pub trait Contains<Target> {
     /// 対象を包含するかを返す
     fn contains(&self, target: &Target) -> bool;

--- a/model/geo_contracts/src/geometry/operations/relation.rs
+++ b/model/geo_contracts/src/geometry/operations/relation.rs
@@ -4,6 +4,12 @@
 
 use crate::Scalar;
 
+/// 対象を包含するかを返す汎用 relation
+pub trait Contains<Target> {
+    /// 対象を包含するかを返す
+    fn contains(&self, target: &Target) -> bool;
+}
+
 /// AABB 2D relation
 pub trait Aabb2DRelation<T: Scalar> {
     /// 点型

--- a/model/geo_contracts/src/lib.rs
+++ b/model/geo_contracts/src/lib.rs
@@ -96,7 +96,7 @@ pub use geometry::core::{
 pub use geometry::foundation::{Bounded, PrimitiveMetadata};
 pub use geometry::operations::{
     Aabb2DRelation, Aabb3DRelation, AdvancedCollision, AngleBetween, AngularRelation,
-    BBoxCollision, BasicCollision, BasicIntersection, ClosestPointPair, CrossDistance,
+    BBoxCollision, BasicCollision, BasicIntersection, ClosestPointPair, Contains, CrossDistance,
     DirectionalRelation, DistanceConvergenceError, EllipseAccuracyAnalysis,
     EllipseAdaptiveCalculation, EllipseCalculation, FallibleCrossDistance, IntersectsRelation,
     MultipleIntersection, OnPlaneRelation, ParallelRelation, PerpendicularRelation, PointDistance,

--- a/model/geo_core/src/aabb_2d.rs
+++ b/model/geo_core/src/aabb_2d.rs
@@ -5,7 +5,7 @@
 
 use crate::Point2D;
 use analysis::abstract_types::Scalar;
-use geo_contracts::{Aabb2DDerived, Aabb2DProperties, Aabb2DRelation};
+use geo_contracts::{Aabb2DDerived, Aabb2DProperties, Aabb2DRelation, Contains};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Aabb2D<T: Scalar> {
@@ -172,10 +172,22 @@ impl<T: Scalar> Aabb2DRelation<T> for Aabb2D<T> {
     }
 }
 
+impl<T: Scalar> Contains<Point2D<T>> for Aabb2D<T> {
+    fn contains(&self, target: &Point2D<T>) -> bool {
+        self.contains_point(target)
+    }
+}
+
+impl<T: Scalar> Contains<Aabb2D<T>> for Aabb2D<T> {
+    fn contains(&self, target: &Aabb2D<T>) -> bool {
+        self.contains_aabb(target)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use geo_contracts::{Aabb2DDerived, Aabb2DProperties, Aabb2DRelation};
+    use geo_contracts::{Aabb2DDerived, Aabb2DProperties, Aabb2DRelation, Contains};
 
     #[test]
     fn test_aabb2d_creation() {
@@ -290,5 +302,14 @@ mod tests {
         ));
         assert!(Aabb2DRelation::contains_bbox(&outer, &inner));
         assert!(Aabb2DRelation::intersects(&outer, &inner));
+    }
+
+    #[test]
+    fn test_contains_trait_for_point_and_aabb() {
+        let outer = Aabb2D::new(Point2D::new(0.0, 0.0), Point2D::new(4.0, 4.0));
+        let inner = Aabb2D::new(Point2D::new(1.0, 1.0), Point2D::new(3.0, 3.0));
+
+        assert!(Contains::contains(&outer, &Point2D::new(2.0, 2.0)));
+        assert!(Contains::contains(&outer, &inner));
     }
 }

--- a/model/geo_core/src/aabb_2d.rs
+++ b/model/geo_core/src/aabb_2d.rs
@@ -311,5 +311,7 @@ mod tests {
 
         assert!(Contains::contains(&outer, &Point2D::new(2.0, 2.0)));
         assert!(Contains::contains(&outer, &inner));
+        assert!(outer.contains(&Point2D::new(2.0, 2.0)));
+        assert!(outer.contains(&inner));
     }
 }

--- a/model/geo_core/src/aabb_3d.rs
+++ b/model/geo_core/src/aabb_3d.rs
@@ -54,11 +54,6 @@ impl<T: Scalar> Aabb3D<T> {
             && (self.min.z() <= p.z() && p.z() <= self.max.z())
     }
 
-    /// 点がAABB内に含まれるか（後方互換エイリアス）
-    pub fn contains(&self, p: &Point3D<T>) -> bool {
-        self.contains_point(p)
-    }
-
     /// 最小点を取得
     pub fn min(&self) -> Point3D<T> {
         self.min
@@ -252,10 +247,9 @@ mod tests {
         let max = Point3D::new(2.0, 2.0, 2.0);
         let aabb = Aabb3D::new(min, max);
         assert!(aabb.contains_point(&Point3D::new(1.0, 1.0, 1.0)));
-        assert!(aabb.contains(&Point3D::new(1.0, 1.0, 1.0)));
-        assert!(aabb.contains(&Point3D::new(0.0, 0.0, 0.0)));
-        assert!(aabb.contains(&Point3D::new(2.0, 2.0, 2.0)));
-        assert!(!aabb.contains(&Point3D::new(3.0, 1.0, 1.0)));
+        assert!(aabb.contains_point(&Point3D::new(0.0, 0.0, 0.0)));
+        assert!(aabb.contains_point(&Point3D::new(2.0, 2.0, 2.0)));
+        assert!(!aabb.contains_point(&Point3D::new(3.0, 1.0, 1.0)));
     }
 
     #[test]

--- a/model/geo_core/src/aabb_3d.rs
+++ b/model/geo_core/src/aabb_3d.rs
@@ -4,7 +4,7 @@
 //! geo_primitives, geo_nurbs など全クレートから共通利用されます。
 
 use analysis::abstract_types::Scalar;
-use geo_contracts::{Aabb3DDerived, Aabb3DProperties, Aabb3DRelation};
+use geo_contracts::{Aabb3DDerived, Aabb3DProperties, Aabb3DRelation, Contains};
 
 use crate::Point3D;
 
@@ -198,10 +198,22 @@ impl<T: Scalar> Aabb3DRelation<T> for Aabb3D<T> {
     }
 }
 
+impl<T: Scalar> Contains<Point3D<T>> for Aabb3D<T> {
+    fn contains(&self, target: &Point3D<T>) -> bool {
+        self.contains_point(target)
+    }
+}
+
+impl<T: Scalar> Contains<Aabb3D<T>> for Aabb3D<T> {
+    fn contains(&self, target: &Aabb3D<T>) -> bool {
+        self.contains_aabb(target)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use geo_contracts::{Aabb3DDerived, Aabb3DProperties, Aabb3DRelation};
+    use geo_contracts::{Aabb3DDerived, Aabb3DProperties, Aabb3DRelation, Contains};
 
     #[test]
     fn test_aabb3d_creation() {
@@ -285,5 +297,14 @@ mod tests {
         ));
         assert!(Aabb3DRelation::contains_bbox(&outer, &inner));
         assert!(Aabb3DRelation::intersects(&outer, &inner));
+    }
+
+    #[test]
+    fn test_contains_trait_for_point_and_aabb() {
+        let outer = Aabb3D::new(Point3D::new(0.0, 0.0, 0.0), Point3D::new(4.0, 4.0, 4.0));
+        let inner = Aabb3D::new(Point3D::new(1.0, 1.0, 1.0), Point3D::new(3.0, 3.0, 3.0));
+
+        assert!(Contains::contains(&outer, &Point3D::new(2.0, 2.0, 2.0)));
+        assert!(Contains::contains(&outer, &inner));
     }
 }

--- a/model/geo_core/src/aabb_3d.rs
+++ b/model/geo_core/src/aabb_3d.rs
@@ -300,5 +300,7 @@ mod tests {
 
         assert!(Contains::contains(&outer, &Point3D::new(2.0, 2.0, 2.0)));
         assert!(Contains::contains(&outer, &inner));
+        assert!(outer.contains(&Point3D::new(2.0, 2.0, 2.0)));
+        assert!(outer.contains(&inner));
     }
 }


### PR DESCRIPTION
含む単位: A-1（`Contains<Target>` trait定義の追加、AABB2D/3Dでの最小導入、Aabb3D点包含エイリアス削除による衝突解消）
含めない単位: A-2以降の他shapeへの横展開、deprecation方針の適用、呼び出し側の全面移行
Phase と PR系列の関係: Phase1 の最小導入として A-1 のみを扱い、段階（Phase）と変更単位（PR系列）を分離しています。

## 概要
- `geo_contracts` にポリモーフィック層として `Contains<Target>` traitを追加
- `geo_contracts` の operations/lib 公開面へ `Contains` を re-export
- `geo_core::Aabb2D` / `geo_core::Aabb3D` に以下を追加
  - `Contains<Point>` 実装
  - `Contains<Self>` 実装
- `contains_point` / `contains_bbox` / `contains_aabb` は維持する
- `geo_core::Aabb3D::contains(&Point3D)` の後方互換エイリアスは削除し、点包含は `contains_point` へ統一
- AABB向けに `Contains::contains(...)` の最小テストを追加

## 破壊的変更
- `geo_core::Aabb3D::contains(&Point3D)` を削除
- 既存の点包含呼び出しは `contains_point(&point)` へ置換が必要

## 検証
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

## 関連
- refs #732