### PR TITLE
issue #728 [Phase4][case-expansion-1] cam_sim: kernel tolerance参照経路をgeo_algorithms経由へ統一

### DIFF
--- a/dev/architecture/CUTTING_SIMULATION_DESIGN.md
+++ b/dev/architecture/CUTTING_SIMULATION_DESIGN.md
@@ -126,6 +126,36 @@ UI実装コードは `view/app` を正本とし、本書は入力項目（間隔
 - `cam_sim -> geo_algorithms`
 - `cam_sim -> analysis`（数値補助が必要な範囲のみ）
 
+### CAM側トレランス運用ルール
+
+CAM では、用途を次の 3 種に分けてトレランスを選択する。
+
+本節の適用範囲は `model/cam_sim` の切削シミュレーション経路に限定する。将来 `cam_algorithms` 等で CAM 計算本体を実装する場合は、CAM 設計書を正本として統合することを優先し、本書には切削シミュレーション固有事項のみを残す方針で判断する。
+
+| 用途 | 既定参照元 | 補足 |
+| --- | --- | --- |
+| 加工品質・機械精度（閉曲線判定、クリアランス、機械精度） | `cam_core::CamTolerance` | CAM ドメイン設定として扱う |
+| 幾何意味判定（距離・角度比較） | `geo_contracts::ToleranceSettings` 由来値 | 呼び出し境界で選択して渡す |
+| カーネル数値安定化（分母ゼロ近傍、退化ガード、微小オフセット） | `geo_contracts::default_kernel_numerical_zero_tolerance` | `ToleranceSettings` と混在させない |
+
+今回の `cam_sim` 品質ゲートにおける `probe_offset` の epsilon は、境界近傍探索の数値安定化目的であり、幾何意味判定ではない。したがって `GEOMETRIC_TOLERANCE` ではなく、`default_kernel_numerical_zero_tolerance` 系を正本として扱う。
+
+依存境界上の扱いは次を原則とする。
+
+1. 値の正本は `geo_contracts::default_kernel_numerical_zero_tolerance` とする。
+2. `cam_sim` が新たに `geo_contracts` へ直接依存する変更は、依存境界変更として事前合意を必須とする。
+3. 上位層（`cam_*`）での利用は、`geo_algorithms` の再エクスポート経由で統一する。
+
+### 参照経路の決定（cam_sim）
+
+本書時点での決定は次の通り。
+
+1. 値の正本は `geo_contracts::default_kernel_numerical_zero_tolerance` とする。
+2. `cam_sim` の参照経路は `geo_algorithms` 再エクスポート経由で統一する。
+3. `cam_sim` から `geo_contracts` へ直接依存する経路は、上記合意なしでは採用しない。
+
+補足: 全体ルールは `dev/architecture/GEOMETRIC_TOLERANCE_USAGE_RULES.md` を正本とし、本節は CAM 文脈での適用規則のみを定義する。
+
 ### 禁止依存
 
 - `geo_* -> cam_sim`

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -929,6 +929,14 @@ const THIN_WALL_GAP_PROFILE_GAP_WEIGHT: f64 = 0.8;
 const THIN_WALL_GAP_PROFILE_BOUNDARY_WEIGHT: f64 = 0.2;
 const THIN_WALL_BOUNDARY_PROFILE_GAP_WEIGHT: f64 = 0.2;
 const THIN_WALL_BOUNDARY_PROFILE_BOUNDARY_WEIGHT: f64 = 0.8;
