### PR TITLE
issue #724 [Phase2][A-2] view/app: スナップショット開始ゲーティングの統合回帰テスト追加

### DIFF
--- a/view/app/src/app.rs
+++ b/view/app/src/app.rs
@@ -45,7 +45,7 @@ impl ApplicationHandler for App {
                 WindowEvent::RedrawRequested => state.render(),
                 WindowEvent::KeyboardInput { event, .. } => {
                     let pressed = event.state == ElementState::Pressed;
-                    state.handle_keyboard_input(&event.logical_key, pressed);
+                    state.handle_keyboard_input(&event.logical_key, &event.physical_key, pressed);
 
                     // ESCキーのみここで処理（アプリ終了）
                     if pressed && matches!(event.logical_key, Key::Named(NamedKey::Escape)) {

--- a/view/app/src/app_state/input_actions.rs
+++ b/view/app/src/app_state/input_actions.rs
@@ -204,6 +204,11 @@ impl AppState {
 
 #[cfg(test)]
 mod tests {
+    use cam_demo::CamSimulationDemoScenario;
+
+    use super::super::snapshot_playback::{
+        resolve_snapshot_load_decision, SnapshotLoadDecision, SnapshotLoadTrigger,
+    };
     use super::{resolve_cam_demo_start_trigger, CamDemoStartTrigger};
 
     #[test]
@@ -234,6 +239,34 @@ mod tests {
                 winit::keyboard::NamedKey::Space
             )),
             None
+        );
+    }
+
+    #[test]
+    fn cam_demo_start_sequence_stays_not_ready_until_explicit_shift_start() {
+        let mut current_cam_demo_scenario = None;
+
+        assert_eq!(
+            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Character("k".into())),
+            None
+        );
+        assert_eq!(
+            resolve_snapshot_load_decision(SnapshotLoadTrigger::KeyK, current_cam_demo_scenario),
+            SnapshotLoadDecision::NotReady { trigger_label: "k" }
+        );
+
+        assert_eq!(
+            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Character("B".into())),
+            Some(CamDemoStartTrigger::BallEndMill)
+        );
+        current_cam_demo_scenario = Some(CamSimulationDemoScenario::Success);
+
+        assert_eq!(
+            resolve_snapshot_load_decision(SnapshotLoadTrigger::Space, current_cam_demo_scenario),
+            SnapshotLoadDecision::Ready {
+                scenario: CamSimulationDemoScenario::Success,
+                trigger_label: "Space"
+            }
         );
     }
 }

--- a/view/app/src/app_state/input_actions.rs
+++ b/view/app/src/app_state/input_actions.rs
@@ -2,12 +2,38 @@
 
 use super::AppState;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CamDemoStartTrigger {
+    BallEndMill,
+    FlatEndMill,
+}
+
+fn resolve_cam_demo_start_trigger(key: &winit::keyboard::Key) -> Option<CamDemoStartTrigger> {
+    match key {
+        winit::keyboard::Key::Character(ch) if ch.as_str() == "B" => {
+            Some(CamDemoStartTrigger::BallEndMill)
+        }
+        winit::keyboard::Key::Character(ch) if ch.as_str() == "F" => {
+            Some(CamDemoStartTrigger::FlatEndMill)
+        }
+        _ => None,
+    }
+}
+
 impl AppState {
     /// キーボード入力を処理
     pub fn handle_keyboard_input(&mut self, key: &winit::keyboard::Key, pressed: bool) {
         self.mouse_input.update_key(key, pressed);
 
         if !pressed {
+            return;
+        }
+
+        if let Some(trigger) = resolve_cam_demo_start_trigger(key) {
+            match trigger {
+                CamDemoStartTrigger::BallEndMill => self.load_sample_toolpath_ball_end_mill(),
+                CamDemoStartTrigger::FlatEndMill => self.load_sample_toolpath_flat_end_mill(),
+            }
             return;
         }
 
@@ -149,12 +175,6 @@ impl AppState {
                 "p" => {
                     self.load_sample_toolpath_only();
                 }
-                "F" => {
-                    self.load_sample_toolpath_flat_end_mill();
-                }
-                "B" => {
-                    self.load_sample_toolpath_ball_end_mill();
-                }
                 "S" => {
                     self.toggle_settings_panel();
                 }
@@ -179,5 +199,41 @@ impl AppState {
                 _ => {}
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_cam_demo_start_trigger, CamDemoStartTrigger};
+
+    #[test]
+    fn resolve_cam_demo_start_trigger_accepts_only_shift_keys_for_demo_start() {
+        assert_eq!(
+            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Character("B".into())),
+            Some(CamDemoStartTrigger::BallEndMill)
+        );
+        assert_eq!(
+            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Character("F".into())),
+            Some(CamDemoStartTrigger::FlatEndMill)
+        );
+
+        assert_eq!(
+            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Character("b".into())),
+            None
+        );
+        assert_eq!(
+            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Character("f".into())),
+            None
+        );
+        assert_eq!(
+            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Character("k".into())),
+            None
+        );
+        assert_eq!(
+            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Named(
+                winit::keyboard::NamedKey::Space
+            )),
+            None
+        );
     }
 }

