### PR TITLE
issue #736 [Phase3][A-1] cam_sim: ゲート再計測テスト基盤とExactWork枝刈りを追加

### DIFF
--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -117,7 +117,7 @@ impl PrimitiveSetExactWork {
     }
 
     fn contains_material(&self, point: &Point3D<f64>) -> bool {
-        assert_eq!(
+        debug_assert_eq!(
             self.removed_primitives.len(),
             self.primitive_bounds.len(),
             "invariant broken: removed_primitives and primitive_bounds lengths differ"
@@ -151,6 +151,11 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
         assert!(radius >= 0.0, "radius must be non-negative");
         self.primitive_bounds.push(primitive_bounds(&primitive));
         self.removed_primitives.push(primitive);
+        assert_eq!(
+            self.removed_primitives.len(),
+            self.primitive_bounds.len(),
+            "invariant broken after apply_primitive"
+        );
     }
 
     fn contains_material_at(&self, point: &Point3D<f64>) -> bool {
@@ -158,7 +163,7 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
     }
 
     fn nearest_removed_surface_distance(&self, point: &Point3D<f64>) -> f64 {
-        assert_eq!(
+        debug_assert_eq!(
             self.removed_primitives.len(),
             self.primitive_bounds.len(),
             "invariant broken: removed_primitives and primitive_bounds lengths differ"

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -113,9 +113,16 @@ impl PrimitiveSetExactWork {
     pub fn estimate_memory_bytes(&self) -> usize {
         std::mem::size_of::<Self>()
             + self.removed_primitives.capacity() * std::mem::size_of::<ExactToolPrimitive<f64>>()
+            + self.primitive_bounds.capacity() * std::mem::size_of::<Aabb3D<f64>>()
     }
 
     fn contains_material(&self, point: &Point3D<f64>) -> bool {
+        debug_assert_eq!(
+            self.removed_primitives.len(),
+            self.primitive_bounds.len(),
+            "invariant broken: removed_primitives and primitive_bounds lengths differ"
+        );
+
         if !bounds_contains_point(&self.bounds, point) {
             return false;
         }
@@ -151,6 +158,12 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
     }
 
     fn nearest_removed_surface_distance(&self, point: &Point3D<f64>) -> f64 {
+        debug_assert_eq!(
+            self.removed_primitives.len(),
+            self.primitive_bounds.len(),
+            "invariant broken: removed_primitives and primitive_bounds lengths differ"
+        );
+
         if !point_is_finite(point) {
             return f64::INFINITY;
         }

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -117,7 +117,7 @@ impl PrimitiveSetExactWork {
     }
 
     fn contains_material(&self, point: &Point3D<f64>) -> bool {
-        debug_assert_eq!(
+        assert_eq!(
             self.removed_primitives.len(),
             self.primitive_bounds.len(),
             "invariant broken: removed_primitives and primitive_bounds lengths differ"
@@ -158,7 +158,7 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
     }
 
     fn nearest_removed_surface_distance(&self, point: &Point3D<f64>) -> f64 {
-        debug_assert_eq!(
+        assert_eq!(
             self.removed_primitives.len(),
             self.primitive_bounds.len(),
             "invariant broken: removed_primitives and primitive_bounds lengths differ"

--- a/model/cam_sim/src/exact_work.rs
+++ b/model/cam_sim/src/exact_work.rs
@@ -54,6 +54,7 @@ pub trait ExactWorkProjectionCache<T: Scalar> {
 pub struct PrimitiveSetExactWork {
     bounds: Aabb3D<f64>,
     removed_primitives: Vec<ExactToolPrimitive<f64>>,
+    primitive_bounds: Vec<Aabb3D<f64>>,
 }
 
 /// `PrimitiveSetExactWork` の初期化失敗を表すエラー。
@@ -87,6 +88,7 @@ impl PrimitiveSetExactWork {
         Ok(Self {
             bounds,
             removed_primitives: Vec::new(),
+            primitive_bounds: Vec::new(),
         })
     }
 
@@ -120,7 +122,11 @@ impl PrimitiveSetExactWork {
         !self
             .removed_primitives
             .iter()
-            .any(|primitive| primitive_contains(primitive, point))
+            .zip(self.primitive_bounds.iter())
+            .any(|(primitive, primitive_bounds)| {
+                bounds_contains_point(primitive_bounds, point)
+                    && primitive_contains(primitive, point)
+            })
     }
 }
 
@@ -136,6 +142,7 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
         );
         assert!(radius.is_finite(), "radius must be finite");
         assert!(radius >= 0.0, "radius must be non-negative");
+        self.primitive_bounds.push(primitive_bounds(&primitive));
         self.removed_primitives.push(primitive);
     }
 
@@ -149,7 +156,16 @@ impl ExactWorkModel<f64> for PrimitiveSetExactWork {
         }
 
         let mut best = f64::INFINITY;
-        for primitive in &self.removed_primitives {
+        for (primitive, primitive_bounds) in self
+            .removed_primitives
+            .iter()
+            .zip(self.primitive_bounds.iter())
+        {
+            let aabb_lower_bound = point_to_aabb_distance(point, primitive_bounds);
+            if aabb_lower_bound >= best {
+                continue;
+            }
+
             let surface_distance = match primitive {
                 ExactToolPrimitive::Ball { segment, radius } => {
                     (point_to_segment_distance(point, segment) - *radius).abs()
@@ -230,6 +246,53 @@ fn aabb_is_finite(aabb: &Aabb3D<f64>) -> bool {
 
 fn bounds_contains_point(bounds: &Aabb3D<f64>, point: &Point3D<f64>) -> bool {
     bounds.contains_point(point)
+}
+
+fn primitive_bounds(primitive: &ExactToolPrimitive<f64>) -> Aabb3D<f64> {
+    let (segment, radius) = match primitive {
+        ExactToolPrimitive::Flat { segment, radius }
+        | ExactToolPrimitive::Ball { segment, radius } => (segment, *radius),
+    };
+
+    let min_x = segment.start().x().min(segment.end().x()) - radius;
+    let min_y = segment.start().y().min(segment.end().y()) - radius;
+    let min_z = segment.start().z().min(segment.end().z()) - radius;
+    let max_x = segment.start().x().max(segment.end().x()) + radius;
+    let max_y = segment.start().y().max(segment.end().y()) + radius;
+    let max_z = segment.start().z().max(segment.end().z()) + radius;
+
+    Aabb3D::new(
+        Point3D::new(min_x, min_y, min_z),
+        Point3D::new(max_x, max_y, max_z),
+    )
+}
+
+fn point_to_aabb_distance(point: &Point3D<f64>, bounds: &Aabb3D<f64>) -> f64 {
+    let dx = if point.x() < bounds.min().x() {
+        bounds.min().x() - point.x()
+    } else if point.x() > bounds.max().x() {
+        point.x() - bounds.max().x()
+    } else {
+        0.0
+    };
+
+    let dy = if point.y() < bounds.min().y() {
+        bounds.min().y() - point.y()
+    } else if point.y() > bounds.max().y() {
+        point.y() - bounds.max().y()
+    } else {
+        0.0
+    };
+
+    let dz = if point.z() < bounds.min().z() {
+        bounds.min().z() - point.z()
+    } else if point.z() > bounds.max().z() {
+        point.z() - bounds.max().z()
+    } else {
+        0.0
+    };
+
+    (dx * dx + dy * dy + dz * dz).sqrt()
 }
 
 fn axis_sample_count(span: f64, sample_pitch: f64) -> usize {

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -1,4 +1,5 @@
 use std::io::Cursor;
+use std::time::Instant;
 
 use cam_core::{
     ArtifactHeaderV1, ArtifactKind, ContourLevelPath, CuttingDirection, SegmentType, Tool,
@@ -10,7 +11,8 @@ use job_runtime::{JobEvent, JobManager, JobRelation, JobSpec, JobStatus, JobType
 
 use crate::{
     CamJobExecutorAdapter, CamWorkflowError, CamWorkflowSubmitter, CuttingSimulator,
-    SimulationError, SnapshotInterval,
+    ExactToolPrimitive, ExactWorkModel, PrimitiveSetExactWork, SimulationError, SnapshotInterval,
+    collect_toolpath_line_segments,
 };
 
 fn cam_spec(input: &str) -> JobSpec {
@@ -900,6 +902,223 @@ fn test_ball_end_mill_z_offset_removes_material_at_shifted_z() {
         "Z=10 の水平経路でフラット(Z=10 で円柱)とボール(Z=15 でカプセル)は除去位置が異なるはず: \
          flat={flat_remaining}, ball={ball_remaining}"
     );
+}
+
+#[derive(Debug, Clone, Copy)]
+struct GateMetrics {
+    removed_voxel: f64,
+    removed_exact: f64,
+    gap: f64,
+    elapsed_voxel_ms: f64,
+    elapsed_exact_ms: f64,
+    elapsed_ratio: f64,
+}
+
+fn run_gate_case(toolpath: &ToolPath<f64>, tool: &Tool<f64>, sample_pitch: f64) -> GateMetrics {
+    let bounds = Aabb3D::new(
+        Point3D::new(0.0, 0.0, 0.0),
+        Point3D::new(100.0, 100.0, 100.0),
+    );
+    let initial_volume = bounds.volume();
+
+    let voxel_started = Instant::now();
+    let mut simulator =
+        CuttingSimulator::new(VoxelOctree::new(bounds, 5), SnapshotInterval::default());
+    simulator
+        .simulate(toolpath, tool)
+        .expect("voxel simulation must succeed");
+    let elapsed_voxel_ms = voxel_started.elapsed().as_secs_f64() * 1000.0;
+    let removed_voxel = initial_volume - simulator.voxel_tree().remaining_volume();
+
+    let exact_started = Instant::now();
+    let mut exact_work = PrimitiveSetExactWork::new(bounds);
+    let segments = collect_toolpath_line_segments(
+        toolpath,
+        geo_algorithms::DEFAULT_CIRCULAR_ARC_CHORD_TOLERANCE_MM,
+    );
+    for (segment, is_cutting) in segments {
+        if !is_cutting {
+            continue;
+        }
+
+        if tool.is_flat_end_mill() {
+            exact_work.apply_primitive(ExactToolPrimitive::Flat {
+                segment,
+                radius: tool.radius(),
+            });
+            continue;
+        }
+
+        if tool.is_ball_end_mill() {
+            let start = Point3D::new(
+                segment.start().x(),
+                segment.start().y(),
+                segment.start().z() + tool.radius(),
+            );
+            let end = Point3D::new(
+                segment.end().x(),
+                segment.end().y(),
+                segment.end().z() + tool.radius(),
+            );
+            let ball_segment =
+                LineSegment3D::new(start, end).expect("ball center segment must be valid");
+            exact_work.apply_primitive(ExactToolPrimitive::Ball {
+                segment: ball_segment,
+                radius: tool.radius(),
+            });
+            continue;
+        }
+    }
+    let removed_exact = initial_volume - exact_work.estimate_remaining_volume(sample_pitch);
+    let elapsed_exact_ms = exact_started.elapsed().as_secs_f64() * 1000.0;
+
+    let gap = if removed_voxel.abs() <= f64::EPSILON {
+        0.0
+    } else {
+        ((removed_exact - removed_voxel).abs()) / removed_voxel.abs()
+    };
+
+    GateMetrics {
+        removed_voxel,
+        removed_exact,
+        gap,
+        elapsed_voxel_ms,
+        elapsed_exact_ms,
+        elapsed_ratio: elapsed_exact_ms / elapsed_voxel_ms.max(1.0e-9),
+    }
+}
+
+fn case_plane_cut_flat() -> (ToolPath<f64>, Tool<f64>) {
+    let segment = cam_core::PathSegment::new_line(
+        Point3D::new(10.0, 50.0, 50.0),
+        Point3D::new(90.0, 50.0, 50.0),
+        SegmentType::Cutting { feed_rate: 300.0 },
+    );
+    let toolpath = ToolPath::new(
+        "plane-cut-flat".to_string(),
+        CuttingDirection::Down,
+        vec![],
+        vec![ContourLevelPath::new(0, 50.0, vec![segment])],
+        vec![],
+    );
+    let tool = Tool::flat_end_mill("flat".to_string(), 10.0, 30.0);
+    (toolpath, tool)
+}
+
+fn case_step_cut_flat() -> (ToolPath<f64>, Tool<f64>) {
+    let level0 = cam_core::PathSegment::new_line(
+        Point3D::new(10.0, 30.0, 40.0),
+        Point3D::new(90.0, 30.0, 40.0),
+        SegmentType::Cutting { feed_rate: 300.0 },
+    );
+    let level1 = cam_core::PathSegment::new_line(
+        Point3D::new(10.0, 70.0, 60.0),
+        Point3D::new(90.0, 70.0, 60.0),
+        SegmentType::Cutting { feed_rate: 300.0 },
+    );
+    let toolpath = ToolPath::new(
+        "step-cut-flat".to_string(),
+        CuttingDirection::Down,
+        vec![],
+        vec![
+            ContourLevelPath::new(0, 40.0, vec![level0]),
+            ContourLevelPath::new(1, 60.0, vec![level1]),
+        ],
+        vec![],
+    );
+    let tool = Tool::flat_end_mill("flat-step".to_string(), 10.0, 30.0);
+    (toolpath, tool)
+}
+
+fn case_diagonal_cut_ball() -> (ToolPath<f64>, Tool<f64>) {
+    let segment = cam_core::PathSegment::new_line(
+        Point3D::new(10.0, 10.0, 20.0),
+        Point3D::new(90.0, 90.0, 80.0),
+        SegmentType::Cutting { feed_rate: 250.0 },
+    );
+    let toolpath = ToolPath::new(
+        "diagonal-cut-ball".to_string(),
+        CuttingDirection::Down,
+        vec![],
+        vec![ContourLevelPath::new(0, 20.0, vec![segment])],
+        vec![],
+    );
+    let tool = Tool::ball_end_mill("ball".to_string(), 10.0, 30.0);
+    (toolpath, tool)
+}
+
+#[test]
+fn phase3_gate_metrics_are_measurable_for_reference_cases() {
+    let cases = [
+        case_plane_cut_flat(),
+        case_step_cut_flat(),
+        case_diagonal_cut_ball(),
+    ];
+
+    for (index, (toolpath, tool)) in cases.iter().enumerate() {
+        let metrics = run_gate_case(toolpath, tool, 2.0);
+        assert!(
+            metrics.removed_voxel.is_finite(),
+            "case[{index}] removed_voxel must be finite"
+        );
+        assert!(
+            metrics.removed_exact.is_finite(),
+            "case[{index}] removed_exact must be finite"
+        );
+        assert!(metrics.gap.is_finite(), "case[{index}] gap must be finite");
+        assert!(
+            metrics.elapsed_voxel_ms.is_finite() && metrics.elapsed_voxel_ms >= 0.0,
+            "case[{index}] elapsed_voxel_ms must be finite and non-negative"
+        );
+        assert!(
+            metrics.elapsed_exact_ms.is_finite() && metrics.elapsed_exact_ms >= 0.0,
+            "case[{index}] elapsed_exact_ms must be finite and non-negative"
+        );
+        assert!(
+            metrics.elapsed_ratio.is_finite(),
+            "case[{index}] elapsed_ratio must be finite"
+        );
+        assert!(
+            metrics.removed_voxel > 0.0,
+            "case[{index}] removed_voxel must be positive"
+        );
+        assert!(
+            metrics.removed_exact > 0.0,
+            "case[{index}] removed_exact must be positive"
+        );
+    }
+}
+
+#[test]
+fn phase3_gate_reproducibility_parallel_matches_sequential_removed_volume() {
+    let (toolpath, tool) = case_diagonal_cut_ball();
+
+    let sequential = run_gate_case(&toolpath, &tool, 2.0);
+
+    let mut workers = Vec::new();
+    for _ in 0..4 {
+        let toolpath_cloned = toolpath.clone();
+        let tool_cloned = tool.clone();
+        workers.push(std::thread::spawn(move || {
+            run_gate_case(&toolpath_cloned, &tool_cloned, 2.0)
+        }));
+    }
+
+    for worker in workers {
+        let parallel = worker.join().expect("parallel worker must finish");
+        assert!(
+            (parallel.removed_voxel - sequential.removed_voxel).abs() <= 1.0e-9,
+            "voxel removed volume mismatch: parallel={}, sequential={}",
+            parallel.removed_voxel,
+            sequential.removed_voxel
+        );
+        assert!(
+            (parallel.removed_exact - sequential.removed_exact).abs() <= 1.0e-9,
+            "exact removed volume mismatch: parallel={}, sequential={}",
+            parallel.removed_exact,
+            sequential.removed_exact
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
含む単位: A-1（#736 着手分）
含めない単位: #736 の最終ゲート達成判定（gap/boundary/elapsed の全閾値達成判定と採否決定）は含めない
Phase と PR系列の関係: Phase3 は実施段階、A-1 はこのPRにまとめる変更単位であり、後続の A-2/A-3 は同一Phase内で分割可能

## 概要
- `model/cam_sim/src/exact_work.rs`
  - Primitive ごとの AABB キャッシュを追加
  - contains 判定と nearest distance 判定で枝刈りを追加
- `model/cam_sim/src/tests.rs`
  - 代表3ケース（PlaneCutFlat / StepCutFlat / DiagonalCutBall）の再計測ハーネスを追加
  - 並列/逐次の再現性確認テストを追加

## 目的
- #736 の保留解除ゲートに向けた「再計測可能な基盤」と「PoC側の初期性能改善」を先行実装する

## 検証
- `cargo clippy -p cam_sim -- -D warnings`
- `cargo fmt`
- `cargo test -p cam_sim`

## 参考
- Issue #736
- 親: #726, #730