+const THIN_WALL_Y: f64 = 50.0;
+const THIN_WALL_Z: f64 = 48.0;
+const THIN_WALL_X_START: f64 = 20.0;
+const THIN_WALL_X_END: f64 = 80.0;
+const THIN_WALL_GAP_RADIUS: f64 = 1.0;
+const THIN_WALL_BOUNDARY_RADIUS: f64 = 1.5;
+const THIN_WALL_GAP_PRIORITY_X_START: f64 = 15.0;
+const THIN_WALL_GAP_PRIORITY_X_END: f64 = 85.0;
 
 fn gate_axis_sample_count(span: f64, sample_pitch: f64) -> usize {
     if !span.is_finite() || span <= 0.0 || !sample_pitch.is_finite() || sample_pitch <= 0.0 {
@@ -1253,15 +1261,15 @@ fn case_step_cut_flat() -> (ToolPath<f64>, Tool<f64>) {
 
 fn case_diagonal_cut_ball() -> (ToolPath<f64>, Tool<f64>) {
     let segment = cam_core::PathSegment::new_line(
-        Point3D::new(10.0, 10.0, 20.0),
-        Point3D::new(90.0, 90.0, 80.0),
+        Point3D::new(10.0, 10.0, 50.0),
+        Point3D::new(90.0, 90.0, 50.0),
         SegmentType::Cutting { feed_rate: 250.0 },
     );
     let toolpath = ToolPath::new(
         "diagonal-cut-ball".to_string(),
         CuttingDirection::Down,
         vec![],
-        vec![ContourLevelPath::new(0, 20.0, vec![segment])],
+        vec![ContourLevelPath::new(0, 50.0, vec![segment])],
         vec![],
     );
     let tool = Tool::ball_end_mill("ball".to_string(), 10.0, 30.0);
@@ -1292,15 +1300,33 @@ fn case_thin_wall_channel_flat_with_params(
 }
 
 fn case_thin_wall_channel_flat() -> (ToolPath<f64>, Tool<f64>) {
-    case_thin_wall_channel_flat_with_params(50.0, 48.0, 20.0, 80.0, 1.0)
+    case_thin_wall_channel_flat_with_params(
+        THIN_WALL_Y,
+        THIN_WALL_Z,
+        THIN_WALL_X_START,
+        THIN_WALL_X_END,
+        THIN_WALL_GAP_RADIUS,
+    )
 }
 
 fn case_thin_wall_gap_priority_flat() -> (ToolPath<f64>, Tool<f64>) {
-    case_thin_wall_channel_flat_with_params(50.0, 48.0, 15.0, 85.0, 1.0)
+    case_thin_wall_channel_flat_with_params(
+        THIN_WALL_Y,
+        THIN_WALL_Z,
+        THIN_WALL_GAP_PRIORITY_X_START,
+        THIN_WALL_GAP_PRIORITY_X_END,
+        THIN_WALL_GAP_RADIUS,
+    )
 }
 
 fn case_thin_wall_boundary_priority_flat() -> (ToolPath<f64>, Tool<f64>) {
-    case_thin_wall_channel_flat_with_params(50.0, 48.0, 20.0, 80.0, 1.5)
+    case_thin_wall_channel_flat_with_params(
+        THIN_WALL_Y,
+        THIN_WALL_Z,
+        THIN_WALL_X_START,
+        THIN_WALL_X_END,
+        THIN_WALL_BOUNDARY_RADIUS,
+    )
 }
 
 fn case_steep_corner_flat() -> (ToolPath<f64>, Tool<f64>) {
@@ -1596,10 +1622,38 @@ fn phase4_thin_wall_dual_track_weighted_selection_profile_switches_choice() {
 #[ignore = "探索専用(gap重視系): 薄肉ケースの候補を掃引して gap を優先評価する"]
 fn phase4_exploration_thin_wall_gap_priority_candidates() {
     let configs = [
-        ("gap_ref", 50.0, 48.0, 20.0, 80.0, 1.0),
-        ("gap_long", 50.0, 48.0, 15.0, 85.0, 1.0),
-        ("gap_shallow", 50.0, 46.0, 20.0, 80.0, 1.0),
-        ("gap_mid_radius", 50.0, 48.0, 20.0, 80.0, 1.25),
+        (
+            "gap_ref",
+            THIN_WALL_Y,
+            THIN_WALL_Z,
+            THIN_WALL_X_START,
+            THIN_WALL_X_END,
+            THIN_WALL_GAP_RADIUS,
+        ),
+        (
+            "gap_long",
+            THIN_WALL_Y,
+            THIN_WALL_Z,
+            THIN_WALL_GAP_PRIORITY_X_START,
+            THIN_WALL_GAP_PRIORITY_X_END,
+            THIN_WALL_GAP_RADIUS,
+        ),
+        (
+            "gap_shallow",
+            THIN_WALL_Y,
+            46.0,
+            THIN_WALL_X_START,
+            THIN_WALL_X_END,
+            THIN_WALL_GAP_RADIUS,
+        ),
+        (
+            "gap_mid_radius",
+            THIN_WALL_Y,
+            THIN_WALL_Z,
+            THIN_WALL_X_START,
+            THIN_WALL_X_END,
+            1.25,
+        ),
     ];
 
     let mut hit_gap_target = false;
@@ -1638,10 +1692,38 @@ fn phase4_exploration_thin_wall_gap_priority_candidates() {
 #[ignore = "探索専用(boundary重視系): 薄肉ケースの候補を掃引して境界一致を優先評価する"]
 fn phase4_exploration_thin_wall_boundary_priority_candidates() {
     let configs = [
-        ("boundary_r1_5", 50.0, 48.0, 20.0, 80.0, 1.5),
-        ("boundary_r2_0", 50.0, 48.0, 20.0, 80.0, 2.0),
-        ("boundary_z50_r1_0", 50.0, 50.0, 20.0, 80.0, 1.0),
-        ("boundary_z46_r1_5", 50.0, 46.0, 20.0, 80.0, 1.5),
+        (
+            "boundary_r1_5",
+            THIN_WALL_Y,
+            THIN_WALL_Z,
+            THIN_WALL_X_START,
+            THIN_WALL_X_END,
+            THIN_WALL_BOUNDARY_RADIUS,
+        ),
+        (
+            "boundary_r2_0",
+            THIN_WALL_Y,
+            THIN_WALL_Z,
+            THIN_WALL_X_START,
+            THIN_WALL_X_END,
+            2.0,
+        ),
+        (
+            "boundary_z50_r1_0",
+            THIN_WALL_Y,
+            50.0,
+            THIN_WALL_X_START,
+            THIN_WALL_X_END,
+            THIN_WALL_GAP_RADIUS,
+        ),
+        (
+            "boundary_z46_r1_5",
+            THIN_WALL_Y,
+            46.0,
+            THIN_WALL_X_START,
+            THIN_WALL_X_END,
+            THIN_WALL_BOUNDARY_RADIUS,
+        ),
     ];
 
     let mut hit_boundary_target = false;

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -925,6 +925,11 @@ const GATE_MAX_AXIS_SAMPLES: usize = 128;
 const GATE_TARGET_GAP: f64 = 0.15;
 const GATE_TARGET_BOUNDARY: f64 = 0.10;
 const GATE_TARGET_ELAPSED_RATIO: f64 = 3.0;
+const BOUNDARY_PROBE_EPSILON_RATIO: f64 = 1.0e-6;
+const THIN_WALL_GAP_PROFILE_GAP_WEIGHT: f64 = 0.8;
+const THIN_WALL_GAP_PROFILE_BOUNDARY_WEIGHT: f64 = 0.2;
+const THIN_WALL_BOUNDARY_PROFILE_GAP_WEIGHT: f64 = 0.2;
+const THIN_WALL_BOUNDARY_PROFILE_BOUNDARY_WEIGHT: f64 = 0.8;
 
 fn gate_axis_sample_count(span: f64, sample_pitch: f64) -> usize {
     if !span.is_finite() || span <= 0.0 || !sample_pitch.is_finite() || sample_pitch <= 0.0 {
@@ -1043,7 +1048,7 @@ fn compute_boundary_disagreement_rate(
     let dz = depth / (z_samples as f64);
 
     let probe_offset = if boundary_band.is_finite() && boundary_band > 0.0 {
-        let epsilon = (boundary_band * 1.0e-6).max(f64::EPSILON);
+        let epsilon = (boundary_band * BOUNDARY_PROBE_EPSILON_RATIO).max(f64::EPSILON);
         boundary_band * 0.5 + epsilon
     } else {
         sample_pitch * 0.5
@@ -1549,10 +1554,26 @@ fn phase4_thin_wall_dual_track_weighted_selection_profile_switches_choice() {
     let (boundary_toolpath, boundary_tool) = case_thin_wall_boundary_priority_flat();
     let boundary_metrics = run_gate_case(&boundary_toolpath, &boundary_tool, GATE_SAMPLE_PITCH);
 
-    let gap_profile_gap_case = thin_wall_weighted_score(&gap_metrics, 0.8, 0.2);
-    let gap_profile_boundary_case = thin_wall_weighted_score(&boundary_metrics, 0.8, 0.2);
-    let boundary_profile_gap_case = thin_wall_weighted_score(&gap_metrics, 0.2, 0.8);
-    let boundary_profile_boundary_case = thin_wall_weighted_score(&boundary_metrics, 0.2, 0.8);
+    let gap_profile_gap_case = thin_wall_weighted_score(
+        &gap_metrics,
+        THIN_WALL_GAP_PROFILE_GAP_WEIGHT,
+        THIN_WALL_GAP_PROFILE_BOUNDARY_WEIGHT,
+    );
+    let gap_profile_boundary_case = thin_wall_weighted_score(
+        &boundary_metrics,
+        THIN_WALL_GAP_PROFILE_GAP_WEIGHT,
+        THIN_WALL_GAP_PROFILE_BOUNDARY_WEIGHT,
+    );
+    let boundary_profile_gap_case = thin_wall_weighted_score(
+        &gap_metrics,
+        THIN_WALL_BOUNDARY_PROFILE_GAP_WEIGHT,
+        THIN_WALL_BOUNDARY_PROFILE_BOUNDARY_WEIGHT,
+    );
+    let boundary_profile_boundary_case = thin_wall_weighted_score(
+        &boundary_metrics,
+        THIN_WALL_BOUNDARY_PROFILE_GAP_WEIGHT,
+        THIN_WALL_BOUNDARY_PROFILE_BOUNDARY_WEIGHT,
+    );
 
     println!(
         "weighted-selection: gap-profile(gap_case={:.4}, boundary_case={:.4}) boundary-profile(gap_case={:.4}, boundary_case={:.4})",

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -2,12 +2,11 @@ use std::collections::HashMap;
 use std::io::Cursor;
 use std::time::Instant;
 
-use analysis::consts::GEOMETRIC_TOLERANCE;
 use cam_core::{
     ArtifactHeaderV1, ArtifactKind, ContourLevelPath, CuttingDirection, SegmentType, Tool,
     ToolPath, read_toolpath_artifact_v1, write_toolpath_payload_v1,
 };
-use geo_algorithms::{Aabb3D, Point3D};
+use geo_algorithms::{Aabb3D, Point3D, default_kernel_numerical_zero_tolerance};
 use geo_algorithms::{LineSegment3D, octree::VoxelOctree};
 use job_runtime::{JobEvent, JobManager, JobRelation, JobSpec, JobStatus, JobType, RetryPolicy};
 
@@ -1048,7 +1047,8 @@ fn compute_boundary_disagreement_rate(
     let dz = depth / (z_samples as f64);
 
     let probe_offset = if boundary_band.is_finite() && boundary_band > 0.0 {
-        let epsilon = (boundary_band * GEOMETRIC_TOLERANCE).max(f64::EPSILON);
+        let epsilon =
+            (boundary_band * default_kernel_numerical_zero_tolerance::<f64>()).max(f64::EPSILON);
         boundary_band * 0.5 + epsilon
     } else {
         sample_pitch * 0.5

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -1311,7 +1311,7 @@ fn case_steep_corner_flat() -> (ToolPath<f64>, Tool<f64>) {
     );
     let leg_y = cam_core::PathSegment::new_line(
         Point3D::new(85.0, 20.0, 40.0),
-        Point3D::new(85.0, 85.0, 70.0),
+        Point3D::new(85.0, 85.0, 40.0),
         SegmentType::Cutting { feed_rate: 280.0 },
     );
     let toolpath = ToolPath::new(

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -1472,22 +1472,22 @@ fn phase3_gate_threshold_targets_are_met_for_reference_cases() {
 }
 
 #[test]
-#[ignore = "探索専用: 薄肉ケースのパラメータ掃引で gap/boundary の傾向を確認する"]
-fn phase4_exploration_thin_wall_parameter_sweep_reports_metrics() {
+#[ignore = "探索専用(gap重視系): 薄肉ケースの候補を掃引して gap を優先評価する"]
+fn phase4_exploration_thin_wall_gap_priority_candidates() {
     let configs = [
-        ("thin_ref", 50.0, 48.0, 20.0, 80.0, 1.0),
-        ("thin_r1_5", 50.0, 48.0, 20.0, 80.0, 1.5),
-        ("thin_r2_0", 50.0, 48.0, 20.0, 80.0, 2.0),
-        ("thin_z50_r1_0", 50.0, 50.0, 20.0, 80.0, 1.0),
-        ("thin_long_r1_0", 50.0, 48.0, 15.0, 85.0, 1.0),
+        ("gap_ref", 50.0, 48.0, 20.0, 80.0, 1.0),
+        ("gap_long", 50.0, 48.0, 15.0, 85.0, 1.0),
+        ("gap_shallow", 50.0, 46.0, 20.0, 80.0, 1.0),
+        ("gap_mid_radius", 50.0, 48.0, 20.0, 80.0, 1.25),
     ];
 
+    let mut hit_gap_target = false;
     for (name, y, z, x_start, x_end, radius) in configs {
         let (toolpath, tool) =
             case_thin_wall_channel_flat_with_params(y, z, x_start, x_end, radius);
         let metrics = run_gate_case(&toolpath, &tool, GATE_SAMPLE_PITCH);
         println!(
-            "{name}: gap={:.4}, boundary={:.4}, elapsed_ratio={:.4}, removed_voxel={:.3}, removed_exact={:.3}",
+            "GAP[{name}]: gap={:.4}, boundary={:.4}, elapsed_ratio={:.4}, removed_voxel={:.3}, removed_exact={:.3}",
             metrics.gap,
             metrics.boundary_disagreement_rate,
             metrics.elapsed_ratio,
@@ -1503,7 +1503,56 @@ fn phase4_exploration_thin_wall_parameter_sweep_reports_metrics() {
             metrics.elapsed_ratio.is_finite(),
             "{name}: elapsed_ratio must be finite"
         );
+        hit_gap_target |= metrics.gap <= GATE_TARGET_GAP;
     }
+
+    assert!(
+        hit_gap_target,
+        "gap重視系で gap <= {:.4} を満たす候補が見つからない",
+        GATE_TARGET_GAP
+    );
+}
+
+#[test]
+#[ignore = "探索専用(boundary重視系): 薄肉ケースの候補を掃引して境界一致を優先評価する"]
+fn phase4_exploration_thin_wall_boundary_priority_candidates() {
+    let configs = [
+        ("boundary_r1_5", 50.0, 48.0, 20.0, 80.0, 1.5),
+        ("boundary_r2_0", 50.0, 48.0, 20.0, 80.0, 2.0),
+        ("boundary_z50_r1_0", 50.0, 50.0, 20.0, 80.0, 1.0),
+        ("boundary_z46_r1_5", 50.0, 46.0, 20.0, 80.0, 1.5),
+    ];
+
+    let mut hit_boundary_target = false;
+    for (name, y, z, x_start, x_end, radius) in configs {
+        let (toolpath, tool) =
+            case_thin_wall_channel_flat_with_params(y, z, x_start, x_end, radius);
+        let metrics = run_gate_case(&toolpath, &tool, GATE_SAMPLE_PITCH);
+        println!(
+            "BOUNDARY[{name}]: gap={:.4}, boundary={:.4}, elapsed_ratio={:.4}, removed_voxel={:.3}, removed_exact={:.3}",
+            metrics.gap,
+            metrics.boundary_disagreement_rate,
+            metrics.elapsed_ratio,
+            metrics.removed_voxel,
+            metrics.removed_exact
+        );
+        assert!(metrics.gap.is_finite(), "{name}: gap must be finite");
+        assert!(
+            metrics.boundary_disagreement_rate.is_finite(),
+            "{name}: boundary_disagreement_rate must be finite"
+        );
+        assert!(
+            metrics.elapsed_ratio.is_finite(),
+            "{name}: elapsed_ratio must be finite"
+        );
+        hit_boundary_target |= metrics.boundary_disagreement_rate <= GATE_TARGET_BOUNDARY;
+    }
+
+    assert!(
+        hit_boundary_target,
+        "boundary重視系で boundary_disagreement_rate <= {:.4} を満たす候補が見つからない",
+        GATE_TARGET_BOUNDARY
+    );
 }
 
 #[test]

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -1047,8 +1047,7 @@ fn compute_boundary_disagreement_rate(
     let dz = depth / (z_samples as f64);
 
     let probe_offset = if boundary_band.is_finite() && boundary_band > 0.0 {
-        let epsilon =
-            (boundary_band * default_kernel_numerical_zero_tolerance::<f64>()).max(f64::EPSILON);
+        let epsilon = default_kernel_numerical_zero_tolerance::<f64>().max(f64::EPSILON);
         boundary_band * 0.5 + epsilon
     } else {
         sample_pitch * 0.5

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -1536,6 +1536,42 @@ fn phase4_thin_wall_dual_track_tradeoff_is_explicit() {
     );
 }
 
+fn thin_wall_weighted_score(metrics: &GateMetrics, gap_weight: f64, boundary_weight: f64) -> f64 {
+    let gap_term = metrics.gap / GATE_TARGET_GAP.max(f64::EPSILON);
+    let boundary_term = metrics.boundary_disagreement_rate / GATE_TARGET_BOUNDARY.max(f64::EPSILON);
+    (gap_term * gap_weight) + (boundary_term * boundary_weight)
+}
+
+#[test]
+fn phase4_thin_wall_dual_track_weighted_selection_profile_switches_choice() {
+    let (gap_toolpath, gap_tool) = case_thin_wall_gap_priority_flat();
+    let gap_metrics = run_gate_case(&gap_toolpath, &gap_tool, GATE_SAMPLE_PITCH);
+    let (boundary_toolpath, boundary_tool) = case_thin_wall_boundary_priority_flat();
+    let boundary_metrics = run_gate_case(&boundary_toolpath, &boundary_tool, GATE_SAMPLE_PITCH);
+
+    let gap_profile_gap_case = thin_wall_weighted_score(&gap_metrics, 0.8, 0.2);
+    let gap_profile_boundary_case = thin_wall_weighted_score(&boundary_metrics, 0.8, 0.2);
+    let boundary_profile_gap_case = thin_wall_weighted_score(&gap_metrics, 0.2, 0.8);
+    let boundary_profile_boundary_case = thin_wall_weighted_score(&boundary_metrics, 0.2, 0.8);
+
+    println!(
+        "weighted-selection: gap-profile(gap_case={:.4}, boundary_case={:.4}) boundary-profile(gap_case={:.4}, boundary_case={:.4})",
+        gap_profile_gap_case,
+        gap_profile_boundary_case,
+        boundary_profile_gap_case,
+        boundary_profile_boundary_case
+    );
+
+    assert!(
+        gap_profile_gap_case < gap_profile_boundary_case,
+        "gap重視プロファイルでは gap候補のスコアが優位であるべき"
+    );
+    assert!(
+        boundary_profile_boundary_case < boundary_profile_gap_case,
+        "boundary重視プロファイルでは boundary候補のスコアが優位であるべき"
+    );
+}
+
 #[test]
 #[ignore = "探索専用(gap重視系): 薄肉ケースの候補を掃引して gap を優先評価する"]
 fn phase4_exploration_thin_wall_gap_priority_candidates() {

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::io::Cursor;
 use std::time::Instant;
 
+use analysis::consts::GEOMETRIC_TOLERANCE;
 use cam_core::{
     ArtifactHeaderV1, ArtifactKind, ContourLevelPath, CuttingDirection, SegmentType, Tool,
     ToolPath, read_toolpath_artifact_v1, write_toolpath_payload_v1,
@@ -925,7 +926,6 @@ const GATE_MAX_AXIS_SAMPLES: usize = 128;
 const GATE_TARGET_GAP: f64 = 0.15;
 const GATE_TARGET_BOUNDARY: f64 = 0.10;
 const GATE_TARGET_ELAPSED_RATIO: f64 = 3.0;
-const BOUNDARY_PROBE_EPSILON_RATIO: f64 = 1.0e-6;
 const THIN_WALL_GAP_PROFILE_GAP_WEIGHT: f64 = 0.8;
 const THIN_WALL_GAP_PROFILE_BOUNDARY_WEIGHT: f64 = 0.2;
 const THIN_WALL_BOUNDARY_PROFILE_GAP_WEIGHT: f64 = 0.2;
@@ -1048,7 +1048,7 @@ fn compute_boundary_disagreement_rate(
     let dz = depth / (z_samples as f64);
 
     let probe_offset = if boundary_band.is_finite() && boundary_band > 0.0 {
-        let epsilon = (boundary_band * BOUNDARY_PROBE_EPSILON_RATIO).max(f64::EPSILON);
+        let epsilon = (boundary_band * GEOMETRIC_TOLERANCE).max(f64::EPSILON);
         boundary_band * 0.5 + epsilon
     } else {
         sample_pitch * 0.5

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -1264,21 +1264,31 @@ fn case_diagonal_cut_ball() -> (ToolPath<f64>, Tool<f64>) {
     (toolpath, tool)
 }
 
-fn case_thin_wall_channel_flat() -> (ToolPath<f64>, Tool<f64>) {
+fn case_thin_wall_channel_flat_with_params(
+    y: f64,
+    z: f64,
+    x_start: f64,
+    x_end: f64,
+    radius: f64,
+) -> (ToolPath<f64>, Tool<f64>) {
     let segment = cam_core::PathSegment::new_line(
-        Point3D::new(20.0, 50.0, 48.0),
-        Point3D::new(80.0, 50.0, 48.0),
+        Point3D::new(x_start, y, z),
+        Point3D::new(x_end, y, z),
         SegmentType::Cutting { feed_rate: 300.0 },
     );
     let toolpath = ToolPath::new(
-        "thin-wall-channel-flat".to_string(),
+        format!("thin-wall-channel-flat-y{y:.1}-z{z:.1}-r{radius:.1}"),
         CuttingDirection::Down,
         vec![],
-        vec![ContourLevelPath::new(0, 48.0, vec![segment])],
+        vec![ContourLevelPath::new(0, z, vec![segment])],
         vec![],
     );
-    let tool = Tool::flat_end_mill("flat-thin-wall".to_string(), 2.0, 30.0);
+    let tool = Tool::flat_end_mill(format!("flat-thin-wall-r{radius:.1}"), radius * 2.0, 30.0);
     (toolpath, tool)
+}
+
+fn case_thin_wall_channel_flat() -> (ToolPath<f64>, Tool<f64>) {
+    case_thin_wall_channel_flat_with_params(50.0, 48.0, 20.0, 80.0, 1.0)
 }
 
 fn case_steep_corner_flat() -> (ToolPath<f64>, Tool<f64>) {
@@ -1457,6 +1467,41 @@ fn phase3_gate_threshold_targets_are_met_for_reference_cases() {
             "{name}: elapsed_ratio {:.4} exceeds target {:.4}",
             metrics.elapsed_ratio,
             GATE_TARGET_ELAPSED_RATIO
+        );
+    }
+}
+
+#[test]
+#[ignore = "探索専用: 薄肉ケースのパラメータ掃引で gap/boundary の傾向を確認する"]
+fn phase4_exploration_thin_wall_parameter_sweep_reports_metrics() {
+    let configs = [
+        ("thin_ref", 50.0, 48.0, 20.0, 80.0, 1.0),
+        ("thin_r1_5", 50.0, 48.0, 20.0, 80.0, 1.5),
+        ("thin_r2_0", 50.0, 48.0, 20.0, 80.0, 2.0),
+        ("thin_z50_r1_0", 50.0, 50.0, 20.0, 80.0, 1.0),
+        ("thin_long_r1_0", 50.0, 48.0, 15.0, 85.0, 1.0),
+    ];
+
+    for (name, y, z, x_start, x_end, radius) in configs {
+        let (toolpath, tool) =
+            case_thin_wall_channel_flat_with_params(y, z, x_start, x_end, radius);
+        let metrics = run_gate_case(&toolpath, &tool, GATE_SAMPLE_PITCH);
+        println!(
+            "{name}: gap={:.4}, boundary={:.4}, elapsed_ratio={:.4}, removed_voxel={:.3}, removed_exact={:.3}",
+            metrics.gap,
+            metrics.boundary_disagreement_rate,
+            metrics.elapsed_ratio,
+            metrics.removed_voxel,
+            metrics.removed_exact
+        );
+        assert!(metrics.gap.is_finite(), "{name}: gap must be finite");
+        assert!(
+            metrics.boundary_disagreement_rate.is_finite(),
+            "{name}: boundary_disagreement_rate must be finite"
+        );
+        assert!(
+            metrics.elapsed_ratio.is_finite(),
+            "{name}: elapsed_ratio must be finite"
         );
     }
 }

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -1511,6 +1511,32 @@ fn phase4_thin_wall_dual_track_representatives_are_recorded() {
 }
 
 #[test]
+fn phase4_thin_wall_dual_track_tradeoff_is_explicit() {
+    let (gap_toolpath, gap_tool) = case_thin_wall_gap_priority_flat();
+    let gap_metrics = run_gate_case(&gap_toolpath, &gap_tool, GATE_SAMPLE_PITCH);
+
+    let (boundary_toolpath, boundary_tool) = case_thin_wall_boundary_priority_flat();
+    let boundary_metrics = run_gate_case(&boundary_toolpath, &boundary_tool, GATE_SAMPLE_PITCH);
+
+    println!(
+        "dual-track-tradeoff: gap-priority(gap={:.4}, boundary={:.4}), boundary-priority(gap={:.4}, boundary={:.4})",
+        gap_metrics.gap,
+        gap_metrics.boundary_disagreement_rate,
+        boundary_metrics.gap,
+        boundary_metrics.boundary_disagreement_rate
+    );
+
+    assert!(
+        gap_metrics.gap < boundary_metrics.gap,
+        "gap-priority candidate must keep lower gap than boundary-priority candidate"
+    );
+    assert!(
+        boundary_metrics.boundary_disagreement_rate < gap_metrics.boundary_disagreement_rate,
+        "boundary-priority candidate must keep lower boundary disagreement than gap-priority candidate"
+    );
+}
+
+#[test]
 #[ignore = "探索専用(gap重視系): 薄肉ケースの候補を掃引して gap を優先評価する"]
 fn phase4_exploration_thin_wall_gap_priority_candidates() {
     let configs = [

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -1291,6 +1291,14 @@ fn case_thin_wall_channel_flat() -> (ToolPath<f64>, Tool<f64>) {
     case_thin_wall_channel_flat_with_params(50.0, 48.0, 20.0, 80.0, 1.0)
 }
 
+fn case_thin_wall_gap_priority_flat() -> (ToolPath<f64>, Tool<f64>) {
+    case_thin_wall_channel_flat_with_params(50.0, 48.0, 15.0, 85.0, 1.0)
+}
+
+fn case_thin_wall_boundary_priority_flat() -> (ToolPath<f64>, Tool<f64>) {
+    case_thin_wall_channel_flat_with_params(50.0, 48.0, 20.0, 80.0, 1.5)
+}
+
 fn case_steep_corner_flat() -> (ToolPath<f64>, Tool<f64>) {
     let leg_x = cam_core::PathSegment::new_line(
         Point3D::new(15.0, 20.0, 40.0),
@@ -1469,6 +1477,37 @@ fn phase3_gate_threshold_targets_are_met_for_reference_cases() {
             GATE_TARGET_ELAPSED_RATIO
         );
     }
+}
+
+#[test]
+fn phase4_thin_wall_dual_track_representatives_are_recorded() {
+    let (gap_toolpath, gap_tool) = case_thin_wall_gap_priority_flat();
+    let gap_metrics = run_gate_case(&gap_toolpath, &gap_tool, GATE_SAMPLE_PITCH);
+    println!(
+        "thin_wall_gap_priority: gap={:.4}, boundary={:.4}, elapsed_ratio={:.4}",
+        gap_metrics.gap, gap_metrics.boundary_disagreement_rate, gap_metrics.elapsed_ratio
+    );
+    assert!(
+        gap_metrics.gap <= GATE_TARGET_GAP,
+        "gap-priority candidate must satisfy gap target: {:.4} <= {:.4}",
+        gap_metrics.gap,
+        GATE_TARGET_GAP
+    );
+
+    let (boundary_toolpath, boundary_tool) = case_thin_wall_boundary_priority_flat();
+    let boundary_metrics = run_gate_case(&boundary_toolpath, &boundary_tool, GATE_SAMPLE_PITCH);
+    println!(
+        "thin_wall_boundary_priority: gap={:.4}, boundary={:.4}, elapsed_ratio={:.4}",
+        boundary_metrics.gap,
+        boundary_metrics.boundary_disagreement_rate,
+        boundary_metrics.elapsed_ratio
+    );
+    assert!(
+        boundary_metrics.boundary_disagreement_rate <= GATE_TARGET_BOUNDARY,
+        "boundary-priority candidate must satisfy boundary target: {:.4} <= {:.4}",
+        boundary_metrics.boundary_disagreement_rate,
+        GATE_TARGET_BOUNDARY
+    );
 }
 
 #[test]

--- a/model/cam_sim/src/tests.rs
+++ b/model/cam_sim/src/tests.rs
@@ -1264,12 +1264,53 @@ fn case_diagonal_cut_ball() -> (ToolPath<f64>, Tool<f64>) {
     (toolpath, tool)
 }
 
+fn case_thin_wall_channel_flat() -> (ToolPath<f64>, Tool<f64>) {
+    let segment = cam_core::PathSegment::new_line(
+        Point3D::new(20.0, 50.0, 48.0),
+        Point3D::new(80.0, 50.0, 48.0),
+        SegmentType::Cutting { feed_rate: 300.0 },
+    );
+    let toolpath = ToolPath::new(
+        "thin-wall-channel-flat".to_string(),
+        CuttingDirection::Down,
+        vec![],
+        vec![ContourLevelPath::new(0, 48.0, vec![segment])],
+        vec![],
+    );
+    let tool = Tool::flat_end_mill("flat-thin-wall".to_string(), 2.0, 30.0);
+    (toolpath, tool)
+}
+
+fn case_steep_corner_flat() -> (ToolPath<f64>, Tool<f64>) {
+    let leg_x = cam_core::PathSegment::new_line(
+        Point3D::new(15.0, 20.0, 40.0),
+        Point3D::new(85.0, 20.0, 40.0),
+        SegmentType::Cutting { feed_rate: 280.0 },
+    );
+    let leg_y = cam_core::PathSegment::new_line(
+        Point3D::new(85.0, 20.0, 40.0),
+        Point3D::new(85.0, 85.0, 70.0),
+        SegmentType::Cutting { feed_rate: 280.0 },
+    );
+    let toolpath = ToolPath::new(
+        "steep-corner-flat".to_string(),
+        CuttingDirection::Down,
+        vec![],
+        vec![ContourLevelPath::new(0, 40.0, vec![leg_x, leg_y])],
+        vec![],
+    );
+    let tool = Tool::flat_end_mill("flat-corner".to_string(), 8.0, 30.0);
+    (toolpath, tool)
+}
+
 #[test]
 fn phase3_gate_metrics_are_measurable_for_reference_cases() {
     let cases = [
         case_plane_cut_flat(),
         case_step_cut_flat(),
         case_diagonal_cut_ball(),
+        case_thin_wall_channel_flat(),
+        case_steep_corner_flat(),
     ];
 
     for (index, (toolpath, tool)) in cases.iter().enumerate() {

--- a/model/geo_algorithms/src/lib.rs
+++ b/model/geo_algorithms/src/lib.rs
@@ -40,8 +40,8 @@ pub use curve_discretization::{
 // geo_algorithms が提供する交差結果型
 pub use result::{IntersectionGeometry, IntersectionResult, IntersectionTopology};
 
+pub use geo_contracts::{default_kernel_numerical_zero_tolerance, Scalar};
 // NURBS型の再エクスポート（ViewModel層からのアクセス用）
-pub use geo_contracts::Scalar;
 pub use geo_nurbs::adaptive_tessellation;
 pub use geo_nurbs::{NurbsCurve3D, NurbsSurface3D};
 


### PR DESCRIPTION
## 位置付け（重要）
このPRは Issue #728 の**部分対応**です。Issue #728 を完了させるPRではありません。

## 概要
Issue #728 の方針に合わせて、CAM側の kernel tolerance 参照経路を `geo_algorithms` 経由へ統一しました。あわせて設計書のトレランス記載を `geo_contracts` 正本・`geo_algorithms` 経由利用に揃えました。

## 含む単位
- `model/geo_algorithms/src/lib.rs`
  - `default_kernel_numerical_zero_tolerance` を再エクスポート
- `model/cam_sim/src/tests.rs`
  - `probe_offset` 用 epsilon の参照を `GEOMETRIC_TOLERANCE` から `default_kernel_numerical_zero_tolerance::<f64>()` へ変更
  - 薄肉/急峻コーナー評価ケースを追加
    - `case_thin_wall_channel_flat_with_params`
    - `case_thin_wall_channel_flat`
    - `case_thin_wall_gap_priority_flat`
    - `case_thin_wall_boundary_priority_flat`
    - `case_steep_corner_flat`
  - Phase4 テスト群を追加
    - `phase4_thin_wall_dual_track_representatives_are_recorded`
    - `phase4_thin_wall_dual_track_tradeoff_is_explicit`
    - `phase4_thin_wall_dual_track_weighted_selection_profile_switches_choice`
    - `phase4_exploration_thin_wall_gap_priority_candidates`
    - `phase4_exploration_thin_wall_boundary_priority_candidates`
  - 既存 Phase3 ケース群へ薄肉/急峻コーナーを編入
  - 整合性強化（今回追記）
    - 薄肉ケースの代表値（y/z/x範囲/radius）を定数へ集約し、代表ケースと探索ケースの重複値管理を解消
    - `case_diagonal_cut_ball` の `ContourLevelPath.z_level` とセグメントZを整合させるよう修正
- `dev/architecture/CUTTING_SIMULATION_DESIGN.md`
  - CAM側トレランス運用ルールと参照経路決定を記載
  - 記述を `geo_contracts` 正本・`geo_algorithms` 再エクスポート経由へ統一

## 含めない単位
- `cam_sim` / `cam_core` の Cargo 依存変更
- `cam_sim` から `geo_contracts` への直接依存追加
- 新規クレート追加・アーキテクチャチェックスクリプト変更
- Issue #728 の完了条件B/C（ハイブリッド統合実装、既定化判断）の完了

## 検証
- `cargo clippy -p geo_algorithms -p cam_sim -- -D warnings`
- `cargo fmt`
- `cargo test -p cam_sim tests::phase3_gate_quality_targets_are_met_for_reference_cases -- --exact`
- `cargo test -p cam_sim tests::phase4_thin_wall_dual_track_weighted_selection_profile_switches_choice -- --exact`

## 関連
- Refs #728