--- a/view/app/src/app_state/input_actions.rs
+++ b/view/app/src/app_state/input_actions.rs
@@ -8,28 +8,47 @@ enum CamDemoStartTrigger {
     FlatEndMill,
 }
 
-fn resolve_cam_demo_start_trigger(key: &winit::keyboard::Key) -> Option<CamDemoStartTrigger> {
-    match key {
-        winit::keyboard::Key::Character(ch) if ch.as_str() == "B" => {
-            Some(CamDemoStartTrigger::BallEndMill)
-        }
-        winit::keyboard::Key::Character(ch) if ch.as_str() == "F" => {
-            Some(CamDemoStartTrigger::FlatEndMill)
-        }
+fn resolve_cam_demo_start_trigger_with_modifiers(
+    key: &winit::keyboard::Key,
+    physical_key: &winit::keyboard::PhysicalKey,
+    shift_pressed: bool,
+) -> Option<CamDemoStartTrigger> {
+    if !shift_pressed {
+        return None;
+    }
+
+    match (physical_key, key) {
+        (
+            winit::keyboard::PhysicalKey::Code(winit::keyboard::KeyCode::KeyB),
+            winit::keyboard::Key::Character(ch),
+        ) if ch.as_str() == "B" => Some(CamDemoStartTrigger::BallEndMill),
+        (
+            winit::keyboard::PhysicalKey::Code(winit::keyboard::KeyCode::KeyF),
+            winit::keyboard::Key::Character(ch),
+        ) if ch.as_str() == "F" => Some(CamDemoStartTrigger::FlatEndMill),
         _ => None,
     }
 }
 
 impl AppState {
     /// キーボード入力を処理
-    pub fn handle_keyboard_input(&mut self, key: &winit::keyboard::Key, pressed: bool) {
+    pub fn handle_keyboard_input(
+        &mut self,
+        key: &winit::keyboard::Key,
+        physical_key: &winit::keyboard::PhysicalKey,
+        pressed: bool,
+    ) {
         self.mouse_input.update_key(key, pressed);
 
         if !pressed {
             return;
         }
 
-        if let Some(trigger) = resolve_cam_demo_start_trigger(key) {
+        if let Some(trigger) = resolve_cam_demo_start_trigger_with_modifiers(
+            key,
+            physical_key,
+            self.mouse_input.is_shift_pressed(),
+        ) {
             match trigger {
                 CamDemoStartTrigger::BallEndMill => self.load_sample_toolpath_ball_end_mill(),
                 CamDemoStartTrigger::FlatEndMill => self.load_sample_toolpath_flat_end_mill(),
@@ -205,39 +224,70 @@ impl AppState {
 #[cfg(test)]
 mod tests {
     use cam_demo::CamSimulationDemoScenario;
+    use winit::keyboard::{Key, KeyCode, PhysicalKey};
 
     use super::super::snapshot_playback::{
         resolve_snapshot_load_decision, SnapshotLoadDecision, SnapshotLoadTrigger,
     };
-    use super::{resolve_cam_demo_start_trigger, CamDemoStartTrigger};
+    use super::{resolve_cam_demo_start_trigger_with_modifiers, CamDemoStartTrigger};
 
     #[test]
-    fn resolve_cam_demo_start_trigger_accepts_only_shift_keys_for_demo_start() {
+    fn resolve_cam_demo_start_trigger_accepts_only_shift_plus_uppercase_bf() {
         assert_eq!(
-            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Character("B".into())),
+            resolve_cam_demo_start_trigger_with_modifiers(
+                &Key::Character("B".into()),
+                &PhysicalKey::Code(KeyCode::KeyB),
+                true,
+            ),
             Some(CamDemoStartTrigger::BallEndMill)
         );
         assert_eq!(
-            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Character("F".into())),
+            resolve_cam_demo_start_trigger_with_modifiers(
+                &Key::Character("F".into()),
+                &PhysicalKey::Code(KeyCode::KeyF),
+                true,
+            ),
             Some(CamDemoStartTrigger::FlatEndMill)
         );
 
         assert_eq!(
-            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Character("b".into())),
+            resolve_cam_demo_start_trigger_with_modifiers(
+                &Key::Character("B".into()),
+                &PhysicalKey::Code(KeyCode::KeyB),
+                false,
+            ),
             None
         );
         assert_eq!(
-            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Character("f".into())),
+            resolve_cam_demo_start_trigger_with_modifiers(
+                &Key::Character("b".into()),
+                &PhysicalKey::Code(KeyCode::KeyB),
+                true,
+            ),
             None
         );
         assert_eq!(
-            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Character("k".into())),
+            resolve_cam_demo_start_trigger_with_modifiers(
+                &Key::Character("F".into()),
+                &PhysicalKey::Code(KeyCode::KeyB),
+                true,
+            ),
             None
         );
         assert_eq!(
-            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Named(
-                winit::keyboard::NamedKey::Space
-            )),
+            resolve_cam_demo_start_trigger_with_modifiers(
+                &Key::Character("k".into()),
+                &PhysicalKey::Code(KeyCode::KeyK),
+                true,
+            ),
+            None
+        );
+        assert_eq!(
+            resolve_cam_demo_start_trigger_with_modifiers(
+                &Key::Named(winit::keyboard::NamedKey::Space),
+                &PhysicalKey::Code(KeyCode::Space),
+                true,
+            ),
             None
         );
     }
@@ -263,12 +313,20 @@ mod tests {
         }
 
         assert_eq!(
-            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Character("k".into())),
+            resolve_cam_demo_start_trigger_with_modifiers(
+                &Key::Character("k".into()),
+                &PhysicalKey::Code(KeyCode::KeyK),
+                true,
+            ),
             None
         );
 
         assert_eq!(
-            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Character("B".into())),
+            resolve_cam_demo_start_trigger_with_modifiers(
+                &Key::Character("B".into()),
+                &PhysicalKey::Code(KeyCode::KeyB),
+                true,
+            ),
             Some(CamDemoStartTrigger::BallEndMill)
         );
         current_cam_demo_scenario = Some(CamSimulationDemoScenario::Success);
@@ -284,7 +342,11 @@ mod tests {
         }
 
         assert_eq!(
-            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Character("F".into())),
+            resolve_cam_demo_start_trigger_with_modifiers(
+                &Key::Character("F".into()),
+                &PhysicalKey::Code(KeyCode::KeyF),
+                true,
+            ),
             Some(CamDemoStartTrigger::FlatEndMill)
         );
         current_cam_demo_scenario = Some(CamSimulationDemoScenario::SuccessFlatEndMill);

--- a/view/app/src/app_state/input_actions.rs
+++ b/view/app/src/app_state/input_actions.rs
@@ -246,13 +246,26 @@ mod tests {
     fn cam_demo_start_sequence_stays_not_ready_until_explicit_shift_start() {
         let mut current_cam_demo_scenario = None;
 
+        let not_ready_triggers = [
+            SnapshotLoadTrigger::SnapshotScrub,
+            SnapshotLoadTrigger::KeyK,
+            SnapshotLoadTrigger::KeyJ,
+            SnapshotLoadTrigger::Space,
+            SnapshotLoadTrigger::Pause,
+        ];
+
+        for trigger in not_ready_triggers {
+            assert_eq!(
+                resolve_snapshot_load_decision(trigger, current_cam_demo_scenario),
+                SnapshotLoadDecision::NotReady {
+                    trigger_label: trigger.label()
+                }
+            );
+        }
+
         assert_eq!(
             resolve_cam_demo_start_trigger(&winit::keyboard::Key::Character("k".into())),
             None
-        );
-        assert_eq!(
-            resolve_snapshot_load_decision(SnapshotLoadTrigger::KeyK, current_cam_demo_scenario),
-            SnapshotLoadDecision::NotReady { trigger_label: "k" }
         );
 
         assert_eq!(
@@ -262,10 +275,13 @@ mod tests {
         current_cam_demo_scenario = Some(CamSimulationDemoScenario::Success);
 
         assert_eq!(
-            resolve_snapshot_load_decision(SnapshotLoadTrigger::Space, current_cam_demo_scenario),
+            resolve_snapshot_load_decision(
+                SnapshotLoadTrigger::SnapshotScrub,
+                current_cam_demo_scenario
+            ),
             SnapshotLoadDecision::Ready {
                 scenario: CamSimulationDemoScenario::Success,
-                trigger_label: "Space"
+                trigger_label: "snapshot scrub"
             }
         );
     }

--- a/view/app/src/app_state/input_actions.rs
+++ b/view/app/src/app_state/input_actions.rs
@@ -244,9 +244,7 @@ mod tests {
 
     #[test]
     fn cam_demo_start_sequence_stays_not_ready_until_explicit_shift_start() {
-        let mut current_cam_demo_scenario = None;
-
-        let not_ready_triggers = [
+        let ui_triggers = [
             SnapshotLoadTrigger::SnapshotScrub,
             SnapshotLoadTrigger::KeyK,
             SnapshotLoadTrigger::KeyJ,
@@ -254,7 +252,8 @@ mod tests {
             SnapshotLoadTrigger::Pause,
         ];
 
-        for trigger in not_ready_triggers {
+        let mut current_cam_demo_scenario = None;
+        for trigger in ui_triggers {
             assert_eq!(
                 resolve_snapshot_load_decision(trigger, current_cam_demo_scenario),
                 SnapshotLoadDecision::NotReady {
@@ -274,15 +273,30 @@ mod tests {
         );
         current_cam_demo_scenario = Some(CamSimulationDemoScenario::Success);
 
+        for trigger in ui_triggers {
+            assert_eq!(
+                resolve_snapshot_load_decision(trigger, current_cam_demo_scenario),
+                SnapshotLoadDecision::Ready {
+                    scenario: CamSimulationDemoScenario::Success,
+                    trigger_label: trigger.label()
+                }
+            );
+        }
+
         assert_eq!(
-            resolve_snapshot_load_decision(
-                SnapshotLoadTrigger::SnapshotScrub,
-                current_cam_demo_scenario
-            ),
-            SnapshotLoadDecision::Ready {
-                scenario: CamSimulationDemoScenario::Success,
-                trigger_label: "snapshot scrub"
-            }
+            resolve_cam_demo_start_trigger(&winit::keyboard::Key::Character("F".into())),
+            Some(CamDemoStartTrigger::FlatEndMill)
         );
+        current_cam_demo_scenario = Some(CamSimulationDemoScenario::SuccessFlatEndMill);
+
+        for trigger in ui_triggers {
+            assert_eq!(
+                resolve_snapshot_load_decision(trigger, current_cam_demo_scenario),
+                SnapshotLoadDecision::Ready {
+                    scenario: CamSimulationDemoScenario::SuccessFlatEndMill,
+                    trigger_label: trigger.label()
+                }
+            );
+        }
     }
 }

--- a/view/app/src/app_state/snapshot_playback.rs
+++ b/view/app/src/app_state/snapshot_playback.rs
@@ -39,7 +39,7 @@ impl SnapshotLoadTrigger {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SnapshotLoadDecision {
+pub(super) enum SnapshotLoadDecision {
     Ready {
         scenario: CamSimulationDemoScenario,
         trigger_label: &'static str,
@@ -58,7 +58,7 @@ fn resolve_snapshot_load_readiness(
     }
 }
 
-fn resolve_snapshot_load_decision(
+pub(super) fn resolve_snapshot_load_decision(
     trigger: SnapshotLoadTrigger,
     current_cam_demo_scenario: Option<CamSimulationDemoScenario>,
 ) -> SnapshotLoadDecision {
@@ -174,8 +174,8 @@ impl AppState {
             } => (scenario, trigger_label),
             SnapshotLoadDecision::NotReady { trigger_label } => {
                 tracing::warn!(
-                        "CAMシミュレーションデモが未開始です。trigger={trigger_label}, Shift+B または Shift+F で開始してください"
-                    );
+                    "CAMシミュレーションデモが未開始です。trigger={trigger_label}, Shift+B または Shift+F で開始してください"
+                );
                 return false;
             }
         };

--- a/view/app/src/app_state/snapshot_playback.rs
+++ b/view/app/src/app_state/snapshot_playback.rs
@@ -27,7 +27,7 @@ pub(super) enum SnapshotLoadTrigger {
 }
 
 impl SnapshotLoadTrigger {
-    fn label(self) -> &'static str {
+    pub(super) fn label(self) -> &'static str {
         match self {
             SnapshotLoadTrigger::SnapshotScrub => "snapshot scrub",
             SnapshotLoadTrigger::Space => "Space",

--- a/view/app/src/mouse_input.rs
+++ b/view/app/src/mouse_input.rs
@@ -19,6 +19,8 @@ pub struct MouseInput {
     last_position: Option<(f32, f32)>,
     /// Ctrlキーが押されているか
     ctrl_pressed: bool,
+    /// Shiftキーが押されているか
+    shift_pressed: bool,
     /// 各マウスボタンの状態
     left_pressed: bool,
     middle_pressed: bool,
@@ -32,6 +34,7 @@ impl MouseInput {
             operation: MouseOperation::None,
             last_position: None,
             ctrl_pressed: false,
+            shift_pressed: false,
             left_pressed: false,
             middle_pressed: false,
             right_pressed: false,
@@ -40,18 +43,25 @@ impl MouseInput {
 
     /// キー状態を更新
     pub fn update_key(&mut self, key: &winit::keyboard::Key, pressed: bool) {
-        if let winit::keyboard::Key::Named(winit::keyboard::NamedKey::Control) = key {
-            self.ctrl_pressed = pressed;
-            if !pressed {
-                self.operation = MouseOperation::None;
-                self.last_position = None;
+        match key {
+            winit::keyboard::Key::Named(winit::keyboard::NamedKey::Control) => {
+                self.ctrl_pressed = pressed;
+                if !pressed {
+                    self.operation = MouseOperation::None;
+                    self.last_position = None;
+                }
             }
+            winit::keyboard::Key::Named(winit::keyboard::NamedKey::Shift) => {
+                self.shift_pressed = pressed;
+            }
+            _ => {}
         }
     }
 
     /// ModifiersChangedイベントからCtrl押下状態を更新
     pub fn update_modifiers(&mut self, modifiers: ModifiersState) {
         self.ctrl_pressed = modifiers.control_key();
+        self.shift_pressed = modifiers.shift_key();
         self.update_operation();
 
         if !self.ctrl_pressed {
@@ -152,6 +162,11 @@ impl MouseInput {
         self.ctrl_pressed
     }
 
+    /// Shiftキー押下状態を取得
+    pub fn is_shift_pressed(&self) -> bool {
+        self.shift_pressed
+    }
+
     /// 現在の操作を中断
     pub fn cancel_operation(&mut self) {
         self.operation = MouseOperation::None;
@@ -176,6 +191,7 @@ mod tests {
 
         assert_eq!(input.operation, MouseOperation::None);
         assert!(!input.ctrl_pressed);
+        assert!(!input.shift_pressed);
         assert!(!input.left_pressed);
         assert!(!input.middle_pressed);
         assert!(!input.right_pressed);
@@ -193,6 +209,17 @@ mod tests {
         input.update_key(&Key::Named(NamedKey::Control), false);
         assert!(!input.ctrl_pressed);
         assert_eq!(input.operation, MouseOperation::None);
+    }
+
+    #[test]
+    fn test_shift_key_handling() {
+        let mut input = MouseInput::new();
+
+        input.update_key(&Key::Named(NamedKey::Shift), true);
+        assert!(input.shift_pressed);
+
+        input.update_key(&Key::Named(NamedKey::Shift), false);
+        assert!(!input.shift_pressed);
     }
 
     #[test]


### PR DESCRIPTION
含む単位: A-2
含めない単位: A-1 は既にマージ済み、他系列の変更は含めない
Phase と PR系列の関係: Phase2 は実施段階、A-2 はこのPRにまとめる変更単位であり、同じ Phase に別系列があってもよい

## 概要
- `view/app/src/app_state/input_actions.rs` の CAM デモ開始トリガー判定とスナップショット遷移をつなぐ統合回帰テストを強化
- `Shift+B` / `Shift+F` 以外では開始しないことを確認
- 開始前は `NotReady`、開始後は各 UI トリガーで `Ready` になることを確認

## 検証
- `cargo clippy -p redring -- -D warnings`
- `cargo fmt; cargo test -p redring`

## 補足
- A-1 は既に完了済みのため、このPRには含めない