### PR TITLE
issue #724 [Phase1][A-1] view/app: snapshot操作のNotReadyガードを固定

### DIFF
--- a/view/app/src/app_state/mouse_actions.rs
+++ b/view/app/src/app_state/mouse_actions.rs
@@ -1,5 +1,6 @@
 //! AppState のマウス入力ハンドリングを扱うモジュール。
 
+use super::snapshot_playback::SnapshotLoadTrigger;
 use super::AppState;
 use crate::selection_rect::SelectionRect;
 
@@ -37,7 +38,7 @@ impl AppState {
 
                 if let Some(cursor) = self.cursor_position {
                     if self.is_cursor_on_snapshot_track(cursor) {
-                        if !self.ensure_snapshot_series_ready("snapshot scrub") {
+                        if !self.ensure_snapshot_series_ready(SnapshotLoadTrigger::SnapshotScrub) {
                             return;
                         }
                         self.snapshot_scrub_active = true;

--- a/view/app/src/app_state/snapshot_playback.rs
+++ b/view/app/src/app_state/snapshot_playback.rs
@@ -17,12 +17,58 @@ enum SnapshotLoadReadiness {
     NotReady,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SnapshotLoadTrigger {
+    SnapshotScrub,
+    Space,
+    KeyK,
+    KeyJ,
+    Pause,
+}
+
+impl SnapshotLoadTrigger {
+    fn label(self) -> &'static str {
+        match self {
+            SnapshotLoadTrigger::SnapshotScrub => "snapshot scrub",
+            SnapshotLoadTrigger::Space => "Space",
+            SnapshotLoadTrigger::KeyK => "k",
+            SnapshotLoadTrigger::KeyJ => "j",
+            SnapshotLoadTrigger::Pause => "pause",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SnapshotLoadDecision {
+    Ready {
+        scenario: CamSimulationDemoScenario,
+        trigger_label: &'static str,
+    },
+    NotReady {
+        trigger_label: &'static str,
+    },
+}
+
 fn resolve_snapshot_load_readiness(
     current_cam_demo_scenario: Option<CamSimulationDemoScenario>,
 ) -> SnapshotLoadReadiness {
     match current_cam_demo_scenario {
         Some(scenario) => SnapshotLoadReadiness::Ready(scenario),
         None => SnapshotLoadReadiness::NotReady,
+    }
+}
+
+fn resolve_snapshot_load_decision(
+    trigger: SnapshotLoadTrigger,
+    current_cam_demo_scenario: Option<CamSimulationDemoScenario>,
+) -> SnapshotLoadDecision {
+    let trigger_label = trigger.label();
+    match resolve_snapshot_load_readiness(current_cam_demo_scenario) {
+        SnapshotLoadReadiness::Ready(scenario) => SnapshotLoadDecision::Ready {
+            scenario,
+            trigger_label,
+        },
+        SnapshotLoadReadiness::NotReady => SnapshotLoadDecision::NotReady { trigger_label },
     }
 }
 
@@ -113,20 +159,24 @@ fn build_segment_weighted_progress_axis(
 }
 
 impl AppState {
-    pub(super) fn ensure_snapshot_series_ready(&mut self, trigger_label: &str) -> bool {
+    pub(super) fn ensure_snapshot_series_ready(&mut self, trigger: SnapshotLoadTrigger) -> bool {
         if self.debug_snapshot.series.is_some() {
             return true;
         }
 
-        let scenario = match resolve_snapshot_load_readiness(self.current_cam_demo_scenario) {
-            SnapshotLoadReadiness::Ready(scenario) => scenario,
-            SnapshotLoadReadiness::NotReady => {
-                tracing::warn!(
+        let (scenario, trigger_label) =
+            match resolve_snapshot_load_decision(trigger, self.current_cam_demo_scenario) {
+                SnapshotLoadDecision::Ready {
+                    scenario,
+                    trigger_label,
+                } => (scenario, trigger_label),
+                SnapshotLoadDecision::NotReady { .. } => {
+                    tracing::warn!(
                     "CAMシミュレーションデモが未開始です。Shift+B または Shift+F で開始してください"
                 );
-                return false;
-            }
-        };
+                    return false;
+                }
+            };
 
         self.load_sample_toolpath_with_scenario(scenario, trigger_label);
         self.debug_snapshot.series.is_some()
@@ -149,7 +199,7 @@ impl AppState {
 
     /// デバッグ用: 次フレームへ進めて内容をログ表示
     pub fn cycle_debug_simulation_snapshot(&mut self) {
-        if !self.ensure_snapshot_series_ready("k") {
+        if !self.ensure_snapshot_series_ready(SnapshotLoadTrigger::KeyK) {
             return;
         }
 
@@ -171,7 +221,7 @@ impl AppState {
 
     /// デバッグ用: 前フレームへ戻して内容をログ表示
     pub fn rewind_debug_simulation_snapshot(&mut self) {
-        if !self.ensure_snapshot_series_ready("j") {
+        if !self.ensure_snapshot_series_ready(SnapshotLoadTrigger::KeyJ) {
             return;
         }
 
@@ -196,7 +246,7 @@ impl AppState {
     }
 
     pub fn toggle_auto_snapshot_playback(&mut self) {
-        if !self.ensure_snapshot_series_ready("Space") {
+        if !self.ensure_snapshot_series_ready(SnapshotLoadTrigger::Space) {
             return;
         }
 
@@ -228,7 +278,7 @@ impl AppState {
     }
 
     pub(crate) fn pause_auto_snapshot_playback(&mut self) {
-        if !self.ensure_snapshot_series_ready("pause") {
+        if !self.ensure_snapshot_series_ready(SnapshotLoadTrigger::Pause) {
             return;
         }
 
@@ -553,7 +603,10 @@ impl AppState {
 mod tests {
     use cam_demo::CamSimulationDemoScenario;
 
-    use super::{resolve_snapshot_load_readiness, SnapshotLoadReadiness};
+    use super::{
+        resolve_snapshot_load_decision, resolve_snapshot_load_readiness, SnapshotLoadDecision,
+        SnapshotLoadReadiness, SnapshotLoadTrigger,
+    };
 
     #[test]
     fn resolve_snapshot_load_readiness_returns_not_ready_when_scenario_is_absent() {
@@ -569,5 +622,46 @@ mod tests {
             resolve_snapshot_load_readiness(Some(CamSimulationDemoScenario::SuccessFlatEndMill)),
             SnapshotLoadReadiness::Ready(CamSimulationDemoScenario::SuccessFlatEndMill)
         );
+    }
+
+    #[test]
+    fn resolve_snapshot_load_decision_returns_not_ready_for_all_ui_triggers_without_scenario() {
+        let triggers = [
+            SnapshotLoadTrigger::SnapshotScrub,
+            SnapshotLoadTrigger::Space,
+            SnapshotLoadTrigger::KeyK,
+            SnapshotLoadTrigger::KeyJ,
+            SnapshotLoadTrigger::Pause,
+        ];
+
+        for trigger in triggers {
+            assert_eq!(
+                resolve_snapshot_load_decision(trigger, None),
+                SnapshotLoadDecision::NotReady {
+                    trigger_label: trigger.label()
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_snapshot_load_decision_returns_ready_for_all_ui_triggers_with_scenario() {
+        let triggers = [
+            SnapshotLoadTrigger::SnapshotScrub,
+            SnapshotLoadTrigger::Space,
+            SnapshotLoadTrigger::KeyK,
+            SnapshotLoadTrigger::KeyJ,
+            SnapshotLoadTrigger::Pause,
+        ];
+
+        for trigger in triggers {
+            assert_eq!(
+                resolve_snapshot_load_decision(trigger, Some(CamSimulationDemoScenario::Success)),
+                SnapshotLoadDecision::Ready {
+                    scenario: CamSimulationDemoScenario::Success,
+                    trigger_label: trigger.label()
+                }
+            );
+        }
     }
 }

--- a/view/app/src/app_state/snapshot_playback.rs
+++ b/view/app/src/app_state/snapshot_playback.rs
@@ -164,19 +164,21 @@ impl AppState {
             return true;
         }
 
-        let (scenario, trigger_label) =
-            match resolve_snapshot_load_decision(trigger, self.current_cam_demo_scenario) {
-                SnapshotLoadDecision::Ready {
-                    scenario,
-                    trigger_label,
-                } => (scenario, trigger_label),
-                SnapshotLoadDecision::NotReady { .. } => {
-                    tracing::warn!(
-                    "CAMシミュレーションデモが未開始です。Shift+B または Shift+F で開始してください"
-                );
-                    return false;
-                }
-            };
+        let (scenario, trigger_label) = match resolve_snapshot_load_decision(
+            trigger,
+            self.current_cam_demo_scenario,
+        ) {
+            SnapshotLoadDecision::Ready {
+                scenario,
+                trigger_label,
+            } => (scenario, trigger_label),
+            SnapshotLoadDecision::NotReady { trigger_label } => {
+                tracing::warn!(
+                        "CAMシミュレーションデモが未開始です。trigger={trigger_label}, Shift+B または Shift+F で開始してください"
+                    );
+                return false;
+            }
+        };
 
         self.load_sample_toolpath_with_scenario(scenario, trigger_label);
         self.debug_snapshot.series.is_some()


### PR DESCRIPTION
## スコープ
- 含む単位: A-1
- 含めない単位: A-2 以降（実ウィンドウ操作を伴うE2E固定、追加の view/app テスト補強）
- Phase と PR系列の関係: Phase1 は NotReady の UI起点回帰防止を進める段階であり、このPRはそのうち snapshot 操作トリガーの未開始ガード固定だけを扱います。

## 変更内容
- snapshot scrub / Space / k / j / pause を `SnapshotLoadTrigger` で明示化
- デモ未開始時に各UIトリガーが NotReady 判定へ落ちることをテストで固定
- snapshot scrub 側の呼び出しを trigger 型に統一

## 検証
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check_pr_preflight.ps1`

## 補足
- 本PRは Issue #724 の一部対応です。
- Shift+B / Shift+F 以外から暗黙ロードで回避できないことの固定は、次の単位で継続します。